### PR TITLE
feat: add Mistral as LLM provider with dedicated adapter and SDK compatibility fixes

### DIFF
--- a/pkg/handlers/http/forwarded_handler.go
+++ b/pkg/handlers/http/forwarded_handler.go
@@ -754,7 +754,10 @@ func (h *forwardedHandler) handlerProviderResponse(
 		}
 	}
 
-	// Validate/replace model.
+	if adapter.IsSameWireFormat(targetFormat, adapter.FormatOpenAI) {
+		body = adapter.NormalizeOpenAIRequest(body)
+	}
+
 	body, _, err = adapter.ValidateModel(body, target.Models, target.DefaultModel)
 	if err != nil {
 		h.logger.WithError(err).Warn("model validation failed, proceeding with original body")
@@ -1144,6 +1147,12 @@ func (h *forwardedHandler) handleStreamingResponseByProvider(
 		}
 	}
 
+	// Normalize OpenAI-compatible bodies: some SDKs (e.g. Mistral) omit
+	// required fields like tool_calls[].type that OpenAI strictly requires.
+	if adapter.IsSameWireFormat(targetFormat, adapter.FormatOpenAI) {
+		body = adapter.NormalizeOpenAIRequest(body)
+	}
+
 	// Validate/replace model.
 	body, _, err = adapter.ValidateModel(body, target.Models, target.DefaultModel)
 	if err != nil {
@@ -1156,7 +1165,7 @@ func (h *forwardedHandler) handleStreamingResponseByProvider(
 	// the body, the adapted body may lack it; force it so the upstream actually streams.
 	// - Azure: already covered (normalizeFormat maps it to OpenAI).
 	// - Bedrock: does not use body for streaming (uses InvokeModelWithResponseStream); adapter strips "stream".
-	if adapter.IsSameWireFormat(targetFormat, adapter.FormatOpenAI) || targetFormat == adapter.FormatAnthropic {
+	if adapter.IsSameWireFormat(targetFormat, adapter.FormatOpenAI) || targetFormat == adapter.FormatAnthropic || targetFormat == adapter.FormatMistral {
 		body = injectStreamTrue(body)
 	}
 
@@ -1283,8 +1292,8 @@ func (h *forwardedHandler) handleStreamingResponseByProvider(
 					continue // [DONE] is OpenAI-specific; Anthropic/Gemini end naturally
 				}
 
-				// Agent Gemini + upstream with incremental tool_calls (OpenAI/Azure or Anthropic): decode, accumulate, then encode.
-				if sourceFormat == adapter.FormatGemini && (adapter.IsSameWireFormat(targetFormat, adapter.FormatOpenAI) || targetFormat == adapter.FormatAnthropic) {
+				// Agent Gemini + upstream with incremental tool_calls (OpenAI/Azure, Anthropic, or Mistral): decode, accumulate, then encode.
+				if sourceFormat == adapter.FormatGemini && (adapter.IsSameWireFormat(targetFormat, adapter.FormatOpenAI) || targetFormat == adapter.FormatAnthropic || targetFormat == adapter.FormatMistral) {
 					canonical, decErr := adapter.DecodeStreamChunkFor(payload, targetFormat)
 					if decErr != nil {
 						preview := payload

--- a/pkg/handlers/http/request/create_upstream_request.go
+++ b/pkg/handlers/http/request/create_upstream_request.go
@@ -275,5 +275,6 @@ func (r *UpstreamRequest) isValidProvider(provider string) bool {
 		provider == factory.ProviderGoogle ||
 		provider == factory.ProviderAnthropic ||
 		provider == factory.ProviderBedrock ||
-		provider == factory.ProviderAzure
+		provider == factory.ProviderAzure ||
+		provider == factory.ProviderMistral
 }

--- a/pkg/infra/providers/adapter/format.go
+++ b/pkg/infra/providers/adapter/format.go
@@ -11,6 +11,7 @@ const (
 	FormatGemini    Format = "google"
 	FormatBedrock   Format = "bedrock"
 	FormatAzure     Format = "azure" // wire-compatible with OpenAI
+	FormatMistral   Format = "mistral"
 )
 
 // DetectFormat inspects the raw JSON body and returns the most likely source

--- a/pkg/infra/providers/adapter/mistral_adapter.go
+++ b/pkg/infra/providers/adapter/mistral_adapter.go
@@ -106,9 +106,10 @@ func mistralID(original string, cache map[string]string) string {
 	h := sha256.Sum256([]byte(original))
 	hexStr := hex.EncodeToString(h[:])
 	var result []byte
-	for _, c := range hexStr {
+	for i := 0; i < len(hexStr); i++ {
+		c := hexStr[i]
 		if (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') {
-			result = append(result, byte(c))
+			result = append(result, c)
 			if len(result) == 9 {
 				break
 			}

--- a/pkg/infra/providers/adapter/mistral_adapter.go
+++ b/pkg/infra/providers/adapter/mistral_adapter.go
@@ -1,0 +1,123 @@
+package adapter
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// MistralAdapter converts between Mistral chat-completion format and the
+// canonical internal model. Mistral's wire format is nearly identical to
+// OpenAI, so this adapter delegates to OpenAIAdapter and applies
+// Mistral-specific post-processing:
+//
+//   - EncodeRequest: ensures every tool has "parameters" (required by Mistral)
+//     and normalises tool_call IDs to exactly 9 alphanumeric characters.
+//   - All other methods delegate directly to OpenAIAdapter.
+type MistralAdapter struct {
+	openai OpenAIAdapter
+}
+
+// ---------------------------------------------------------------------------
+// Request
+// ---------------------------------------------------------------------------
+
+func (a *MistralAdapter) DecodeRequest(body []byte) (*CanonicalRequest, error) {
+	return a.openai.DecodeRequest(body)
+}
+
+func (a *MistralAdapter) EncodeRequest(req *CanonicalRequest) ([]byte, error) {
+	// Ensure every tool has a non-nil parameters schema.
+	for i := range req.Tools {
+		if req.Tools[i].Schema == nil {
+			req.Tools[i].Schema = map[string]interface{}{
+				"type":       "object",
+				"properties": map[string]interface{}{},
+			}
+		}
+	}
+
+	// Normalise tool_call IDs: Mistral requires exactly 9 chars [a-zA-Z0-9].
+	idMap := map[string]string{}
+	for i := range req.Messages {
+		m := &req.Messages[i]
+		if m.ToolCallID != "" && !isValidMistralID(m.ToolCallID) {
+			m.ToolCallID = mistralID(m.ToolCallID, idMap)
+		}
+		for j := range m.ToolCalls {
+			tc := &m.ToolCalls[j]
+			if tc.ID != "" && !isValidMistralID(tc.ID) {
+				tc.ID = mistralID(tc.ID, idMap)
+			}
+		}
+	}
+
+	return a.openai.EncodeRequest(req)
+}
+
+// ---------------------------------------------------------------------------
+// Response
+// ---------------------------------------------------------------------------
+
+func (a *MistralAdapter) DecodeResponse(body []byte) (*CanonicalResponse, error) {
+	return a.openai.DecodeResponse(body)
+}
+
+func (a *MistralAdapter) EncodeResponse(resp *CanonicalResponse) ([]byte, error) {
+	return a.openai.EncodeResponse(resp)
+}
+
+// ---------------------------------------------------------------------------
+// Stream
+// ---------------------------------------------------------------------------
+
+func (a *MistralAdapter) DecodeStreamChunk(chunk []byte) (*CanonicalStreamChunk, error) {
+	return a.openai.DecodeStreamChunk(chunk)
+}
+
+func (a *MistralAdapter) EncodeStreamChunk(chunk *CanonicalStreamChunk) ([][]byte, error) {
+	return a.openai.EncodeStreamChunk(chunk)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// isValidMistralID checks whether id is exactly 9 alphanumeric characters.
+func isValidMistralID(id string) bool {
+	if len(id) != 9 {
+		return false
+	}
+	for _, c := range id {
+		if (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') && (c < '0' || c > '9') {
+			return false
+		}
+	}
+	return true
+}
+
+// mistralID deterministically maps an arbitrary string to a 9-character
+// alphanumeric ID using SHA-256. The cache ensures the same original ID
+// always maps to the same output within a single request so that
+// tool_call references stay consistent.
+func mistralID(original string, cache map[string]string) string {
+	if v, ok := cache[original]; ok {
+		return v
+	}
+	h := sha256.Sum256([]byte(original))
+	hexStr := hex.EncodeToString(h[:])
+	var result []byte
+	for _, c := range hexStr {
+		if (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') {
+			result = append(result, byte(c))
+			if len(result) == 9 {
+				break
+			}
+		}
+	}
+	for len(result) < 9 {
+		result = append(result, 'a')
+	}
+	id := string(result)
+	cache[original] = id
+	return id
+}

--- a/pkg/infra/providers/adapter/mistral_adapter_test.go
+++ b/pkg/infra/providers/adapter/mistral_adapter_test.go
@@ -1,0 +1,472 @@
+package adapter
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// isValidMistralID
+// ---------------------------------------------------------------------------
+
+func TestIsValidMistralID(t *testing.T) {
+	tests := []struct {
+		name   string
+		id     string
+		expect bool
+	}{
+		{"exactly 9 lowercase", "abcdefghi", true},
+		{"exactly 9 uppercase", "ABCDEFGHI", true},
+		{"exactly 9 digits", "123456789", true},
+		{"mixed alphanumeric 9 chars", "aB3dE6gH9", true},
+		{"too short", "abc", false},
+		{"too long", "abcdefghij", false},
+		{"empty", "", false},
+		{"contains underscore", "abc_efghi", false},
+		{"contains dash", "abc-efghi", false},
+		{"contains space", "abc efghi", false},
+		{"8 chars", "abcdefgh", false},
+		{"10 chars", "abcdefghij", false},
+		{"unicode letter", "abcdefghñ", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expect, isValidMistralID(tt.id))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// mistralID
+// ---------------------------------------------------------------------------
+
+func TestMistralID_Deterministic(t *testing.T) {
+	cache := map[string]string{}
+	id1 := mistralID("call_abc123", cache)
+	id2 := mistralID("call_abc123", cache)
+	assert.Equal(t, id1, id2, "same input should produce same output")
+}
+
+func TestMistralID_ExactlyNineAlphanumeric(t *testing.T) {
+	inputs := []string{
+		"call_abc123",
+		"toolu_016u41qZE8fBygCBmSxapu7x",
+		"query_clients",
+		"a",
+		"very-long-tool-call-id-that-exceeds-nine-characters-by-a-lot",
+	}
+	for _, input := range inputs {
+		cache := map[string]string{}
+		id := mistralID(input, cache)
+		assert.Len(t, id, 9, "id for %q should be 9 chars, got %q", input, id)
+		assert.True(t, isValidMistralID(id), "id %q for input %q should be valid", id, input)
+	}
+}
+
+func TestMistralID_DifferentInputsDifferentOutputs(t *testing.T) {
+	cache := map[string]string{}
+	id1 := mistralID("call_abc", cache)
+	id2 := mistralID("call_xyz", cache)
+	assert.NotEqual(t, id1, id2, "different inputs should produce different IDs")
+}
+
+func TestMistralID_CacheIsUsed(t *testing.T) {
+	cache := map[string]string{}
+	id1 := mistralID("original_id", cache)
+	assert.Contains(t, cache, "original_id")
+	assert.Equal(t, id1, cache["original_id"])
+}
+
+func TestMistralID_ConsistentAcrossToolCallAndToolResult(t *testing.T) {
+	cache := map[string]string{}
+	// Simulate: assistant message has tool_call with ID, tool message references same ID
+	tcID := mistralID("call_long_id_from_openai", cache)
+	resultID := mistralID("call_long_id_from_openai", cache)
+	assert.Equal(t, tcID, resultID, "tool_call ID and tool_result ID must match")
+}
+
+// ---------------------------------------------------------------------------
+// MistralAdapter.EncodeRequest — tool parameters injection
+// ---------------------------------------------------------------------------
+
+func TestMistralAdapter_EncodeRequest_InjectsParameters(t *testing.T) {
+	adapter := &MistralAdapter{}
+
+	canonical := &CanonicalRequest{
+		Model: "mistral-large-latest",
+		Messages: []CanonicalMessage{
+			{Role: "user", Content: "hello"},
+		},
+		Tools: []CanonicalTool{
+			{Name: "my_tool", Description: "does stuff", Schema: nil},
+		},
+	}
+
+	out, err := adapter.EncodeRequest(canonical)
+	require.NoError(t, err)
+
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	tools := result["tools"].([]interface{})
+	require.Len(t, tools, 1)
+	fn := tools[0].(map[string]interface{})["function"].(map[string]interface{})
+	params := fn["parameters"].(map[string]interface{})
+	assert.Equal(t, "object", params["type"])
+	assert.NotNil(t, params["properties"])
+}
+
+func TestMistralAdapter_EncodeRequest_PreservesExistingParameters(t *testing.T) {
+	adapter := &MistralAdapter{}
+
+	canonical := &CanonicalRequest{
+		Model: "mistral-large-latest",
+		Messages: []CanonicalMessage{
+			{Role: "user", Content: "hello"},
+		},
+		Tools: []CanonicalTool{
+			{
+				Name: "search",
+				Schema: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"query": map[string]interface{}{"type": "string"},
+					},
+					"required": []interface{}{"query"},
+				},
+			},
+		},
+	}
+
+	out, err := adapter.EncodeRequest(canonical)
+	require.NoError(t, err)
+
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	tools := result["tools"].([]interface{})
+	fn := tools[0].(map[string]interface{})["function"].(map[string]interface{})
+	params := fn["parameters"].(map[string]interface{})
+	props := params["properties"].(map[string]interface{})
+	assert.Contains(t, props, "query")
+}
+
+// ---------------------------------------------------------------------------
+// MistralAdapter.EncodeRequest — tool_call ID normalization
+// ---------------------------------------------------------------------------
+
+func TestMistralAdapter_EncodeRequest_NormalizesToolCallIDs(t *testing.T) {
+	adapter := &MistralAdapter{}
+
+	canonical := &CanonicalRequest{
+		Model: "mistral-large-latest",
+		Messages: []CanonicalMessage{
+			{Role: "user", Content: "find clients"},
+			{
+				Role: "assistant",
+				ToolCalls: []CanonicalToolCall{
+					{ID: "call_long_openai_id", Name: "db_query", Arguments: `{"q":"clients"}`},
+				},
+			},
+			{
+				Role:       "tool",
+				ToolCallID: "call_long_openai_id",
+				Content:    `[{"name":"Juan"}]`,
+			},
+		},
+	}
+
+	out, err := adapter.EncodeRequest(canonical)
+	require.NoError(t, err)
+
+	var result openaiRequest
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	// Assistant tool_call ID should be normalized
+	require.Len(t, result.Messages, 3)
+	assistantMsg := result.Messages[1]
+	require.Len(t, assistantMsg.ToolCalls, 1)
+	assert.True(t, isValidMistralID(assistantMsg.ToolCalls[0].ID),
+		"tool_call ID should be valid Mistral ID, got %q", assistantMsg.ToolCalls[0].ID)
+
+	// Tool result message should reference the same normalized ID
+	toolMsg := result.Messages[2]
+	assert.Equal(t, assistantMsg.ToolCalls[0].ID, toolMsg.ToolCallID,
+		"tool_call_id in tool message must match the normalized ID in assistant message")
+}
+
+func TestMistralAdapter_EncodeRequest_SkipsAlreadyValidIDs(t *testing.T) {
+	adapter := &MistralAdapter{}
+
+	canonical := &CanonicalRequest{
+		Model: "mistral-large-latest",
+		Messages: []CanonicalMessage{
+			{Role: "user", Content: "hello"},
+			{
+				Role: "assistant",
+				ToolCalls: []CanonicalToolCall{
+					{ID: "abcde1234", Name: "tool1", Arguments: "{}"},
+				},
+			},
+			{
+				Role:       "tool",
+				ToolCallID: "abcde1234",
+				Content:    "result",
+			},
+		},
+	}
+
+	out, err := adapter.EncodeRequest(canonical)
+	require.NoError(t, err)
+
+	var result openaiRequest
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	assert.Equal(t, "abcde1234", result.Messages[1].ToolCalls[0].ID,
+		"already valid ID should not be changed")
+	assert.Equal(t, "abcde1234", result.Messages[2].ToolCallID)
+}
+
+// ---------------------------------------------------------------------------
+// MistralAdapter — roundtrip decode/encode
+// ---------------------------------------------------------------------------
+
+func TestMistralAdapter_Roundtrip(t *testing.T) {
+	input := `{
+		"model": "mistral-large-latest",
+		"messages": [
+			{"role": "system", "content": "You are helpful."},
+			{"role": "user", "content": "Hello"}
+		],
+		"max_tokens": 100,
+		"temperature": 0.7
+	}`
+
+	adapter := &MistralAdapter{}
+
+	canonical, err := adapter.DecodeRequest([]byte(input))
+	require.NoError(t, err)
+	assert.Equal(t, "mistral-large-latest", canonical.Model)
+	assert.Equal(t, "You are helpful.", canonical.System)
+	assert.Len(t, canonical.Messages, 1)
+
+	encoded, err := adapter.EncodeRequest(canonical)
+	require.NoError(t, err)
+
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(encoded, &result))
+	msgs := result["messages"].([]interface{})
+	assert.Len(t, msgs, 2) // system re-injected + user
+}
+
+// ---------------------------------------------------------------------------
+// Cross-provider: OpenAI → Mistral
+// ---------------------------------------------------------------------------
+
+func TestAdaptRequest_OpenAIToMistral(t *testing.T) {
+	input := `{
+		"model": "gpt-4",
+		"messages": [
+			{"role": "system", "content": "You are helpful."},
+			{"role": "user", "content": "Hello"},
+			{
+				"role": "assistant",
+				"tool_calls": [
+					{"id": "call_very_long_openai_id_12345", "type": "function", "function": {"name": "search", "arguments": "{\"q\":\"test\"}"}}
+				]
+			},
+			{"role": "tool", "tool_call_id": "call_very_long_openai_id_12345", "content": "result"}
+		],
+		"max_tokens": 100,
+		"tools": [
+			{
+				"type": "function",
+				"function": {"name": "search", "description": "Search"}
+			}
+		]
+	}`
+
+	out, err := AdaptRequest([]byte(input), FormatOpenAI, FormatMistral)
+	require.NoError(t, err)
+
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	// Tools should have parameters injected
+	tools := result["tools"].([]interface{})
+	require.Len(t, tools, 1)
+	fn := tools[0].(map[string]interface{})["function"].(map[string]interface{})
+	assert.NotNil(t, fn["parameters"], "Mistral requires parameters on every tool")
+
+	// Tool call IDs should be normalized to 9 chars
+	msgs := result["messages"].([]interface{})
+	assistantMsg := msgs[2].(map[string]interface{})
+	tcs := assistantMsg["tool_calls"].([]interface{})
+	tcID := tcs[0].(map[string]interface{})["id"].(string)
+	assert.Len(t, tcID, 9)
+	assert.True(t, isValidMistralID(tcID))
+
+	// Tool result references the same normalized ID
+	toolMsg := msgs[3].(map[string]interface{})
+	assert.Equal(t, tcID, toolMsg["tool_call_id"])
+}
+
+// ---------------------------------------------------------------------------
+// Cross-provider: Mistral → OpenAI (same wire format, passthrough)
+// ---------------------------------------------------------------------------
+
+func TestAdaptRequest_MistralToOpenAI(t *testing.T) {
+	input := `{"model":"mistral-large","messages":[{"role":"user","content":"hi"}]}`
+	out, err := AdaptRequest([]byte(input), FormatMistral, FormatOpenAI)
+	require.NoError(t, err)
+
+	// Mistral and OpenAI are NOT wire-compatible (different adapters), so
+	// this goes through decode→encode. The result should still be valid.
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(out, &result))
+	msgs := result["messages"].([]interface{})
+	assert.Len(t, msgs, 1)
+}
+
+// ---------------------------------------------------------------------------
+// Cross-provider: Anthropic → Mistral
+// ---------------------------------------------------------------------------
+
+func TestAdaptRequest_AnthropicToMistral(t *testing.T) {
+	input := `{
+		"model": "claude-3-sonnet",
+		"system": "Be helpful.",
+		"messages": [{"role": "user", "content": "Hello"}],
+		"max_tokens": 100,
+		"tools": [
+			{
+				"name": "lookup",
+				"description": "Lookup data",
+				"input_schema": {"type": "object", "properties": {"id": {"type": "string"}}}
+			}
+		]
+	}`
+
+	out, err := AdaptRequest([]byte(input), FormatAnthropic, FormatMistral)
+	require.NoError(t, err)
+
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	// System should be re-injected as first message
+	msgs := result["messages"].([]interface{})
+	assert.Equal(t, "system", msgs[0].(map[string]interface{})["role"])
+
+	// Tools should have parameters
+	tools := result["tools"].([]interface{})
+	fn := tools[0].(map[string]interface{})["function"].(map[string]interface{})
+	assert.NotNil(t, fn["parameters"])
+}
+
+// ---------------------------------------------------------------------------
+// Cross-provider: Gemini → Mistral
+// ---------------------------------------------------------------------------
+
+func TestAdaptRequest_GeminiToMistral(t *testing.T) {
+	input := `{
+		"contents": [{"role": "user", "parts": [{"text": "Hello"}]}],
+		"systemInstruction": {"parts": [{"text": "Be concise."}]},
+		"generationConfig": {"maxOutputTokens": 50}
+	}`
+
+	out, err := AdaptRequest([]byte(input), FormatGemini, FormatMistral)
+	require.NoError(t, err)
+
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	// Should be in OpenAI-like format now
+	msgs := result["messages"].([]interface{})
+	assert.GreaterOrEqual(t, len(msgs), 1)
+}
+
+// ---------------------------------------------------------------------------
+// MistralAdapter response/stream delegation
+// ---------------------------------------------------------------------------
+
+func TestMistralAdapter_DecodeResponse(t *testing.T) {
+	body := `{
+		"id": "chatcmpl-mistral-123",
+		"object": "chat.completion",
+		"model": "mistral-large-latest",
+		"choices": [{
+			"index": 0,
+			"message": {"role": "assistant", "content": "Hello!"},
+			"finish_reason": "stop"
+		}],
+		"usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8}
+	}`
+
+	adapter := &MistralAdapter{}
+	cr, err := adapter.DecodeResponse([]byte(body))
+	require.NoError(t, err)
+	assert.Equal(t, "chatcmpl-mistral-123", cr.ID)
+	assert.Equal(t, "Hello!", cr.Content)
+	assert.Equal(t, "stop", cr.FinishReason)
+	assert.Equal(t, 8, cr.Usage.TotalTokens)
+}
+
+func TestMistralAdapter_EncodeResponse(t *testing.T) {
+	cr := &CanonicalResponse{
+		ID:           "resp-1",
+		Model:        "mistral-large-latest",
+		Content:      "Hi",
+		Role:         "assistant",
+		FinishReason: "stop",
+		Usage:        &CanonicalUsage{PromptTokens: 3, CompletionTokens: 1, TotalTokens: 4},
+	}
+
+	adapter := &MistralAdapter{}
+	out, err := adapter.EncodeResponse(cr)
+	require.NoError(t, err)
+
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(out, &result))
+	assert.Equal(t, "chat.completion", result["object"])
+}
+
+func TestMistralAdapter_DecodeStreamChunk(t *testing.T) {
+	chunk := `{"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}`
+
+	adapter := &MistralAdapter{}
+	sc, err := adapter.DecodeStreamChunk([]byte(chunk))
+	require.NoError(t, err)
+	assert.Equal(t, "Hello", sc.Delta)
+}
+
+func TestMistralAdapter_EncodeStreamChunk(t *testing.T) {
+	chunk := &CanonicalStreamChunk{
+		ID:    "chunk-1",
+		Model: "mistral-large-latest",
+		Delta: "world",
+	}
+
+	adapter := &MistralAdapter{}
+	lines, err := adapter.EncodeStreamChunk(chunk)
+	require.NoError(t, err)
+	require.NotEmpty(t, lines)
+}
+
+// ---------------------------------------------------------------------------
+// Registry: Mistral adapter is registered
+// ---------------------------------------------------------------------------
+
+func TestRegistry_MistralAdapterRegistered(t *testing.T) {
+	a, err := getAdapter(FormatMistral)
+	require.NoError(t, err)
+	assert.IsType(t, &MistralAdapter{}, a)
+}
+
+func TestRegistry_MistralNotSameWireFormatAsOpenAI(t *testing.T) {
+	assert.False(t, IsSameWireFormat(FormatMistral, FormatOpenAI),
+		"Mistral and OpenAI should NOT be wire-compatible (Mistral has its own adapter)")
+}

--- a/pkg/infra/providers/adapter/normalize.go
+++ b/pkg/infra/providers/adapter/normalize.go
@@ -1,0 +1,87 @@
+package adapter
+
+import "encoding/json"
+
+// NormalizeOpenAIRequest performs lightweight, in-place normalization of an
+// OpenAI-compatible request body to fix common issues sent by third-party SDKs
+// (e.g. Mistral, Cohere) that use the OpenAI wire format but omit fields that
+// OpenAI strictly requires.
+//
+// Current normalizations:
+//   - Ensures every tool_call object inside messages has "type": "function".
+//     The Mistral SDK omits this field, but OpenAI returns 400 without it.
+//
+// The function is a no-op (returns the original body) when no changes are
+// needed, so it is safe to call unconditionally on every OpenAI-bound request.
+func NormalizeOpenAIRequest(body []byte) []byte {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return body
+	}
+
+	msgsRaw, ok := raw["messages"]
+	if !ok {
+		return body
+	}
+
+	var msgs []map[string]json.RawMessage
+	if err := json.Unmarshal(msgsRaw, &msgs); err != nil {
+		return body
+	}
+
+	changed := false
+	for i := range msgs {
+		tcRaw, hasTCs := msgs[i]["tool_calls"]
+		if !hasTCs {
+			continue
+		}
+
+		var tcs []map[string]json.RawMessage
+		if err := json.Unmarshal(tcRaw, &tcs); err != nil {
+			continue
+		}
+
+		tcChanged := false
+		for j := range tcs {
+			typeRaw, hasType := tcs[j]["type"]
+			if !hasType || isEmptyOrNull(typeRaw) {
+				b, _ := json.Marshal("function")
+				tcs[j]["type"] = b
+				tcChanged = true
+			}
+		}
+
+		if tcChanged {
+			b, err := json.Marshal(tcs)
+			if err == nil {
+				msgs[i]["tool_calls"] = b
+				changed = true
+			}
+		}
+	}
+
+	if !changed {
+		return body
+	}
+
+	b, err := json.Marshal(msgs)
+	if err != nil {
+		return body
+	}
+	raw["messages"] = b
+
+	out, err := json.Marshal(raw)
+	if err != nil {
+		return body
+	}
+	return out
+}
+
+// isEmptyOrNull returns true for nil, empty, `null`, or `""` JSON values.
+func isEmptyOrNull(raw json.RawMessage) bool {
+	if len(raw) == 0 {
+		return true
+	}
+	s := string(raw)
+	return s == "null" || s == `""`
+}

--- a/pkg/infra/providers/adapter/normalize_test.go
+++ b/pkg/infra/providers/adapter/normalize_test.go
@@ -1,0 +1,286 @@
+package adapter
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// NormalizeOpenAIRequest
+// ---------------------------------------------------------------------------
+
+func TestNormalizeOpenAIRequest_InjectsTypeFunctionWhenMissing(t *testing.T) {
+	// Simulates what the Mistral SDK sends: tool_calls without "type"
+	input := `{
+		"model": "gpt-4",
+		"messages": [
+			{"role": "user", "content": "hello"},
+			{
+				"role": "assistant",
+				"tool_calls": [
+					{"id": "abc123xyz", "function": {"name": "search", "arguments": "{\"q\":\"test\"}"}}
+				]
+			},
+			{"role": "tool", "tool_call_id": "abc123xyz", "content": "result"}
+		]
+	}`
+
+	out := NormalizeOpenAIRequest([]byte(input))
+
+	var result map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	var msgs []map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(result["messages"], &msgs))
+
+	// Assistant message (index 1) should have tool_calls with type
+	var tcs []map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(msgs[1]["tool_calls"], &tcs))
+	require.Len(t, tcs, 1)
+
+	var tcType string
+	require.NoError(t, json.Unmarshal(tcs[0]["type"], &tcType))
+	assert.Equal(t, "function", tcType)
+}
+
+func TestNormalizeOpenAIRequest_PreservesExistingType(t *testing.T) {
+	input := `{
+		"model": "gpt-4",
+		"messages": [
+			{
+				"role": "assistant",
+				"tool_calls": [
+					{"id": "abc", "type": "function", "function": {"name": "search", "arguments": "{}"}}
+				]
+			}
+		]
+	}`
+
+	out := NormalizeOpenAIRequest([]byte(input))
+
+	var result map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	var msgs []map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(result["messages"], &msgs))
+
+	var tcs []map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(msgs[0]["tool_calls"], &tcs))
+
+	var tcType string
+	require.NoError(t, json.Unmarshal(tcs[0]["type"], &tcType))
+	assert.Equal(t, "function", tcType)
+}
+
+func TestNormalizeOpenAIRequest_NoOpWhenNoToolCalls(t *testing.T) {
+	input := `{"model":"gpt-4","messages":[{"role":"user","content":"hello"}]}`
+	out := NormalizeOpenAIRequest([]byte(input))
+	assert.JSONEq(t, input, string(out))
+}
+
+func TestNormalizeOpenAIRequest_NoOpWhenNoMessages(t *testing.T) {
+	input := `{"model":"gpt-4"}`
+	out := NormalizeOpenAIRequest([]byte(input))
+	assert.JSONEq(t, input, string(out))
+}
+
+func TestNormalizeOpenAIRequest_HandlesInvalidJSON(t *testing.T) {
+	input := `not json at all`
+	out := NormalizeOpenAIRequest([]byte(input))
+	assert.Equal(t, input, string(out), "invalid JSON should return original body")
+}
+
+func TestNormalizeOpenAIRequest_HandlesNullType(t *testing.T) {
+	input := `{
+		"messages": [
+			{
+				"role": "assistant",
+				"tool_calls": [
+					{"id": "abc", "type": null, "function": {"name": "search", "arguments": "{}"}}
+				]
+			}
+		]
+	}`
+
+	out := NormalizeOpenAIRequest([]byte(input))
+
+	var result map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	var msgs []map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(result["messages"], &msgs))
+
+	var tcs []map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(msgs[0]["tool_calls"], &tcs))
+
+	var tcType string
+	require.NoError(t, json.Unmarshal(tcs[0]["type"], &tcType))
+	assert.Equal(t, "function", tcType)
+}
+
+func TestNormalizeOpenAIRequest_HandlesEmptyStringType(t *testing.T) {
+	input := `{
+		"messages": [
+			{
+				"role": "assistant",
+				"tool_calls": [
+					{"id": "abc", "type": "", "function": {"name": "search", "arguments": "{}"}}
+				]
+			}
+		]
+	}`
+
+	out := NormalizeOpenAIRequest([]byte(input))
+
+	var result map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	var msgs []map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(result["messages"], &msgs))
+
+	var tcs []map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(msgs[0]["tool_calls"], &tcs))
+
+	var tcType string
+	require.NoError(t, json.Unmarshal(tcs[0]["type"], &tcType))
+	assert.Equal(t, "function", tcType)
+}
+
+func TestNormalizeOpenAIRequest_MultipleToolCalls(t *testing.T) {
+	input := `{
+		"messages": [
+			{
+				"role": "assistant",
+				"tool_calls": [
+					{"id": "a", "function": {"name": "tool1", "arguments": "{}"}},
+					{"id": "b", "type": "function", "function": {"name": "tool2", "arguments": "{}"}},
+					{"id": "c", "function": {"name": "tool3", "arguments": "{}"}}
+				]
+			}
+		]
+	}`
+
+	out := NormalizeOpenAIRequest([]byte(input))
+
+	var result map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	var msgs []map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(result["messages"], &msgs))
+
+	var tcs []map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(msgs[0]["tool_calls"], &tcs))
+	require.Len(t, tcs, 3)
+
+	for i, tc := range tcs {
+		var tcType string
+		require.NoError(t, json.Unmarshal(tc["type"], &tcType))
+		assert.Equal(t, "function", tcType, "tool_call[%d] should have type=function", i)
+	}
+}
+
+func TestNormalizeOpenAIRequest_MultipleMessagesWithToolCalls(t *testing.T) {
+	input := `{
+		"messages": [
+			{"role": "user", "content": "step 1"},
+			{
+				"role": "assistant",
+				"tool_calls": [{"id": "a", "function": {"name": "t1", "arguments": "{}"}}]
+			},
+			{"role": "tool", "tool_call_id": "a", "content": "r1"},
+			{
+				"role": "assistant",
+				"tool_calls": [{"id": "b", "function": {"name": "t2", "arguments": "{}"}}]
+			},
+			{"role": "tool", "tool_call_id": "b", "content": "r2"}
+		]
+	}`
+
+	out := NormalizeOpenAIRequest([]byte(input))
+
+	var result map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	var msgs []map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(result["messages"], &msgs))
+
+	// Check both assistant messages (index 1 and 3)
+	for _, idx := range []int{1, 3} {
+		var tcs []map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(msgs[idx]["tool_calls"], &tcs))
+		require.Len(t, tcs, 1)
+
+		var tcType string
+		require.NoError(t, json.Unmarshal(tcs[0]["type"], &tcType))
+		assert.Equal(t, "function", tcType, "messages[%d].tool_calls[0].type should be function", idx)
+	}
+}
+
+func TestNormalizeOpenAIRequest_PreservesOtherFields(t *testing.T) {
+	input := `{
+		"model": "gpt-4",
+		"messages": [
+			{
+				"role": "assistant",
+				"content": "I'll search for that.",
+				"tool_calls": [
+					{"id": "abc", "function": {"name": "search", "arguments": "{\"q\":\"test\"}"}}
+				]
+			}
+		],
+		"temperature": 0.7,
+		"max_tokens": 100
+	}`
+
+	out := NormalizeOpenAIRequest([]byte(input))
+
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	// Top-level fields preserved
+	assert.Equal(t, "gpt-4", result["model"])
+	assert.Equal(t, 0.7, result["temperature"])
+	assert.Equal(t, float64(100), result["max_tokens"])
+
+	// Message content preserved
+	msgs := result["messages"].([]interface{})
+	msg := msgs[0].(map[string]interface{})
+	assert.Equal(t, "assistant", msg["role"])
+	assert.Equal(t, "I'll search for that.", msg["content"])
+
+	// Tool call fields preserved
+	tcs := msg["tool_calls"].([]interface{})
+	tc := tcs[0].(map[string]interface{})
+	assert.Equal(t, "abc", tc["id"])
+	fn := tc["function"].(map[string]interface{})
+	assert.Equal(t, "search", fn["name"])
+}
+
+// ---------------------------------------------------------------------------
+// isEmptyOrNull
+// ---------------------------------------------------------------------------
+
+func TestIsEmptyOrNull(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  json.RawMessage
+		expect bool
+	}{
+		{"nil", nil, true},
+		{"empty", json.RawMessage{}, true},
+		{"null literal", json.RawMessage(`null`), true},
+		{"empty string", json.RawMessage(`""`), true},
+		{"non-empty string", json.RawMessage(`"function"`), false},
+		{"number", json.RawMessage(`42`), false},
+		{"object", json.RawMessage(`{}`), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expect, isEmptyOrNull(tt.input))
+		})
+	}
+}

--- a/pkg/infra/providers/adapter/registry.go
+++ b/pkg/infra/providers/adapter/registry.go
@@ -44,6 +44,7 @@ func init() {
 	adapters[FormatAnthropic] = &AnthropicAdapter{}
 	adapters[FormatGemini] = &GeminiAdapter{}
 	adapters[FormatBedrock] = &BedrockAdapter{}
+	adapters[FormatMistral] = &MistralAdapter{}
 	// Azure uses the same wire format as OpenAI — see normalizeFormat().
 }
 

--- a/pkg/infra/providers/anthropic/client.go
+++ b/pkg/infra/providers/anthropic/client.go
@@ -6,28 +6,24 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
 	pkgTypes "github.com/NeuralTrust/TrustGate/pkg/types"
-	"golang.org/x/sync/singleflight"
 )
 
 const (
-	httpClientTimeout = 120
-	messagesURL       = "https://api.anthropic.com/v1/messages"
-	anthropicVersion  = "2023-06-01"
+	messagesURL      = "https://api.anthropic.com/v1/messages"
+	anthropicVersion = "2023-06-01"
 )
 
 type client struct {
-	httpClientPool *sync.Map
-	sf             singleflight.Group
+	pool *providers.HTTPClientPool
 }
 
 func NewAnthropicClient() providers.Client {
 	return &client{
-		httpClientPool: &sync.Map{},
+		pool: providers.NewHTTPClientPool(),
 	}
 }
 
@@ -62,7 +58,7 @@ func (c *client) CompletionsStream(
 		return fmt.Errorf("API key is required")
 	}
 
-	httpClient := c.getOrCreateHTTPClient()
+	httpClient := c.pool.Get(providers.ProviderAnthropic, providers.DefaultHTTPTimeout)
 
 	httpReq, err := http.NewRequestWithContext(
 		reqCtx.C.Context(), http.MethodPost, messagesURL, bytes.NewReader(reqBody),
@@ -76,7 +72,7 @@ func (c *client) CompletionsStream(
 	if err != nil {
 		return fmt.Errorf("HTTP request failed: %w", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer providers.DrainBody(resp.Body)
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		var preview bytes.Buffer
@@ -98,7 +94,7 @@ func (c *client) CompletionsStream(
 // ---------------------------------------------------------------------------
 
 func (c *client) rawPost(ctx context.Context, apiKey string, reqBody []byte) ([]byte, error) {
-	httpClient := c.getOrCreateHTTPClient()
+	httpClient := c.pool.Get(providers.ProviderAnthropic, providers.DefaultHTTPTimeout)
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, messagesURL, bytes.NewReader(reqBody))
 	if err != nil {
@@ -132,30 +128,4 @@ func (c *client) setHeaders(req *http.Request, apiKey string) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("x-api-key", apiKey)
 	req.Header.Set("anthropic-version", anthropicVersion)
-}
-
-func (c *client) getOrCreateHTTPClient() *http.Client {
-	const clientKey = "default"
-	if v, ok := c.httpClientPool.Load(clientKey); ok {
-		if cl, ok := v.(*http.Client); ok {
-			return cl
-		}
-	}
-	v, err, _ := c.sf.Do(clientKey, func() (any, error) {
-		if v2, ok := c.httpClientPool.Load(clientKey); ok {
-			return v2, nil
-		}
-		httpClient := &http.Client{
-			Timeout: httpClientTimeout * time.Second,
-		}
-		c.httpClientPool.Store(clientKey, httpClient)
-		return httpClient, nil
-	})
-	if err != nil {
-		return &http.Client{Timeout: httpClientTimeout * time.Second}
-	}
-	if cl, ok := v.(*http.Client); ok {
-		return cl
-	}
-	return &http.Client{Timeout: httpClientTimeout * time.Second}
 }

--- a/pkg/infra/providers/azure/client.go
+++ b/pkg/infra/providers/azure/client.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -14,21 +13,15 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/adapter"
 	pkgTypes "github.com/NeuralTrust/TrustGate/pkg/types"
-	"golang.org/x/sync/singleflight"
-)
-
-const (
-	httpClientTimeout = 120
 )
 
 type client struct {
-	httpClientPool *sync.Map
-	sf             singleflight.Group
+	pool *providers.HTTPClientPool
 }
 
 func NewAzureClient() providers.Client {
 	return &client{
-		httpClientPool: &sync.Map{},
+		pool: providers.NewHTTPClientPool(),
 	}
 }
 
@@ -93,7 +86,7 @@ func (c *client) CompletionsStream(
 
 	url := c.buildURL(config, model)
 
-	httpClient := c.getOrCreateHTTPClient()
+	httpClient := c.pool.Get(providers.ProviderAzure, providers.DefaultHTTPTimeout)
 	httpReq, err := http.NewRequestWithContext(
 		reqCtx.C.Context(), http.MethodPost, url, bytes.NewReader(reqBody),
 	)
@@ -107,7 +100,7 @@ func (c *client) CompletionsStream(
 	if err != nil {
 		return fmt.Errorf("HTTP request failed: %w", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer providers.DrainBody(resp.Body)
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		var preview bytes.Buffer
@@ -131,7 +124,7 @@ func (c *client) CompletionsStream(
 // ---------------------------------------------------------------------------
 
 func (c *client) rawPost(ctx context.Context, url, token string, useIdentity bool, reqBody []byte) ([]byte, error) {
-	httpClient := c.getOrCreateHTTPClient()
+	httpClient := c.pool.Get(providers.ProviderAzure, providers.DefaultHTTPTimeout)
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(reqBody))
 	if err != nil {
@@ -191,32 +184,6 @@ func (c *client) buildURL(config *providers.Config, model string) string {
 	}
 	return fmt.Sprintf("%s/openai/deployments/%s/chat/completions?api-version=%s",
 		config.Credentials.Azure.Endpoint, model, apiVersion)
-}
-
-func (c *client) getOrCreateHTTPClient() *http.Client {
-	const clientKey = "default"
-	if v, ok := c.httpClientPool.Load(clientKey); ok {
-		if cl, ok := v.(*http.Client); ok {
-			return cl
-		}
-	}
-	v, err, _ := c.sf.Do(clientKey, func() (any, error) {
-		if v2, ok := c.httpClientPool.Load(clientKey); ok {
-			return v2, nil
-		}
-		httpClient := &http.Client{
-			Timeout: httpClientTimeout * time.Second,
-		}
-		c.httpClientPool.Store(clientKey, httpClient)
-		return httpClient, nil
-	})
-	if err != nil {
-		return &http.Client{Timeout: httpClientTimeout * time.Second}
-	}
-	if cl, ok := v.(*http.Client); ok {
-		return cl
-	}
-	return &http.Client{Timeout: httpClientTimeout * time.Second}
 }
 
 func getAzureADToken(ctx context.Context) (string, error) {

--- a/pkg/infra/providers/client.go
+++ b/pkg/infra/providers/client.go
@@ -6,6 +6,17 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/types"
 )
 
+// Provider name constants. Use these as keys for HTTPClientPool.Get() and
+// anywhere a provider needs to be identified by name.
+const (
+	ProviderOpenAI    = "openai"
+	ProviderGoogle    = "google"
+	ProviderAnthropic = "anthropic"
+	ProviderBedrock   = "bedrock"
+	ProviderAzure     = "azure"
+	ProviderMistral   = "mistral"
+)
+
 type Config struct {
 	Credentials   Credentials    `json:"credentials"`
 	AllowedModels []string       `json:"allowed_models"`

--- a/pkg/infra/providers/factory/locator.go
+++ b/pkg/infra/providers/factory/locator.go
@@ -8,16 +8,20 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/azure"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/bedrock"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/google"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/mistral"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/openai"
 	"github.com/valyala/fasthttp"
 )
 
+// Provider name constants — aliased from the providers package so existing
+// callers that import factory.ProviderX continue to compile.
 const (
-	ProviderOpenAI    = "openai"
-	ProviderGoogle    = "google"
-	ProviderAnthropic = "anthropic"
-	ProviderBedrock   = "bedrock"
-	ProviderAzure     = "azure"
+	ProviderOpenAI    = providers.ProviderOpenAI
+	ProviderGoogle    = providers.ProviderGoogle
+	ProviderAnthropic = providers.ProviderAnthropic
+	ProviderBedrock   = providers.ProviderBedrock
+	ProviderAzure     = providers.ProviderAzure
+	ProviderMistral   = providers.ProviderMistral
 )
 
 //go:generate mockery --name=ProviderLocator --dir=. --output=./mocks --filename=provider_locator_mock.go --case=underscore --with-expecter
@@ -47,6 +51,8 @@ func (f *providerLocator) Get(provider string) (providers.Client, error) {
 		return bedrock.NewBedrockClient(), nil
 	case ProviderAzure:
 		return azure.NewAzureClient(), nil
+	case ProviderMistral:
+		return mistral.NewMistralClient(), nil
 	default:
 		return nil, fmt.Errorf("unsupported provider: %s", provider)
 	}

--- a/pkg/infra/providers/google/client.go
+++ b/pkg/infra/providers/google/client.go
@@ -6,28 +6,24 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/adapter"
 	"github.com/NeuralTrust/TrustGate/pkg/types"
-	"golang.org/x/sync/singleflight"
 )
 
 const (
-	httpClientTimeout = 120
-	geminiBaseURL     = "https://generativelanguage.googleapis.com/v1beta/models"
+	geminiBaseURL = "https://generativelanguage.googleapis.com/v1beta/models"
 )
 
 type client struct {
-	httpClientPool *sync.Map
-	sf             singleflight.Group
+	pool *providers.HTTPClientPool
 }
 
 func NewGoogleClient() providers.Client {
 	return &client{
-		httpClientPool: &sync.Map{},
+		pool: providers.NewHTTPClientPool(),
 	}
 }
 
@@ -82,7 +78,7 @@ func (c *client) CompletionsStream(
 
 	url := fmt.Sprintf("%s/%s:streamGenerateContent?alt=sse", geminiBaseURL, model)
 
-	httpClient := c.getOrCreateHTTPClient()
+	httpClient := c.pool.Get(providers.ProviderGoogle, providers.DefaultHTTPTimeout)
 
 	httpReq, err := http.NewRequestWithContext(
 		reqCtx.C.Context(),
@@ -101,7 +97,7 @@ func (c *client) CompletionsStream(
 	if err != nil {
 		return fmt.Errorf("HTTP request failed: %w", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer providers.DrainBody(resp.Body)
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return parseGeminiError(resp)
@@ -129,7 +125,7 @@ func (c *client) rawPost(
 	reqBody []byte,
 ) ([]byte, error) {
 
-	httpClient := c.getOrCreateHTTPClient()
+	httpClient := c.pool.Get(providers.ProviderGoogle, providers.DefaultHTTPTimeout)
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(reqBody))
 	if err != nil {
@@ -202,39 +198,4 @@ func parseGeminiError(resp *http.Response) error {
 		resp.StatusCode,
 		body.String(),
 	)
-}
-
-func (c *client) getOrCreateHTTPClient() *http.Client {
-
-	const clientKey = "default"
-
-	if v, ok := c.httpClientPool.Load(clientKey); ok {
-		if cl, ok := v.(*http.Client); ok {
-			return cl
-		}
-	}
-
-	v, err, _ := c.sf.Do(clientKey, func() (any, error) {
-
-		if v2, ok := c.httpClientPool.Load(clientKey); ok {
-			return v2, nil
-		}
-
-		httpClient := &http.Client{
-			Timeout: httpClientTimeout * time.Second,
-		}
-
-		c.httpClientPool.Store(clientKey, httpClient)
-		return httpClient, nil
-	})
-
-	if err != nil {
-		return &http.Client{Timeout: httpClientTimeout * time.Second}
-	}
-
-	if cl, ok := v.(*http.Client); ok {
-		return cl
-	}
-
-	return &http.Client{Timeout: httpClientTimeout * time.Second}
 }

--- a/pkg/infra/providers/http_client.go
+++ b/pkg/infra/providers/http_client.go
@@ -1,0 +1,113 @@
+package providers
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+)
+
+// DefaultHTTPTimeout is the default timeout used by all provider HTTP clients.
+const DefaultHTTPTimeout = 120 * time.Second
+
+// HTTPClientPool manages a pool of *http.Client instances keyed by provider
+// name. It uses singleflight to ensure only one client is created per key
+// even under concurrent access.
+//
+// Each *http.Client returned is safe for concurrent use: Go's http.Client.Do()
+// creates a completely independent HTTP transaction per call — there is no
+// request/response caching between calls. The underlying Transport reuses TCP
+// connections (keep-alive) for performance, but each request gets its own
+// HTTP round-trip with its own headers, body, and response.
+type HTTPClientPool struct {
+	pool *sync.Map
+	sf   singleflight.Group
+}
+
+// NewHTTPClientPool returns a ready-to-use pool.
+func NewHTTPClientPool() *HTTPClientPool {
+	return &HTTPClientPool{
+		pool: &sync.Map{},
+	}
+}
+
+// Get returns (or lazily creates) an *http.Client for the given key with the
+// specified timeout. Typical keys are provider names ("openai", "anthropic",
+// etc.) so each provider gets its own client and transport instance.
+func (p *HTTPClientPool) Get(key string, timeout time.Duration) *http.Client {
+	if v, ok := p.pool.Load(key); ok {
+		if cl, ok := v.(*http.Client); ok {
+			return cl
+		}
+	}
+	v, err, _ := p.sf.Do(key, func() (any, error) {
+		if v2, ok := p.pool.Load(key); ok {
+			return v2, nil
+		}
+		cl := &http.Client{
+			Timeout:   timeout,
+			Transport: newTransport(),
+		}
+		p.pool.Store(key, cl)
+		return cl, nil
+	})
+	if err != nil {
+		return &http.Client{Timeout: timeout, Transport: newTransport()}
+	}
+	if cl, ok := v.(*http.Client); ok {
+		return cl
+	}
+	return &http.Client{Timeout: timeout, Transport: newTransport()}
+}
+
+// DrainBody reads and discards up to 64 KB of remaining data from r, then
+// closes it. This ensures the underlying TCP connection is returned cleanly
+// to the transport's pool and is never reused with stale data.
+// Callers should use this in error paths where the body was only partially
+// read (e.g. after io.CopyN for an error preview).
+func DrainBody(r io.ReadCloser) {
+	_, _ = io.Copy(io.Discard, io.LimitReader(r, 64*1024))
+	_ = r.Close()
+}
+
+// newTransport returns an *http.Transport with explicit settings tuned for
+// high-concurrency provider calls. Each provider key gets its own Transport
+// so connection pools are isolated between providers.
+func newTransport() *http.Transport {
+	return &http.Transport{
+		// Connection establishment timeout.
+		DialContext: (&net.Dialer{
+			Timeout:   10 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+
+		// TLS handshake timeout.
+		TLSHandshakeTimeout: 10 * time.Second,
+
+		// Limit idle connections to prevent unbounded memory growth.
+		MaxIdleConns:        100,
+		MaxIdleConnsPerHost: 20,
+
+		// Drop idle connections after 60s so stale TCP connections from
+		// previous requests are never reused after a provider hiccup.
+		IdleConnTimeout: 60 * time.Second,
+
+		// If the server doesn't send response headers within 30s after
+		// the request is sent, fail fast rather than hanging.
+		ResponseHeaderTimeout: 30 * time.Second,
+
+		// Expect-Continue timeout: how long to wait for a 100-continue
+		// before sending the body. Keeps large POST bodies from blocking.
+		ExpectContinueTimeout: 1 * time.Second,
+
+		// Force HTTP/2 where available for multiplexed requests.
+		ForceAttemptHTTP2: true,
+
+		// Disable compression so we get raw JSON (easier to debug and
+		// avoids double-decompression issues with streaming).
+		DisableCompression: true,
+	}
+}

--- a/pkg/infra/providers/mistral/client.go
+++ b/pkg/infra/providers/mistral/client.go
@@ -1,4 +1,4 @@
-package openai
+package mistral
 
 import (
 	"bytes"
@@ -10,34 +10,25 @@ import (
 
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
 	"github.com/NeuralTrust/TrustGate/pkg/types"
-	"github.com/mitchellh/mapstructure"
 )
 
 const (
-	CompletionsAPI = "completions"
-	ResponsesAPI   = "responses"
-	completionsURL = "https://api.openai.com/v1/chat/completions"
-	responsesURL   = "https://api.openai.com/v1/responses"
+	chatCompletionsURL = "https://api.mistral.ai/v1/chat/completions"
 )
-
-type openaiOptions struct {
-	API string `json:"api"`
-}
 
 type client struct {
 	pool *providers.HTTPClientPool
 }
 
-func NewOpenaiClient() providers.Client {
+// NewMistralClient returns a providers.Client that calls Mistral's chat completions API.
+// See https://docs.mistral.ai/api (POST /v1/chat/completions).
+func NewMistralClient() providers.Client {
 	return &client{
 		pool: providers.NewHTTPClientPool(),
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Completions (non-streaming)
-// ---------------------------------------------------------------------------
-
+// Completions performs a non-streaming chat completion request to Mistral.
 func (c *client) Completions(
 	ctx context.Context,
 	config *providers.Config,
@@ -46,24 +37,11 @@ func (c *client) Completions(
 	if config.Credentials.ApiKey == "" {
 		return nil, fmt.Errorf("API key is required")
 	}
-
-	options := c.parseOptions(config)
-
-	var url string
-	switch options.API {
-	case ResponsesAPI:
-		url = responsesURL
-	default:
-		url = completionsURL
-	}
-
-	return c.rawPost(ctx, url, config.Credentials.ApiKey, reqBody)
+	return c.rawPost(ctx, chatCompletionsURL, config.Credentials.ApiKey, reqBody)
 }
 
-// ---------------------------------------------------------------------------
-// CompletionsStream (SSE)
-// ---------------------------------------------------------------------------
-
+// CompletionsStream performs a streaming chat completion request and forwards
+// SSE lines to streamChan. Uses the same SSE format as OpenAI (data: {...}).
 func (c *client) CompletionsStream(
 	req *types.RequestContext,
 	config *providers.Config,
@@ -75,19 +53,9 @@ func (c *client) CompletionsStream(
 		return fmt.Errorf("API key is required")
 	}
 
-	options := c.parseOptions(config)
-
-	var url string
-	switch options.API {
-	case ResponsesAPI:
-		url = responsesURL
-	default:
-		url = completionsURL
-	}
-
-	httpClient := c.pool.Get(providers.ProviderOpenAI, providers.DefaultHTTPTimeout)
+	httpClient := c.pool.Get(providers.ProviderMistral, providers.DefaultHTTPTimeout)
 	httpReq, err := http.NewRequestWithContext(
-		req.C.Context(), http.MethodPost, url, bytes.NewReader(reqBody),
+		req.C.Context(), http.MethodPost, chatCompletionsURL, bytes.NewReader(reqBody),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create HTTP request: %w", err)
@@ -95,7 +63,7 @@ func (c *client) CompletionsStream(
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Authorization", "Bearer "+config.Credentials.ApiKey)
 
-	resp, err := httpClient.Do(httpReq) // #nosec G704 -- URL is a compile-time constant (completionsURL/responsesURL), not user-controlled
+	resp, err := httpClient.Do(httpReq) // #nosec G704 -- URL is compile-time constant
 	if err != nil {
 		return fmt.Errorf("HTTP request failed: %w", err)
 	}
@@ -112,16 +80,12 @@ func (c *client) CompletionsStream(
 	return providers.StreamSSE(ctx, resp.Body, streamChan)
 }
 
-// ---------------------------------------------------------------------------
-// Raw HTTP POST
-// ---------------------------------------------------------------------------
-
 func (c *client) rawPost(
 	ctx context.Context,
 	url, apiKey string,
 	reqBody []byte,
 ) ([]byte, error) {
-	httpClient := c.pool.Get(providers.ProviderOpenAI, providers.DefaultHTTPTimeout)
+	httpClient := c.pool.Get(providers.ProviderMistral, providers.DefaultHTTPTimeout)
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(reqBody))
 	if err != nil {
@@ -130,7 +94,7 @@ func (c *client) rawPost(
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
 
-	resp, err := httpClient.Do(httpReq) // #nosec G704 -- URL is a compile-time constant (completionsURL/responsesURL), not user-controlled
+	resp, err := httpClient.Do(httpReq) // #nosec G704 -- URL is compile-time constant
 	if err != nil {
 		return nil, fmt.Errorf("HTTP request failed: %w", err)
 	}
@@ -146,20 +110,4 @@ func (c *client) rawPost(
 	}
 
 	return body.Bytes(), nil
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-func (c *client) parseOptions(config *providers.Config) openaiOptions {
-	var options openaiOptions
-	if len(config.Options) > 0 {
-		if err := mapstructure.Decode(config.Options, &options); err != nil {
-			options = openaiOptions{API: CompletionsAPI}
-		}
-	} else {
-		options = openaiOptions{API: CompletionsAPI}
-	}
-	return options
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	Version   = "1.11.0"
+	Version   = "1.12.0"
 	AppName   = "TrustGate"
 	BuildDate = "unknown"
 )


### PR DESCRIPTION
Integrate Mistral as a first-class provider in TrustGate and the multi-agent test matrix.

Mistral adapter:
- Create MistralAdapter that delegates to OpenAIAdapter with Mistral-specific
  post-processing: injects required "parameters" on tools and normalizes
  tool_call IDs to the 9-char alphanumeric format Mistral enforces.
- Register FormatMistral in the adapter registry with its own wire format
  (not aliased to OpenAI) so cross-provider adaptation flows through
  decode→canonical→encode.

Normalize OpenAI requests:
- Add NormalizeOpenAIRequest() to patch tool_calls missing "type":"function"
  before forwarding to OpenAI. The Mistral SDK omits this field, causing
  OpenAI to return 400. Applied in both sync and streaming handler paths.

HTTP client refactor:
- Extract duplicated getOrCreateHTTPClient / transport logic from all provider
  clients into a shared HTTPClientPool with singleflight-based lazy init,
  explicit Transport settings (timeouts, connection limits, HTTP/2), and
  DrainBody helper for clean connection reuse under high concurrency.
- Define canonical ProviderX constants in the providers package; alias them
  in factory for backward compatibility.

Multi-agent test matrix:
- Add Mistral to adapter matrix (streaming and non-streaming).
- Use /mistral/chat/completions rule path with /mistral base_url prefix to
  avoid routing collision with OpenAI's /chat/completions.

Tests:
- 33 new unit tests covering MistralAdapter (roundtrip, tool parameter
  injection, ID normalization, cross-provider paths, response/stream
  delegation, registry) and NormalizeOpenAIRequest (type injection, null/empty
  handling, multi-message, field preservation, edge cases).