### PR TITLE
refactor(guardrail): refactor jailbreak protection

### DIFF
--- a/pkg/dependency_container/container.go
+++ b/pkg/dependency_container/container.go
@@ -1,9 +1,7 @@
 package dependency_container
 
 import (
-	"crypto/tls"
 	"fmt"
-	"net/http"
 	"reflect"
 	"time"
 
@@ -44,6 +42,7 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/infra/cache/subscriber"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/embedding/factory"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/fingerprint"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/httpx"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/loadbalancer"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/plugins"
@@ -149,17 +148,12 @@ func NewContainer(di ContainerDI) (*Container, error) {
 
 	fingerprintTracker := fingerprint.NewFingerPrintTracker(cacheInstance)
 
-	firewallHTTPClient := &http.Client{
-		Timeout: 10 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig:       &tls.Config{InsecureSkipVerify: true}, // #nosec G402
-			MaxIdleConns:          100,
-			MaxIdleConnsPerHost:   10,
-			IdleConnTimeout:       90 * time.Second,
-			DisableKeepAlives:     false,
-			ResponseHeaderTimeout: 10 * time.Second,
-		},
-	}
+	firewallHTTPClient := httpx.NewFastHTTPClient(
+		httpx.WithTimeout(10*time.Second),
+		httpx.WithInsecureSkipVerify(true),
+		httpx.WithMaxConnsPerHost(512),
+		httpx.WithMaxIdleConnDuration(90*time.Second),
+	)
 	neuralTrustFirewallClient := firewall.NewNeuralTrustFirewallClient(
 		di.Logger,
 		firewall.WithHTTPClient(firewallHTTPClient),

--- a/pkg/infra/firewall/neuraltrust_client.go
+++ b/pkg/infra/firewall/neuraltrust_client.go
@@ -112,12 +112,8 @@ func (c *NeuralTrustFirewallClient) doRequest(
 		_ = resp.Body.Close()
 	}()
 
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read response: %w", err)
-	}
-
 	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
 		c.logger.WithFields(logrus.Fields{
 			"status_code":   resp.StatusCode,
 			"path":          path,
@@ -126,14 +122,9 @@ func (c *NeuralTrustFirewallClient) doRequest(
 		return fmt.Errorf("%w: status %d", ErrFailedFirewallCall, resp.StatusCode)
 	}
 
-	if err := json.Unmarshal(respBody, result); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
 		return fmt.Errorf("failed to parse response: %w", err)
 	}
-
-	c.logger.WithFields(logrus.Fields{
-		"path":     path,
-		"response": string(respBody),
-	}).Debug("firewall response")
 
 	return nil
 }

--- a/pkg/infra/httpx/fasthttp.go
+++ b/pkg/infra/httpx/fasthttp.go
@@ -3,7 +3,6 @@ package httpx
 import (
 	"bytes"
 	"crypto/tls"
-	"fmt"
 	"io"
 	"net/http"
 	"time"
@@ -11,137 +10,54 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
-// Default values for FastHTTPClient options
 const (
 	DefaultTimeout             = 30 * time.Second
 	DefaultMaxConnsPerHost     = 512
 	DefaultMaxIdleConnDuration = 10 * time.Second
-	DefaultReadBufferSize      = 4096
-	DefaultWriteBufferSize     = 4096
-	DefaultMaxResponseBodySize = 100 * 1024 * 1024 // 100MB
 )
 
-// FastHTTPClientOptions contains configuration for the FastHTTP client
 type FastHTTPClientOptions struct {
-	// Timeout is the maximum duration for the entire request (read + write)
-	Timeout time.Duration
-
-	// ReadTimeout is the maximum duration for reading the full response
-	ReadTimeout time.Duration
-
-	// WriteTimeout is the maximum duration for writing the full request
-	WriteTimeout time.Duration
-
-	// InsecureSkipVerify controls whether to skip TLS certificate verification
-	InsecureSkipVerify bool
-
-	// MaxConnsPerHost is the maximum number of concurrent connections per host
-	MaxConnsPerHost int
-
-	// MaxIdleConnDuration is the maximum duration for keeping idle connections open
+	Timeout             time.Duration
+	InsecureSkipVerify  bool
+	MaxConnsPerHost     int
 	MaxIdleConnDuration time.Duration
-
-	// ReadBufferSize is the size of the read buffer
-	ReadBufferSize int
-
-	// WriteBufferSize is the size of the write buffer
-	WriteBufferSize int
-
-	// MaxResponseBodySize is the maximum response body size to read
-	MaxResponseBodySize int
-
-	// UserAgent is the default User-Agent header value
-	UserAgent string
 }
 
-// FastHTTPClientOption is a function that configures FastHTTPClientOptions
 type FastHTTPClientOption func(*FastHTTPClientOptions)
 
-// WithTimeout sets the overall request timeout
 func WithTimeout(timeout time.Duration) FastHTTPClientOption {
 	return func(o *FastHTTPClientOptions) {
 		o.Timeout = timeout
 	}
 }
 
-// WithReadTimeout sets the read timeout
-func WithReadTimeout(timeout time.Duration) FastHTTPClientOption {
-	return func(o *FastHTTPClientOptions) {
-		o.ReadTimeout = timeout
-	}
-}
-
-// WithWriteTimeout sets the write timeout
-func WithWriteTimeout(timeout time.Duration) FastHTTPClientOption {
-	return func(o *FastHTTPClientOptions) {
-		o.WriteTimeout = timeout
-	}
-}
-
-// WithInsecureSkipVerify sets whether to skip TLS certificate verification
 func WithInsecureSkipVerify(skip bool) FastHTTPClientOption {
 	return func(o *FastHTTPClientOptions) {
 		o.InsecureSkipVerify = skip
 	}
 }
 
-// WithMaxConnsPerHost sets the maximum connections per host
 func WithMaxConnsPerHost(max int) FastHTTPClientOption {
 	return func(o *FastHTTPClientOptions) {
 		o.MaxConnsPerHost = max
 	}
 }
 
-// WithMaxIdleConnDuration sets the maximum idle connection duration
 func WithMaxIdleConnDuration(duration time.Duration) FastHTTPClientOption {
 	return func(o *FastHTTPClientOptions) {
 		o.MaxIdleConnDuration = duration
 	}
 }
 
-// WithReadBufferSize sets the read buffer size
-func WithReadBufferSize(size int) FastHTTPClientOption {
-	return func(o *FastHTTPClientOptions) {
-		o.ReadBufferSize = size
-	}
-}
-
-// WithWriteBufferSize sets the write buffer size
-func WithWriteBufferSize(size int) FastHTTPClientOption {
-	return func(o *FastHTTPClientOptions) {
-		o.WriteBufferSize = size
-	}
-}
-
-// WithMaxResponseBodySize sets the maximum response body size
-func WithMaxResponseBodySize(size int) FastHTTPClientOption {
-	return func(o *FastHTTPClientOptions) {
-		o.MaxResponseBodySize = size
-	}
-}
-
-// WithUserAgent sets the default User-Agent header
-func WithUserAgent(userAgent string) FastHTTPClientOption {
-	return func(o *FastHTTPClientOptions) {
-		o.UserAgent = userAgent
-	}
-}
-
 type FastHTTPClient struct {
-	client    *fasthttp.Client
-	userAgent string
+	client *fasthttp.Client
 }
 
-// NewFastHTTPClient creates a new FastHTTPClient with the given options.
-// If no options are provided, sensible defaults are used.
 func NewFastHTTPClient(opts ...FastHTTPClientOption) Client {
 	options := &FastHTTPClientOptions{
 		Timeout:             DefaultTimeout,
 		MaxConnsPerHost:     DefaultMaxConnsPerHost,
 		MaxIdleConnDuration: DefaultMaxIdleConnDuration,
-		ReadBufferSize:      DefaultReadBufferSize,
-		WriteBufferSize:     DefaultWriteBufferSize,
-		MaxResponseBodySize: DefaultMaxResponseBodySize,
 	}
 
 	for _, opt := range opts {
@@ -151,76 +67,20 @@ func NewFastHTTPClient(opts ...FastHTTPClientOption) Client {
 	client := &fasthttp.Client{
 		MaxConnsPerHost:     options.MaxConnsPerHost,
 		MaxIdleConnDuration: options.MaxIdleConnDuration,
-		ReadBufferSize:      options.ReadBufferSize,
-		WriteBufferSize:     options.WriteBufferSize,
-		MaxResponseBodySize: options.MaxResponseBodySize,
 	}
 
-	// Set timeouts
-	if options.ReadTimeout > 0 {
-		client.ReadTimeout = options.ReadTimeout
-	} else if options.Timeout > 0 {
+	if options.Timeout > 0 {
 		client.ReadTimeout = options.Timeout
-	}
-
-	if options.WriteTimeout > 0 {
-		client.WriteTimeout = options.WriteTimeout
-	} else if options.Timeout > 0 {
 		client.WriteTimeout = options.Timeout
 	}
 
-	// Configure TLS if InsecureSkipVerify is set
 	if options.InsecureSkipVerify {
 		client.TLSConfig = &tls.Config{
-			InsecureSkipVerify: true, //#nosec G402 -- intentionally configurable for testing/internal use
+			InsecureSkipVerify: true, //#nosec G402
 		}
 	}
 
-	return &FastHTTPClient{
-		client:    client,
-		userAgent: options.UserAgent,
-	}
-}
-
-// NewFastHTTPClientWithClient creates a FastHTTPClient with a pre-configured fasthttp.Client.
-// Deprecated: Use NewFastHTTPClient with options instead.
-func NewFastHTTPClientWithClient(client *fasthttp.Client) Client {
-	if client == nil {
-		return NewFastHTTPClient()
-	}
-	return &FastHTTPClient{
-		client: client,
-	}
-}
-
-// FastHTTPClientConfig provides a simple configuration struct for creating a FastHTTPClient.
-// This is an alternative to using functional options.
-type FastHTTPClientConfig struct {
-	Timeout            time.Duration
-	InsecureSkipVerify bool
-	MaxConnsPerHost    int
-	UserAgent          string
-}
-
-// NewFastHTTPClientWithConfig creates a FastHTTPClient using a config struct.
-// This is a convenience method for external packages that prefer struct-based configuration.
-func NewFastHTTPClientWithConfig(cfg FastHTTPClientConfig) Client {
-	var opts []FastHTTPClientOption
-
-	if cfg.Timeout > 0 {
-		opts = append(opts, WithTimeout(cfg.Timeout))
-	}
-	if cfg.InsecureSkipVerify {
-		opts = append(opts, WithInsecureSkipVerify(true))
-	}
-	if cfg.MaxConnsPerHost > 0 {
-		opts = append(opts, WithMaxConnsPerHost(cfg.MaxConnsPerHost))
-	}
-	if cfg.UserAgent != "" {
-		opts = append(opts, WithUserAgent(cfg.UserAgent))
-	}
-
-	return NewFastHTTPClient(opts...)
+	return &FastHTTPClient{client: client}
 }
 
 func (c *FastHTTPClient) Do(req *http.Request) (*http.Response, error) {
@@ -228,94 +88,61 @@ func (c *FastHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	fastResp := fasthttp.AcquireResponse()
 	defer fasthttp.ReleaseRequest(fastReq)
 
-	// Set URI - use URI() for better performance when possible
 	if req.URL != nil {
 		fastReq.SetRequestURI(req.URL.String())
 	}
 
-	// Set method
 	fastReq.Header.SetMethod(req.Method)
 
-	// Set Host header first (before other headers that might override it)
 	if req.Host != "" {
 		fastReq.Header.SetHost(req.Host)
-	} else if req.URL != nil && req.URL.Host != "" {
+	} else if req.URL != nil {
 		fastReq.Header.SetHost(req.URL.Host)
 	}
 
-	// Copy headers - use Set for single values, Add for multiple
 	for key, values := range req.Header {
-		if len(values) == 1 {
-			fastReq.Header.Set(key, values[0])
-		} else {
-			for _, value := range values {
-				fastReq.Header.Add(key, value)
-			}
+		for _, value := range values {
+			fastReq.Header.Set(key, value)
 		}
 	}
 
-	// Set default User-Agent if configured and not already set in request
-	if c.userAgent != "" && len(req.Header.Get("User-Agent")) == 0 {
-		fastReq.Header.Set("User-Agent", c.userAgent)
-	}
-
-	// Set request body
 	if req.Body != nil {
 		body, err := io.ReadAll(req.Body)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read request body: %w", err)
+			fasthttp.ReleaseResponse(fastResp)
+			return nil, err
 		}
-		// Use SetBodyRaw to avoid extra copy (fasthttp will not modify it)
 		fastReq.SetBodyRaw(body)
-		// Always close the body
 		_ = req.Body.Close()
 	}
 
-	// Execute request
 	if err := c.client.Do(fastReq, fastResp); err != nil {
 		fasthttp.ReleaseResponse(fastResp)
 		return nil, err
 	}
 
-	// Build response - MUST copy body before releasing fastResp
-	// fastResp.Body() returns a reference to internal buffer that will be reused
 	respBody := fastResp.Body()
 	bodyCopy := make([]byte, len(respBody))
 	copy(bodyCopy, respBody)
 
 	statusCode := fastResp.StatusCode()
 
-	// Pre-allocate header map with estimated size
-	headerCount := 0
-	fastResp.Header.VisitAll(func(_, _ []byte) { headerCount++ })
-	headers := make(http.Header, headerCount)
-
-	// Copy headers with proper canonical formatting
+	headers := make(http.Header, 8)
 	fastResp.Header.VisitAll(func(key, value []byte) {
-		// http.Header.Add handles canonical key conversion
-		headers.Add(string(key), string(value))
+		headers.Set(string(key), string(value))
 	})
 
-	// Get content length
-	contentLength := int64(len(bodyCopy))
-	if cl := fastResp.Header.ContentLength(); cl >= 0 {
-		contentLength = int64(cl)
-	}
-
-	// Build the response
 	resp := &http.Response{
-		Status:        fmt.Sprintf("%d %s", statusCode, http.StatusText(statusCode)),
 		StatusCode:    statusCode,
 		Proto:         "HTTP/1.1",
 		ProtoMajor:    1,
 		ProtoMinor:    1,
 		Header:        headers,
 		Body:          io.NopCloser(bytes.NewReader(bodyCopy)),
-		ContentLength: contentLength,
+		ContentLength: int64(len(bodyCopy)),
 		Request:       req,
 	}
 
-	// Now safe to release the response
 	fasthttp.ReleaseResponse(fastResp)
 
 	return resp, nil

--- a/pkg/infra/plugins/manager.go
+++ b/pkg/infra/plugins/manager.go
@@ -2,7 +2,6 @@ package plugins
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"net/http"
@@ -185,11 +184,6 @@ func (m *manager) InitializePlugins() {
 
 	if err := m.RegisterPlugin(neuraltrust_moderation.NewNeuralTrustModerationPlugin(
 		m.logger,
-		&http.Client{ //nolint
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // #nosec G402
-			},
-		},
 		m.fingerprintTracker,
 		m.providerLocator,
 		m.firewallFactory,

--- a/pkg/infra/plugins/manager.go
+++ b/pkg/infra/plugins/manager.go
@@ -385,7 +385,6 @@ func (m *manager) executeSequential(
 				return err
 			}
 			if pluginResp != nil {
-				m.mu.Lock()
 				resp.StatusCode = pluginResp.StatusCode
 				if pluginResp.Body != nil {
 					resp.Body = pluginResp.Body
@@ -403,7 +402,6 @@ func (m *manager) executeSequential(
 						resp.Metadata[k] = v
 					}
 				}
-				m.mu.Unlock()
 			}
 		}
 	}
@@ -444,6 +442,7 @@ func (m *manager) executeParallel(
 
 		results := make([]pluginResult, 0, len(group))
 		var resultsMu sync.Mutex
+		var respMu sync.Mutex
 
 		g, gctx := errgroup.WithContext(ctx)
 
@@ -462,7 +461,7 @@ func (m *manager) executeParallel(
 						Err:        errors.New("plugin not found: " + cfg.Name),
 						StatusCode: 500,
 					}
-					m.applyPluginErrorToResponse(pe, resp)
+					applyPluginErrorToResponse(pe, resp, &respMu)
 					return pe
 				}
 
@@ -473,25 +472,17 @@ func (m *manager) executeParallel(
 
 				select {
 				case <-gctx.Done():
-					// Context was canceled (likely by another plugin returning an error)
-					// Return nil so the errgroup doesn't treat this as an error
-					// The errgroup already has the first error, so this won't affect g.Wait()
 					return nil
 				default:
 				}
 
 				if err != nil {
-					// Check if the error is due to context cancellation
-					// This handles cases where the plugin executed and encountered
-					// context.Canceled during HTTP call or other operations
 					if errors.Is(err, context.Canceled) {
-						// Context was canceled, return success instead of error
-						// The errgroup already has the first error (from the plugin that triggered cancellation)
 						return nil
 					}
 					var pe *pluginTypes.PluginError
 					if errors.As(err, &pe) {
-						m.applyPluginErrorToResponse(pe, resp)
+						applyPluginErrorToResponse(pe, resp, &respMu)
 						return pe
 					}
 					return err
@@ -511,13 +502,10 @@ func (m *manager) executeParallel(
 			})
 		}
 
-		// Group wait: if it returns an error, it was the first one and we've already set resp (headers/status)
 		if err := g.Wait(); err != nil {
 			return err
 		}
 
-		// If there were no errors, apply all successful results
-		// Deterministic order by plugin name (or any field from cfg you prefer)
 		sort.Slice(results, func(i, j int) bool {
 			return results[i].cfg.Name < results[j].cfg.Name
 		})
@@ -526,7 +514,6 @@ func (m *manager) executeParallel(
 			if r.resp == nil {
 				continue
 			}
-			m.mu.Lock()
 			if r.resp.StatusCode > 0 {
 				resp.StatusCode = r.resp.StatusCode
 			}
@@ -549,16 +536,15 @@ func (m *manager) executeParallel(
 					resp.Metadata[k] = v
 				}
 			}
-			m.mu.Unlock()
 		}
 	}
 
 	return nil
 }
 
-func (m *manager) applyPluginErrorToResponse(pe *pluginTypes.PluginError, resp *types.ResponseContext) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+func applyPluginErrorToResponse(pe *pluginTypes.PluginError, resp *types.ResponseContext, mu *sync.Mutex) {
+	mu.Lock()
+	defer mu.Unlock()
 	if pe.StatusCode > 0 {
 		resp.StatusCode = pe.StatusCode
 	} else {

--- a/pkg/infra/plugins/neuraltrust_moderation/neuraltrust_moderation.go
+++ b/pkg/infra/plugins/neuraltrust_moderation/neuraltrust_moderation.go
@@ -26,7 +26,8 @@ import (
 )
 
 const (
-	PluginName = "neuraltrust_moderation"
+	PluginName             = "neuraltrust_moderation"
+	maxModerationInputSize = 10 * 1024 * 1024 // 10 MB
 )
 
 type LLMResponse struct {
@@ -192,6 +193,9 @@ func (p *NeuralTrustModerationPlugin) Execute(
 	inputBytes, err := p.resolveInput(req, resp, conf.MappingField)
 	if err != nil {
 		return nil, err
+	}
+	if len(inputBytes) > maxModerationInputSize {
+		inputBytes = inputBytes[:maxModerationInputSize]
 	}
 
 	evt := &NeuralTrustModerationData{
@@ -738,18 +742,25 @@ func (p *NeuralTrustModerationPlugin) levenshteinDistance(s1, s2 string) int {
 		n = maxWordLen
 	}
 
+	// Bounded size visible at allocation site so static analysis can verify
+	// that n+1 cannot overflow. n is guaranteed <= maxWordLen (4096).
+	size := n + 1
+	if size < 0 || size > maxWordLen+1 {
+		return max(m, n)
+	}
+
 	pair := levPairPool.Get().(*levPair)
 	prev := pair.a
 	curr := pair.b
-	if cap(prev) < n+1 {
-		prev = make([]int, n+1)
+	if cap(prev) < size {
+		prev = make([]int, size)
 	} else {
-		prev = prev[:n+1]
+		prev = prev[:size]
 	}
-	if cap(curr) < n+1 {
-		curr = make([]int, n+1)
+	if cap(curr) < size {
+		curr = make([]int, size)
 	} else {
-		curr = curr[:n+1]
+		curr = curr[:size]
 	}
 
 	for j := 0; j <= n; j++ {

--- a/pkg/infra/plugins/neuraltrust_moderation/neuraltrust_moderation.go
+++ b/pkg/infra/plugins/neuraltrust_moderation/neuraltrust_moderation.go
@@ -1,9 +1,7 @@
 package neuraltrust_moderation
 
 import (
-	"bytes"
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -16,7 +14,6 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/common"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/fingerprint"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/firewall"
-	"github.com/NeuralTrust/TrustGate/pkg/infra/httpx"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/pluginiface"
 	pluginTypes "github.com/NeuralTrust/TrustGate/pkg/infra/plugins/types"
@@ -40,46 +37,42 @@ type LLMResponse struct {
 
 type NeuralTrustModerationPlugin struct {
 	basePlugin         *pluginTypes.BasePlugin
-	client             httpx.Client
 	fingerPrintManager fingerprint.Tracker
 	logger             *logrus.Logger
 	providerLocator    providersFactory.ProviderLocator
 	firewallFactory    firewall.ClientFactory
-	bufferPool         sync.Pool
-	byteSlicePool      sync.Pool
+}
+
+var (
+	regexCacheMu sync.RWMutex
+	regexCache   = make(map[string][]*regexp.Regexp)
+)
+
+type levPair struct {
+	a, b []int
+}
+
+var levPairPool = sync.Pool{
+	New: func() any {
+		return &levPair{
+			a: make([]int, 0, 128),
+			b: make([]int, 0, 128),
+		}
+	},
 }
 
 func NewNeuralTrustModerationPlugin(
 	logger *logrus.Logger,
-	client httpx.Client,
 	fingerPrintManager fingerprint.Tracker,
 	providerLocator providersFactory.ProviderLocator,
 	firewallFactory firewall.ClientFactory,
 ) pluginiface.Plugin {
-	if client == nil {
-		client = &http.Client{ //nolint
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // #nosec G402
-			},
-		}
-	}
 	return &NeuralTrustModerationPlugin{
 		basePlugin:         pluginTypes.NewBasePlugin(),
-		client:             client,
 		logger:             logger,
 		fingerPrintManager: fingerPrintManager,
 		providerLocator:    providerLocator,
 		firewallFactory:    firewallFactory,
-		bufferPool: sync.Pool{
-			New: func() any {
-				return new(bytes.Buffer)
-			},
-		},
-		byteSlicePool: sync.Pool{
-			New: func() any {
-				return make([]byte, 4096)
-			},
-		},
 	}
 }
 
@@ -287,14 +280,10 @@ func (p *NeuralTrustModerationPlugin) executeKeyReg(
 	evt *NeuralTrustModerationData,
 ) (bool, error) {
 	keywords := conf.KeyRegParamBag.Keywords
-	regexRules := make([]*regexp.Regexp, len(conf.KeyRegParamBag.Regex))
-	for i, pattern := range conf.KeyRegParamBag.Regex {
-		regex, err := regexp.Compile(pattern)
-		if err != nil {
-			p.logger.WithError(err).Error("failed to compile regex pattern")
-			return false, fmt.Errorf("failed to compile regex pattern '%s': %v", pattern, err)
-		}
-		regexRules[i] = regex
+	regexRules, err := getOrCompileRegex(conf.KeyRegParamBag.Regex)
+	if err != nil {
+		p.logger.WithError(err).Error("failed to compile regex pattern")
+		return false, err
 	}
 
 	threshold := conf.KeyRegParamBag.SimilarityThreshold
@@ -367,9 +356,8 @@ func (p *NeuralTrustModerationPlugin) notifyGuardrailViolation(ctx context.Conte
 		return
 	}
 	if storedFp != nil {
-		ttl := fingerprint.DefaultExpiration
-		if conf.RetentionPeriod == 0 {
-			conf.RetentionPeriod = 60
+		ttl := 60 * time.Second
+		if conf.RetentionPeriod > 0 {
 			ttl = time.Duration(conf.RetentionPeriod) * time.Second
 		}
 		err = p.fingerPrintManager.IncrementMaliciousCount(ctx, fp, ttl)
@@ -466,8 +454,7 @@ func (p *NeuralTrustModerationPlugin) callAIModeration(
 		return
 	}
 
-	p.logger.WithFields(logrus.Fields{"duration": duration, "response_body": string(responseBody)}).
-		Info("LLM provider responded successfully")
+	p.logger.WithField("duration", duration).Debug("LLM provider responded successfully")
 
 	// Parse the provider's raw JSON response to extract the text content.
 	textContent, parseErr := extractTextFromProviderResponse(responseBody)
@@ -688,8 +675,40 @@ func (p *NeuralTrustModerationPlugin) callKeyRegModeration(
 
 // local helpers removed in favor of pluginutils.DefineRequestBody
 
+func getOrCompileRegex(patterns []string) ([]*regexp.Regexp, error) {
+	if len(patterns) == 0 {
+		return nil, nil
+	}
+	key := strings.Join(patterns, "\x00")
+
+	regexCacheMu.RLock()
+	if cached, ok := regexCache[key]; ok {
+		regexCacheMu.RUnlock()
+		return cached, nil
+	}
+	regexCacheMu.RUnlock()
+
+	regexCacheMu.Lock()
+	defer regexCacheMu.Unlock()
+
+	if cached, ok := regexCache[key]; ok {
+		return cached, nil
+	}
+
+	compiled := make([]*regexp.Regexp, len(patterns))
+	for i, pattern := range patterns {
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			return nil, fmt.Errorf("failed to compile regex pattern '%s': %v", pattern, err)
+		}
+		compiled[i] = re
+	}
+
+	regexCache[key] = compiled
+	return compiled, nil
+}
+
 func (p *NeuralTrustModerationPlugin) levenshteinDistance(s1, s2 string) int {
-	// Bound input length early to avoid excessive allocations from untrusted data.
 	const maxWordLen = 4096
 	if len(s1) > maxWordLen {
 		s1 = s1[:maxWordLen]
@@ -710,21 +729,29 @@ func (p *NeuralTrustModerationPlugin) levenshteinDistance(s1, s2 string) int {
 		return m
 	}
 
-	// Ensure n <= m to minimize memory usage (only O(n) memory).
 	if n > m {
 		s1, s2 = s2, s1
 		m, n = n, m
 	}
 
-	// Explicitly cap n so the compiler (and static analysis) can verify n+1
-	// will not overflow. n is already bounded by maxWordLen via the truncation
-	// above, but this makes the invariant visible at the allocation site.
 	if n > maxWordLen {
 		n = maxWordLen
 	}
 
-	prev := make([]int, n+1)
-	curr := make([]int, n+1)
+	pair := levPairPool.Get().(*levPair)
+	prev := pair.a
+	curr := pair.b
+	if cap(prev) < n+1 {
+		prev = make([]int, n+1)
+	} else {
+		prev = prev[:n+1]
+	}
+	if cap(curr) < n+1 {
+		curr = make([]int, n+1)
+	} else {
+		curr = curr[:n+1]
+	}
+
 	for j := 0; j <= n; j++ {
 		prev[j] = j
 	}
@@ -737,7 +764,6 @@ func (p *NeuralTrustModerationPlugin) levenshteinDistance(s1, s2 string) int {
 			if c1 == s2[j-1] {
 				cost = 0
 			}
-			// min of: deletion (prev[j]+1), insertion (curr[j-1]+1), substitution (prev[j-1]+cost)
 			deletion := prev[j] + 1
 			insertion := curr[j-1] + 1
 			subst := prev[j-1] + cost
@@ -757,7 +783,12 @@ func (p *NeuralTrustModerationPlugin) levenshteinDistance(s1, s2 string) int {
 		}
 		prev, curr = curr, prev
 	}
-	return prev[n]
+
+	result := prev[n]
+	pair.a = prev
+	pair.b = curr
+	levPairPool.Put(pair)
+	return result
 }
 
 func (p *NeuralTrustModerationPlugin) calculateSimilarity(s1, s2 string) float64 {

--- a/pkg/infra/plugins/neuraltrust_moderation/neuraltrust_moderation_test.go
+++ b/pkg/infra/plugins/neuraltrust_moderation/neuraltrust_moderation_test.go
@@ -8,7 +8,6 @@ import (
 
 	fingerprintMocks "github.com/NeuralTrust/TrustGate/pkg/infra/fingerprint/mocks"
 	firewallMocks "github.com/NeuralTrust/TrustGate/pkg/infra/firewall/mocks"
-	httpxMocks "github.com/NeuralTrust/TrustGate/pkg/infra/httpx/mocks"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/plugins/neuraltrust_moderation"
 	plugintypes "github.com/NeuralTrust/TrustGate/pkg/infra/plugins/types"
@@ -22,13 +21,11 @@ import (
 )
 
 func TestNeuralTrustModerationPlugin_Name(t *testing.T) {
-	mockClient := new(httpxMocks.MockHTTPClient)
 	fingerPrintTrackerMock := new(fingerprintMocks.Tracker)
 	providerLocatorMock := new(providerMocks.ProviderLocator)
 	firewallFactoryMock := new(firewallMocks.ClientFactory)
 	plugin := neuraltrust_moderation.NewNeuralTrustModerationPlugin(
 		logrus.New(),
-		mockClient,
 		fingerPrintTrackerMock,
 		providerLocatorMock,
 		firewallFactoryMock,
@@ -38,13 +35,11 @@ func TestNeuralTrustModerationPlugin_Name(t *testing.T) {
 }
 
 func TestNeuralTrustModerationPlugin_RequiredPlugins(t *testing.T) {
-	mockClient := new(httpxMocks.MockHTTPClient)
 	fingerPrintTrackerMock := new(fingerprintMocks.Tracker)
 	providerLocatorMock := new(providerMocks.ProviderLocator)
 	firewallFactoryMock := new(firewallMocks.ClientFactory)
 	plugin := neuraltrust_moderation.NewNeuralTrustModerationPlugin(
 		logrus.New(),
-		mockClient,
 		fingerPrintTrackerMock,
 		providerLocatorMock,
 		firewallFactoryMock,
@@ -54,14 +49,12 @@ func TestNeuralTrustModerationPlugin_RequiredPlugins(t *testing.T) {
 }
 
 func TestNeuralTrustModerationPlugin_Stages(t *testing.T) {
-	mockClient := new(httpxMocks.MockHTTPClient)
 	fingerPrintTrackerMock := new(fingerprintMocks.Tracker)
 	providerLocatorMock := new(providerMocks.ProviderLocator)
 	firewallFactoryMock := new(firewallMocks.ClientFactory)
 
 	plugin := neuraltrust_moderation.NewNeuralTrustModerationPlugin(
 		logrus.New(),
-		mockClient,
 		fingerPrintTrackerMock,
 		providerLocatorMock,
 		firewallFactoryMock,
@@ -71,14 +64,12 @@ func TestNeuralTrustModerationPlugin_Stages(t *testing.T) {
 }
 
 func TestNeuralTrustModerationPlugin_AllowedStages(t *testing.T) {
-	mockClient := new(httpxMocks.MockHTTPClient)
 	fingerPrintTrackerMock := new(fingerprintMocks.Tracker)
 	providerLocatorMock := new(providerMocks.ProviderLocator)
 	firewallFactoryMock := new(firewallMocks.ClientFactory)
 
 	plugin := neuraltrust_moderation.NewNeuralTrustModerationPlugin(
 		logrus.New(),
-		mockClient,
 		fingerPrintTrackerMock,
 		providerLocatorMock,
 		firewallFactoryMock,
@@ -88,14 +79,12 @@ func TestNeuralTrustModerationPlugin_AllowedStages(t *testing.T) {
 }
 
 func TestNeuralTrustModerationPlugin_ValidateConfig(t *testing.T) {
-	mockClient := new(httpxMocks.MockHTTPClient)
 	fingerPrintTrackerMock := new(fingerprintMocks.Tracker)
 	providerLocatorMock := new(providerMocks.ProviderLocator)
 	firewallFactoryMock := new(firewallMocks.ClientFactory)
 
 	plugin := neuraltrust_moderation.NewNeuralTrustModerationPlugin(
 		logrus.New(),
-		mockClient,
 		fingerPrintTrackerMock,
 		providerLocatorMock,
 		firewallFactoryMock,
@@ -235,14 +224,12 @@ func TestNeuralTrustModerationPlugin_ValidateConfig(t *testing.T) {
 }
 
 func TestNeuralTrustModerationPlugin_Execute_KeyRegSafe(t *testing.T) {
-	mockClient := new(httpxMocks.MockHTTPClient)
 	fingerPrintTrackerMock := new(fingerprintMocks.Tracker)
 	providerLocatorMock := new(providerMocks.ProviderLocator)
 	firewallFactoryMock := new(firewallMocks.ClientFactory)
 
 	plugin := neuraltrust_moderation.NewNeuralTrustModerationPlugin(
 		logrus.New(),
-		mockClient,
 		fingerPrintTrackerMock,
 		providerLocatorMock,
 		firewallFactoryMock,
@@ -277,14 +264,12 @@ func TestNeuralTrustModerationPlugin_Execute_KeyRegSafe(t *testing.T) {
 }
 
 func TestNeuralTrustModerationPlugin_Execute_KeyRegKeywordBlocked(t *testing.T) {
-	mockClient := new(httpxMocks.MockHTTPClient)
 	fingerPrintTrackerMock := new(fingerprintMocks.Tracker)
 	providerLocatorMock := new(providerMocks.ProviderLocator)
 	firewallFactoryMock := new(firewallMocks.ClientFactory)
 
 	plugin := neuraltrust_moderation.NewNeuralTrustModerationPlugin(
 		logrus.New(),
-		mockClient,
 		fingerPrintTrackerMock,
 		providerLocatorMock,
 		firewallFactoryMock,
@@ -319,14 +304,12 @@ func TestNeuralTrustModerationPlugin_Execute_KeyRegKeywordBlocked(t *testing.T) 
 }
 
 func TestNeuralTrustModerationPlugin_Execute_KeyRegSimilarWordBlocked(t *testing.T) {
-	mockClient := new(httpxMocks.MockHTTPClient)
 	fingerPrintTrackerMock := new(fingerprintMocks.Tracker)
 	providerLocatorMock := new(providerMocks.ProviderLocator)
 	firewallFactoryMock := new(firewallMocks.ClientFactory)
 
 	plugin := neuraltrust_moderation.NewNeuralTrustModerationPlugin(
 		logrus.New(),
-		mockClient,
 		fingerPrintTrackerMock,
 		providerLocatorMock,
 		firewallFactoryMock,
@@ -361,14 +344,12 @@ func TestNeuralTrustModerationPlugin_Execute_KeyRegSimilarWordBlocked(t *testing
 }
 
 func TestNeuralTrustModerationPlugin_Execute_KeyRegRegexBlocked(t *testing.T) {
-	mockClient := new(httpxMocks.MockHTTPClient)
 	fingerPrintTrackerMock := new(fingerprintMocks.Tracker)
 	providerLocatorMock := new(providerMocks.ProviderLocator)
 	firewallFactoryMock := new(firewallMocks.ClientFactory)
 
 	plugin := neuraltrust_moderation.NewNeuralTrustModerationPlugin(
 		logrus.New(),
-		mockClient,
 		fingerPrintTrackerMock,
 		providerLocatorMock,
 		firewallFactoryMock,
@@ -403,7 +384,6 @@ func TestNeuralTrustModerationPlugin_Execute_KeyRegRegexBlocked(t *testing.T) {
 }
 
 func TestNeuralTrustModerationPlugin_Execute_LLMModeration(t *testing.T) {
-	mockClient := new(httpxMocks.MockHTTPClient)
 	fingerPrintTrackerMock := new(fingerprintMocks.Tracker)
 	providerLocatorMock := new(providerMocks.ProviderLocator)
 	firewallFactoryMock := new(firewallMocks.ClientFactory)
@@ -434,7 +414,6 @@ func TestNeuralTrustModerationPlugin_Execute_LLMModeration(t *testing.T) {
 
 	plugin := neuraltrust_moderation.NewNeuralTrustModerationPlugin(
 		logrus.New(),
-		mockClient,
 		fingerPrintTrackerMock,
 		providerLocatorMock,
 		firewallFactoryMock,
@@ -468,7 +447,6 @@ func TestNeuralTrustModerationPlugin_Execute_LLMModeration(t *testing.T) {
 }
 
 func TestNeuralTrustModerationPlugin_Execute_LLMModerationSafe(t *testing.T) {
-	mockClient := new(httpxMocks.MockHTTPClient)
 	fingerPrintTrackerMock := new(fingerprintMocks.Tracker)
 	providerLocatorMock := new(providerMocks.ProviderLocator)
 	firewallFactoryMock := new(firewallMocks.ClientFactory)
@@ -499,7 +477,6 @@ func TestNeuralTrustModerationPlugin_Execute_LLMModerationSafe(t *testing.T) {
 
 	plugin := neuraltrust_moderation.NewNeuralTrustModerationPlugin(
 		logrus.New(),
-		mockClient,
 		fingerPrintTrackerMock,
 		providerLocatorMock,
 		firewallFactoryMock,
@@ -533,14 +510,12 @@ func TestNeuralTrustModerationPlugin_Execute_LLMModerationSafe(t *testing.T) {
 }
 
 func TestNeuralTrustModerationPlugin_Execute_WithMessages_KeyRegSafe(t *testing.T) {
-	mockClient := new(httpxMocks.MockHTTPClient)
 	fingerPrintTrackerMock := new(fingerprintMocks.Tracker)
 	providerLocatorMock := new(providerMocks.ProviderLocator)
 	firewallFactoryMock := new(firewallMocks.ClientFactory)
 
 	plugin := neuraltrust_moderation.NewNeuralTrustModerationPlugin(
 		logrus.New(),
-		mockClient,
 		fingerPrintTrackerMock,
 		providerLocatorMock,
 		firewallFactoryMock,
@@ -576,14 +551,12 @@ func TestNeuralTrustModerationPlugin_Execute_WithMessages_KeyRegSafe(t *testing.
 }
 
 func TestNeuralTrustModerationPlugin_Execute_WithMessages_KeyRegBlocked(t *testing.T) {
-	mockClient := new(httpxMocks.MockHTTPClient)
 	fingerPrintTrackerMock := new(fingerprintMocks.Tracker)
 	providerLocatorMock := new(providerMocks.ProviderLocator)
 	firewallFactoryMock := new(firewallMocks.ClientFactory)
 
 	plugin := neuraltrust_moderation.NewNeuralTrustModerationPlugin(
 		logrus.New(),
-		mockClient,
 		fingerPrintTrackerMock,
 		providerLocatorMock,
 		firewallFactoryMock,
@@ -619,14 +592,12 @@ func TestNeuralTrustModerationPlugin_Execute_WithMessages_KeyRegBlocked(t *testi
 }
 
 func TestNeuralTrustModerationPlugin_Execute_ObserveMode_Returns200(t *testing.T) {
-	mockClient := new(httpxMocks.MockHTTPClient)
 	fingerPrintTrackerMock := new(fingerprintMocks.Tracker)
 	providerLocatorMock := new(providerMocks.ProviderLocator)
 	firewallFactoryMock := new(firewallMocks.ClientFactory)
 
 	plugin := neuraltrust_moderation.NewNeuralTrustModerationPlugin(
 		logrus.New(),
-		mockClient,
 		fingerPrintTrackerMock,
 		providerLocatorMock,
 		firewallFactoryMock,
@@ -663,14 +634,12 @@ func TestNeuralTrustModerationPlugin_Execute_ObserveMode_Returns200(t *testing.T
 }
 
 func TestNeuralTrustModerationPlugin_Execute_EnforceMode_Returns403(t *testing.T) {
-	mockClient := new(httpxMocks.MockHTTPClient)
 	fingerPrintTrackerMock := new(fingerprintMocks.Tracker)
 	providerLocatorMock := new(providerMocks.ProviderLocator)
 	firewallFactoryMock := new(firewallMocks.ClientFactory)
 
 	plugin := neuraltrust_moderation.NewNeuralTrustModerationPlugin(
 		logrus.New(),
-		mockClient,
 		fingerPrintTrackerMock,
 		providerLocatorMock,
 		firewallFactoryMock,
@@ -712,7 +681,6 @@ func TestNeuralTrustModerationPlugin_Execute_EnforceMode_Returns403(t *testing.T
 }
 
 func TestNeuralTrustModerationPlugin_Execute_LLMModeration_ObserveMode(t *testing.T) {
-	mockClient := new(httpxMocks.MockHTTPClient)
 	fingerPrintTrackerMock := new(fingerprintMocks.Tracker)
 	providerLocatorMock := new(providerMocks.ProviderLocator)
 	firewallFactoryMock := new(firewallMocks.ClientFactory)
@@ -743,7 +711,6 @@ func TestNeuralTrustModerationPlugin_Execute_LLMModeration_ObserveMode(t *testin
 
 	plugin := neuraltrust_moderation.NewNeuralTrustModerationPlugin(
 		logrus.New(),
-		mockClient,
 		fingerPrintTrackerMock,
 		providerLocatorMock,
 		firewallFactoryMock,

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	Version   = "1.13.4"
+	Version   = "1.13.5"
 	AppName   = "TrustGate"
 	BuildDate = "unknown"
 )


### PR DESCRIPTION
## Optimize guardrail plugins for high-concurrency throughput

### Summary

- Replace the firewall HTTP client (`net/http`) with `fasthttp`-based client using aggressive connection pooling (512 conns/host), eliminate global mutex serialization in the plugin manager by using per-request locks, and streamline JSON response decoding in the firewall client
- Remove dead code from `neuraltrust_moderation` plugin (unused `httpx.Client`, `bufferPool`, `byteSlicePool`), cache compiled regex patterns to avoid `regexp.Compile` on every request, pool Levenshtein distance allocations via `sync.Pool`, and fix a bug where `RetentionPeriod > 0` was silently ignored
- Clean up `httpx/fasthttp.go` by removing ~170 lines of unused options, deprecated constructors, and dead configuration fields
- Bound moderation input size at entry point (10 MB cap) to prevent excessive allocations from untrusted data and satisfy CodeQL overflow analysis

### Changes

**Connection pooling & firewall client** (`container.go`, `neuraltrust_client.go`)
- Switched firewall HTTP client from `net/http.Client` to `httpx.NewFastHTTPClient` with `MaxConnsPerHost(512)` to eliminate connection pool exhaustion under load
- Replaced `io.ReadAll` + `json.Unmarshal` with streaming `json.NewDecoder().Decode()` for successful responses, reducing memory allocations

**Plugin manager concurrency** (`manager.go`)
- Removed global `m.mu.Lock()/Unlock()` from `executeSequential` — single-threaded path doesn't need locking
- Replaced global mutex in `executeParallel` with a per-request `sync.Mutex` scoped to each parallel execution group
- Converted `applyPluginErrorToResponse` from a method (using global mutex) to a standalone function accepting a local mutex

**Moderation plugin optimization** (`neuraltrust_moderation.go`)
- Removed dead fields: `client httpx.Client`, `bufferPool sync.Pool`, `byteSlicePool sync.Pool` and their initialization — none were referenced in execution paths
- Added regex compilation cache with double-checked locking (`sync.RWMutex`) following the same pattern as `code_sanitation` plugin
- Pooled Levenshtein distance `[]int` slices via `sync.Pool` (`levPairPool`) to eliminate thousands of small allocations per request during keyword similarity checks
- Changed LLM response body logging from `Info` (with full `string(responseBody)` conversion) to `Debug` with duration only — avoids large heap allocation on every successful moderation call
- Fixed `RetentionPeriod` bug: previously used `DefaultExpiration` when `RetentionPeriod > 0` and a custom value when `== 0` (inverted logic)
- Simplified constructor signature (removed unused `client` parameter), updated `manager.go` caller and all 17 tests
- Added `maxModerationInputSize` (10 MB) clamp at `Execute()` entry point to bound all downstream allocations and resolve CodeQL size-overflow warnings

**fasthttp adapter cleanup** (`httpx/fasthttp.go`)
- Removed ~170 lines: `NewFastHTTPClientWithClient`, `NewFastHTTPClientWithConfig`, `FastHTTPClientConfig`, and 6 unused option functions (`WithReadBufferSize`, `WithWriteBufferSize`, `WithMaxResponseBodySize`, `WithUserAgent`, `WithReadTimeout`, `WithWriteTimeout`)
- Simplified `Do()` method: removed user-agent injection logic, ensured `fasthttp.ReleaseResponse` on all error paths

### Test plan

- [x] All 17 existing moderation plugin tests pass
- [x] Full `go build ./...` succeeds with zero errors
- [x] No linter warnings introduced