### PR TITLE
testes ai gateway stream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,9 @@ config.*.yaml
 # Debug files
 __debug_bin
 
+# Stream response dumps (TG_SAVE_STREAM_DEBUG=1)
+streams/
+
 # Air live reload
 tmp/
 .mydocs

--- a/pkg/app/upstream/finder.go
+++ b/pkg/app/upstream/finder.go
@@ -42,7 +42,7 @@ func (f *finder) Find(ctx context.Context, gatewayID, upstreamID uuid.UUID) (*do
 		f.saveUpstreamToMemoryCache(ctx, cachedUpstream)
 		return cachedUpstream, nil
 	} else if err != nil {
-		f.logger.WithError(err).Warn("distributed cache read upstream failure")
+		f.logger.WithError(err).Debug("distributed cache read upstream failure")
 	}
 	upstream, err := f.repo.GetUpstream(ctx, upstreamID)
 	if err != nil {

--- a/pkg/handlers/http/forwarded_handler.go
+++ b/pkg/handlers/http/forwarded_handler.go
@@ -11,6 +11,9 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -612,6 +615,7 @@ func (h *forwardedHandler) forwardRequest(
 		h.logger.WithFields(logrus.Fields{
 			"attempt":   attempt + 1,
 			"provider":  target.Provider,
+			"stream":    target.Stream,
 			"target_id": target.ID,
 		}).Debug("Attempting request")
 
@@ -1100,6 +1104,22 @@ func (h *forwardedHandler) getPathParamsFromContext(ctx context.Context) map[str
 	return nil
 }
 
+// injectStreamTrue sets "stream": true in a JSON request body so that upstreams
+// using OpenAI-style API (openai, azure) actually use streaming when the agent
+// format (e.g. Gemini) does not include stream in the body. Returns body unchanged on parse error.
+func injectStreamTrue(body []byte) []byte {
+	var m map[string]interface{}
+	if err := json.Unmarshal(body, &m); err != nil {
+		return body
+	}
+	m["stream"] = true
+	out, err := json.Marshal(m)
+	if err != nil {
+		return body
+	}
+	return out
+}
+
 func (h *forwardedHandler) handleStreamingResponseByProvider(
 	req *types.RequestContext,
 	target *types.UpstreamTargetDTO,
@@ -1129,6 +1149,15 @@ func (h *forwardedHandler) handleStreamingResponseByProvider(
 	if err != nil {
 		h.logger.WithError(err).Warn("model validation failed, proceeding with original body")
 		body = req.Body
+	}
+
+	// Upstreams that require "stream": true in the body (OpenAI, Azure, Anthropic)
+	// for streaming. When the agent format (e.g. Gemini) does not send stream in
+	// the body, the adapted body may lack it; force it so the upstream actually streams.
+	// - Azure: already covered (normalizeFormat maps it to OpenAI).
+	// - Bedrock: does not use body for streaming (uses InvokeModelWithResponseStream); adapter strips "stream".
+	if adapter.IsSameWireFormat(targetFormat, adapter.FormatOpenAI) || targetFormat == adapter.FormatAnthropic {
+		body = injectStreamTrue(body)
 	}
 
 	streamChan := make(chan []byte)
@@ -1186,8 +1215,59 @@ func (h *forwardedHandler) handleStreamingResponseByProvider(
 		break
 	}
 
+	// Optional: save the response stream to a file for debugging (compare upstream_agent combos).
+	var streamFile *os.File
+	if os.Getenv("TG_SAVE_STREAM_DEBUG") != "" {
+		dir := "streams"
+		_ = os.MkdirAll(dir, 0750)
+		upstreamName := string(targetFormat)
+		agentName := string(sourceFormat)
+		ts := time.Now().Format("20060102-150405")
+		name := fmt.Sprintf("%s_%s_%s.sse", upstreamName, agentName, ts)
+		path := filepath.Join(dir, name)
+		f, err := os.Create(path) // #nosec G304 -- path is from format names and timestamp, not user input
+		if err != nil {
+			h.logger.WithError(err).Warn("could not create stream debug file")
+		} else {
+			streamFile = f
+			h.logger.WithField("path", path).Info("saving stream response to file")
+		}
+	}
+
 	req.C.Context().SetBodyStreamWriter(func(w *bufio.Writer) {
 		defer close(streamResponse)
+		if streamFile != nil {
+			defer func() { _ = streamFile.Close() }()
+		}
+		writeLine := func(line []byte) {
+			_, _ = w.Write(line)
+			_, _ = w.Write([]byte("\n"))
+			if streamFile != nil {
+				_, _ = streamFile.Write(line)
+				_, _ = streamFile.Write([]byte("\n"))
+			}
+		}
+		writeAdaptedLines := func(lines [][]byte) {
+			for _, line := range lines {
+				writeLine(line)
+			}
+			_ = w.Flush()
+			for _, line := range lines {
+				if bytes.HasPrefix(line, []byte("data:")) {
+					mp := bytes.TrimSpace(bytes.TrimPrefix(line, []byte("data:")))
+					if len(mp) > 0 {
+						streamResponse <- mp
+					}
+				}
+			}
+		}
+		// When agent is Gemini and upstream streams tool_calls (e.g. OpenAI), we accumulate
+		// arguments per tool call and emit Gemini-style functionCall parts on finish.
+		var toolCallAcc map[int]*struct {
+			ID   string
+			Name string
+			Args string
+		}
 		for msg := range streamChan {
 			// -----------------------------------------------------------------
 			// Cross-provider adaptation: the encoder produces full SSE lines
@@ -1203,31 +1283,113 @@ func (h *forwardedHandler) handleStreamingResponseByProvider(
 					continue // [DONE] is OpenAI-specific; Anthropic/Gemini end naturally
 				}
 
+				// Agent Gemini + upstream with incremental tool_calls (OpenAI/Azure or Anthropic): decode, accumulate, then encode.
+				if sourceFormat == adapter.FormatGemini && (adapter.IsSameWireFormat(targetFormat, adapter.FormatOpenAI) || targetFormat == adapter.FormatAnthropic) {
+					canonical, decErr := adapter.DecodeStreamChunkFor(payload, targetFormat)
+					if decErr != nil {
+						preview := payload
+						if len(preview) > 200 {
+							preview = preview[:200]
+						}
+						h.logger.WithError(decErr).WithField("payload_preview", string(preview)).Warn("stream decode chunk failed")
+						continue
+					}
+					if canonical == nil {
+						continue
+					}
+					// Merge tool call deltas by index.
+					for i := range canonical.ToolCallDeltas {
+						tc := &canonical.ToolCallDeltas[i]
+						if toolCallAcc == nil {
+							toolCallAcc = make(map[int]*struct{ ID, Name, Args string })
+						}
+						cur := toolCallAcc[tc.Index]
+						if cur == nil {
+							cur = &struct{ ID, Name, Args string }{ID: tc.ID, Name: tc.Name}
+							toolCallAcc[tc.Index] = cur
+						}
+						if tc.Name != "" {
+							cur.Name = tc.Name
+						}
+						if tc.ID != "" {
+							cur.ID = tc.ID
+						}
+						cur.Args += tc.ArgumentsDelta
+					}
+					// Emit role chunk (first chunk from upstream often has role only).
+					if canonical.Role != "" {
+						roleChunk := &adapter.CanonicalStreamChunk{Role: canonical.Role}
+						lines, encErr := adapter.EncodeStreamChunkFor(roleChunk, sourceFormat)
+						if encErr == nil && len(lines) > 0 {
+							writeAdaptedLines(lines)
+						}
+					}
+					// Emit text delta.
+					if canonical.Delta != "" {
+						deltaChunk := &adapter.CanonicalStreamChunk{Delta: canonical.Delta}
+						lines, encErr := adapter.EncodeStreamChunkFor(deltaChunk, sourceFormat)
+						if encErr == nil && len(lines) > 0 {
+							writeAdaptedLines(lines)
+						}
+					}
+					// On finish: emit accumulated tool calls as Gemini functionCall parts, then finish chunk.
+					if canonical.FinishReason != "" && len(toolCallAcc) > 0 {
+						indices := make([]int, 0, len(toolCallAcc))
+						for idx := range toolCallAcc {
+							indices = append(indices, idx)
+						}
+						sort.Ints(indices)
+						var deltas []adapter.StreamToolCallDelta
+						for _, idx := range indices {
+							cur := toolCallAcc[idx]
+							if cur == nil {
+								continue
+							}
+							deltas = append(deltas, adapter.StreamToolCallDelta{
+								Index:          idx,
+								ID:             cur.ID,
+								Name:           cur.Name,
+								ArgumentsDelta: cur.Args,
+							})
+						}
+						tcChunk := &adapter.CanonicalStreamChunk{ToolCallDeltas: deltas}
+						lines, encErr := adapter.EncodeStreamChunkFor(tcChunk, sourceFormat)
+						if encErr == nil && len(lines) > 0 {
+							writeAdaptedLines(lines)
+						}
+						toolCallAcc = nil
+					}
+					if canonical.FinishReason != "" {
+						finishChunk := &adapter.CanonicalStreamChunk{FinishReason: canonical.FinishReason}
+						lines, encErr := adapter.EncodeStreamChunkFor(finishChunk, sourceFormat)
+						if encErr == nil && len(lines) > 0 {
+							writeAdaptedLines(lines)
+						}
+					}
+					continue
+				}
+
 				adaptedLines, adaptErr := adapter.AdaptStreamChunk(payload, sourceFormat, targetFormat)
 				if adaptErr != nil {
-					h.logger.WithError(adaptErr).Warn("failed to adapt stream chunk")
+					preview := payload
+					if len(preview) > 200 {
+						preview = preview[:200]
+					}
+					h.logger.WithError(adaptErr).WithField("payload_preview", string(preview)).Warn("stream adapt chunk failed")
 					continue
 				}
 				if len(adaptedLines) == 0 {
+					// Decoder returned nil (skip) or encoder produced nothing; log at debug for openai→anthropic diagnostics
+					if h.logger.GetLevel() == logrus.DebugLevel {
+						preview := payload
+						if len(preview) > 200 {
+							preview = preview[:200]
+						}
+						h.logger.WithField("payload_preview", string(preview)).WithField("source", sourceFormat).WithField("target", targetFormat).Debug("stream chunk skipped (empty adapted result)")
+					}
 					continue
 				}
-
-				// Write all adapted SSE lines.
-				for _, line := range adaptedLines {
-					_, _ = w.Write(line)
-					_, _ = w.Write([]byte("\n"))
-				}
-				_ = w.Flush()
-
-				// Extract data: payloads for metrics.
-				for _, line := range adaptedLines {
-					if bytes.HasPrefix(line, []byte("data:")) {
-						mp := bytes.TrimSpace(bytes.TrimPrefix(line, []byte("data:")))
-						if len(mp) > 0 {
-							streamResponse <- mp
-						}
-					}
-				}
+				writeAdaptedLines(adaptedLines)
 				continue
 			}
 
@@ -1244,8 +1406,7 @@ func (h *forwardedHandler) handleStreamingResponseByProvider(
 				}
 			}
 
-			_, _ = w.Write(msg)
-			_, _ = w.Write([]byte("\n"))
+			writeLine(msg)
 			_ = w.Flush()
 		}
 	})

--- a/pkg/infra/providers/adapter/adapter_test.go
+++ b/pkg/infra/providers/adapter/adapter_test.go
@@ -704,6 +704,43 @@ func TestAdaptStreamChunk_AnthropicNonContentSkipped(t *testing.T) {
 	assert.Empty(t, out, "non-content events should be skipped")
 }
 
+// TestAdaptStreamChunk_OpenAIToolCallsToAnthropic ensures OpenAI stream chunks
+// with tool_calls are converted to Anthropic content_block_start(tool_use) and
+// content_block_delta(input_json_delta) so the agent receives a valid stream.
+func TestAdaptStreamChunk_OpenAIToolCallsToAnthropic(t *testing.T) {
+	// First chunk: role + tool_calls with id, name, empty arguments
+	input := `{"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_abc","type":"function","function":{"name":"database_agent","arguments":""}}]}}]}`
+	lines, err := AdaptStreamChunk([]byte(input), FormatAnthropic, FormatOpenAI)
+	require.NoError(t, err)
+	require.NotEmpty(t, lines)
+	// Expect message_start and content_block_start(tool_use)
+	var seenMessageStart, seenBlockStart bool
+	for _, line := range lines {
+		if bytes.Contains(line, []byte("message_start")) {
+			seenMessageStart = true
+		}
+		if bytes.Contains(line, []byte("tool_use")) && bytes.Contains(line, []byte("database_agent")) {
+			seenBlockStart = true
+		}
+	}
+	assert.True(t, seenMessageStart, "expected message_start event")
+	assert.True(t, seenBlockStart, "expected content_block_start with tool_use and name")
+
+	// Chunk with only arguments delta
+	input2 := `{"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"query\":\"test\"}"}}]}}]}`
+	lines2, err := AdaptStreamChunk([]byte(input2), FormatAnthropic, FormatOpenAI)
+	require.NoError(t, err)
+	require.NotEmpty(t, lines2)
+	var seenInputDelta bool
+	for _, line := range lines2 {
+		if bytes.Contains(line, []byte("input_json_delta")) && bytes.Contains(line, []byte("partial_json")) {
+			seenInputDelta = true
+			break
+		}
+	}
+	assert.True(t, seenInputDelta, "expected content_block_delta with input_json_delta")
+}
+
 // ---------------------------------------------------------------------------
 // Cross-format: Gemini → Anthropic (via canonical, no two-hop hack)
 // ---------------------------------------------------------------------------

--- a/pkg/infra/providers/adapter/anthropic_adapter.go
+++ b/pkg/infra/providers/adapter/anthropic_adapter.go
@@ -95,10 +95,11 @@ type anthropicCacheCreation struct {
 // Stream event types — Decode (incoming)
 
 type anthropicStreamEvent struct {
-	Type    string          `json:"type"`
-	Message json.RawMessage `json:"message,omitempty"`
-	Delta   json.RawMessage `json:"delta,omitempty"`
-	Index   int             `json:"index,omitempty"`
+	Type         string          `json:"type"`
+	Message      json.RawMessage `json:"message,omitempty"`
+	Delta        json.RawMessage `json:"delta,omitempty"`
+	Index        int             `json:"index,omitempty"`
+	ContentBlock json.RawMessage `json:"content_block,omitempty"`
 }
 
 type anthropicMessageStart struct {
@@ -108,9 +109,10 @@ type anthropicMessageStart struct {
 }
 
 type anthropicDelta struct {
-	Type       string `json:"type,omitempty"`
-	Text       string `json:"text,omitempty"`
-	StopReason string `json:"stop_reason,omitempty"`
+	Type        string `json:"type,omitempty"`
+	Text        string `json:"text,omitempty"`
+	PartialJSON string `json:"partial_json,omitempty"` // for input_json_delta (tool_use streaming)
+	StopReason  string `json:"stop_reason,omitempty"`
 }
 
 // Stream event types — Encode (outgoing, faithful to Anthropic API)
@@ -143,8 +145,11 @@ type anthropicSSEContentBlockStart struct {
 }
 
 type anthropicSSEContentBlock struct {
-	Type string `json:"type"`
-	Text string `json:"text"`
+	Type  string          `json:"type"`
+	Text  string          `json:"text,omitempty"`
+	ID    string          `json:"id,omitempty"`
+	Name  string          `json:"name,omitempty"`
+	Input json.RawMessage `json:"input,omitempty"`
 }
 
 type anthropicSSEContentBlockDelta struct {
@@ -551,7 +556,41 @@ func (a *AnthropicAdapter) DecodeStreamChunk(chunk []byte) (*CanonicalStreamChun
 		if delta.Type == "text_delta" && delta.Text != "" {
 			return &CanonicalStreamChunk{Delta: delta.Text}, nil
 		}
+		if delta.Type == "input_json_delta" {
+			return &CanonicalStreamChunk{
+				ToolCallDeltas: []StreamToolCallDelta{{
+					Index:          event.Index,
+					ArgumentsDelta: delta.PartialJSON,
+				}},
+			}, nil
+		}
 		return nil, nil
+
+	case "content_block_start":
+		if len(event.ContentBlock) == 0 {
+			return nil, nil
+		}
+		var cb anthropicContentBlock
+		if err := json.Unmarshal(event.ContentBlock, &cb); err != nil {
+			return nil, nil
+		}
+		if cb.Type == "tool_use" {
+			inputStr := strings.TrimSpace(string(cb.Input))
+			// Anthropic sends "input": {} (empty object) in content_block_start; do not pass
+			// "{}" as first delta or the OpenAI client merges "{}" + partial_json → invalid JSON.
+			if inputStr == "" || inputStr == "{}" {
+				inputStr = ""
+			}
+			return &CanonicalStreamChunk{
+				ToolCallDeltas: []StreamToolCallDelta{{
+					Index:          event.Index,
+					ID:             cb.ID,
+					Name:           cb.Name,
+					ArgumentsDelta: inputStr,
+				}},
+			}, nil
+		}
+		return nil, nil // text/thinking block start: no delta yet, skip
 
 	case "message_start":
 		var msg anthropicMessageStart
@@ -597,11 +636,10 @@ func (a *AnthropicAdapter) DecodeStreamChunk(chunk []byte) (*CanonicalStreamChun
 // ---------------------------------------------------------------------------
 
 func (a *AnthropicAdapter) EncodeStreamChunk(chunk *CanonicalStreamChunk) ([][]byte, error) {
-	// --- message_start → also emit content_block_start -----------------------
+	// --- message_start (when role is set) ------------------------------------
 	if chunk.Role != "" {
 		var lines [][]byte
 
-		// 1. event: message_start
 		msgStart := anthropicSSEMessageStartPayload{
 			Type: "message_start",
 			Message: anthropicSSEMessageInfo{
@@ -616,22 +654,96 @@ func (a *AnthropicAdapter) EncodeStreamChunk(chunk *CanonicalStreamChunk) ([][]b
 		data, _ := json.Marshal(msgStart)
 		lines = append(lines, SSEEvent("message_start", data)...)
 
-		// 2. event: content_block_start (index 0, text block)
-		cbStart := anthropicSSEContentBlockStart{
-			Type:  "content_block_start",
-			Index: 0,
-			ContentBlock: anthropicSSEContentBlock{
-				Type: "text",
-				Text: "",
-			},
+		// If this chunk has tool_calls, emit tool_use block(s) instead of text block.
+		if len(chunk.ToolCallDeltas) > 0 {
+			for _, tc := range chunk.ToolCallDeltas {
+				if tc.ID != "" || tc.Name != "" {
+					cbStart := anthropicSSEContentBlockStart{
+						Type:  "content_block_start",
+						Index: tc.Index,
+						ContentBlock: anthropicSSEContentBlock{
+							Type:  "tool_use",
+							ID:    tc.ID,
+							Name:  tc.Name,
+							Input: []byte("{}"),
+						},
+					}
+					data, _ = json.Marshal(cbStart)
+					lines = append(lines, SSEEvent("content_block_start", data)...)
+				}
+				if tc.ArgumentsDelta != "" {
+					cbDelta := anthropicSSEContentBlockDelta{
+						Type:  "content_block_delta",
+						Index: tc.Index,
+						Delta: anthropicDelta{Type: "input_json_delta", PartialJSON: tc.ArgumentsDelta},
+					}
+					data, _ = json.Marshal(cbDelta)
+					lines = append(lines, SSEEvent("content_block_delta", data)...)
+				}
+			}
+		} else if chunk.Delta != "" {
+			// Role + text in same chunk
+			cbStart := anthropicSSEContentBlockStart{
+				Type:  "content_block_start",
+				Index: 0,
+				ContentBlock: anthropicSSEContentBlock{Type: "text", Text: ""},
+			}
+			data, _ := json.Marshal(cbStart)
+			lines = append(lines, SSEEvent("content_block_start", data)...)
+			cbDelta := anthropicSSEContentBlockDelta{
+				Type:  "content_block_delta",
+				Index: 0,
+				Delta: anthropicDelta{Type: "text_delta", Text: chunk.Delta},
+			}
+			data, _ = json.Marshal(cbDelta)
+			lines = append(lines, SSEEvent("content_block_delta", data)...)
+		} else {
+			// Role only (text response will follow in next chunks)
+			cbStart := anthropicSSEContentBlockStart{
+				Type:  "content_block_start",
+				Index: 0,
+				ContentBlock: anthropicSSEContentBlock{Type: "text", Text: ""},
+			}
+			data, _ := json.Marshal(cbStart)
+			lines = append(lines, SSEEvent("content_block_start", data)...)
 		}
-		data, _ = json.Marshal(cbStart)
-		lines = append(lines, SSEEvent("content_block_start", data)...)
-
 		return lines, nil
 	}
 
-	// --- content_block_delta -------------------------------------------------
+	// --- tool_call deltas only (no role in this chunk) -----------------------
+	if len(chunk.ToolCallDeltas) > 0 {
+		var lines [][]byte
+		for _, tc := range chunk.ToolCallDeltas {
+			if tc.ID != "" || tc.Name != "" {
+				cbStart := anthropicSSEContentBlockStart{
+					Type:  "content_block_start",
+					Index: tc.Index,
+					ContentBlock: anthropicSSEContentBlock{
+						Type:  "tool_use",
+						ID:    tc.ID,
+						Name:  tc.Name,
+						Input: []byte("{}"),
+					},
+				}
+				data, _ := json.Marshal(cbStart)
+				lines = append(lines, SSEEvent("content_block_start", data)...)
+			}
+			if tc.ArgumentsDelta != "" {
+				cbDelta := anthropicSSEContentBlockDelta{
+					Type:  "content_block_delta",
+					Index: tc.Index,
+					Delta: anthropicDelta{Type: "input_json_delta", PartialJSON: tc.ArgumentsDelta},
+				}
+				data, _ := json.Marshal(cbDelta)
+				lines = append(lines, SSEEvent("content_block_delta", data)...)
+			}
+		}
+		if len(lines) > 0 {
+			return lines, nil
+		}
+	}
+
+	// --- text content_block_delta --------------------------------------------
 	if chunk.Delta != "" {
 		cbDelta := anthropicSSEContentBlockDelta{
 			Type:  "content_block_delta",
@@ -653,28 +765,19 @@ func (a *AnthropicAdapter) EncodeStreamChunk(chunk *CanonicalStreamChunk) ([][]b
 		}
 
 		var lines [][]byte
-
-		// 1. event: content_block_stop
 		cbStop := anthropicSSEContentBlockStop{Type: "content_block_stop", Index: 0}
 		data, _ := json.Marshal(cbStop)
 		lines = append(lines, SSEEvent("content_block_stop", data)...)
-
-		// 2. event: message_delta
 		msgDelta := anthropicSSEMessageDelta{
-			Type: "message_delta",
-			Delta: anthropicSSEMessageDeltaBody{
-				StopReason: sr,
-			},
+			Type:  "message_delta",
+			Delta: anthropicSSEMessageDeltaBody{StopReason: sr},
 			Usage: anthropicSSEUsage{OutputTokens: 0},
 		}
 		data, _ = json.Marshal(msgDelta)
 		lines = append(lines, SSEEvent("message_delta", data)...)
-
-		// 3. event: message_stop
 		msgStop := anthropicSSESimple{Type: "message_stop"}
 		data, _ = json.Marshal(msgStop)
 		lines = append(lines, SSEEvent("message_stop", data)...)
-
 		return lines, nil
 	}
 

--- a/pkg/infra/providers/adapter/canonical.go
+++ b/pkg/infra/providers/adapter/canonical.go
@@ -92,11 +92,21 @@ type CanonicalUsage struct {
 // Stream chunk types
 // ---------------------------------------------------------------------------
 
+// StreamToolCallDelta is one tool-call delta in a streamed response (OpenAI
+// streams tool_calls with incremental arguments; Anthropic uses input_json_delta).
+type StreamToolCallDelta struct {
+	Index          int    `json:"index"`
+	ID             string `json:"id,omitempty"`
+	Name           string `json:"name,omitempty"`
+	ArgumentsDelta string `json:"arguments_delta,omitempty"` // incremental piece
+}
+
 // CanonicalStreamChunk is one piece of a streamed response.
 type CanonicalStreamChunk struct {
-	ID           string `json:"id,omitempty"`
-	Model        string `json:"model,omitempty"`
-	Role         string `json:"role,omitempty"`  // only on first chunk
-	Delta        string `json:"delta,omitempty"` // text content delta
-	FinishReason string `json:"finish_reason,omitempty"`
+	ID             string                `json:"id,omitempty"`
+	Model          string                `json:"model,omitempty"`
+	Role           string                `json:"role,omitempty"`   // only on first chunk
+	Delta          string                `json:"delta,omitempty"`  // text content delta
+	FinishReason   string                `json:"finish_reason,omitempty"`
+	ToolCallDeltas []StreamToolCallDelta `json:"tool_call_deltas,omitempty"`
 }

--- a/pkg/infra/providers/adapter/gemini_adapter.go
+++ b/pkg/infra/providers/adapter/gemini_adapter.go
@@ -442,15 +442,52 @@ func (a *GeminiAdapter) DecodeStreamChunk(chunk []byte) (*CanonicalStreamChunk, 
 		return nil, nil
 	}
 
-	var text string
-	for _, p := range resp.Candidates[0].Content.Parts {
-		text += p.Text
+	cand := resp.Candidates[0]
+	content := cand.Content
+	sc := &CanonicalStreamChunk{}
+
+	// Role: Gemini "model" → canonical "assistant"
+	if content.Role != "" {
+		sc.Role = content.Role
+		if sc.Role == "model" {
+			sc.Role = "assistant"
+		}
 	}
-	if text == "" {
+
+	// Text and functionCall parts
+	var text string
+	for i, p := range content.Parts {
+		text += p.Text
+		if p.FunctionCall != nil {
+			argsBytes, _ := json.Marshal(p.FunctionCall.Args)
+			sc.ToolCallDeltas = append(sc.ToolCallDeltas, StreamToolCallDelta{
+				Index:          i,
+				ID:            p.FunctionCall.Name, // Gemini often uses name as id
+				Name:          p.FunctionCall.Name,
+				ArgumentsDelta: string(argsBytes),
+			})
+		}
+	}
+	sc.Delta = text
+
+	// FinishReason: Gemini STOP/MAX_TOKENS/OTHER → canonical stop/length
+	switch cand.FinishReason {
+	case "STOP":
+		sc.FinishReason = "stop"
+	case "MAX_TOKENS":
+		sc.FinishReason = "length"
+	default:
+		if cand.FinishReason != "" {
+			sc.FinishReason = cand.FinishReason
+		}
+	}
+
+	// Skip chunks with no content (so we don't emit empty OpenAI chunks from ping-like events).
+	if sc.Delta == "" && sc.Role == "" && sc.FinishReason == "" && len(sc.ToolCallDeltas) == 0 {
 		return nil, nil
 	}
 
-	return &CanonicalStreamChunk{Delta: text}, nil
+	return sc, nil
 }
 
 // ---------------------------------------------------------------------------
@@ -458,18 +495,50 @@ func (a *GeminiAdapter) DecodeStreamChunk(chunk []byte) (*CanonicalStreamChunk, 
 // ---------------------------------------------------------------------------
 
 func (a *GeminiAdapter) EncodeStreamChunk(chunk *CanonicalStreamChunk) ([][]byte, error) {
-	if chunk.Delta == "" && chunk.FinishReason == "" {
+	// Emit for Role (assistant start), Delta (text), ToolCallDeltas (complete tool calls), or FinishReason.
+	hasContent := chunk.Delta != "" || chunk.FinishReason != "" || chunk.Role != "" || len(chunk.ToolCallDeltas) > 0
+	if !hasContent {
 		return nil, nil
+	}
+
+	role := chunk.Role
+	if role == "" || role == "assistant" {
+		role = "model" // Gemini stream expects "model"
 	}
 
 	var parts []geminiPart
 	if chunk.Delta != "" {
 		parts = append(parts, geminiPart{Text: chunk.Delta})
 	}
+	for _, tc := range chunk.ToolCallDeltas {
+		var args map[string]interface{}
+		argsStr := tc.ArgumentsDelta
+		if argsStr == "" {
+			args = make(map[string]interface{})
+		} else if err := json.Unmarshal([]byte(argsStr), &args); err != nil {
+			args = map[string]interface{}{"__raw": argsStr}
+		}
+		parts = append(parts, geminiPart{
+			FunctionCall: &geminiFunctionCall{Name: tc.Name, Args: args},
+		})
+	}
+
+	finishReason := ""
+	switch chunk.FinishReason {
+	case "stop", "tool_calls":
+		finishReason = "STOP"
+	case "length":
+		finishReason = "MAX_TOKENS"
+	default:
+		if chunk.FinishReason != "" {
+			finishReason = chunk.FinishReason
+		}
+	}
 
 	out := geminiResponse{
 		Candidates: []geminiCandidate{{
-			Content: geminiContent{Role: "model", Parts: parts},
+			Content:      geminiContent{Role: role, Parts: parts},
+			FinishReason: finishReason,
 		}},
 	}
 

--- a/pkg/infra/providers/adapter/openai_adapter.go
+++ b/pkg/infra/providers/adapter/openai_adapter.go
@@ -101,8 +101,21 @@ type openaiStreamChoice struct {
 }
 
 type openaiStreamDelta struct {
-	Role    string `json:"role,omitempty"`
-	Content string `json:"content,omitempty"`
+	Role      string                 `json:"role,omitempty"`
+	Content   string                 `json:"content,omitempty"`
+	ToolCalls []openaiStreamToolCall `json:"tool_calls,omitempty"`
+}
+
+type openaiStreamToolCall struct {
+	Index    int                     `json:"index"`
+	ID       string                  `json:"id,omitempty"`
+	Type     string                  `json:"type,omitempty"`
+	Function openaiStreamToolCallFn  `json:"function,omitempty"`
+}
+
+type openaiStreamToolCallFn struct {
+	Name      string `json:"name,omitempty"`
+	Arguments string `json:"arguments,omitempty"` // streamed incrementally
 }
 
 // ---------------------------------------------------------------------------
@@ -383,18 +396,29 @@ func (a *OpenAIAdapter) DecodeStreamChunk(chunk []byte) (*CanonicalStreamChunk, 
 	}
 
 	choice := raw.Choices[0]
+	delta := choice.Delta
 	sc := &CanonicalStreamChunk{
 		ID:    raw.ID,
 		Model: raw.Model,
-		Role:  choice.Delta.Role,
-		Delta: choice.Delta.Content,
+		Role:  delta.Role,
+		Delta: delta.Content,
 	}
 	if choice.FinishReason != nil {
 		sc.FinishReason = *choice.FinishReason
 	}
 
-	// Skip empty chunks.
-	if sc.Delta == "" && sc.Role == "" && sc.FinishReason == "" {
+	// Map OpenAI stream tool_calls to canonical tool call deltas.
+	for _, tc := range delta.ToolCalls {
+		sc.ToolCallDeltas = append(sc.ToolCallDeltas, StreamToolCallDelta{
+			Index:          tc.Index,
+			ID:             tc.ID,
+			Name:           tc.Function.Name,
+			ArgumentsDelta: tc.Function.Arguments,
+		})
+	}
+
+	// Skip chunks with no content (text, role, finish_reason, or tool_calls).
+	if sc.Delta == "" && sc.Role == "" && sc.FinishReason == "" && len(sc.ToolCallDeltas) == 0 {
 		return nil, nil
 	}
 
@@ -409,6 +433,17 @@ func (a *OpenAIAdapter) EncodeStreamChunk(chunk *CanonicalStreamChunk) ([][]byte
 	delta := openaiStreamDelta{
 		Role:    chunk.Role,
 		Content: chunk.Delta,
+	}
+	for _, tc := range chunk.ToolCallDeltas {
+		delta.ToolCalls = append(delta.ToolCalls, openaiStreamToolCall{
+			Index: tc.Index,
+			ID:    tc.ID,
+			Type:  "function",
+			Function: openaiStreamToolCallFn{
+				Name:      tc.Name,
+				Arguments: tc.ArgumentsDelta,
+			},
+		})
 	}
 
 	choice := openaiStreamChoice{

--- a/pkg/infra/providers/adapter/stream.go
+++ b/pkg/infra/providers/adapter/stream.go
@@ -27,6 +27,31 @@ func SSEData(dataJSON []byte) [][]byte {
 	}
 }
 
+// DecodeStreamChunkFor decodes a single SSE data payload from the given
+// provider format into a canonical stream chunk. Used by the handler when
+// it needs to accumulate (e.g. tool call arguments) before encoding to source.
+func DecodeStreamChunkFor(chunk []byte, target Format) (*CanonicalStreamChunk, error) {
+	ad, err := getAdapter(target)
+	if err != nil {
+		return nil, fmt.Errorf("adapter stream: %w", err)
+	}
+	return ad.DecodeStreamChunk(chunk)
+}
+
+// EncodeStreamChunkFor encodes a canonical stream chunk into the given
+// provider's SSE format. Used by the handler after accumulation (e.g. when
+// target is Gemini and tool calls were merged from upstream OpenAI deltas).
+func EncodeStreamChunkFor(canonical *CanonicalStreamChunk, source Format) ([][]byte, error) {
+	if canonical == nil {
+		return nil, nil
+	}
+	ad, err := getAdapter(source)
+	if err != nil {
+		return nil, fmt.Errorf("adapter stream: %w", err)
+	}
+	return ad.EncodeStreamChunk(canonical)
+}
+
 // AdaptStreamChunk transforms a single SSE data payload from the target
 // provider format to the source (caller) format via the canonical model.
 //

--- a/pkg/infra/providers/stream.go
+++ b/pkg/infra/providers/stream.go
@@ -7,7 +7,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
+	"time"
 )
 
 // StreamSSE reads an SSE stream line-by-line and sends each line (pass-through)
@@ -20,12 +23,29 @@ import (
 // use [DONE] (Anthropic, Gemini) the loop ends naturally when the reader is
 // exhausted.
 //
+// If TG_SAVE_STREAM_RAW is set, the raw upstream stream (before any adaptation)
+// is written to streams/raw_<timestamp>.sse for debugging (e.g. to confirm whether
+// the upstream already returns empty or the problem is in response conversion).
+//
 // This function is safe to call from a goroutine — it must receive a context
 // that does NOT depend on Fiber's request lifecycle (e.g. context.Background()).
 func StreamSSE(ctx context.Context, r io.Reader, out chan<- []byte) error {
 	sc := bufio.NewScanner(r)
 	buf := make([]byte, 0, 512*1024)
 	sc.Buffer(buf, 2*1024*1024)
+
+	var rawFile *os.File
+	if os.Getenv("TG_SAVE_STREAM_RAW") != "" {
+		dir := "streams"
+		_ = os.MkdirAll(dir, 0750)
+		ts := time.Now().Format("20060102-150405")
+		path := filepath.Join(dir, "raw_"+ts+".sse")
+		f, err := os.Create(path) // #nosec G304 -- path is from constant dir and timestamp, not user input
+		if err == nil {
+			rawFile = f
+			defer func() { _ = rawFile.Close() }()
+		}
+	}
 
 	for sc.Scan() {
 		select {
@@ -36,6 +56,11 @@ func StreamSSE(ctx context.Context, r io.Reader, out chan<- []byte) error {
 
 		// Copy: the Scanner reuses its internal buffer.
 		line := append([]byte(nil), sc.Bytes()...)
+
+		if rawFile != nil {
+			_, _ = rawFile.Write(line)
+			_, _ = rawFile.Write([]byte("\n"))
+		}
 
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
============================================================
Matriz Upstream × Agent (OpenAI | Anthropic | Google) — STREAM
Prompt: 'buscame en la base de datos el cliente Juan'
Stream: True
============================================================

[openai → openai]   Gateway created: 01f108f7-043e-6898-bf86-fc5cee906c4d
  Upstream created: 01f108f7-043f-6edd-bf86-fc5cee906c4d
  Service created: 01f108f7-043f-6426-bf86-fc5cee906c4d
  Rule created: /chat/completions -> service 01f108f7-043f-6426-bf86-fc5cee906c4d
  Rule created: /v1/messages -> service 01f108f7-043f-6426-bf86-fc5cee906c4d
  Rule created: /v1beta/models/gpt-4o-mini:generateContent -> service 01f108f7-043f-6426-bf86-fc5cee906c4d
  Rule created: /v1beta/models/gpt-4o-mini:streamGenerateContent -> service 01f108f7-043f-6426-bf86-fc5cee906c4d
  API key created
OK

[openai → anthropic]   Gateway created: 01f108f7-097c-6c4b-bf86-fc5cee906c4d
  Upstream created: 01f108f7-097d-6b32-bf86-fc5cee906c4d
  Service created: 01f108f7-097e-6bbb-bf86-fc5cee906c4d
  Rule created: /chat/completions -> service 01f108f7-097e-6bbb-bf86-fc5cee906c4d
  Rule created: /v1/messages -> service 01f108f7-097e-6bbb-bf86-fc5cee906c4d
  Rule created: /v1beta/models/gpt-4o-mini:generateContent -> service 01f108f7-097e-6bbb-bf86-fc5cee906c4d
  Rule created: /v1beta/models/gpt-4o-mini:streamGenerateContent -> service 01f108f7-097e-6bbb-bf86-fc5cee906c4d
  API key created
OK

[openai → google]   Gateway created: 01f108f7-0f66-6fd9-bf86-fc5cee906c4d
  Upstream created: 01f108f7-0f67-6f1f-bf86-fc5cee906c4d
  Service created: 01f108f7-0f68-67d9-bf86-fc5cee906c4d
  Rule created: /chat/completions -> service 01f108f7-0f68-67d9-bf86-fc5cee906c4d
  Rule created: /v1/messages -> service 01f108f7-0f68-67d9-bf86-fc5cee906c4d
  Rule created: /v1beta/models/gpt-4o-mini:generateContent -> service 01f108f7-0f68-67d9-bf86-fc5cee906c4d
  Rule created: /v1beta/models/gpt-4o-mini:streamGenerateContent -> service 01f108f7-0f68-67d9-bf86-fc5cee906c4d
  API key created
OK

[anthropic → openai]   Gateway created: 01f108f7-16cb-6bee-bf86-fc5cee906c4d
  Upstream created: 01f108f7-16cc-6e46-bf86-fc5cee906c4d
  Service created: 01f108f7-16cc-6bdd-bf86-fc5cee906c4d
  Rule created: /chat/completions -> service 01f108f7-16cc-6bdd-bf86-fc5cee906c4d
  Rule created: /v1/messages -> service 01f108f7-16cc-6bdd-bf86-fc5cee906c4d
  Rule created: /v1beta/models/claude-sonnet-4-20250514:generateContent -> service 01f108f7-16cc-6bdd-bf86-fc5cee906c4d
  Rule created: /v1beta/models/claude-sonnet-4-20250514:streamGenerateContent -> service 01f108f7-16cc-6bdd-bf86-fc5cee906c4d
  API key created
OK

[anthropic → anthropic]   Gateway created: 01f108f7-1da3-6d71-bf86-fc5cee906c4d
  Upstream created: 01f108f7-1da4-6fd6-bf86-fc5cee906c4d
  Service created: 01f108f7-1da4-6f02-bf86-fc5cee906c4d
  Rule created: /chat/completions -> service 01f108f7-1da4-6f02-bf86-fc5cee906c4d
  Rule created: /v1/messages -> service 01f108f7-1da4-6f02-bf86-fc5cee906c4d
  Rule created: /v1beta/models/claude-sonnet-4-20250514:generateContent -> service 01f108f7-1da4-6f02-bf86-fc5cee906c4d
  Rule created: /v1beta/models/claude-sonnet-4-20250514:streamGenerateContent -> service 01f108f7-1da4-6f02-bf86-fc5cee906c4d
  API key created
OK

[anthropic → google]   Gateway created: 01f108f7-244f-61f5-bf86-fc5cee906c4d
  Upstream created: 01f108f7-2450-6056-bf86-fc5cee906c4d
  Service created: 01f108f7-2450-60fd-bf86-fc5cee906c4d
  Rule created: /chat/completions -> service 01f108f7-2450-60fd-bf86-fc5cee906c4d
  Rule created: /v1/messages -> service 01f108f7-2450-60fd-bf86-fc5cee906c4d
  Rule created: /v1beta/models/claude-sonnet-4-20250514:generateContent -> service 01f108f7-2450-60fd-bf86-fc5cee906c4d
  Rule created: /v1beta/models/claude-sonnet-4-20250514:streamGenerateContent -> service 01f108f7-2450-60fd-bf86-fc5cee906c4d
  API key created
OK

[google → openai]   Gateway created: 01f108f7-2b55-6867-bf86-fc5cee906c4d
  Upstream created: 01f108f7-2b56-6e3b-bf86-fc5cee906c4d
  Service created: 01f108f7-2b57-603f-bf86-fc5cee906c4d
  Rule created: /chat/completions -> service 01f108f7-2b57-603f-bf86-fc5cee906c4d
  Rule created: /v1/messages -> service 01f108f7-2b57-603f-bf86-fc5cee906c4d
  Rule created: /v1beta/models/gemini-2.5-flash:generateContent -> service 01f108f7-2b57-603f-bf86-fc5cee906c4d
  Rule created: /v1beta/models/gemini-2.5-flash:streamGenerateContent -> service 01f108f7-2b57-603f-bf86-fc5cee906c4d
  API key created
OK

[google → anthropic]   Gateway created: 01f108f7-2e0d-6dcd-bf86-fc5cee906c4d
  Upstream created: 01f108f7-2e0e-6f53-bf86-fc5cee906c4d
  Service created: 01f108f7-2e0f-6b8b-bf86-fc5cee906c4d
  Rule created: /chat/completions -> service 01f108f7-2e0f-6b8b-bf86-fc5cee906c4d
  Rule created: /v1/messages -> service 01f108f7-2e0f-6b8b-bf86-fc5cee906c4d
  Rule created: /v1beta/models/gemini-2.5-flash:generateContent -> service 01f108f7-2e0f-6b8b-bf86-fc5cee906c4d
  Rule created: /v1beta/models/gemini-2.5-flash:streamGenerateContent -> service 01f108f7-2e0f-6b8b-bf86-fc5cee906c4d
  API key created
OK

[google → google]   Gateway created: 01f108f7-312a-6e19-bf86-fc5cee906c4d
  Upstream created: 01f108f7-312b-62f4-bf86-fc5cee906c4d
  Service created: 01f108f7-312b-6f94-bf86-fc5cee906c4d
  Rule created: /chat/completions -> service 01f108f7-312b-6f94-bf86-fc5cee906c4d
  Rule created: /v1/messages -> service 01f108f7-312b-6f94-bf86-fc5cee906c4d
  Rule created: /v1beta/models/gemini-2.5-flash:generateContent -> service 01f108f7-312b-6f94-bf86-fc5cee906c4d
  Rule created: /v1beta/models/gemini-2.5-flash:streamGenerateContent -> service 01f108f7-312b-6f94-bf86-fc5cee906c4d
  API key created
OK

============================================================
RESUMEN
============================================================

Correctas (Upstream → Agent):
  • openai → openai
  • openai → anthropic
  • openai → google
  • anthropic → openai
  • anthropic → anthropic
  • anthropic → google
  • google → openai
  • google → anthropic
  • google → google

Fallidas:
  (ninguna)