### PR TITLE
fix: streaming outside provider

### DIFF
--- a/pkg/handlers/http/forwarded_handler.go
+++ b/pkg/handlers/http/forwarded_handler.go
@@ -723,7 +723,7 @@ func (h *forwardedHandler) forwardRequest(
 	default:
 		close(streamResponse)
 	}
-	return nil, fmt.Errorf("%v", reqErr)
+	return nil, fmt.Errorf("%w", reqErr)
 }
 
 func (h *forwardedHandler) applyTargetOAuth(

--- a/pkg/handlers/http/forwarded_handler.go
+++ b/pkg/handlers/http/forwarded_handler.go
@@ -396,10 +396,19 @@ func (h *forwardedHandler) Handle(c *fiber.Ctx) error {
 		lb,
 	)
 	if err != nil {
-		h.logger.WithError(err).Error("Failed to forward request")
-		h.registryFailedEvent(metricsCollector, fiber.StatusInternalServerError, err, respCtx)
 		close(streamPluginData)
 		close(pluginsDone)
+
+		if adapter.IsRequestDecodeError(err) {
+			h.logger.WithError(err).Warn("Invalid request body")
+			h.registryFailedEvent(metricsCollector, fiber.StatusBadRequest, err, respCtx)
+			return h.handleErrorResponse(c, fiber.StatusBadRequest, fiber.Map{
+				"error": "invalid request body: the payload does not match the expected API format for the configured upstream",
+			})
+		}
+
+		h.logger.WithError(err).Error("Failed to forward request")
+		h.registryFailedEvent(metricsCollector, fiber.StatusInternalServerError, err, respCtx)
 		return h.handleErrorResponse(c, fiber.StatusBadGateway, fiber.Map{
 			"error":   "failed to forward request",
 			"message": err.Error(),
@@ -1126,24 +1135,8 @@ func (h *forwardedHandler) handleStreamingRequest(dto *forwardedRequestDTO, clie
 }
 
 func (h *forwardedHandler) handleStreamingResponse(dto *forwardedRequestDTO, client *http.Client) (*types.ResponseContext, error) {
-	req := dto.req
-	target := dto.target
-
-	pathParams := h.getPathParamsFromContext(req.Context)
-	upstreamURL := h.buildUpstreamTargetUrl(target, pathParams)
-
-	if len(req.Query) > 0 {
-		queryString := req.Query.Encode()
-		if queryString != "" {
-			if strings.Contains(upstreamURL, "?") {
-				upstreamURL += "&" + queryString
-			} else {
-				upstreamURL += "?" + queryString
-			}
-		}
-	}
-
-	return infrahttpx.HandleHTTPStream(h.logger, client, upstreamURL, req, target, dto.streamResponse)
+	upstreamURL := h.rewriteTargetURL(dto)
+	return infrahttpx.HandleHTTPStream(h.logger, client, upstreamURL, dto.req, dto.target, dto.streamResponse)
 }
 
 func (h *forwardedHandler) buildUpstreamTargetUrl(target *types.UpstreamTargetDTO, pathParams map[string]string) string {

--- a/pkg/infra/httpx/http_response_handler.go
+++ b/pkg/infra/httpx/http_response_handler.go
@@ -3,7 +3,6 @@ package httpx
 import (
 	"bufio"
 	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -38,8 +37,12 @@ func HandleHTTPStream(
 		}
 	}
 
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Accept", "text/event-stream")
+	if httpReq.Header.Get("Content-Type") == "" {
+		httpReq.Header.Set("Content-Type", "application/json")
+	}
+	if httpReq.Header.Get("Accept") == "" {
+		httpReq.Header.Set("Accept", "text/event-stream")
+	}
 	httpReq.Header.Set("Cache-Control", "no-cache")
 	httpReq.Header.Set("Connection", "keep-alive")
 
@@ -97,6 +100,10 @@ func HandleHTTPStream(
 		reader := bufio.NewReader(resp.Body)
 		for {
 			line, err := reader.ReadBytes('\n')
+			if len(line) > 0 {
+				_, _ = w.Write(line)
+				_ = w.Flush()
+			}
 			if err != nil {
 				if err != io.EOF {
 					logger.WithError(err).Error("error reading streaming response")
@@ -104,33 +111,12 @@ func HandleHTTPStream(
 				break
 			}
 
-			if bytes.HasPrefix(line, []byte("data: ")) {
-				line = bytes.TrimPrefix(line, []byte("data: "))
+			if bytes.HasPrefix(line, sseDataPrefix) {
+				payload := bytes.TrimSpace(bytes.TrimPrefix(line, sseDataPrefix))
+				if len(payload) > 0 && !bytes.Equal(payload, sseDoneMarker) {
+					fwd.Send(payload)
+				}
 			}
-
-			if len(line) <= 1 {
-				continue
-			}
-
-			var parsed map[string]interface{}
-			if err := json.Unmarshal(line, &parsed); err != nil {
-				fwd.Send(line)
-				_, _ = fmt.Fprintf(w, "data: %s\n", string(line)) // #nosec G705
-				_ = w.Flush()
-				continue
-			}
-
-			var buffer bytes.Buffer
-			encoder := json.NewEncoder(&buffer)
-			encoder.SetEscapeHTML(false)
-
-			if err := encoder.Encode(parsed); err != nil {
-				logger.WithError(err).Error("error encoding stream payload")
-				return
-			}
-			fwd.Send(buffer.Bytes())
-			_, _ = fmt.Fprintf(w, "data: %s\n", buffer.String())
-			_ = w.Flush()
 		}
 	})
 

--- a/pkg/infra/providers/adapter/registry.go
+++ b/pkg/infra/providers/adapter/registry.go
@@ -1,6 +1,38 @@
 package adapter
 
-import "fmt"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// RequestDecodeError signals that the incoming request body could not be
+// parsed into the expected provider format.  The handler should surface this
+// as an HTTP 400 instead of a 502.
+type RequestDecodeError struct {
+	Format Format
+	Cause  error
+}
+
+func (e *RequestDecodeError) Error() string {
+	return fmt.Sprintf("invalid request body for format %q: the payload could not be parsed as a valid %s API request", e.Format, e.Format)
+}
+
+func (e *RequestDecodeError) Unwrap() error { return e.Cause }
+
+// IsRequestDecodeError returns true when err (or any error in its chain) is a
+// RequestDecodeError, i.e. the caller sent a body that does not match the
+// expected provider format.
+func IsRequestDecodeError(err error) bool {
+	var target *RequestDecodeError
+	return errors.As(err, &target)
+}
+
+func isJSONError(err error) bool {
+	var synErr *json.SyntaxError
+	var typeErr *json.UnmarshalTypeError
+	return errors.As(err, &synErr) || errors.As(err, &typeErr)
+}
 
 // RequestAdapter converts between a provider's native request format and the
 // canonical internal model.
@@ -82,7 +114,14 @@ func (r *Registry) DecodeRequestFor(body []byte, providerFormat Format) (*Canoni
 	if err != nil {
 		return nil, fmt.Errorf("adapter request: %w", err)
 	}
-	return a.DecodeRequest(body)
+	cr, decErr := a.DecodeRequest(body)
+	if decErr != nil {
+		if isJSONError(decErr) {
+			return nil, &RequestDecodeError{Format: providerFormat, Cause: decErr}
+		}
+		return nil, decErr
+	}
+	return cr, nil
 }
 
 // AdaptRequest transforms a request body from source format to target format
@@ -105,6 +144,9 @@ func (r *Registry) AdaptRequest(body []byte, source, target Format) ([]byte, err
 
 	canonical, err := srcAdapter.DecodeRequest(body)
 	if err != nil {
+		if isJSONError(err) {
+			return nil, &RequestDecodeError{Format: source, Cause: err}
+		}
 		return nil, fmt.Errorf("adapter request decode (%s): %w", source, err)
 	}
 

--- a/tests/functional/invalid_request_body_test.go
+++ b/tests/functional/invalid_request_body_test.go
@@ -1,0 +1,172 @@
+package functional_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInvalidRequestBody_Returns400 verifies that sending a malformed request
+// body to a provider-backed upstream returns HTTP 400 (Bad Request) with a
+// user-friendly error message, instead of the previous behaviour of returning
+// 502 (Bad Gateway) with raw JSON parsing internals leaked in the response.
+func TestInvalidRequestBody_Returns400(t *testing.T) {
+	defer RunTest(t, "InvalidRequestBody", time.Now())()
+
+	subdomain := fmt.Sprintf("invalid-body-%d", time.Now().Unix())
+	gatewayID := CreateGateway(t, map[string]interface{}{
+		"name":      "Invalid Request Body Test Gateway",
+		"subdomain": subdomain,
+	})
+
+	apiKey := CreateApiKey(t, gatewayID)
+
+	upstreamID := CreateUpstream(t, gatewayID, map[string]interface{}{
+		"name":      fmt.Sprintf("invalid-body-upstream-%d", time.Now().Unix()),
+		"algorithm": "round-robin",
+		"targets": []map[string]interface{}{
+			{
+				"provider":      "google",
+				"weight":        100,
+				"priority":      1,
+				"default_model": "gemini-2.0-flash-001",
+				"models":        []string{"gemini-2.0-flash-001"},
+				"credentials":   map[string]string{"api_key": "fake-key-for-decode-test"},
+			},
+		},
+	})
+
+	serviceID := CreateService(t, gatewayID, map[string]interface{}{
+		"name":        fmt.Sprintf("invalid-body-service-%d", time.Now().Unix()),
+		"type":        "upstream",
+		"description": "Invalid request body test service",
+		"upstream_id": upstreamID,
+	})
+
+	CreateRules(t, gatewayID, map[string]interface{}{
+		"path":       "/v1/chat/completions",
+		"service_id": serviceID,
+		"methods":    []string{"POST"},
+		"strip_path": false,
+		"active":     true,
+	})
+
+	time.Sleep(2 * time.Second)
+
+	host := fmt.Sprintf("%s.%s", subdomain, BaseDomain)
+
+	tests := []struct {
+		name        string
+		body        string
+		contentType string
+		wantStatus  int
+		wantError   string
+	}{
+		{
+			name:        "completely invalid JSON",
+			body:        `{this is not json at all}`,
+			contentType: "application/json",
+			wantStatus:  http.StatusBadRequest,
+			wantError:   "invalid request body",
+		},
+		{
+			name:        "truncated JSON",
+			body:        `{"model": "gpt-4", "messages": [{"role": "user", "content":`,
+			contentType: "application/json",
+			wantStatus:  http.StatusBadRequest,
+			wantError:   "invalid request body",
+		},
+		{
+			name:        "temperature as string instead of number",
+			body:        `{"model": "gpt-4", "messages": [{"role": "user", "content": "hi"}], "temperature": "hot"}`,
+			contentType: "application/json",
+			wantStatus:  http.StatusBadRequest,
+			wantError:   "invalid request body",
+		},
+		{
+			name:        "binary-like garbage",
+			body:        "\x00\x01\x02\x03\x04",
+			contentType: "application/json",
+			wantStatus:  http.StatusBadRequest,
+			wantError:   "invalid request body",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest(
+				http.MethodPost,
+				ProxyUrl+"/v1/chat/completions",
+				io.NopCloser(strings.NewReader(tt.body)),
+			)
+			require.NoError(t, err)
+
+			req.Host = host
+			req.Header.Set("Host", host)
+			req.Header.Set("X-TG-API-Key", apiKey)
+			req.Header.Set("Content-Type", tt.contentType)
+
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer func() { _ = resp.Body.Close() }()
+
+			assert.Equal(t, tt.wantStatus, resp.StatusCode,
+				"expected %d but got %d", tt.wantStatus, resp.StatusCode)
+
+			respBytes, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			var respData map[string]interface{}
+			if json.Unmarshal(respBytes, &respData) == nil {
+				errorMsg, _ := respData["error"].(string)
+
+				assert.Contains(t, errorMsg, tt.wantError,
+					"error message should contain %q, got: %s", tt.wantError, errorMsg)
+
+				assert.NotContains(t, errorMsg, "invalid character",
+					"error should NOT leak raw JSON parsing details")
+				assert.NotContains(t, errorMsg, "numeric literal",
+					"error should NOT leak raw JSON parsing details")
+			}
+
+			t.Logf("got %d with body: %s", resp.StatusCode, string(respBytes))
+		})
+	}
+
+	t.Run("valid OpenAI body is NOT rejected as 400", func(t *testing.T) {
+		validBody, _ := json.Marshal(map[string]interface{}{
+			"model":    "gemini-2.0-flash-001",
+			"messages": []map[string]string{{"role": "user", "content": "hello"}},
+		})
+
+		req, err := http.NewRequest(
+			http.MethodPost,
+			ProxyUrl+"/v1/chat/completions",
+			bytes.NewReader(validBody),
+		)
+		require.NoError(t, err)
+
+		req.Host = host
+		req.Header.Set("Host", host)
+		req.Header.Set("X-TG-API-Key", apiKey)
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+
+		assert.NotEqual(t, http.StatusBadRequest, resp.StatusCode,
+			"valid body should NOT return 400; got %d (may be 401/502 with fake key, but not 400)",
+		)
+
+		t.Logf("valid body returned status %d (expected anything except 400)", resp.StatusCode)
+	})
+}


### PR DESCRIPTION
Fix missing strip_path in raw proxy streaming path: handleStreamingResponse was calling buildUpstreamTargetUrl directly, bypassing the rewriteTargetURL logic that applies strip_path and appends the remaining path after route match. This caused streaming requests to lose dynamic path segments (e.g., /models/gemini-2.5-flash:streamGenerateContent), while non-streaming requests worked correctly. Now both paths use rewriteTargetURL.

Fix lossy JSON re-encoding in HandleHTTPStream: The raw proxy streaming handler was deserializing each SSE data line into map[string]interface{} and re-serializing it before forwarding. This caused three problems: JSON key reordering (Go maps don't preserve order), loss of integer precision (int64 → float64), and corrupted SSE framing (json.Encoder.Encode() appends \n, then fmt.Fprintf added another \n, producing a triple newline that broke downstream SSE parsers). Replaced with transparent byte-level passthrough — upstream bytes are forwarded as-is, and only the data: payload is extracted for metrics/plugins.

Preserve client headers in raw proxy streaming: Content-Type and Accept headers are now set as defaults only when the client didn't provide them, instead of unconditionally overwriting client-sent values.

Preserve SSE event delimiters: Empty lines (SSE event boundaries) were being filtered out by a len(line) <= 1 check. These are now forwarded to maintain correct SSE framing for strict parsers.

