### PR TITLE
refactor(telemetry): rename policy_chain/policies_ms and keep full response body

### DIFF
--- a/pkg/app/metrics/builder.go
+++ b/pkg/app/metrics/builder.go
@@ -58,7 +58,7 @@ func (b *Builder) Build(
 	served, attempts := b.foldLLMSpans(requestTrace)
 	chain, pluginsMs, flagged, security := b.foldPluginSpans(requestTrace)
 	evt.Attempts = attempts
-	evt.PluginChain = chain
+	evt.PolicyChain = chain
 	evt.IsFlagged = flagged
 	evt.Security = security
 
@@ -68,7 +68,7 @@ func (b *Builder) Build(
 	evt.Latency = events.Latency{
 		TotalMs:    totalMs,
 		ProviderMs: providerMs,
-		PluginsMs:  pluginsMs,
+		PoliciesMs: pluginsMs,
 		RoutingMs:  routingMs,
 		GatewayMs:  pluginsMs + routingMs,
 	}
@@ -110,11 +110,11 @@ func (b *Builder) foldLLMSpans(requestTrace *trace.RequestTrace) (*trace.LLMAttr
 	return served, attempts
 }
 
-func (b *Builder) foldPluginSpans(requestTrace *trace.RequestTrace) ([]events.PluginEntry, int64, bool, []string) {
+func (b *Builder) foldPluginSpans(requestTrace *trace.RequestTrace) ([]events.PolicyEntry, int64, bool, []string) {
 	if requestTrace == nil {
 		return nil, 0, false, nil
 	}
-	var chain []events.PluginEntry
+	var chain []events.PolicyEntry
 	var pluginsMs int64
 	anyFlagged := false
 	seenLabels := make(map[string]struct{})
@@ -138,7 +138,7 @@ func (b *Builder) foldPluginSpans(requestTrace *trace.RequestTrace) ([]events.Pl
 				}
 			}
 		}
-		chain = append(chain, events.PluginEntry{
+		chain = append(chain, events.PolicyEntry{
 			Name:       span.Name,
 			Stage:      attrs.Stage,
 			Decision:   attrs.Decision,
@@ -204,7 +204,7 @@ func (b *Builder) fillResponse(evt *events.Event, resp *infracontext.ResponseCon
 		evt.Response.FinishReason = served.FinishReason
 	}
 	if len(resp.Body) > 0 {
-		body := events.SanitizeBody(resp.Body, resp.Headers)
+		body := events.SanitizeBodyFull(resp.Body, resp.Headers)
 		evt.Response.Body = &body
 	}
 }

--- a/pkg/app/metrics/builder_test.go
+++ b/pkg/app/metrics/builder_test.go
@@ -126,15 +126,15 @@ func TestBuilder_SyncSuccessFoldsCostAndLatency(t *testing.T) {
 
 	assert.Equal(t, int64(320), evt.Latency.TotalMs)
 	assert.Equal(t, int64(300), evt.Latency.ProviderMs)
-	assert.Equal(t, int64(6), evt.Latency.PluginsMs)
+	assert.Equal(t, int64(6), evt.Latency.PoliciesMs)
 	assert.Equal(t, int64(14), evt.Latency.RoutingMs)
 	assert.Equal(t, int64(20), evt.Latency.GatewayMs)
 
 	require.Len(t, evt.Attempts, 1)
 	assert.Equal(t, "openai", evt.Attempts[0].Provider)
-	require.Len(t, evt.PluginChain, 1)
-	assert.Equal(t, "rate_limiter", evt.PluginChain[0].Name)
-	assert.False(t, evt.PluginChain[0].Flagged)
+	require.Len(t, evt.PolicyChain, 1)
+	assert.Equal(t, "rate_limiter", evt.PolicyChain[0].Name)
+	assert.False(t, evt.PolicyChain[0].Flagged)
 	assert.False(t, evt.IsFlagged)
 }
 
@@ -184,8 +184,8 @@ func TestBuilder_FailoverAttemptsAndFlaggedPlugin(t *testing.T) {
 	assert.True(t, evt.Attempts[1].Fallback)
 	assert.Equal(t, int64(300), evt.Latency.ProviderMs)
 
-	require.Len(t, evt.PluginChain, 1)
-	assert.True(t, evt.PluginChain[0].Flagged)
+	require.Len(t, evt.PolicyChain, 1)
+	assert.True(t, evt.PolicyChain[0].Flagged)
 	assert.True(t, evt.IsFlagged)
 	assert.Equal(t, []string{"toxicity"}, evt.Security)
 

--- a/pkg/infra/metrics/events/event.go
+++ b/pkg/infra/metrics/events/event.go
@@ -29,7 +29,7 @@ type Event struct {
 	Latency  Latency  `json:"latency"`
 
 	Attempts    []Attempt     `json:"attempts,omitempty"`
-	PluginChain []PluginEntry `json:"plugin_chain,omitempty"`
+	PolicyChain []PolicyEntry `json:"policy_chain,omitempty"`
 }
 
 type Consumer struct {
@@ -86,7 +86,7 @@ type Cost struct {
 type Latency struct {
 	TotalMs    int64 `json:"total_ms"`
 	ProviderMs int64 `json:"provider_ms"`
-	PluginsMs  int64 `json:"plugins_ms"`
+	PoliciesMs int64 `json:"policies_ms"`
 	RoutingMs  int64 `json:"routing_ms"`
 	GatewayMs  int64 `json:"gateway_ms"`
 }
@@ -101,7 +101,7 @@ type Attempt struct {
 	LatencyMs  int64  `json:"latency_ms"`
 }
 
-type PluginEntry struct {
+type PolicyEntry struct {
 	Name       string      `json:"name"`
 	Stage      string      `json:"stage,omitempty"`
 	Decision   string      `json:"decision,omitempty"`

--- a/pkg/infra/metrics/events/sanitize.go
+++ b/pkg/infra/metrics/events/sanitize.go
@@ -39,27 +39,40 @@ var sensitiveHeaders = map[string]struct{}{
 
 // SanitizeBody returns a loggable representation of a request/response body.
 // Multipart payloads are reduced to their field names and file metadata so raw
-// file contents never reach an exporter, and oversized bodies are truncated.
+// file contents never reach an exporter, and oversized bodies are truncated to
+// maxSanitizedBodyBytes.
 func SanitizeBody(body []byte, headers map[string][]string) string {
+	return sanitizeBody(body, headers, maxSanitizedBodyBytes)
+}
+
+// SanitizeBodyFull behaves like SanitizeBody but never truncates by size, so the
+// full body is preserved (e.g. complete streamed responses). Multipart payloads
+// are still reduced to field/file metadata so raw file contents never reach an
+// exporter.
+func SanitizeBodyFull(body []byte, headers map[string][]string) string {
+	return sanitizeBody(body, headers, 0)
+}
+
+func sanitizeBody(body []byte, headers map[string][]string, maxBytes int) string {
 	if len(body) == 0 {
 		return ""
 	}
 
 	contentType := lookupHeader(headers, "Content-Type")
 	if contentType == "" {
-		return capBody(body)
+		return capBody(body, maxBytes)
 	}
 
 	mediaType, params, err := mime.ParseMediaType(contentType)
 	if err != nil {
-		return capBody(body)
+		return capBody(body, maxBytes)
 	}
 
 	if mediaType == "multipart/form-data" {
 		return extractMultipartFileNames(body, params["boundary"])
 	}
 
-	return capBody(body)
+	return capBody(body, maxBytes)
 }
 
 // RedactHeaders returns a copy of headers with the values of sensitive headers
@@ -79,11 +92,13 @@ func RedactHeaders(headers map[string][]string) map[string][]string {
 	return out
 }
 
-func capBody(body []byte) string {
-	if len(body) <= maxSanitizedBodyBytes {
+// capBody truncates body to maxBytes, appending a marker. A non-positive maxBytes
+// disables truncation and returns the full body.
+func capBody(body []byte, maxBytes int) string {
+	if maxBytes <= 0 || len(body) <= maxBytes {
 		return string(body)
 	}
-	return string(body[:maxSanitizedBodyBytes]) + truncatedSuffix
+	return string(body[:maxBytes]) + truncatedSuffix
 }
 
 func extractMultipartFileNames(body []byte, boundary string) string {


### PR DESCRIPTION
Follow-up to #19. Base: `develop`. Single commit.

## Summary
- **Event schema rename** (`pkg/infra/metrics/events`): `plugin_chain` → `policy_chain` (`PluginChain`/`PluginEntry` → `PolicyChain`/`PolicyEntry`) and `latency.plugins_ms` → `latency.policies_ms` (`Latency.PluginsMs` → `PoliciesMs`), to match the policy terminology.
- **Full response body** (`pkg/app/metrics/builder.go`): the response body now uses a non-truncating sanitizer (`SanitizeBodyFull`) so streamed SSE responses are captured in full instead of being cut at 64KB. The request body keeps the 64KB cap.

## Note
- Without a response-body cap, very large streamed responses can exceed Kafka's `message.max.bytes` (~1MB default). Bump the producer/broker limits if responses can grow beyond that.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/app/metrics/...`
- [ ] Verify the event emits `policy_chain` / `latency.policies_ms`
- [ ] Verify a long streamed `response.body` is stored without `...[truncated]`

Made with [Cursor](https://cursor.com)