### PR TITLE
feat(api): partial updates for policy, registry, consumer, gateway and auth

### DIFF
--- a/pkg/api/handler/http/auth/request/update_auth_request.go
+++ b/pkg/api/handler/http/auth/request/update_auth_request.go
@@ -5,31 +5,43 @@ import (
 	"strings"
 
 	commonerrors "github.com/NeuralTrust/AgentGateway/pkg/common/errors"
+	domain "github.com/NeuralTrust/AgentGateway/pkg/domain/auth"
 )
 
 type UpdateAuthRequest struct {
-	Name    string        `json:"name"`
-	Type    string        `json:"type"`
-	Enabled *bool         `json:"enabled,omitempty"`
-	Config  ConfigRequest `json:"config"`
+	Name    *string        `json:"name,omitempty"`
+	Type    *string        `json:"type,omitempty"`
+	Enabled *bool          `json:"enabled,omitempty"`
+	Config  *ConfigRequest `json:"config,omitempty"`
 }
 
 func (r UpdateAuthRequest) Validate() error {
-	if strings.TrimSpace(r.Name) == "" {
-		return fmt.Errorf("name is required: %w", commonerrors.ErrValidation)
+	if r.Name != nil {
+		if strings.TrimSpace(*r.Name) == "" {
+			return fmt.Errorf("name is required: %w", commonerrors.ErrValidation)
+		}
+		if len(*r.Name) > 255 {
+			return fmt.Errorf("name too long (max 255): %w", commonerrors.ErrValidation)
+		}
 	}
-	if len(r.Name) > 255 {
-		return fmt.Errorf("name too long (max 255): %w", commonerrors.ErrValidation)
-	}
-	if strings.TrimSpace(r.Type) == "" {
+	if r.Type != nil && strings.TrimSpace(*r.Type) == "" {
 		return fmt.Errorf("type is required: %w", commonerrors.ErrValidation)
 	}
 	return nil
 }
 
-func (r UpdateAuthRequest) IsEnabled() bool {
-	if r.Enabled == nil {
-		return true
+func (r UpdateAuthRequest) ToType() *domain.Type {
+	if r.Type == nil {
+		return nil
 	}
-	return *r.Enabled
+	t := domain.Type(*r.Type)
+	return &t
+}
+
+func (r UpdateAuthRequest) ToConfig() *domain.Config {
+	if r.Config == nil {
+		return nil
+	}
+	cfg := r.Config.ToDomain()
+	return &cfg
 }

--- a/pkg/api/handler/http/auth/update_auth_handler.go
+++ b/pkg/api/handler/http/auth/update_auth_handler.go
@@ -8,7 +8,6 @@ import (
 	"github.com/NeuralTrust/AgentGateway/pkg/api/handler/http/helpers"
 	appauth "github.com/NeuralTrust/AgentGateway/pkg/app/auth"
 	commonerrors "github.com/NeuralTrust/AgentGateway/pkg/common/errors"
-	domain "github.com/NeuralTrust/AgentGateway/pkg/domain/auth"
 	"github.com/NeuralTrust/AgentGateway/pkg/domain/ids"
 	"github.com/gofiber/fiber/v2"
 )
@@ -55,9 +54,9 @@ func (h *UpdateAuthHandler) Handle(c *fiber.Ctx) error {
 		ID:        id,
 		GatewayID: gatewayID,
 		Name:      req.Name,
-		Type:      domain.Type(req.Type),
-		Enabled:   req.IsEnabled(),
-		Config:    req.Config.ToDomain(),
+		Type:      req.ToType(),
+		Enabled:   req.Enabled,
+		Config:    req.ToConfig(),
 	})
 	if err != nil {
 		return helpers.WriteError(c, err)

--- a/pkg/api/handler/http/consumer/request/update_consumer_request.go
+++ b/pkg/api/handler/http/consumer/request/update_consumer_request.go
@@ -10,32 +10,45 @@ import (
 )
 
 type UpdateConsumerRequest struct {
-	Name            string                  `json:"name"`
-	Type            string                  `json:"type,omitempty"`
-	Path            string                  `json:"path"`
-	Algorithm       string                  `json:"algorithm,omitempty"`
+	Name            *string                 `json:"name,omitempty"`
+	Type            *string                 `json:"type,omitempty"`
+	Path            *string                 `json:"path,omitempty"`
+	Algorithm       *string                 `json:"algorithm,omitempty"`
 	EmbeddingConfig *EmbeddingConfigRequest `json:"embedding_config,omitempty"`
-	Headers         map[string]string       `json:"headers,omitempty"`
+	Headers         *map[string]string      `json:"headers,omitempty"`
 	Active          *bool                   `json:"active,omitempty"`
 	Fallback        *FallbackRequest        `json:"fallback,omitempty"`
-	ModelPolicies   []ModelPolicyRequest    `json:"model_policies,omitempty"`
+	ModelPolicies   *[]ModelPolicyRequest   `json:"model_policies,omitempty"`
 }
 
 func (r UpdateConsumerRequest) Validate() error {
-	if strings.TrimSpace(r.Name) == "" {
-		return fmt.Errorf("name is required: %w", commonerrors.ErrValidation)
+	if r.Name != nil {
+		if strings.TrimSpace(*r.Name) == "" {
+			return fmt.Errorf("name is required: %w", commonerrors.ErrValidation)
+		}
+		if len(*r.Name) > 255 {
+			return fmt.Errorf("name too long (max 255): %w", commonerrors.ErrValidation)
+		}
 	}
-	if len(r.Name) > 255 {
-		return fmt.Errorf("name too long (max 255): %w", commonerrors.ErrValidation)
-	}
-	if strings.TrimSpace(r.Path) == "" {
+	if r.Path != nil && strings.TrimSpace(*r.Path) == "" {
 		return fmt.Errorf("path is required: %w", commonerrors.ErrValidation)
 	}
 	return nil
 }
 
-func (r UpdateConsumerRequest) ToType() domain.Type {
-	return domain.Type(r.Type)
+func (r UpdateConsumerRequest) ToType() *domain.Type {
+	if r.Type == nil || strings.TrimSpace(*r.Type) == "" {
+		return nil
+	}
+	t := domain.Type(*r.Type)
+	return &t
+}
+
+func (r UpdateConsumerRequest) ToAlgorithm() *string {
+	if r.Algorithm == nil || strings.TrimSpace(*r.Algorithm) == "" {
+		return nil
+	}
+	return r.Algorithm
 }
 
 func (r UpdateConsumerRequest) ToEmbeddingConfig() *registrydomain.EmbeddingConfig {
@@ -46,6 +59,13 @@ func (r UpdateConsumerRequest) ToFallback() (*domain.Fallback, error) {
 	return r.Fallback.ToFallback()
 }
 
-func (r UpdateConsumerRequest) ToModelPolicies() (domain.ModelPolicies, error) {
-	return parseModelPolicies(r.ModelPolicies)
+func (r UpdateConsumerRequest) ToModelPolicies() (*domain.ModelPolicies, error) {
+	if r.ModelPolicies == nil {
+		return nil, nil
+	}
+	mp, err := parseModelPolicies(*r.ModelPolicies)
+	if err != nil {
+		return nil, err
+	}
+	return &mp, nil
 }

--- a/pkg/api/handler/http/consumer/request/update_consumer_request_test.go
+++ b/pkg/api/handler/http/consumer/request/update_consumer_request_test.go
@@ -1,0 +1,59 @@
+package request
+
+import (
+	"testing"
+
+	domain "github.com/NeuralTrust/AgentGateway/pkg/domain/consumer"
+)
+
+func strPtr(v string) *string { return &v }
+
+func TestUpdateConsumerRequest_ToType(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   *string
+		want *domain.Type
+	}{
+		{"omitted", nil, nil},
+		{"empty", strPtr(""), nil},
+		{"whitespace", strPtr("   "), nil},
+		{"value", strPtr("MCP"), func() *domain.Type { v := domain.Type("MCP"); return &v }()},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := UpdateConsumerRequest{Type: tc.in}.ToType()
+			if (got == nil) != (tc.want == nil) {
+				t.Fatalf("ToType() nilness mismatch: got=%v want=%v", got, tc.want)
+			}
+			if got != nil && *got != *tc.want {
+				t.Fatalf("ToType() = %q, want %q", *got, *tc.want)
+			}
+		})
+	}
+}
+
+func TestUpdateConsumerRequest_ToAlgorithm(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   *string
+		want *string
+	}{
+		{"omitted", nil, nil},
+		{"empty", strPtr(""), nil},
+		{"whitespace", strPtr("   "), nil},
+		{"value", strPtr("round-robin"), strPtr("round-robin")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := UpdateConsumerRequest{Algorithm: tc.in}.ToAlgorithm()
+			if (got == nil) != (tc.want == nil) {
+				t.Fatalf("ToAlgorithm() nilness mismatch: got=%v want=%v", got, tc.want)
+			}
+			if got != nil && *got != *tc.want {
+				t.Fatalf("ToAlgorithm() = %q, want %q", *got, *tc.want)
+			}
+		})
+	}
+}

--- a/pkg/api/handler/http/consumer/update_consumer_handler.go
+++ b/pkg/api/handler/http/consumer/update_consumer_handler.go
@@ -65,7 +65,7 @@ func (h *UpdateConsumerHandler) Handle(c *fiber.Ctx) error {
 		Name:            req.Name,
 		Type:            req.ToType(),
 		Path:            req.Path,
-		Algorithm:       req.Algorithm,
+		Algorithm:       req.ToAlgorithm(),
 		EmbeddingConfig: req.ToEmbeddingConfig(),
 		Headers:         req.Headers,
 		Active:          req.Active,

--- a/pkg/api/handler/http/gateway/request/update_gateway_request.go
+++ b/pkg/api/handler/http/gateway/request/update_gateway_request.go
@@ -10,19 +10,21 @@ import (
 )
 
 type UpdateGatewayRequest struct {
-	Name            string                 `json:"name"`
-	Status          string                 `json:"status"`
-	Telemetry       *telemetry.Telemetry   `json:"telemetry,omitempty"`
-	ClientTLSConfig domain.ClientTLSConfig `json:"client_tls,omitempty"`
-	SessionConfig   *domain.SessionConfig  `json:"session_config,omitempty"`
+	Name            *string                 `json:"name,omitempty"`
+	Status          *string                 `json:"status,omitempty"`
+	Telemetry       *telemetry.Telemetry    `json:"telemetry,omitempty"`
+	ClientTLSConfig *domain.ClientTLSConfig `json:"client_tls,omitempty"`
+	SessionConfig   *domain.SessionConfig   `json:"session_config,omitempty"`
 }
 
 func (r UpdateGatewayRequest) Validate() error {
-	if strings.TrimSpace(r.Name) == "" {
-		return fmt.Errorf("name is required: %w", commonerrors.ErrValidation)
-	}
-	if len(r.Name) > 255 {
-		return fmt.Errorf("name too long (max 255): %w", commonerrors.ErrValidation)
+	if r.Name != nil {
+		if strings.TrimSpace(*r.Name) == "" {
+			return fmt.Errorf("name is required: %w", commonerrors.ErrValidation)
+		}
+		if len(*r.Name) > 255 {
+			return fmt.Errorf("name too long (max 255): %w", commonerrors.ErrValidation)
+		}
 	}
 	return nil
 }

--- a/pkg/api/handler/http/policy/request/update_policy_request.go
+++ b/pkg/api/handler/http/policy/request/update_policy_request.go
@@ -9,39 +9,38 @@ import (
 )
 
 type UpdatePolicyRequest struct {
-	Name        string         `json:"name"`
-	Description string         `json:"description,omitempty"`
-	Slug        string         `json:"slug"`
-	Enabled     bool           `json:"enabled"`
-	Priority    int            `json:"priority,omitempty"`
-	Parallel    *bool          `json:"parallel,omitempty"`
-	Settings    map[string]any `json:"settings,omitempty"`
-	Stages      []string       `json:"stages,omitempty"`
+	Name        *string         `json:"name,omitempty"`
+	Description *string         `json:"description,omitempty"`
+	Slug        *string         `json:"slug,omitempty"`
+	Enabled     *bool           `json:"enabled,omitempty"`
+	Priority    *int            `json:"priority,omitempty"`
+	Parallel    *bool           `json:"parallel,omitempty"`
+	Settings    *map[string]any `json:"settings,omitempty"`
+	Stages      *[]string       `json:"stages,omitempty"`
 }
 
 func (r UpdatePolicyRequest) Validate() error {
-	if strings.TrimSpace(r.Name) == "" {
-		return fmt.Errorf("name is required: %w", commonerrors.ErrValidation)
+	if r.Name != nil {
+		if strings.TrimSpace(*r.Name) == "" {
+			return fmt.Errorf("name is required: %w", commonerrors.ErrValidation)
+		}
+		if len(*r.Name) > 255 {
+			return fmt.Errorf("name too long (max 255): %w", commonerrors.ErrValidation)
+		}
 	}
-	if len(r.Name) > 255 {
-		return fmt.Errorf("name too long (max 255): %w", commonerrors.ErrValidation)
-	}
-	if len(r.Description) > maxPolicyDescriptionLen {
+	if r.Description != nil && len(*r.Description) > maxPolicyDescriptionLen {
 		return fmt.Errorf("description too long (max %d): %w", maxPolicyDescriptionLen, commonerrors.ErrValidation)
 	}
-	if strings.TrimSpace(r.Slug) == "" {
+	if r.Slug != nil && strings.TrimSpace(*r.Slug) == "" {
 		return fmt.Errorf("slug is required: %w", commonerrors.ErrValidation)
 	}
 	return nil
 }
 
-func (r UpdatePolicyRequest) ToStages() []domain.Stage {
-	return toStages(r.Stages)
-}
-
-func (r UpdatePolicyRequest) ParallelOrDefault() bool {
-	if r.Parallel == nil {
-		return true
+func (r UpdatePolicyRequest) ToStages() *[]domain.Stage {
+	if r.Stages == nil {
+		return nil
 	}
-	return *r.Parallel
+	stages := toStages(*r.Stages)
+	return &stages
 }

--- a/pkg/api/handler/http/policy/update_policy_handler.go
+++ b/pkg/api/handler/http/policy/update_policy_handler.go
@@ -58,7 +58,7 @@ func (h *UpdatePolicyHandler) Handle(c *fiber.Ctx) error {
 		Slug:        req.Slug,
 		Enabled:     req.Enabled,
 		Priority:    req.Priority,
-		Parallel:    req.ParallelOrDefault(),
+		Parallel:    req.Parallel,
 		Settings:    req.Settings,
 		Stages:      req.ToStages(),
 	})

--- a/pkg/api/handler/http/registry/request/update_registry_request.go
+++ b/pkg/api/handler/http/registry/request/update_registry_request.go
@@ -9,26 +9,28 @@ import (
 )
 
 type UpdateRegistryRequest struct {
-	Name            string               `json:"name"`
-	Provider        string               `json:"provider"`
-	ProviderOptions map[string]any       `json:"provider_options,omitempty"`
-	Description     string               `json:"description,omitempty"`
-	Weight          int                  `json:"weight,omitempty"`
+	Name            *string              `json:"name,omitempty"`
+	Provider        *string              `json:"provider,omitempty"`
+	ProviderOptions *map[string]any      `json:"provider_options,omitempty"`
+	Description     *string              `json:"description,omitempty"`
+	Weight          *int                 `json:"weight,omitempty"`
 	Auth            *TargetAuthRequest   `json:"auth,omitempty"`
 	HealthChecks    *HealthChecksRequest `json:"health_checks,omitempty"`
 }
 
 func (r UpdateRegistryRequest) Validate() error {
-	if strings.TrimSpace(r.Name) == "" {
-		return fmt.Errorf("name is required: %w", commonerrors.ErrValidation)
+	if r.Name != nil {
+		if strings.TrimSpace(*r.Name) == "" {
+			return fmt.Errorf("name is required: %w", commonerrors.ErrValidation)
+		}
+		if len(*r.Name) > 255 {
+			return fmt.Errorf("name too long (max 255): %w", commonerrors.ErrValidation)
+		}
 	}
-	if len(r.Name) > 255 {
-		return fmt.Errorf("name too long (max 255): %w", commonerrors.ErrValidation)
-	}
-	if strings.TrimSpace(r.Provider) == "" {
+	if r.Provider != nil && strings.TrimSpace(*r.Provider) == "" {
 		return fmt.Errorf("provider is required: %w", commonerrors.ErrValidation)
 	}
-	if r.Weight < 0 {
+	if r.Weight != nil && *r.Weight < 0 {
 		return fmt.Errorf("weight cannot be negative: %w", commonerrors.ErrValidation)
 	}
 	return nil

--- a/pkg/app/auth/updater.go
+++ b/pkg/app/auth/updater.go
@@ -13,10 +13,10 @@ import (
 type UpdateInput struct {
 	ID        ids.AuthID
 	GatewayID ids.GatewayID
-	Name      string
-	Type      domain.Type
-	Enabled   bool
-	Config    domain.Config
+	Name      *string
+	Type      *domain.Type
+	Enabled   *bool
+	Config    *domain.Config
 }
 
 //go:generate mockery --name=Updater --dir=. --output=./mocks --filename=auth_updater_mock.go --case=underscore --with-expecter
@@ -57,11 +57,19 @@ func (u *updater) Update(ctx context.Context, in UpdateInput) (*domain.Auth, err
 	if !in.GatewayID.IsNil() && in.GatewayID != existing.GatewayID {
 		return nil, domain.ErrInvalidGatewayID
 	}
-	existing.Name = in.Name
-	existing.Type = in.Type
-	existing.Enabled = in.Enabled
-	in.Config.ResolveSecretsFrom(existing.Config)
-	existing.Config = in.Config
+	if in.Name != nil {
+		existing.Name = *in.Name
+	}
+	if in.Type != nil {
+		existing.Type = *in.Type
+	}
+	if in.Enabled != nil {
+		existing.Enabled = *in.Enabled
+	}
+	if in.Config != nil {
+		in.Config.ResolveSecretsFrom(existing.Config)
+		existing.Config = *in.Config
+	}
 	existing.UpdatedAt = time.Now().UTC()
 	if err := existing.Validate(); err != nil {
 		return nil, err

--- a/pkg/app/auth/updater_test.go
+++ b/pkg/app/auth/updater_test.go
@@ -13,8 +13,26 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+func ptr[T any](v T) *T { return &v }
+
 func existingAuth(gwID ids.GatewayID) *domain.Auth {
 	a, _ := domain.NewAuth(gwID, "current", domain.TypeAPIKey, true, validConfig())
+	return a
+}
+
+func oauth2Config(clientSecret string) domain.Config {
+	return domain.Config{
+		OAuth2: &domain.OAuth2Config{
+			Issuer:       "https://issuer.example.com",
+			JWKSURL:      "https://issuer.example.com/jwks",
+			ClientID:     "client-123",
+			ClientSecret: clientSecret,
+		},
+	}
+}
+
+func existingOAuth2Auth(gwID ids.GatewayID) *domain.Auth {
+	a, _ := domain.NewAuth(gwID, "oauth-cred", domain.TypeOAuth2, true, oauth2Config("real-secret"))
 	return a
 }
 
@@ -35,16 +53,74 @@ func TestUpdater_Update_Success(t *testing.T) {
 	got, err := updater.Update(context.Background(), appauth.UpdateInput{
 		ID:        existing.ID,
 		GatewayID: gwID,
-		Name:      "renamed",
-		Type:      domain.TypeAPIKey,
-		Enabled:   true,
-		Config:    validConfig(),
+		Name:      ptr("renamed"),
+		Type:      ptr(domain.TypeAPIKey),
+		Enabled:   ptr(true),
+		Config:    ptr(validConfig()),
 	})
 	if err != nil {
 		t.Fatalf("Update error: %v", err)
 	}
 	if got.Name != "renamed" {
 		t.Fatalf("expected renamed, got %s", got.Name)
+	}
+}
+
+func TestUpdater_Update_Partial_PreservesTypeAndConfig(t *testing.T) {
+	t.Parallel()
+	repo := repomocks.NewRepository(t)
+	gwID := ids.New[ids.GatewayKind]()
+	existing := existingOAuth2Auth(gwID)
+	repo.EXPECT().FindByID(mock.Anything, existing.ID).Return(existing, nil).Once()
+	repo.EXPECT().
+		Update(mock.Anything, mock.MatchedBy(func(a *domain.Auth) bool {
+			return a.Name == "renamed" && a.Type == domain.TypeOAuth2 &&
+				a.Config.OAuth2 != nil && a.Config.OAuth2.ClientSecret == "real-secret"
+		})).
+		Return(nil).
+		Once()
+
+	updater := appauth.NewUpdater(repo, newCacheManager(), cachetest.NoopPublisher(), newTestLogger())
+	got, err := updater.Update(context.Background(), appauth.UpdateInput{
+		ID:        existing.ID,
+		GatewayID: gwID,
+		Name:      ptr("renamed"),
+	})
+	if err != nil {
+		t.Fatalf("Update error: %v", err)
+	}
+	if got.Type != domain.TypeOAuth2 {
+		t.Fatalf("Type = %q, want preserved oauth2", got.Type)
+	}
+	if got.Config.OAuth2 == nil || got.Config.OAuth2.ClientSecret != "real-secret" {
+		t.Fatalf("oauth2 config not preserved: %+v", got.Config.OAuth2)
+	}
+}
+
+func TestUpdater_Update_PreservesSecretWhenMasked(t *testing.T) {
+	t.Parallel()
+	repo := repomocks.NewRepository(t)
+	gwID := ids.New[ids.GatewayKind]()
+	existing := existingOAuth2Auth(gwID)
+	repo.EXPECT().FindByID(mock.Anything, existing.ID).Return(existing, nil).Once()
+	repo.EXPECT().
+		Update(mock.Anything, mock.MatchedBy(func(a *domain.Auth) bool {
+			return a.Config.OAuth2 != nil && a.Config.OAuth2.ClientSecret == "real-secret"
+		})).
+		Return(nil).
+		Once()
+
+	updater := appauth.NewUpdater(repo, newCacheManager(), cachetest.NoopPublisher(), newTestLogger())
+	got, err := updater.Update(context.Background(), appauth.UpdateInput{
+		ID:        existing.ID,
+		GatewayID: gwID,
+		Config:    ptr(oauth2Config("***")),
+	})
+	if err != nil {
+		t.Fatalf("Update error: %v", err)
+	}
+	if got.Config.OAuth2 == nil || got.Config.OAuth2.ClientSecret != "real-secret" {
+		t.Fatalf("masked secret not resolved to stored value: %+v", got.Config.OAuth2)
 	}
 }
 
@@ -58,9 +134,9 @@ func TestUpdater_Update_GatewayMismatch(t *testing.T) {
 	_, err := updater.Update(context.Background(), appauth.UpdateInput{
 		ID:        existing.ID,
 		GatewayID: ids.New[ids.GatewayKind](),
-		Name:      "renamed",
-		Type:      domain.TypeAPIKey,
-		Config:    validConfig(),
+		Name:      ptr("renamed"),
+		Type:      ptr(domain.TypeAPIKey),
+		Config:    ptr(validConfig()),
 	})
 	if !errors.Is(err, domain.ErrInvalidGatewayID) {
 		t.Fatalf("err = %v, want ErrInvalidGatewayID", err)
@@ -76,9 +152,9 @@ func TestUpdater_Update_NotFound(t *testing.T) {
 	updater := appauth.NewUpdater(repo, newCacheManager(), cachetest.NoopPublisher(), newTestLogger())
 	_, err := updater.Update(context.Background(), appauth.UpdateInput{
 		ID:     id,
-		Name:   "x",
-		Type:   domain.TypeAPIKey,
-		Config: validConfig(),
+		Name:   ptr("x"),
+		Type:   ptr(domain.TypeAPIKey),
+		Config: ptr(validConfig()),
 	})
 	if !errors.Is(err, domain.ErrNotFound) {
 		t.Fatalf("err = %v, want ErrNotFound", err)

--- a/pkg/app/consumer/updater.go
+++ b/pkg/app/consumer/updater.go
@@ -15,15 +15,15 @@ import (
 type UpdateInput struct {
 	ID              ids.ConsumerID
 	GatewayID       ids.GatewayID
-	Name            string
-	Type            domain.Type
-	Path            string
-	Algorithm       string
+	Name            *string
+	Type            *domain.Type
+	Path            *string
+	Algorithm       *string
 	EmbeddingConfig *registrydomain.EmbeddingConfig
-	Headers         map[string]string
+	Headers         *map[string]string
 	Active          *bool
 	Fallback        *domain.Fallback
-	ModelPolicies   domain.ModelPolicies
+	ModelPolicies   *domain.ModelPolicies
 }
 
 //go:generate mockery --name=Updater --dir=. --output=./mocks --filename=consumer_updater_mock.go --case=underscore --with-expecter
@@ -62,22 +62,34 @@ func (u *updater) Update(ctx context.Context, in UpdateInput) (*domain.Consumer,
 	if !in.GatewayID.IsNil() && in.GatewayID != existing.GatewayID {
 		return nil, domain.ErrInvalidGatewayID
 	}
-	existing.Name = in.Name
-	if in.Type != "" {
-		existing.Type = in.Type
+	if in.Name != nil {
+		existing.Name = *in.Name
 	}
-	existing.Path = in.Path
-	existing.Algorithm = in.Algorithm
+	if in.Type != nil {
+		existing.Type = *in.Type
+	}
+	if in.Path != nil {
+		existing.Path = *in.Path
+	}
+	if in.Algorithm != nil {
+		existing.Algorithm = *in.Algorithm
+	}
 	if in.EmbeddingConfig != nil {
 		in.EmbeddingConfig.ResolveSecretsFrom(existing.EmbeddingConfig)
+		existing.EmbeddingConfig = in.EmbeddingConfig
 	}
-	existing.EmbeddingConfig = in.EmbeddingConfig
-	existing.Headers = in.Headers
+	if in.Headers != nil {
+		existing.Headers = *in.Headers
+	}
 	if in.Active != nil {
 		existing.Active = *in.Active
 	}
-	existing.Fallback = in.Fallback
-	existing.ModelPolicies = in.ModelPolicies
+	if in.Fallback != nil {
+		existing.Fallback = in.Fallback
+	}
+	if in.ModelPolicies != nil {
+		existing.ModelPolicies = *in.ModelPolicies
+	}
 	existing.UpdatedAt = time.Now().UTC()
 	if err := validateRegistryRefsAssociated(existing); err != nil {
 		return nil, err

--- a/pkg/app/consumer/updater_test.go
+++ b/pkg/app/consumer/updater_test.go
@@ -8,12 +8,14 @@ import (
 
 	appconsumer "github.com/NeuralTrust/AgentGateway/pkg/app/consumer"
 	domain "github.com/NeuralTrust/AgentGateway/pkg/domain/consumer"
-	"github.com/NeuralTrust/AgentGateway/pkg/domain/ids"
 	repomocks "github.com/NeuralTrust/AgentGateway/pkg/domain/consumer/mocks"
+	"github.com/NeuralTrust/AgentGateway/pkg/domain/ids"
 	registrydomain "github.com/NeuralTrust/AgentGateway/pkg/domain/registry"
 	"github.com/NeuralTrust/AgentGateway/pkg/infra/cache/cachetest"
 	"github.com/stretchr/testify/mock"
 )
+
+func ptr[T any](v T) *T { return &v }
 
 func existingConsumer(gwID ids.GatewayID, beID ids.RegistryID) *domain.Consumer {
 	now := time.Now().UTC()
@@ -49,16 +51,50 @@ func TestUpdater_Update_Success(t *testing.T) {
 	got, err := updater.Update(context.Background(), appconsumer.UpdateInput{
 		ID:        existing.ID,
 		GatewayID: gwID,
-		Name:      "new",
-		Type:      domain.TypeMCP,
-		Path:      "/v1/messages",
-		Algorithm: "round-robin",
+		Name:      ptr("new"),
+		Type:      ptr(domain.TypeMCP),
+		Path:      ptr("/v1/messages"),
+		Algorithm: ptr("round-robin"),
 	})
 	if err != nil {
 		t.Fatalf("Update error: %v", err)
 	}
 	if got.Name != "new" || got.Type != domain.TypeMCP {
 		t.Fatalf("not applied: %+v", got)
+	}
+}
+
+func TestUpdater_Update_Partial_PreservesFieldsAndAssociations(t *testing.T) {
+	t.Parallel()
+	gwID := ids.New[ids.GatewayKind]()
+	beID := ids.New[ids.RegistryKind]()
+	existing := existingConsumer(gwID, beID)
+
+	repo := repomocks.NewRepository(t)
+	repo.EXPECT().FindByID(mock.Anything, existing.ID).Return(existing, nil).Once()
+	repo.EXPECT().
+		Update(mock.Anything, mock.MatchedBy(func(c *domain.Consumer) bool {
+			return c.Name == "renamed" && c.Path == "/v1/chat" &&
+				c.Algorithm == "round-robin" && c.Type == domain.TypeLLM &&
+				len(c.RegistryIDs) == 1 && c.RegistryIDs[0] == beID
+		})).
+		Return(nil).
+		Once()
+
+	updater := appconsumer.NewUpdater(repo, newCacheManager(), cachetest.NoopPublisher(), newTestLogger())
+	got, err := updater.Update(context.Background(), appconsumer.UpdateInput{
+		ID:        existing.ID,
+		GatewayID: gwID,
+		Name:      ptr("renamed"),
+	})
+	if err != nil {
+		t.Fatalf("Update error: %v", err)
+	}
+	if got.Path != "/v1/chat" || got.Algorithm != "round-robin" {
+		t.Fatalf("fields not preserved: %+v", got)
+	}
+	if len(got.RegistryIDs) != 1 || got.RegistryIDs[0] != beID {
+		t.Fatalf("associations not preserved: %+v", got.RegistryIDs)
 	}
 }
 
@@ -91,12 +127,12 @@ func TestUpdater_Update_RejectsModelPolicyForUnassociatedRegistry(t *testing.T) 
 	_, err := updater.Update(context.Background(), appconsumer.UpdateInput{
 		ID:        existing.ID,
 		GatewayID: gwID,
-		Name:      "n",
-		Type:      domain.TypeLLM,
-		Path:      "/v1/chat",
-		ModelPolicies: domain.ModelPolicies{
+		Name:      ptr("n"),
+		Type:      ptr(domain.TypeLLM),
+		Path:      ptr("/v1/chat"),
+		ModelPolicies: ptr(domain.ModelPolicies{
 			ids.New[ids.RegistryKind](): {},
-		},
+		}),
 	})
 	if !errors.Is(err, registrydomain.ErrInvalidRegistryID) {
 		t.Fatalf("err = %v, want ErrInvalidRegistryID", err)
@@ -118,12 +154,12 @@ func TestUpdater_Update_AllowsModelPolicyForAssociatedRegistry(t *testing.T) {
 	_, err := updater.Update(context.Background(), appconsumer.UpdateInput{
 		ID:        existing.ID,
 		GatewayID: gwID,
-		Name:      "n",
-		Type:      domain.TypeLLM,
-		Path:      "/v1/chat",
-		ModelPolicies: domain.ModelPolicies{
+		Name:      ptr("n"),
+		Type:      ptr(domain.TypeLLM),
+		Path:      ptr("/v1/chat"),
+		ModelPolicies: ptr(domain.ModelPolicies{
 			beID: {Allowed: []string{"gpt-4o"}, Default: "gpt-4o"},
-		},
+		}),
 	})
 	if err != nil {
 		t.Fatalf("Update error: %v", err)
@@ -144,7 +180,7 @@ func TestUpdater_Update_RejectsCrossGateway(t *testing.T) {
 	_, err := updater.Update(context.Background(), appconsumer.UpdateInput{
 		ID:        existing.ID,
 		GatewayID: otherGW,
-		Name:      "n",
+		Name:      ptr("n"),
 	})
 	if !errors.Is(err, domain.ErrInvalidGatewayID) {
 		t.Fatalf("err = %v, want ErrInvalidGatewayID", err)

--- a/pkg/app/gateway/updater.go
+++ b/pkg/app/gateway/updater.go
@@ -13,10 +13,10 @@ import (
 
 type UpdateInput struct {
 	ID              ids.GatewayID
-	Name            string
-	Status          string
+	Name            *string
+	Status          *string
 	Telemetry       *telemetry.Telemetry
-	ClientTLSConfig domain.ClientTLSConfig
+	ClientTLSConfig *domain.ClientTLSConfig
 	SessionConfig   *domain.SessionConfig
 }
 
@@ -53,11 +53,21 @@ func (u *updater) Update(ctx context.Context, in UpdateInput) (*domain.Gateway, 
 	if err != nil {
 		return nil, err
 	}
-	g.Name = in.Name
-	g.Status = in.Status
-	g.Telemetry = in.Telemetry
-	g.ClientTLSConfig = in.ClientTLSConfig
-	g.SessionConfig = in.SessionConfig
+	if in.Name != nil {
+		g.Name = *in.Name
+	}
+	if in.Status != nil {
+		g.Status = *in.Status
+	}
+	if in.Telemetry != nil {
+		g.Telemetry = in.Telemetry
+	}
+	if in.ClientTLSConfig != nil {
+		g.ClientTLSConfig = *in.ClientTLSConfig
+	}
+	if in.SessionConfig != nil {
+		g.SessionConfig = in.SessionConfig
+	}
 	g.UpdatedAt = time.Now().UTC()
 	if err := g.Validate(); err != nil {
 		return nil, err

--- a/pkg/app/gateway/updater_test.go
+++ b/pkg/app/gateway/updater_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+func ptr[T any](v T) *T { return &v }
+
 func TestUpdater_Update_Success(t *testing.T) {
 	t.Parallel()
 	repo := repomocks.NewRepository(t)
@@ -36,8 +38,8 @@ func TestUpdater_Update_Success(t *testing.T) {
 
 	got, err := updater.Update(context.Background(), appgateway.UpdateInput{
 		ID:     id,
-		Name:   "new",
-		Status: "paused",
+		Name:   ptr("new"),
+		Status: ptr("paused"),
 	})
 	if err != nil {
 		t.Fatalf("Update error: %v", err)
@@ -64,10 +66,38 @@ func TestUpdater_Update_NotFound(t *testing.T) {
 	updater := appgateway.NewUpdater(repo, newCacheManager(), cachetest.NoopPublisher(), newTestLogger())
 	_, err := updater.Update(context.Background(), appgateway.UpdateInput{
 		ID:   id,
-		Name: "x",
+		Name: ptr("x"),
 	})
 	if !errors.Is(err, commonerrors.ErrNotFound) {
 		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestUpdater_Update_Partial_PreservesStatus(t *testing.T) {
+	t.Parallel()
+	repo := repomocks.NewRepository(t)
+	id := ids.New[ids.GatewayKind]()
+	now := time.Now().UTC()
+	existing := domain.Rehydrate(id, "old", "paused", nil, nil, nil, now, now)
+
+	repo.EXPECT().FindByID(mock.Anything, id).Return(existing, nil).Once()
+	repo.EXPECT().
+		Update(mock.Anything, mock.MatchedBy(func(g *domain.Gateway) bool {
+			return g.Name == "renamed" && g.Status == "paused"
+		})).
+		Return(nil).
+		Once()
+
+	updater := appgateway.NewUpdater(repo, newCacheManager(), cachetest.NoopPublisher(), newTestLogger())
+	got, err := updater.Update(context.Background(), appgateway.UpdateInput{
+		ID:   id,
+		Name: ptr("renamed"),
+	})
+	if err != nil {
+		t.Fatalf("Update error: %v", err)
+	}
+	if got.Status != "paused" {
+		t.Fatalf("Status = %q, want preserved paused", got.Status)
 	}
 }
 
@@ -84,7 +114,7 @@ func TestUpdater_Update_RejectsEmptyName(t *testing.T) {
 	updater := appgateway.NewUpdater(repo, newCacheManager(), cachetest.NoopPublisher(), newTestLogger())
 	_, err := updater.Update(context.Background(), appgateway.UpdateInput{
 		ID:   id,
-		Name: "",
+		Name: ptr(""),
 	})
 	if err == nil {
 		t.Fatal("expected validation error, got nil")

--- a/pkg/app/policy/updater.go
+++ b/pkg/app/policy/updater.go
@@ -14,14 +14,14 @@ import (
 type UpdateInput struct {
 	ID          ids.PolicyID
 	GatewayID   ids.GatewayID
-	Name        string
-	Description string
-	Slug        string
-	Enabled     bool
-	Priority    int
-	Parallel    bool
-	Settings    map[string]any
-	Stages      []domain.Stage
+	Name        *string
+	Description *string
+	Slug        *string
+	Enabled     *bool
+	Priority    *int
+	Parallel    *bool
+	Settings    *map[string]any
+	Stages      *[]domain.Stage
 }
 
 //go:generate mockery --name=Updater --dir=. --output=./mocks --filename=policy_updater_mock.go --case=underscore --with-expecter
@@ -63,19 +63,35 @@ func (u *updater) Update(ctx context.Context, in UpdateInput) (*domain.Policy, e
 	if !in.GatewayID.IsNil() && in.GatewayID != existing.GatewayID {
 		return nil, domain.ErrInvalidGatewayID
 	}
-	existing.Name = in.Name
-	existing.Description = in.Description
-	existing.Slug = in.Slug
-	existing.Enabled = in.Enabled
-	existing.Priority = in.Priority
-	existing.Parallel = in.Parallel
-	existing.Settings = in.Settings
-	existing.Stages = in.Stages
+	if in.Name != nil {
+		existing.Name = *in.Name
+	}
+	if in.Description != nil {
+		existing.Description = *in.Description
+	}
+	if in.Slug != nil {
+		existing.Slug = *in.Slug
+	}
+	if in.Enabled != nil {
+		existing.Enabled = *in.Enabled
+	}
+	if in.Priority != nil {
+		existing.Priority = *in.Priority
+	}
+	if in.Parallel != nil {
+		existing.Parallel = *in.Parallel
+	}
+	if in.Settings != nil {
+		existing.Settings = *in.Settings
+	}
+	if in.Stages != nil {
+		existing.Stages = *in.Stages
+	}
 	existing.UpdatedAt = time.Now().UTC()
 	if err := existing.Validate(); err != nil {
 		return nil, err
 	}
-	if err := validatePlugin(u.registry, in.Slug, in.Stages, in.Settings); err != nil {
+	if err := validatePlugin(u.registry, existing.Slug, existing.Stages, existing.Settings); err != nil {
 		return nil, err
 	}
 	if err := u.repo.Update(ctx, existing); err != nil {

--- a/pkg/app/policy/updater_test.go
+++ b/pkg/app/policy/updater_test.go
@@ -22,13 +22,15 @@ func existingPolicy(t *testing.T) *domain.Policy {
 	return p
 }
 
+func ptr[T any](v T) *T { return &v }
+
 func validUpdateInput(id ids.PolicyID) apppolicy.UpdateInput {
 	return apppolicy.UpdateInput{
 		ID:          id,
-		Name:        "new",
-		Description: "new description",
-		Slug:        "rate_limiter",
-		Enabled:     true,
+		Name:        ptr("new"),
+		Description: ptr("new description"),
+		Slug:        ptr("rate_limiter"),
+		Enabled:     ptr(true),
 	}
 }
 
@@ -51,6 +53,34 @@ func TestUpdater_Update_Success(t *testing.T) {
 	}
 	if got.Description != "new description" {
 		t.Fatalf("Description = %q, want %q", got.Description, "new description")
+	}
+}
+
+func TestUpdater_Update_Partial(t *testing.T) {
+	t.Parallel()
+	repo := repomocks.NewRepository(t)
+	existing := existingPolicy(t)
+	repo.EXPECT().FindByID(mock.Anything, existing.ID).Return(existing, nil).Once()
+	repo.EXPECT().Update(mock.Anything, mock.MatchedBy(func(p *domain.Policy) bool {
+		return p.Name == "renamed" && p.Slug == "rate_limiter" && p.Description == "old description"
+	})).Return(nil).Once()
+
+	updater := apppolicy.NewUpdater(repo, newRegistryMock(t, nil), newCacheManager(), cachetest.NoopPublisher(), newTestLogger())
+	got, err := updater.Update(context.Background(), apppolicy.UpdateInput{
+		ID:   existing.ID,
+		Name: ptr("renamed"),
+	})
+	if err != nil {
+		t.Fatalf("Update error: %v", err)
+	}
+	if got.Name != "renamed" {
+		t.Fatalf("Name = %q, want renamed", got.Name)
+	}
+	if got.Slug != "rate_limiter" {
+		t.Fatalf("Slug = %q, want preserved rate_limiter", got.Slug)
+	}
+	if got.Description != "old description" {
+		t.Fatalf("Description = %q, want preserved old description", got.Description)
 	}
 }
 

--- a/pkg/app/registry/updater.go
+++ b/pkg/app/registry/updater.go
@@ -13,11 +13,11 @@ import (
 type UpdateInput struct {
 	ID              ids.RegistryID
 	GatewayID       ids.GatewayID
-	Name            string
-	Provider        string
-	ProviderOptions map[string]any
-	Description     string
-	Weight          int
+	Name            *string
+	Provider        *string
+	ProviderOptions *map[string]any
+	Description     *string
+	Weight          *int
 	Auth            *domain.TargetAuth
 	HealthChecks    *domain.HealthChecks
 }
@@ -58,16 +58,28 @@ func (u *updater) Update(ctx context.Context, in UpdateInput) (*domain.Registry,
 	if !in.GatewayID.IsNil() && in.GatewayID != existing.GatewayID {
 		return nil, domain.ErrInvalidGatewayID
 	}
-	existing.Name = in.Name
-	existing.Provider = in.Provider
-	existing.ProviderOptions = in.ProviderOptions
-	existing.Description = in.Description
-	existing.Weight = in.Weight
+	if in.Name != nil {
+		existing.Name = *in.Name
+	}
+	if in.Provider != nil {
+		existing.Provider = *in.Provider
+	}
+	if in.ProviderOptions != nil {
+		existing.ProviderOptions = *in.ProviderOptions
+	}
+	if in.Description != nil {
+		existing.Description = *in.Description
+	}
+	if in.Weight != nil {
+		existing.Weight = *in.Weight
+	}
 	if in.Auth != nil {
 		in.Auth.ResolveSecretsFrom(existing.Auth)
 		existing.Auth = in.Auth
 	}
-	existing.HealthChecks = in.HealthChecks
+	if in.HealthChecks != nil {
+		existing.HealthChecks = in.HealthChecks
+	}
 	existing.UpdatedAt = time.Now().UTC()
 	if err := existing.Validate(); err != nil {
 		return nil, err

--- a/pkg/app/registry/updater_test.go
+++ b/pkg/app/registry/updater_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+func ptr[T any](v T) *T { return &v }
+
 func TestUpdater_Update_Success(t *testing.T) {
 	t.Parallel()
 	repo := repomocks.NewRepository(t)
@@ -25,8 +27,8 @@ func TestUpdater_Update_Success(t *testing.T) {
 	updater := appregistry.NewUpdater(repo, newCacheManager(), cachetest.NoopPublisher(), newTestLogger())
 	got, err := updater.Update(context.Background(), appregistry.UpdateInput{
 		ID:       existing.ID,
-		Name:     "new",
-		Provider: "openai",
+		Name:     ptr("new"),
+		Provider: ptr("openai"),
 		Auth:     domain.NewAPIKeyAuth("sk-1"),
 	})
 	if err != nil {
@@ -34,6 +36,39 @@ func TestUpdater_Update_Success(t *testing.T) {
 	}
 	if got.Name != "new" {
 		t.Fatalf("Name = %q, want %q", got.Name, "new")
+	}
+}
+
+func TestUpdater_Update_Partial_PreservesProviderOptionsAndHealthChecks(t *testing.T) {
+	t.Parallel()
+	repo := repomocks.NewRepository(t)
+	opts := map[string]any{"base_url": "https://example.com"}
+	hc := &domain.HealthChecks{Threshold: 3, Interval: 10}
+	existing, _ := domain.NewRegistry(ids.New[ids.GatewayKind](), "old", "openai", opts, "", 1, domain.NewAPIKeyAuth("sk-real"), hc)
+	repo.EXPECT().FindByID(mock.Anything, existing.ID).Return(existing, nil).Once()
+	repo.EXPECT().Update(mock.Anything, mock.MatchedBy(func(b *domain.Registry) bool {
+		return b.Name == "renamed" &&
+			b.ProviderOptions["base_url"] == "https://example.com" &&
+			b.HealthChecks != nil && b.HealthChecks.Threshold == 3 &&
+			b.Auth != nil && b.Auth.APIKey != nil && b.Auth.APIKey.APIKey == "sk-real"
+	})).Return(nil).Once()
+
+	updater := appregistry.NewUpdater(repo, newCacheManager(), cachetest.NoopPublisher(), newTestLogger())
+	got, err := updater.Update(context.Background(), appregistry.UpdateInput{
+		ID:   existing.ID,
+		Name: ptr("renamed"),
+	})
+	if err != nil {
+		t.Fatalf("Update error: %v", err)
+	}
+	if got.ProviderOptions["base_url"] != "https://example.com" {
+		t.Fatalf("provider_options not preserved: %+v", got.ProviderOptions)
+	}
+	if got.HealthChecks == nil || got.HealthChecks.Threshold != 3 {
+		t.Fatalf("health_checks not preserved: %+v", got.HealthChecks)
+	}
+	if got.Auth == nil || got.Auth.APIKey.APIKey != "sk-real" {
+		t.Fatalf("auth not preserved: %+v", got.Auth)
 	}
 }
 
@@ -49,8 +84,8 @@ func TestUpdater_Update_PreservesRedactedSecret(t *testing.T) {
 	updater := appregistry.NewUpdater(repo, newCacheManager(), cachetest.NoopPublisher(), newTestLogger())
 	got, err := updater.Update(context.Background(), appregistry.UpdateInput{
 		ID:       existing.ID,
-		Name:     "old",
-		Provider: "openai",
+		Name:     ptr("old"),
+		Provider: ptr("openai"),
 		Auth:     domain.NewAPIKeyAuth("***"),
 	})
 	if err != nil {
@@ -73,8 +108,8 @@ func TestUpdater_Update_PreservesSecretWhenAuthOmitted(t *testing.T) {
 	updater := appregistry.NewUpdater(repo, newCacheManager(), cachetest.NoopPublisher(), newTestLogger())
 	got, err := updater.Update(context.Background(), appregistry.UpdateInput{
 		ID:       existing.ID,
-		Name:     "renamed",
-		Provider: "openai",
+		Name:     ptr("renamed"),
+		Provider: ptr("openai"),
 	})
 	if err != nil {
 		t.Fatalf("Update error: %v", err)
@@ -94,8 +129,8 @@ func TestUpdater_Update_RejectsGatewayIDChange(t *testing.T) {
 	_, err := updater.Update(context.Background(), appregistry.UpdateInput{
 		ID:        existing.ID,
 		GatewayID: ids.New[ids.GatewayKind](),
-		Name:      "x",
-		Provider:  "openai",
+		Name:      ptr("x"),
+		Provider:  ptr("openai"),
 		Auth:      domain.NewAPIKeyAuth("sk-1"),
 	})
 	if !errors.Is(err, domain.ErrInvalidGatewayID) {
@@ -112,8 +147,8 @@ func TestUpdater_Update_NotFound(t *testing.T) {
 	updater := appregistry.NewUpdater(repo, newCacheManager(), cachetest.NoopPublisher(), newTestLogger())
 	_, err := updater.Update(context.Background(), appregistry.UpdateInput{
 		ID:       id,
-		Name:     "x",
-		Provider: "openai",
+		Name:     ptr("x"),
+		Provider: ptr("openai"),
 		Auth:     domain.NewAPIKeyAuth("sk-1"),
 	})
 	if !errors.Is(err, domain.ErrNotFound) {

--- a/pkg/infra/plugins/cors/config.go
+++ b/pkg/infra/plugins/cors/config.go
@@ -23,8 +23,8 @@ var allowedHTTPMethods = map[string]struct{}{
 }
 
 func parseConfig(settings map[string]any) (*config, error) {
-	var cfg config
-	if err := pluginutil.Decode(settings, &cfg); err != nil {
+	cfg, err := pluginutil.Parse[config](settings)
+	if err != nil {
 		return nil, err
 	}
 	if err := cfg.validate(); err != nil {

--- a/pkg/infra/plugins/pluginutil/decode.go
+++ b/pkg/infra/plugins/pluginutil/decode.go
@@ -24,3 +24,11 @@ func Decode(settings map[string]any, target any) error {
 	}
 	return nil
 }
+
+func Parse[T any](settings map[string]any) (T, error) {
+	var cfg T
+	if err := Decode(settings, &cfg); err != nil {
+		return cfg, err
+	}
+	return cfg, nil
+}

--- a/pkg/infra/plugins/ratelimit/config.go
+++ b/pkg/infra/plugins/ratelimit/config.go
@@ -36,8 +36,8 @@ type actionsConfig struct {
 }
 
 func parseConfig(settings map[string]any) (*config, error) {
-	var cfg config
-	if err := pluginutil.Decode(settings, &cfg); err != nil {
+	cfg, err := pluginutil.Parse[config](settings)
+	if err != nil {
 		return nil, err
 	}
 	if err := cfg.validate(); err != nil {

--- a/pkg/infra/plugins/requestsize/config.go
+++ b/pkg/infra/plugins/requestsize/config.go
@@ -27,8 +27,8 @@ type config struct {
 }
 
 func parseConfig(settings map[string]any) (*config, error) {
-	var cfg config
-	if err := pluginutil.Decode(settings, &cfg); err != nil {
+	cfg, err := pluginutil.Parse[config](settings)
+	if err != nil {
 		return nil, err
 	}
 	if err := cfg.validate(); err != nil {

--- a/pkg/infra/plugins/semanticcache/config.go
+++ b/pkg/infra/plugins/semanticcache/config.go
@@ -28,8 +28,8 @@ type config struct {
 }
 
 func parseConfig(settings map[string]any) (*config, error) {
-	var cfg config
-	if err := pluginutil.Decode(settings, &cfg); err != nil {
+	cfg, err := pluginutil.Parse[config](settings)
+	if err != nil {
 		return nil, err
 	}
 	cfg.applyDefaults()

--- a/pkg/infra/plugins/tokenratelimit/config.go
+++ b/pkg/infra/plugins/tokenratelimit/config.go
@@ -25,8 +25,8 @@ var validUnits = map[string]int{
 }
 
 func parseConfig(settings map[string]any) (*config, error) {
-	var cfg config
-	if err := pluginutil.Decode(settings, &cfg); err != nil {
+	cfg, err := pluginutil.Parse[config](settings)
+	if err != nil {
 		return nil, err
 	}
 	if err := cfg.validate(); err != nil {

--- a/tests/functional/update_auth_test.go
+++ b/tests/functional/update_auth_test.go
@@ -38,6 +38,36 @@ func TestUpdateAuth_Success(t *testing.T) {
 	assert.False(t, hasAPIKeyCfg, "api_key auth must not carry a config.api_key block: %v", cfg)
 }
 
+func TestUpdateAuth_Partial_OAuth2PreservesConfig(t *testing.T) {
+	defer Track(t, "UpdateAuth")()
+	gwID := CreateGateway(t, map[string]any{"name": uniqueName("auth-upd-oauth-gw")})
+	id := CreateAuth(t, gwID, map[string]any{
+		"name": uniqueName("oauth-cred"),
+		"type": "oauth2",
+		"config": map[string]any{
+			"oauth2": map[string]any{
+				"issuer":        "https://issuer.example.com",
+				"jwks_url":      "https://issuer.example.com/jwks",
+				"client_id":     "client-123",
+				"client_secret": "super-secret",
+			},
+		},
+	})
+
+	renamed := uniqueName("oauth-renamed")
+	url := fmt.Sprintf("%s/v1/gateways/%s/auths/%s", AdminURL, gwID, id)
+	status, body := sendRequest(t, http.MethodPut, url, nil, map[string]any{"name": renamed})
+	require.Equal(t, http.StatusOK, status, "body=%v", body)
+	assert.Equal(t, renamed, body["name"])
+	assert.Equal(t, "oauth2", body["type"], "type must be preserved on a partial update")
+
+	cfg, ok := body["config"].(map[string]any)
+	require.True(t, ok, "config must be preserved on a partial update: %v", body)
+	oauth2, ok := cfg["oauth2"].(map[string]any)
+	require.True(t, ok, "oauth2 config block must be preserved: %v", cfg)
+	assert.Equal(t, "https://issuer.example.com", oauth2["issuer"])
+}
+
 func TestUpdateAuth_Validation(t *testing.T) {
 	defer Track(t, "UpdateAuth")()
 	gwID := CreateGateway(t, map[string]any{"name": uniqueName("auth-upd-val")})

--- a/tests/functional/update_consumer_test.go
+++ b/tests/functional/update_consumer_test.go
@@ -117,6 +117,42 @@ func TestUpdateConsumer_RejectsModelPolicyForUnassociatedRegistry(t *testing.T) 
 	assert.Equal(t, "validation_failed", body["error"])
 }
 
+func TestUpdateConsumer_Partial(t *testing.T) {
+	defer Track(t, "UpdateConsumer")()
+	gwID := CreateGateway(t, map[string]any{"name": uniqueName("co-upd-partial-gw")})
+	name := uniqueName("co-upd-partial")
+	coID := CreateConsumer(t, gwID, validConsumerPayload(name))
+	expectedPath := "/v1/" + name
+
+	renamed := uniqueName("co-upd-partial-to")
+	url := fmt.Sprintf("%s/v1/gateways/%s/consumers/%s", AdminURL, gwID, coID)
+	status, body := sendRequest(t, http.MethodPut, url, nil, map[string]any{"name": renamed})
+	require.Equal(t, http.StatusOK, status, "body=%v", body)
+	assert.Equal(t, renamed, body["name"])
+
+	status, body = sendRequest(t, http.MethodGet, url, nil, nil)
+	require.Equal(t, http.StatusOK, status)
+	assert.Equal(t, renamed, body["name"])
+	assert.Equal(t, expectedPath, body["path"], "path must be preserved on a partial update")
+}
+
+func TestUpdateConsumer_Partial_EmptyTypePreservesExisting(t *testing.T) {
+	defer Track(t, "UpdateConsumer")()
+	gwID := CreateGateway(t, map[string]any{"name": uniqueName("co-upd-empty-type-gw")})
+	name := uniqueName("co-upd-empty-type")
+	payload := validConsumerPayload(name)
+	payload["type"] = "MCP"
+	coID := CreateConsumer(t, gwID, payload)
+
+	url := fmt.Sprintf("%s/v1/gateways/%s/consumers/%s", AdminURL, gwID, coID)
+	status, body := sendRequest(t, http.MethodPut, url, nil, map[string]any{"type": ""})
+	require.Equal(t, http.StatusOK, status, "body=%v", body)
+
+	status, body = sendRequest(t, http.MethodGet, url, nil, nil)
+	require.Equal(t, http.StatusOK, status)
+	assert.Equal(t, "MCP", body["type"], "empty type must be treated as no-change, not reset to LLM")
+}
+
 func TestUpdateConsumer_NotFound(t *testing.T) {
 	defer Track(t, "UpdateConsumer")()
 	gwID := CreateGateway(t, map[string]any{"name": uniqueName("co-upd-missing-gw")})

--- a/tests/functional/update_gateway_test.go
+++ b/tests/functional/update_gateway_test.go
@@ -39,6 +39,26 @@ func TestUpdateGateway_Success(t *testing.T) {
 	assert.Equal(t, "inactive", body["status"])
 }
 
+func TestUpdateGateway_Partial(t *testing.T) {
+	defer Track(t, "UpdateGateway")()
+	id := CreateGateway(t, map[string]any{"name": uniqueName("upd-partial")})
+	url := fmt.Sprintf("%s/v1/gateways/%s", AdminURL, id)
+
+	status, body := sendRequest(t, http.MethodPut, url, nil, map[string]any{"status": "inactive"})
+	require.Equal(t, http.StatusOK, status, "body=%v", body)
+	assert.Equal(t, "inactive", body["status"])
+
+	renamed := uniqueName("upd-partial-to")
+	status, body = sendRequest(t, http.MethodPut, url, nil, map[string]any{"name": renamed})
+	require.Equal(t, http.StatusOK, status, "body=%v", body)
+	assert.Equal(t, renamed, body["name"])
+
+	status, body = sendRequest(t, http.MethodGet, url, nil, nil)
+	require.Equal(t, http.StatusOK, status)
+	assert.Equal(t, renamed, body["name"])
+	assert.Equal(t, "inactive", body["status"], "status must be preserved on a partial update")
+}
+
 func TestUpdateGateway_NotFound(t *testing.T) {
 	defer Track(t, "UpdateGateway")()
 	missing := uuid.NewString()

--- a/tests/functional/update_policy_test.go
+++ b/tests/functional/update_policy_test.go
@@ -41,6 +41,25 @@ func TestUpdatePolicy_Success(t *testing.T) {
 	assert.Equal(t, "cors", body["slug"])
 }
 
+func TestUpdatePolicy_Partial(t *testing.T) {
+	defer Track(t, "UpdatePolicy")()
+	gwID := CreateGateway(t, map[string]any{"name": uniqueName("polu-partial-gw")})
+	id := CreatePolicy(t, gwID, validPolicyPayload(uniqueName("polu-partial")))
+
+	renamed := uniqueName("polu-partial-to")
+	url := fmt.Sprintf("%s/v1/gateways/%s/policies/%s", AdminURL, gwID, id)
+	status, body := sendRequest(t, http.MethodPut, url, nil, map[string]any{"name": renamed})
+	require.Equal(t, http.StatusOK, status, "body=%v", body)
+	assert.Equal(t, renamed, body["name"])
+
+	status, body = sendRequest(t, http.MethodGet, url, nil, nil)
+	require.Equal(t, http.StatusOK, status)
+	assert.Equal(t, renamed, body["name"])
+	assert.Equal(t, "rate_limiter", body["slug"], "slug must be preserved on a partial update")
+	assert.Equal(t, true, body["enabled"], "enabled must be preserved on a partial update")
+	assert.NotNil(t, body["settings"], "settings must be preserved on a partial update")
+}
+
 func TestUpdatePolicy_NotFound(t *testing.T) {
 	defer Track(t, "UpdatePolicy")()
 	gwID := CreateGateway(t, map[string]any{"name": uniqueName("polu-gw2")})

--- a/tests/functional/update_registry_test.go
+++ b/tests/functional/update_registry_test.go
@@ -39,6 +39,24 @@ func TestUpdateRegistry_Success(t *testing.T) {
 	assert.Equal(t, "anthropic", body["provider"])
 }
 
+func TestUpdateRegistry_Partial(t *testing.T) {
+	defer Track(t, "UpdateRegistry")()
+	gwID := CreateGateway(t, map[string]any{"name": uniqueName("be-upd-partial-gw")})
+	beID := CreateRegistry(t, gwID, validRegistryPayload(uniqueName("be-upd-partial")))
+
+	renamed := uniqueName("be-upd-partial-to")
+	url := fmt.Sprintf("%s/v1/gateways/%s/registries/%s", AdminURL, gwID, beID)
+	status, body := sendRequest(t, http.MethodPut, url, nil, map[string]any{"name": renamed})
+	require.Equal(t, http.StatusOK, status, "body=%v", body)
+	assert.Equal(t, renamed, body["name"])
+
+	status, body = sendRequest(t, http.MethodGet, url, nil, nil)
+	require.Equal(t, http.StatusOK, status)
+	assert.Equal(t, renamed, body["name"])
+	assert.Equal(t, "openai", body["provider"], "provider must be preserved on a partial update")
+	assert.NotNil(t, body["auth"], "auth must be preserved when omitted on update")
+}
+
 func TestUpdateRegistry_NotFound(t *testing.T) {
 	defer Track(t, "UpdateRegistry")()
 	gwID := CreateGateway(t, map[string]any{"name": uniqueName("be-upd-missing-gw")})


### PR DESCRIPTION
## Summary
- Los PUT de **policy, registry, consumer, gateway y auth** pasan a ser **parciales**: el cliente envía solo los campos a cambiar y el resto conserva su valor almacenado (antes los campos ausentes llegaban como su valor cero y sobreescribían lo guardado).
- Implementado con **punteros** en los request DTO y en el `UpdateInput` de cada updater: un campo ausente (`nil`) se distingue de uno presente (aunque su valor sea el cero). La validación de dominio corre sobre la entidad final fusionada.
- **Secretos preservados**: `registry.auth`, `consumer.embedding_config` y `auth.config` mantienen el secreto almacenado vía `ResolveSecretsFrom` cuando el bloque se omite o llega enmascarado (`***`).
- **Arreglos de borrado/reset silencioso**: omitir `health_checks`/`provider_options` (registry), `model_policies`/`headers`/`fallback` (consumer) o `status` (gateway) ya no los borra/resetea. En consumer, `type`/`algorithm` vacíos se tratan como "sin cambio" para evitar coacción silenciosa a `LLM`/`RoundRobin`.
- **Auth** ahora permite cambiar `type` y `config` de forma parcial (antes solo `name`/`enabled`); el cambio de `type` exige su bloque de `config` acorde (validación de dominio).
- Añadido helper genérico **`pluginutil.Parse[T]`** y refactorizados los `parseConfig` de los 5 plugins (`cors`, `ratelimit`, `tokenratelimit`, `requestsize`, `semanticcache`) sin cambios de comportamiento.

## Semántica
- **Omitir = conservar.** No hay tri-state (no se soporta borrar enviando `null`); para vaciar se envía el valor vacío explícito donde aplique.
- **Maps y slices** (`settings`, `provider_options`, `headers`, `model_policies`, `client_tls`): si vienen presentes se reemplazan enteros; si no, se conservan.

## Test plan
- [x] `go build ./...` y `go vet ./...`
- [x] `go test ./...` (suite completa en verde)
- [x] Tests unitarios de update parcial por recurso (preservación de campos omitidos, secretos, asociaciones)
- [x] Tests de mapeo `ToType`/`ToAlgorithm` (nil/vacío/espacios/valor)
- [x] `go vet -tags functional ./tests/functional/...` (compila)
- [x] `golangci-lint run` sobre los paquetes afectados: 0 issues
- [ ] Funcionales end-to-end (`make test-functional`) contra entorno levantado: `TestUpdate<Resource>_Partial` + caso oauth2 + `type` vacío preservado