### PR TITLE
Add observe mode tests for neuraltrust_jailbreak and neuraltrust_moderation plugins

### DIFF
--- a/pkg/infra/plugins/neuraltrust_jailbreak/config.go
+++ b/pkg/infra/plugins/neuraltrust_jailbreak/config.go
@@ -1,12 +1,12 @@
-package neuraltrust_toxicity
+package neuraltrust_jailbreak
 
 type Config struct {
-	Provider         string            `mapstructure:"provider"`
-	Credentials      Credentials       `mapstructure:"credentials"`
-	ToxicityParamBag *ToxicityParamBag `mapstructure:"toxicity"`
-	MappingField     string            `mapstructure:"mapping_field"`
-	RetentionPeriod  int               `mapstructure:"retention_period"`
-	Mode             string            `mapstructure:"mode"`
+	Provider          string             `mapstructure:"provider"`
+	Credentials       Credentials        `mapstructure:"credentials"`
+	JailbreakParamBag *JailbreakParamBag `mapstructure:"jailbreak"`
+	MappingField      string             `mapstructure:"mapping_field"`
+	RetentionPeriod   int                `mapstructure:"retention_period"`
+	Mode              string             `mapstructure:"mode"`
 }
 
 type Credentials struct {
@@ -27,6 +27,6 @@ type OpenAICredentials struct {
 	APIKey string `mapstructure:"api_key"`
 }
 
-type ToxicityParamBag struct {
+type JailbreakParamBag struct {
 	Threshold float64 `mapstructure:"threshold"`
 }

--- a/pkg/infra/plugins/neuraltrust_jailbreak/data.go
+++ b/pkg/infra/plugins/neuraltrust_jailbreak/data.go
@@ -12,6 +12,8 @@ type NeuralTrustJailbreakData struct {
 	Violation *ViolationInfo   `json:"violation,omitempty"`
 
 	DetectionLatencyMs int64 `json:"detection_latency_ms"`
+
+	Mode string `json:"mode"`
 }
 
 type JailbreakScores struct {

--- a/pkg/infra/plugins/neuraltrust_moderation/config.go
+++ b/pkg/infra/plugins/neuraltrust_moderation/config.go
@@ -6,6 +6,7 @@ type Config struct {
 	NTTopicParamBag *NTTopicParamBag `mapstructure:"nt_topic_moderation"`
 	RetentionPeriod int              `mapstructure:"retention_period"`
 	MappingField    string           `mapstructure:"mapping_field"`
+	Mode            string           `mapstructure:"mode"`
 }
 
 type NeuralTrustCreds struct {

--- a/pkg/infra/plugins/neuraltrust_moderation/data.go
+++ b/pkg/infra/plugins/neuraltrust_moderation/data.go
@@ -8,6 +8,8 @@ type NeuralTrustModerationData struct {
 	KeyRegModeration  *KeyRegModeration  `json:"keyreg_moderation,omitempty"`
 	LLMModeration     *LLMModeration     `json:"llm_moderation,omitempty"`
 	NTTopicModeration *NTTopicModeration `json:"slm_moderation,omitempty"`
+
+	Mode string `json:"mode"`
 }
 
 type KeyRegModeration struct {

--- a/pkg/infra/plugins/neuraltrust_toxicity/data.go
+++ b/pkg/infra/plugins/neuraltrust_toxicity/data.go
@@ -12,6 +12,8 @@ type ToxicityData struct {
 	Violation *ViolationInfo  `json:"violation,omitempty"`
 
 	DetectionLatencyMs int64 `json:"detection_latency_ms"`
+
+	Mode string `json:"mode"`
 }
 
 type ToxicityScores struct {

--- a/pkg/infra/plugins/types/plugin.go
+++ b/pkg/infra/plugins/types/plugin.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"errors"
+	"fmt"
 )
 
 var (
@@ -20,6 +21,9 @@ const (
 	PostRequest  Stage = "post_request"
 	PreResponse  Stage = "pre_response"
 	PostResponse Stage = "post_response"
+
+	ModeObserve string = "observe"
+	ModeEnforce string = "enforce"
 )
 
 // PluginConfig represents the configuration for a plugin
@@ -53,9 +57,22 @@ func (e *PluginError) Error() string {
 	return e.Message
 }
 
-// PluginChain represents a sequence of plugins to be executed
 type PluginChain struct {
 	Stage    Stage          `json:"stage"`
 	Parallel bool           `json:"parallel"`
 	Plugins  []PluginConfig `json:"plugins"`
+}
+
+type BasePlugin struct {
+}
+
+func NewBasePlugin() *BasePlugin {
+	return &BasePlugin{}
+}
+
+func (p *BasePlugin) ValidateMode(mode string) error {
+	if mode != ModeObserve && mode != ModeEnforce {
+		return fmt.Errorf("mode must be either observe or enforce")
+	}
+	return nil
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	Version   = "1.9.50"
+	Version   = "1.10.0"
 	AppName   = "TrustGate"
 	BuildDate = "unknown"
 )


### PR DESCRIPTION
Add unit and integration tests for the new mode configuration option (observe/enforce)
in neuraltrust_jailbreak and neuraltrust_moderation plugins.

Changes:
- Extract config structs to config.go in neuraltrust_jailbreak plugin
- Add ValidateMode tests to verify mode validation (observe, enforce, invalid)
- Add unit tests for observe mode execution returning 200 instead of 403
- Add unit tests for enforce mode execution returning 403
- Add functional/integration tests for observe mode in both plugins:
  - neuraltrust_jailbreak observe mode test
  - neuraltrust_moderation keyreg observe mode test
  - neuraltrust_moderation nt_topic observe mode test