### PR TITLE
fix: remove trailing slash when path params match exactly

### DIFF
--- a/pkg/app/routing/rule_matcher.go
+++ b/pkg/app/routing/rule_matcher.go
@@ -103,9 +103,6 @@ func (m *ruleMatcher) ExtractPathAfterMatch(requestPath string, rulePath string)
 
 	if strings.HasPrefix(requestPath, matchedPath) {
 		remaining := requestPath[len(matchedPath):]
-		if remaining == "" {
-			return "/"
-		}
 		return remaining
 	}
 

--- a/pkg/app/routing/rule_matcher_test.go
+++ b/pkg/app/routing/rule_matcher_test.go
@@ -320,7 +320,7 @@ func TestRuleMatcher_ExtractPathAfterMatch(t *testing.T) {
 			name:        "path with single param - no remaining",
 			requestPath: "/api/v1/users/123",
 			rulePath:    "/api/v1/users/{id}",
-			wantResult:  "/",
+			wantResult:  "",
 		},
 		{
 			name:        "path with multiple params - remaining path",
@@ -332,7 +332,7 @@ func TestRuleMatcher_ExtractPathAfterMatch(t *testing.T) {
 			name:        "path with multiple params - no remaining",
 			requestPath: "/api/v1/users/123/posts/456",
 			rulePath:    "/api/v1/users/{userId}/posts/{postId}",
-			wantResult:  "/",
+			wantResult:  "",
 		},
 		{
 			name:        "path with trailing slash",


### PR DESCRIPTION
When a request path like /api/cats/cat1 matched a rule path like /api/cats/{text}, ExtractPathAfterMatch was returning "/" instead of "" when there was no remaining path. This caused the upstream URL to have a trailing slash (e.g., /api/cats/cat1/) which broke some backend services.