### PR TITLE
test: add functional e2e tests for each plugin

### DIFF
--- a/pkg/app/proxy/forwarder.go
+++ b/pkg/app/proxy/forwarder.go
@@ -45,6 +45,10 @@ type forwardRequestDTO struct {
 	request  *infracontext.RequestContext
 	response *infracontext.ResponseContext
 	policies []*policydomain.Policy
+	// baseHeaders are the response headers contributed by the pre_request
+	// plugin stage (e.g. CORS, rate-limit quota headers). They are preserved
+	// across failover attempts so the upstream relay does not drop them.
+	baseHeaders map[string][]string
 }
 
 //go:generate mockery --name=Forwarder --dir=. --output=./mocks --filename=forwarder_mock.go --case=underscore --with-expecter
@@ -116,7 +120,13 @@ func (f *forwarder) Forward(ctx context.Context, in ForwardInput) (*ForwardResul
 		return short, nil
 	}
 
-	dto := &forwardRequestDTO{backend: bk, request: in.Request, response: resp, policies: policies}
+	dto := &forwardRequestDTO{
+		backend:     bk,
+		request:     in.Request,
+		response:    resp,
+		policies:    policies,
+		baseHeaders: cloneHeaders(resp.Headers),
+	}
 	stream := DetectStream(dto.request)
 
 	return f.invokeWithFailover(ctx, lb, in.Consumer, dto, stream)
@@ -325,7 +335,7 @@ func (f *forwarder) finalizeBody(
 	providerResp *ProviderResponse,
 ) *ForwardResult {
 	pluginResp := dto.response
-	pluginResp.Headers = nil
+	pluginResp.Headers = cloneHeaders(dto.baseHeaders)
 	mergeProviderResponse(pluginResp, providerResp, false)
 	f.runPreResponse(ctx, dto.policies, dto.request, pluginResp)
 	f.firePostResponse(dto.policies, dto.request, pluginResp)
@@ -342,7 +352,7 @@ func (f *forwarder) finalizeBodyGated(
 	providerResp *ProviderResponse,
 ) (*ForwardResult, *appplugins.PluginError) {
 	pluginResp := dto.response
-	pluginResp.Headers = nil
+	pluginResp.Headers = cloneHeaders(dto.baseHeaders)
 	mergeProviderResponse(pluginResp, providerResp, false)
 	if pe := f.runPreResponseGated(ctx, dto.policies, dto.request, pluginResp); pe != nil {
 		return pluginErrorResult(pe), pe

--- a/pkg/app/proxy/plugin_runner.go
+++ b/pkg/app/proxy/plugin_runner.go
@@ -198,6 +198,19 @@ func snapshotResponse(resp *infracontext.ResponseContext) *infracontext.Response
 	return &clone
 }
 
+// cloneHeaders returns a deep copy of the header map so callers can reset a
+// response's headers to a known baseline without aliasing the source slices.
+func cloneHeaders(headers map[string][]string) map[string][]string {
+	if len(headers) == 0 {
+		return nil
+	}
+	out := make(map[string][]string, len(headers))
+	for name, values := range headers {
+		out[name] = append([]string(nil), values...)
+	}
+	return out
+}
+
 func copyMetadata(in map[string]interface{}) map[string]interface{} {
 	if in == nil {
 		return nil

--- a/pkg/container/modules/server_proxy.go
+++ b/pkg/container/modules/server_proxy.go
@@ -19,7 +19,6 @@ type proxyMiddlewares struct {
 	RequestID       *middleware.RequestIDMiddleware
 	PanicRecover    *middleware.PanicRecoverMiddleware
 	AccessLog       *middleware.AccessLogMiddleware
-	CORS            *middleware.CORSMiddleware
 	SecurityHeaders *middleware.SecurityHeadersMiddleware
 	Session         *middleware.SessionMiddleware
 	FingerPrint     *middleware.FingerPrintMiddleware
@@ -27,11 +26,15 @@ type proxyMiddlewares struct {
 	Metrics         *middleware.MetricsMiddleware
 }
 
+// proxyTransport intentionally omits the gateway-wide CORS middleware: on the
+// proxy plane CORS is owned per-route by the `cors` policy plugin, which
+// negotiates origins/methods and short-circuits preflight requests. Mounting
+// the global middleware here would intercept OPTIONS preflights before the
+// plugin runs and apply the gateway-wide defaults instead of the route policy.
 func proxyTransport(m proxyMiddlewares) *middleware.Transport {
 	return middleware.NewTransport(
 		m.RequestID,
 		m.SecurityHeaders,
-		m.CORS,
 		m.PanicRecover,
 		m.AccessLog,
 		m.Session,

--- a/tests/functional/plugin_cors_test.go
+++ b/tests/functional/plugin_cors_test.go
@@ -53,6 +53,7 @@ func TestPluginE2E_CORS(t *testing.T) {
 	})
 
 	t.Run("valid preflight short-circuits with negotiated headers", func(t *testing.T) {
+		hitsBefore := up.Hits()
 		status, headers, _ := proxyRequest(t, http.MethodOptions, gatewayID, path,
 			map[string]string{
 				"Origin":                        "https://allowed.com",
@@ -63,7 +64,7 @@ func TestPluginE2E_CORS(t *testing.T) {
 		assert.Equal(t, "https://allowed.com", headers.Get("Access-Control-Allow-Origin"))
 		assert.Contains(t, headers.Get("Access-Control-Allow-Methods"), "POST")
 		assert.Equal(t, "600s", headers.Get("Access-Control-Max-Age"))
-		assert.Equal(t, 0, up.Hits(), "a preflight must never reach the upstream")
+		assert.Equal(t, hitsBefore, up.Hits(), "a preflight must never reach the upstream")
 	})
 
 	t.Run("preflight with disallowed method is rejected", func(t *testing.T) {

--- a/tests/functional/plugin_cors_test.go
+++ b/tests/functional/plugin_cors_test.go
@@ -1,0 +1,128 @@
+package functional_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// corsSettings is the plugin configuration shared by the CORS e2e cases: a
+// single explicit origin and a small method allow-list.
+func corsSettings() map[string]any {
+	return map[string]any{
+		"allowed_origins":   []string{"https://allowed.com"},
+		"allowed_methods":   []string{"GET", "POST"},
+		"allow_credentials": false,
+		"max_age":           "600s",
+		"expose_headers":    []string{"X-Test"},
+		"log_violations":    true,
+	}
+}
+
+func TestPluginE2E_CORS(t *testing.T) {
+	defer Track(t, "PluginCORS")()
+
+	up := newJSONUpstream(t, "cors-upstream")
+	gatewayID, path := setupPolicyRoute(t, up,
+		policyPlugin("cors", "pre_request", corsSettings()),
+	)
+
+	t.Run("allowed origin simple request passes through", func(t *testing.T) {
+		status, _, body := proxyRequest(t, http.MethodPost, gatewayID, path,
+			map[string]string{"Origin": "https://allowed.com"},
+			mustJSON(t, chatRequest(false)),
+		)
+		assert.Equal(t, http.StatusOK, status, "body: %s", body)
+		assert.Contains(t, string(body), "cors-upstream")
+	})
+
+	t.Run("disallowed origin is rejected", func(t *testing.T) {
+		status, _, _ := proxyRequest(t, http.MethodPost, gatewayID, path,
+			map[string]string{"Origin": "https://evil.com"},
+			mustJSON(t, chatRequest(false)),
+		)
+		assert.Equal(t, http.StatusForbidden, status)
+	})
+
+	t.Run("missing origin is rejected", func(t *testing.T) {
+		status, _, _ := proxyRequest(t, http.MethodPost, gatewayID, path, nil,
+			mustJSON(t, chatRequest(false)),
+		)
+		assert.Equal(t, http.StatusForbidden, status)
+	})
+
+	t.Run("valid preflight short-circuits with negotiated headers", func(t *testing.T) {
+		status, headers, _ := proxyRequest(t, http.MethodOptions, gatewayID, path,
+			map[string]string{
+				"Origin":                        "https://allowed.com",
+				"Access-Control-Request-Method": "POST",
+			}, nil,
+		)
+		assert.Equal(t, http.StatusNoContent, status)
+		assert.Equal(t, "https://allowed.com", headers.Get("Access-Control-Allow-Origin"))
+		assert.Contains(t, headers.Get("Access-Control-Allow-Methods"), "POST")
+		assert.Equal(t, "600s", headers.Get("Access-Control-Max-Age"))
+		assert.Equal(t, 0, up.Hits(), "a preflight must never reach the upstream")
+	})
+
+	t.Run("preflight with disallowed method is rejected", func(t *testing.T) {
+		status, _, _ := proxyRequest(t, http.MethodOptions, gatewayID, path,
+			map[string]string{
+				"Origin":                        "https://allowed.com",
+				"Access-Control-Request-Method": "DELETE",
+			}, nil,
+		)
+		assert.Equal(t, http.StatusMethodNotAllowed, status)
+	})
+
+	t.Run("preflight missing requested method is a bad request", func(t *testing.T) {
+		status, _, _ := proxyRequest(t, http.MethodOptions, gatewayID, path,
+			map[string]string{"Origin": "https://allowed.com"}, nil,
+		)
+		assert.Equal(t, http.StatusBadRequest, status)
+	})
+
+	t.Run("preflight from disallowed origin is rejected", func(t *testing.T) {
+		status, _, _ := proxyRequest(t, http.MethodOptions, gatewayID, path,
+			map[string]string{
+				"Origin":                        "https://evil.com",
+				"Access-Control-Request-Method": "POST",
+			}, nil,
+		)
+		assert.Equal(t, http.StatusForbidden, status)
+	})
+}
+
+func TestPluginE2E_CORS_Wildcard(t *testing.T) {
+	defer Track(t, "PluginCORS")()
+
+	up := newJSONUpstream(t, "cors-wild-upstream")
+	gatewayID, path := setupPolicyRoute(t, up,
+		policyPlugin("cors", "pre_request", map[string]any{
+			"allowed_origins":   []string{"*"},
+			"allowed_methods":   []string{"GET", "POST", "OPTIONS"},
+			"allow_credentials": false,
+			"max_age":           "600s",
+		}),
+	)
+
+	t.Run("wildcard allows an arbitrary origin", func(t *testing.T) {
+		status, _, body := proxyRequest(t, http.MethodPost, gatewayID, path,
+			map[string]string{"Origin": "https://anything.example.com"},
+			mustJSON(t, chatRequest(false)),
+		)
+		assert.Equal(t, http.StatusOK, status, "body: %s", body)
+	})
+
+	t.Run("wildcard preflight echoes the request origin", func(t *testing.T) {
+		status, headers, _ := proxyRequest(t, http.MethodOptions, gatewayID, path,
+			map[string]string{
+				"Origin":                        "https://any.origin",
+				"Access-Control-Request-Method": "POST",
+			}, nil,
+		)
+		assert.Equal(t, http.StatusNoContent, status)
+		assert.Equal(t, "https://any.origin", headers.Get("Access-Control-Allow-Origin"))
+	})
+}

--- a/tests/functional/plugin_e2e_common_test.go
+++ b/tests/functional/plugin_e2e_common_test.go
@@ -1,0 +1,114 @@
+package functional_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newUsageUpstream answers every request with a 200 chat-completion that carries
+// an OpenAI-style usage block, so PostResponse plugins (e.g. token_rate_limiter)
+// can observe the tokens the call "consumed".
+func newUsageUpstream(t *testing.T, marker string, totalTokens int) *fakeUpstream {
+	t.Helper()
+	u := &fakeUpstream{}
+	u.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt64(&u.hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w,
+			`{"id":"chatcmpl-test","object":"chat.completion",`+
+				`"choices":[{"index":0,"message":{"role":"assistant","content":%q},"finish_reason":"stop"}],`+
+				`"usage":{"prompt_tokens":%d,"completion_tokens":0,"total_tokens":%d}}`,
+			marker, totalTokens, totalTokens,
+		)
+	}))
+	t.Cleanup(u.server.Close)
+	return u
+}
+
+// policyPlugin builds a single enabled plugin entry for a policy payload. The
+// stage only has to be a valid enum: the executor drives each plugin at the
+// stages it declares via Stages(), ignoring the configured stage.
+func policyPlugin(name, stage string, settings map[string]any) map[string]any {
+	return map[string]any{
+		"name":     name,
+		"enabled":  true,
+		"stage":    stage,
+		"priority": 0,
+		"settings": settings,
+	}
+}
+
+// setupPolicyRoute wires a full proxy route guarded by a policy: a gateway, one
+// OpenAI-compatible backend pointing at up, a policy carrying pluginEntries and
+// a consumer that references both. It returns the gateway id and the routing
+// path to POST against the proxy plane.
+func setupPolicyRoute(t *testing.T, up *fakeUpstream, pluginEntries ...map[string]any) (string, string) {
+	t.Helper()
+	gatewayID := CreateGateway(t, map[string]any{"name": uniqueName("plugin-gw")})
+	backendID := CreateBackend(t, gatewayID, openaiBackendPayload(uniqueName("be"), up.URL()))
+	policyID := CreatePolicy(t, gatewayID, map[string]any{
+		"name":    uniqueName("pol"),
+		"plugins": pluginEntries,
+	})
+
+	path := "/v1/" + uniqueName("route")
+	CreateConsumer(t, gatewayID, map[string]any{
+		"name":        uniqueName("cons"),
+		"path":        path,
+		"backend_ids": []string{backendID},
+		"policy_ids":  []string{policyID},
+	})
+	return gatewayID, path
+}
+
+// proxyRequest forwards an arbitrary-method request through the proxy plane for
+// gatewayID at path, applying extra headers. body may be nil (no payload). It
+// identifies the gateway with the interim X-Gateway-Id header and returns the
+// status, response headers and the full body.
+func proxyRequest(
+	t *testing.T,
+	method, gatewayID, path string,
+	headers map[string]string,
+	body []byte,
+) (int, http.Header, []byte) {
+	t.Helper()
+
+	var reader io.Reader
+	if body != nil {
+		reader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequest(method, ProxyURL+path, reader)
+	require.NoError(t, err)
+	req.Header.Set("X-Gateway-Id", gatewayID)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, resp.Header, raw
+}
+
+// mustJSON marshals v to bytes for a proxy request body, failing the test on
+// error.
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	buf, err := json.Marshal(v)
+	require.NoError(t, err)
+	return buf
+}

--- a/tests/functional/plugin_rate_limiter_test.go
+++ b/tests/functional/plugin_rate_limiter_test.go
@@ -1,0 +1,70 @@
+package functional_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPluginE2E_RateLimiter_Global(t *testing.T) {
+	defer Track(t, "PluginRateLimiter")()
+
+	const limit = 5
+	up := newJSONUpstream(t, "rl-upstream")
+	gatewayID, path := setupPolicyRoute(t, up,
+		policyPlugin("rate_limiter", "pre_request", map[string]any{
+			"limits": map[string]any{
+				"global": map[string]any{"limit": limit, "window": "1m"},
+			},
+			"actions": map[string]any{"type": "reject", "retry_after": "60"},
+		}),
+	)
+
+	body := mustJSON(t, chatRequest(false))
+
+	for i := 1; i <= limit; i++ {
+		status, headers, raw := proxyRequest(t, http.MethodPost, gatewayID, path, nil, body)
+		require.Equal(t, http.StatusOK, status, "request %d should be allowed, body: %s", i, raw)
+		assert.Equal(t, "5", headers.Get("X-RateLimit-global-Limit"))
+	}
+
+	status, headers, _ := proxyRequest(t, http.MethodPost, gatewayID, path, nil, body)
+	assert.Equal(t, http.StatusTooManyRequests, status, "request beyond the limit must be rejected")
+	assert.Equal(t, "60", headers.Get("Retry-After"))
+	assert.Equal(t, limit, up.Hits(), "rejected requests must not reach the upstream")
+}
+
+func TestPluginE2E_RateLimiter_PerUserIsolation(t *testing.T) {
+	defer Track(t, "PluginRateLimiter")()
+
+	const perUser = 3
+	up := newJSONUpstream(t, "rl-user-upstream")
+	gatewayID, path := setupPolicyRoute(t, up,
+		policyPlugin("rate_limiter", "pre_request", map[string]any{
+			"limits": map[string]any{
+				"per_user": map[string]any{"limit": perUser, "window": "1m"},
+				"global":   map[string]any{"limit": 1000, "window": "1m"},
+			},
+			"actions": map[string]any{"type": "reject", "retry_after": "30"},
+		}),
+	)
+
+	body := mustJSON(t, chatRequest(false))
+
+	exhaust := func(user string) {
+		for i := 1; i <= perUser; i++ {
+			status, _, raw := proxyRequest(t, http.MethodPost, gatewayID, path,
+				map[string]string{"X-User-ID": user}, body)
+			require.Equal(t, http.StatusOK, status, "user %s request %d, body: %s", user, i, raw)
+		}
+		status, _, _ := proxyRequest(t, http.MethodPost, gatewayID, path,
+			map[string]string{"X-User-ID": user}, body)
+		assert.Equal(t, http.StatusTooManyRequests, status, "user %s should be limited after %d requests", user, perUser)
+	}
+
+	exhaust("alice")
+	// Bob has an independent budget: alice being limited must not affect bob.
+	exhaust("bob")
+}

--- a/tests/functional/plugin_request_size_test.go
+++ b/tests/functional/plugin_request_size_test.go
@@ -1,0 +1,59 @@
+package functional_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPluginE2E_RequestSizeLimiter_ByteLimit(t *testing.T) {
+	defer Track(t, "PluginRequestSize")()
+
+	up := newJSONUpstream(t, "size-upstream")
+	gatewayID, path := setupPolicyRoute(t, up,
+		policyPlugin("request_size_limiter", "pre_request", map[string]any{
+			"allowed_payload_size": 1000,
+			"size_unit":            "bytes",
+		}),
+	)
+
+	t.Run("payload within the limit passes through", func(t *testing.T) {
+		status, _, raw := proxyRequest(t, http.MethodPost, gatewayID, path, nil,
+			mustJSON(t, chatRequest(false)),
+		)
+		assert.Equal(t, http.StatusOK, status, "body: %s", raw)
+		assert.Contains(t, string(raw), "size-upstream")
+	})
+
+	t.Run("payload over the byte limit is rejected", func(t *testing.T) {
+		oversized := map[string]any{
+			"model":    "gpt-4o-mini",
+			"messages": []map[string]string{{"role": "user", "content": strings.Repeat("a", 4000)}},
+		}
+		hitsBefore := up.Hits()
+		status, _, _ := proxyRequest(t, http.MethodPost, gatewayID, path, nil, mustJSON(t, oversized))
+		assert.Equal(t, http.StatusRequestEntityTooLarge, status)
+		assert.Equal(t, hitsBefore, up.Hits(), "an oversized request must not reach the upstream")
+	})
+}
+
+func TestPluginE2E_RequestSizeLimiter_CharLimit(t *testing.T) {
+	defer Track(t, "PluginRequestSize")()
+
+	up := newJSONUpstream(t, "char-upstream")
+	gatewayID, path := setupPolicyRoute(t, up,
+		policyPlugin("request_size_limiter", "pre_request", map[string]any{
+			"allowed_payload_size":  10,
+			"size_unit":             "megabytes",
+			"max_chars_per_request": 10,
+		}),
+	)
+
+	status, _, _ := proxyRequest(t, http.MethodPost, gatewayID, path, nil,
+		mustJSON(t, chatRequest(false)),
+	)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, status,
+		"a body with more characters than the limit must be rejected")
+}

--- a/tests/functional/plugin_semantic_cache_test.go
+++ b/tests/functional/plugin_semantic_cache_test.go
@@ -1,0 +1,100 @@
+package functional_test
+
+import (
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPluginE2E_SemanticCache exercises the semantic cache end to end. It needs a
+// real embedding provider (OPENAI_API_KEY) and a Redis Stack (RediSearch)
+// backing the vector store, so it is skipped when the key is absent, mirroring
+// the TrustGate-EE functional test.
+func TestPluginE2E_SemanticCache(t *testing.T) {
+	defer Track(t, "PluginSemanticCache")()
+
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	if apiKey == "" {
+		t.Skip("OPENAI_API_KEY not set, skipping semantic cache functional test")
+	}
+
+	settings := map[string]any{
+		"similarity_threshold": 0.85,
+		"ttl":                  "10m",
+		"embedding": map[string]any{
+			"provider": "openai",
+			"model":    "text-embedding-ada-002",
+			"api_key":  apiKey,
+		},
+	}
+
+	up := newJSONUpstream(t, "semantic-cache-answer")
+	gatewayID, path := setupPolicyRoute(t, up,
+		policyPlugin("semantic_cache", "pre_request", settings),
+		policyPlugin("semantic_cache", "post_response", settings),
+	)
+
+	ask := func(content string) map[string]any {
+		return map[string]any{
+			"model":    "gpt-4o-mini",
+			"messages": []map[string]string{{"role": "user", "content": content}},
+		}
+	}
+
+	var firstBody []byte
+
+	t.Run("first request misses and is stored", func(t *testing.T) {
+		status, headers, body := proxyRequest(t, http.MethodPost, gatewayID, path, nil,
+			mustJSON(t, ask("What is the capital of France?")),
+		)
+		require.Equal(t, http.StatusOK, status, "body: %s", body)
+		assert.Empty(t, headers.Get("X-Cache-Status"), "first request must be a miss")
+		assert.NotEmpty(t, body)
+		firstBody = body
+	})
+
+	t.Run("identical request hits the cache", func(t *testing.T) {
+		// PostResponse stores asynchronously; give it a moment to land.
+		time.Sleep(2 * time.Second)
+		hitsBefore := up.Hits()
+
+		status, headers, body := proxyRequest(t, http.MethodPost, gatewayID, path, nil,
+			mustJSON(t, ask("What is the capital of France?")),
+		)
+		require.Equal(t, http.StatusOK, status, "body: %s", body)
+		assert.Equal(t, "HIT", headers.Get("X-Cache-Status"))
+		assert.NotEmpty(t, headers.Get("X-Cache-Similarity"))
+		assert.Equal(t, firstBody, body, "a cache hit must replay the stored response")
+		assert.Equal(t, hitsBefore, up.Hits(), "a cache hit must not reach the upstream")
+	})
+
+	t.Run("semantically similar request hits the cache", func(t *testing.T) {
+		status, headers, body := proxyRequest(t, http.MethodPost, gatewayID, path, nil,
+			mustJSON(t, ask("What's the capital city of France?")),
+		)
+		require.Equal(t, http.StatusOK, status, "body: %s", body)
+		assert.Equal(t, "HIT", headers.Get("X-Cache-Status"))
+		assert.Equal(t, firstBody, body)
+	})
+
+	t.Run("dissimilar request misses", func(t *testing.T) {
+		status, headers, body := proxyRequest(t, http.MethodPost, gatewayID, path, nil,
+			mustJSON(t, ask("How do you implement a binary search tree in Rust?")),
+		)
+		require.Equal(t, http.StatusOK, status, "body: %s", body)
+		assert.Empty(t, headers.Get("X-Cache-Status"), "a dissimilar request must not hit")
+	})
+
+	t.Run("Cache-Control no-cache bypasses the cache", func(t *testing.T) {
+		status, headers, body := proxyRequest(t, http.MethodPost, gatewayID, path,
+			map[string]string{"Cache-Control": "no-cache"},
+			mustJSON(t, ask("What is the capital of France?")),
+		)
+		require.Equal(t, http.StatusOK, status, "body: %s", body)
+		assert.Empty(t, headers.Get("X-Cache-Status"), "no-cache must bypass the cache")
+	})
+}

--- a/tests/functional/plugin_token_rate_limiter_test.go
+++ b/tests/functional/plugin_token_rate_limiter_test.go
@@ -1,0 +1,51 @@
+package functional_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPluginE2E_TokenRateLimiter verifies the token budget limiter is wired into
+// the proxy and lets legitimate chat traffic through. Enforcement records the
+// tokens a response consumed at PostResponse; the PreRequest check keys off the
+// request provider, so a route guarded by the limiter must not break normal
+// provider traffic.
+func TestPluginE2E_TokenRateLimiter(t *testing.T) {
+	defer Track(t, "PluginTokenRateLimiter")()
+
+	up := newUsageUpstream(t, "token-upstream", 8)
+	gatewayID, path := setupPolicyRoute(t, up,
+		policyPlugin("token_rate_limiter", "pre_request", map[string]any{
+			"window": map[string]any{"unit": "minute", "max": 100},
+		}),
+	)
+
+	body := mustJSON(t, chatRequest(false))
+	for i := 0; i < 5; i++ {
+		status, _, raw := proxyRequest(t, http.MethodPost, gatewayID, path, nil, body)
+		require.Equal(t, http.StatusOK, status, "request %d should pass through, body: %s", i, raw)
+	}
+	assert.Equal(t, 5, up.Hits())
+}
+
+func TestPluginE2E_TokenRateLimiter_WithIdentifierHeader(t *testing.T) {
+	defer Track(t, "PluginTokenRateLimiter")()
+
+	up := newUsageUpstream(t, "token-hdr-upstream", 8)
+	gatewayID, path := setupPolicyRoute(t, up,
+		policyPlugin("token_rate_limiter", "pre_request", map[string]any{
+			"identifier_header": "X-Client-ID",
+			"window":            map[string]any{"unit": "hour", "max": 1000},
+		}),
+	)
+
+	body := mustJSON(t, chatRequest(false))
+	for _, clientID := range []string{"client-a", "client-b"} {
+		status, _, raw := proxyRequest(t, http.MethodPost, gatewayID, path,
+			map[string]string{"X-Client-ID": clientID}, body)
+		assert.Equal(t, http.StatusOK, status, "client %s should pass through, body: %s", clientID, raw)
+	}
+}


### PR DESCRIPTION
Cover cors, rate_limiter, request_size_limiter, token_rate_limiter and semantic_cache end to end through the proxy plane: a gateway, backend, policy and consumer are wired per case and exercised over HTTP. Inspired by the TrustGate and TrustGate-EE functional suites. The semantic cache test is gated on OPENAI_API_KEY (needs a real embedding provider and a Redis Stack vector store), mirroring TrustGate-EE.