### PR TITLE
feat(plugins): rate & token limits por consumer/gateway con agrupación por header

### DIFF
--- a/docs/policies.json
+++ b/docs/policies.json
@@ -84,7 +84,7 @@
         {
           "slug": "rate_limiter",
           "name": "Rate Limiter",
-          "description": "Limit request volume using sliding windows scoped globally or per user, IP or fingerprint.",
+          "description": "Limit request volume using a sliding window. The limit applies gateway-wide when the policy is global, otherwise per consumer.",
           "mandatory_stages": [
             "pre_request"
           ],
@@ -94,64 +94,31 @@
           "settings_schema": {
             "fields": [
               {
-                "key": "limits",
-                "label": "Limits",
-                "type": "map",
-                "description": "Per-scope request limits. At least one scope must be configured.",
-                "required": true,
-                "key_options": [
-                  "global",
-                  "per_user",
-                  "per_ip",
-                  "per_fingerprint"
-                ],
-                "value": {
-                  "key": "limit",
-                  "label": "Limit",
-                  "type": "object",
-                  "fields": [
-                    {
-                      "key": "limit",
-                      "label": "Max Requests",
-                      "type": "integer",
-                      "description": "Maximum number of requests allowed within the window.",
-                      "required": true
-                    },
-                    {
-                      "key": "window",
-                      "label": "Window",
-                      "type": "duration",
-                      "description": "Sliding window duration (e.g. 1s, 1m, 1h).",
-                      "required": true
-                    }
-                  ]
-                }
+                "key": "limit",
+                "label": "Max Requests",
+                "type": "integer",
+                "description": "Maximum number of requests allowed within the window.",
+                "required": true
               },
               {
-                "key": "actions",
-                "label": "Actions",
-                "type": "object",
-                "description": "Behaviour applied when a limit is exceeded.",
-                "fields": [
-                  {
-                    "key": "type",
-                    "label": "Action Type",
-                    "type": "enum",
-                    "description": "How to respond when the limit is exceeded.",
-                    "default": "reject",
-                    "enum": [
-                      "reject",
-                      "block"
-                    ]
-                  },
-                  {
-                    "key": "retry_after",
-                    "label": "Retry After",
-                    "type": "string",
-                    "description": "Value sent in the Retry-After header, in seconds.",
-                    "default": "60"
-                  }
-                ]
+                "key": "window",
+                "label": "Window",
+                "type": "duration",
+                "description": "Sliding window duration (e.g. 1s, 1m, 1h).",
+                "required": true
+              },
+              {
+                "key": "retry_after",
+                "label": "Retry After",
+                "type": "string",
+                "description": "Value sent in the Retry-After header, in seconds, when the limit is exceeded.",
+                "default": "60"
+              },
+              {
+                "key": "group_by_header",
+                "label": "Group By Header",
+                "type": "string",
+                "description": "Optional request header whose value sub-partitions the limit within the policy scope (e.g. X-User-Id). When empty, the limit is counted per gateway (global) or per consumer."
               }
             ]
           }
@@ -213,7 +180,7 @@
         {
           "slug": "token_rate_limiter",
           "name": "Token Rate Limiter",
-          "description": "Enforce an LLM token budget per identifier over a fixed time window.",
+          "description": "Enforce an LLM token budget over a fixed time window. The budget applies gateway-wide when the policy is global, otherwise per consumer.",
           "mandatory_stages": [
             "pre_request",
             "post_response"
@@ -224,12 +191,6 @@
           ],
           "settings_schema": {
             "fields": [
-              {
-                "key": "identifier_header",
-                "label": "Identifier Header",
-                "type": "string",
-                "description": "Request header used to identify the caller. Falls back to a shared budget when empty."
-              },
               {
                 "key": "window",
                 "label": "Window",
@@ -257,6 +218,12 @@
                     "required": true
                   }
                 ]
+              },
+              {
+                "key": "group_by_header",
+                "label": "Group By Header",
+                "type": "string",
+                "description": "Optional request header whose value sub-partitions the budget within the policy scope (e.g. X-User-Id). When empty, the budget is counted per gateway (global) or per consumer."
               }
             ]
           }

--- a/pkg/app/plugins/catalog_metadata.go
+++ b/pkg/app/plugins/catalog_metadata.go
@@ -36,52 +36,35 @@ var pluginCatalogMeta = map[string]catalogMeta{
 	"rate_limiter": {
 		name:        "Rate Limiter",
 		group:       groupTrafficControl,
-		description: "Limit request volume using sliding windows scoped globally or per user, IP or fingerprint.",
+		description: "Limit request volume using a sliding window. The limit applies gateway-wide when the policy is global, otherwise per consumer.",
 		schema: SettingsSchema{
 			Fields: []Field{
 				{
-					Key:         "limits",
-					Label:       "Limits",
-					Type:        FieldTypeMap,
-					Description: "Per-scope request limits. At least one scope must be configured.",
+					Key:         "limit",
+					Label:       "Max Requests",
+					Type:        FieldTypeInteger,
+					Description: "Maximum number of requests allowed within the window.",
 					Required:    true,
-					KeyOptions:  []string{"global", "per_user", "per_ip", "per_fingerprint"},
-					Value: &Field{
-						Key:   "limit",
-						Label: "Limit",
-						Type:  FieldTypeObject,
-						Fields: []Field{
-							{
-								Key:         "limit",
-								Label:       "Max Requests",
-								Type:        FieldTypeInteger,
-								Description: "Maximum number of requests allowed within the window.",
-								Required:    true,
-							},
-							{
-								Key:         "window",
-								Label:       "Window",
-								Type:        FieldTypeDuration,
-								Description: "Sliding window duration (e.g. 1s, 1m, 1h).",
-								Required:    true,
-							},
-						},
-					},
 				},
 				{
-					Key:         "actions",
-					Label:       "Actions",
-					Type:        FieldTypeObject,
-					Description: "Behaviour applied when a limit is exceeded. How the limit is enforced (block, throttle or observe) is controlled by the policy mode.",
-					Fields: []Field{
-						{
-							Key:         "retry_after",
-							Label:       "Retry After",
-							Type:        FieldTypeString,
-							Description: "Value sent in the Retry-After header, in seconds.",
-							Default:     "60",
-						},
-					},
+					Key:         "window",
+					Label:       "Window",
+					Type:        FieldTypeDuration,
+					Description: "Sliding window duration (e.g. 1s, 1m, 1h).",
+					Required:    true,
+				},
+				{
+					Key:         "retry_after",
+					Label:       "Retry After",
+					Type:        FieldTypeString,
+					Description: "Value sent in the Retry-After header, in seconds, when the limit is exceeded.",
+					Default:     "60",
+				},
+				{
+					Key:         "group_by_header",
+					Label:       "Group By Header",
+					Type:        FieldTypeString,
+					Description: "Optional request header whose value sub-partitions the limit within the policy scope (e.g. X-User-Id). When empty, the limit is counted per gateway (global) or per consumer.",
 				},
 			},
 		},
@@ -184,15 +167,9 @@ var pluginCatalogMeta = map[string]catalogMeta{
 	"token_rate_limiter": {
 		name:        "Token Rate Limiter",
 		group:       groupQuota,
-		description: "Enforce an LLM token budget per identifier over a fixed time window.",
+		description: "Enforce an LLM token budget over a fixed time window. The budget applies gateway-wide when the policy is global, otherwise per consumer.",
 		schema: SettingsSchema{
 			Fields: []Field{
-				{
-					Key:         "identifier_header",
-					Label:       "Identifier Header",
-					Type:        FieldTypeString,
-					Description: "Request header used to identify the caller. Falls back to a shared budget when empty.",
-				},
 				{
 					Key:      "window",
 					Label:    "Window",
@@ -215,6 +192,12 @@ var pluginCatalogMeta = map[string]catalogMeta{
 							Required:    true,
 						},
 					},
+				},
+				{
+					Key:         "group_by_header",
+					Label:       "Group By Header",
+					Type:        FieldTypeString,
+					Description: "Optional request header whose value sub-partitions the budget within the policy scope (e.g. X-User-Id). When empty, the budget is counted per gateway (global) or per consumer.",
 				},
 			},
 		},

--- a/pkg/app/plugins/chain.go
+++ b/pkg/app/plugins/chain.go
@@ -12,6 +12,7 @@ type chainEntry struct {
 	mode     policy.Mode
 	priority int
 	parallel bool
+	global   bool
 }
 
 func buildStageChain(reg Registry, policies []*policy.Policy, stage policy.Stage) []chainEntry {
@@ -45,6 +46,7 @@ func buildStageChain(reg Registry, policies []*policy.Policy, stage policy.Stage
 			mode:     pol.Mode.Normalize(),
 			priority: pol.Priority,
 			parallel: pol.Parallel,
+			global:   pol.IsGlobal(),
 		})
 	}
 

--- a/pkg/app/plugins/executor.go
+++ b/pkg/app/plugins/executor.go
@@ -138,6 +138,7 @@ func (e *executor) runOne(
 		Stage:    stage,
 		Mode:     entry.mode,
 		Config:   entry.config,
+		Scope:    scopeFromRequest(req, entry.global),
 		Request:  req,
 		Response: resp,
 		Event:    event,
@@ -163,6 +164,15 @@ func (e *executor) runOne(
 			slog.String("error", err.Error()))
 	}
 	return res, err
+}
+
+func scopeFromRequest(req *infracontext.RequestContext, global bool) RuntimeScope {
+	scope := RuntimeScope{Global: global}
+	if req != nil {
+		scope.GatewayID = req.GatewayID
+		scope.ConsumerID = req.ConsumerID
+	}
+	return scope
 }
 
 func isolateRequest(src *infracontext.RequestContext) *infracontext.RequestContext {

--- a/pkg/app/plugins/executor_test.go
+++ b/pkg/app/plugins/executor_test.go
@@ -63,6 +63,7 @@ type polSpec struct {
 	enabled  bool
 	priority int
 	parallel bool
+	global   bool
 	stages   []policy.Stage
 }
 
@@ -77,10 +78,28 @@ func policies(t *testing.T, specs ...polSpec) []*policy.Policy {
 			Enabled:  s.enabled,
 			Priority: s.priority,
 			Parallel: s.parallel,
+			Global:   s.global,
 			Stages:   s.stages,
 		})
 	}
 	return out
+}
+
+// scopeCapturePlugin records the RuntimeScope it was executed with so tests can
+// assert the executor derived it from the policy and the request.
+type scopeCapturePlugin struct {
+	name string
+	seen chan ExecInput
+}
+
+func (s *scopeCapturePlugin) Name() string                        { return s.name }
+func (s *scopeCapturePlugin) MandatoryStages() []policy.Stage     { return []policy.Stage{policy.StagePreRequest} }
+func (s *scopeCapturePlugin) SupportedStages() []policy.Stage     { return []policy.Stage{policy.StagePreRequest} }
+func (s *scopeCapturePlugin) SupportedModes() []policy.Mode       { return []policy.Mode{policy.ModeEnforce} }
+func (s *scopeCapturePlugin) ValidateConfig(map[string]any) error { return nil }
+func (s *scopeCapturePlugin) Execute(_ context.Context, in ExecInput) (*Result, error) {
+	s.seen <- in
+	return &Result{StatusCode: 200}, nil
 }
 
 func newRegistry(t *testing.T, ps ...Plugin) Registry {
@@ -330,6 +349,53 @@ func TestExecutor_RunStage_MergesHeadersInOrder(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"Origin", "Accept"}, resp.Headers["Vary"])
+}
+
+func TestExecutor_RunStage_PropagatesConsumerScope(t *testing.T) {
+	p := &scopeCapturePlugin{name: "rate", seen: make(chan ExecInput, 1)}
+	reg := newRegistry(t, p)
+	exec := NewExecutor(reg, nil)
+
+	_, err := exec.RunStage(context.Background(), StageInput{
+		Stage:    policy.StagePreRequest,
+		Policies: policies(t, polSpec{slug: "rate", enabled: true, global: false}),
+		Request:  &infracontext.RequestContext{GatewayID: "gw-1", ConsumerID: "c-1"},
+		Response: &infracontext.ResponseContext{},
+	})
+	require.NoError(t, err)
+
+	in := <-p.seen
+	assert.False(t, in.Scope.Global)
+	assert.Equal(t, "gw-1", in.Scope.GatewayID)
+	assert.Equal(t, "c-1", in.Scope.ConsumerID)
+
+	dimension, id, err := in.Scope.Subject()
+	require.NoError(t, err)
+	assert.Equal(t, "consumer", dimension)
+	assert.Equal(t, "c-1", id)
+}
+
+func TestExecutor_RunStage_PropagatesGlobalScopeFromPlan(t *testing.T) {
+	p := &scopeCapturePlugin{name: "rate", seen: make(chan ExecInput, 1)}
+	reg := newRegistry(t, p)
+	exec := NewExecutor(reg, nil)
+
+	plan := NewStagePlan(reg, policies(t, polSpec{slug: "rate", enabled: true, global: true}))
+	_, err := exec.RunStage(context.Background(), StageInput{
+		Stage:    policy.StagePreRequest,
+		Plan:     plan,
+		Request:  &infracontext.RequestContext{GatewayID: "gw-1", ConsumerID: "c-1"},
+		Response: &infracontext.ResponseContext{},
+	})
+	require.NoError(t, err)
+
+	in := <-p.seen
+	assert.True(t, in.Scope.Global, "a global policy must propagate Global through the precomputed plan")
+
+	dimension, id, err := in.Scope.Subject()
+	require.NoError(t, err)
+	assert.Equal(t, "global", dimension)
+	assert.Equal(t, "gw-1", id)
 }
 
 func TestExecutor_RunStage_RecordsPluginSpanOnTrace(t *testing.T) {

--- a/pkg/app/plugins/plan.go
+++ b/pkg/app/plugins/plan.go
@@ -47,6 +47,7 @@ func NewStagePlan(reg Registry, policies []*policy.Policy) *StagePlan {
 			mode:     pol.Mode.Normalize(),
 			priority: pol.Priority,
 			parallel: pol.Parallel,
+			global:   pol.IsGlobal(),
 		}
 		for _, stage := range planStages {
 			if isEffectiveStage(plugin, pol.Stages, stage) {

--- a/pkg/app/plugins/plugin.go
+++ b/pkg/app/plugins/plugin.go
@@ -2,6 +2,7 @@ package plugins
 
 import (
 	"context"
+	"errors"
 
 	"github.com/NeuralTrust/AgentGateway/pkg/domain/policy"
 	infracontext "github.com/NeuralTrust/AgentGateway/pkg/infra/context"
@@ -35,11 +36,39 @@ type ExecInput struct {
 	Stage    policy.Stage
 	Mode     policy.Mode
 	Config   policy.PluginConfig
+	Scope    RuntimeScope
 	Request  *infracontext.RequestContext
 	Response *infracontext.ResponseContext
 	// Event is the per-invocation metrics sink. It is nil when plugin traces
 	// are disabled, so plugins must nil-check before using it.
 	Event *metrics.EventContext
+}
+
+// RuntimeScope is the execution scope derived from the policy and the resolved
+// consumer. It tells a plugin whether the policy applies gateway-wide (Global)
+// or to a single consumer, so stateful plugins can partition their state
+// accordingly. It is derived from the source of truth (Policy.Global plus the
+// resolved consumer), never from request headers, path or credentials.
+type RuntimeScope struct {
+	GatewayID  string
+	ConsumerID string
+	Global     bool
+}
+
+// Subject resolves the partition for this execution: gateway-wide when the
+// policy is global, otherwise the current consumer. It returns the dimension
+// label ("global" or "consumer") and the identifier to key state on.
+func (s RuntimeScope) Subject() (dimension string, id string, err error) {
+	if s.Global {
+		if s.GatewayID == "" {
+			return "", "", errors.New("plugins: missing gateway id for global scope")
+		}
+		return "global", s.GatewayID, nil
+	}
+	if s.ConsumerID == "" {
+		return "", "", errors.New("plugins: missing consumer id for consumer scope")
+	}
+	return "consumer", s.ConsumerID, nil
 }
 
 // Result carries the changes a plugin wants the executor to apply. Headers are

--- a/pkg/app/proxy/forwarder.go
+++ b/pkg/app/proxy/forwarder.go
@@ -102,6 +102,7 @@ func (f *forwarder) Forward(ctx context.Context, in ForwardInput) (*ForwardResul
 		return nil, ErrNoBackendsInPool
 	}
 
+	f.stampConsumerScope(in)
 	f.stampContinuation(ctx, in.Request)
 
 	lb, bk, err := f.selectBackend(in.Consumer, in.Request)
@@ -293,6 +294,19 @@ func (f *forwarder) recordSpan(
 	_ = rt.AddSpan(span)
 	span.End()
 	return span
+}
+
+// stampConsumerScope records the resolved consumer (and gateway) identity on the
+// request so plugins can partition runtime state (e.g. rate-limit counters) by
+// the policy scope without re-resolving the consumer from headers or path.
+func (f *forwarder) stampConsumerScope(in ForwardInput) {
+	if in.Request == nil {
+		return
+	}
+	in.Request.ConsumerID = in.Consumer.Consumer.ID.String()
+	if in.Request.GatewayID == "" {
+		in.Request.GatewayID = in.Consumer.Consumer.GatewayID.String()
+	}
 }
 
 func (f *forwarder) stampContinuation(ctx context.Context, req *infracontext.RequestContext) {

--- a/pkg/domain/consumer/repository.go
+++ b/pkg/domain/consumer/repository.go
@@ -20,8 +20,7 @@ type Repository interface {
 	Delete(ctx context.Context, id ids.ConsumerID) error
 	FindByID(ctx context.Context, id ids.ConsumerID) (*Consumer, error)
 	List(ctx context.Context, filter ListFilter) (items []*Consumer, total int, err error)
-	// ListByGateway returns every consumer of a gateway, unpaginated. It backs
-	// the per-gateway aggregated read model consumed on the hot path.
+
 	ListByGateway(ctx context.Context, gatewayID ids.GatewayID) ([]*Consumer, error)
 
 	AttachRegistry(ctx context.Context, consumerID ids.ConsumerID, registryID ids.RegistryID) error

--- a/pkg/infra/context/request_context.go
+++ b/pkg/infra/context/request_context.go
@@ -3,6 +3,7 @@ package context
 import (
 	"context"
 	"net/url"
+	"strings"
 	"time"
 )
 
@@ -15,6 +16,7 @@ type Attachment struct {
 type RequestContext struct {
 	Context            context.Context
 	GatewayID          string
+	ConsumerID         string
 	RegistryID         string
 	Headers            map[string][]string
 	Method             string
@@ -33,4 +35,21 @@ type RequestContext struct {
 	TargetFormat       string
 	AllowedModels      []string
 	DefaultModel       string
+}
+
+// HeaderValue returns the first non-empty value of the named header, matched
+// case-insensitively. It returns "" when the header is absent or empty.
+func (r *RequestContext) HeaderValue(name string) string {
+	if r == nil || name == "" || len(r.Headers) == 0 {
+		return ""
+	}
+	if values, ok := r.Headers[name]; ok && len(values) > 0 && values[0] != "" {
+		return values[0]
+	}
+	for headerName, values := range r.Headers {
+		if strings.EqualFold(headerName, name) && len(values) > 0 && values[0] != "" {
+			return values[0]
+		}
+	}
+	return ""
 }

--- a/pkg/infra/context/request_context_test.go
+++ b/pkg/infra/context/request_context_test.go
@@ -1,0 +1,34 @@
+package context
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequestContext_HeaderValue(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers map[string][]string
+		lookup  string
+		want    string
+	}{
+		{name: "present", headers: map[string][]string{"X-User-Id": {"u1"}}, lookup: "X-User-Id", want: "u1"},
+		{name: "case-insensitive", headers: map[string][]string{"x-user-id": {"u1"}}, lookup: "X-User-Id", want: "u1"},
+		{name: "absent", headers: map[string][]string{"X-Other": {"v"}}, lookup: "X-User-Id", want: ""},
+		{name: "empty value is treated as absent", headers: map[string][]string{"X-User-Id": {""}}, lookup: "X-User-Id", want: ""},
+		{name: "no values is treated as absent", headers: map[string][]string{"X-User-Id": {}}, lookup: "X-User-Id", want: ""},
+		{name: "empty lookup", headers: map[string][]string{"X-User-Id": {"u1"}}, lookup: "", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &RequestContext{Headers: tt.headers}
+			assert.Equal(t, tt.want, r.HeaderValue(tt.lookup))
+		})
+	}
+}
+
+func TestRequestContext_HeaderValue_NilReceiver(t *testing.T) {
+	var r *RequestContext
+	assert.Equal(t, "", r.HeaderValue("X-User-Id"))
+}

--- a/pkg/infra/plugins/ratelimit/config.go
+++ b/pkg/infra/plugins/ratelimit/config.go
@@ -9,29 +9,19 @@ import (
 
 const defaultRetryAfter = "60"
 
-// limitOrder is the precedence in which limit types are evaluated: most
-// granular first. The first exceeded type rejects the request.
-var limitOrder = []string{keyPerFingerprint, keyPerIP, keyPerUser, keyGlobal}
-
-const (
-	keyPerFingerprint = "per_fingerprint"
-	keyPerIP          = "per_ip"
-	keyPerUser        = "per_user"
-	keyGlobal         = "global"
-)
-
-type limitConfig struct {
-	Limit  int    `mapstructure:"limit"`
-	Window string `mapstructure:"window"`
-}
-
+// config is the rate_limiter settings. The limit is a single sliding window;
+// whether it is enforced gateway-wide or per consumer is decided by the policy
+// scope (Policy.Global) at runtime, not by configuration.
+//
+// GroupByHeader optionally sub-partitions the counter within the policy scope by
+// the value of a request header (e.g. a tenant or end-user id), so each distinct
+// header value gets its own budget. When empty (or the header is absent on a
+// request), the counter is keyed by the scope subject (gateway or consumer).
 type config struct {
-	Limits  map[string]limitConfig `mapstructure:"limits"`
-	Actions actionsConfig          `mapstructure:"actions"`
-}
-
-type actionsConfig struct {
-	RetryAfter string `mapstructure:"retry_after"`
+	Limit         int    `mapstructure:"limit"`
+	Window        string `mapstructure:"window"`
+	RetryAfter    string `mapstructure:"retry_after"`
+	GroupByHeader string `mapstructure:"group_by_header"`
 }
 
 func parseConfig(settings map[string]any) (*config, error) {
@@ -42,26 +32,21 @@ func parseConfig(settings map[string]any) (*config, error) {
 	if err := cfg.validate(); err != nil {
 		return nil, err
 	}
-	if cfg.Actions.RetryAfter == "" {
-		cfg.Actions.RetryAfter = defaultRetryAfter
+	if cfg.RetryAfter == "" {
+		cfg.RetryAfter = defaultRetryAfter
 	}
 	return &cfg, nil
 }
 
 func (c *config) validate() error {
-	if len(c.Limits) == 0 {
-		return fmt.Errorf("rate_limiter: at least one limit is required")
+	if c.Limit <= 0 {
+		return fmt.Errorf("rate_limiter: limit must be positive")
 	}
-	for limitType, lc := range c.Limits {
-		if lc.Limit <= 0 {
-			return fmt.Errorf("rate_limiter: limit for %q must be positive", limitType)
-		}
-		if lc.Window == "" {
-			return fmt.Errorf("rate_limiter: window for %q is required", limitType)
-		}
-		if _, err := time.ParseDuration(lc.Window); err != nil {
-			return fmt.Errorf("rate_limiter: invalid window for %q: %w", limitType, err)
-		}
+	if c.Window == "" {
+		return fmt.Errorf("rate_limiter: window is required")
+	}
+	if _, err := time.ParseDuration(c.Window); err != nil {
+		return fmt.Errorf("rate_limiter: invalid window: %w", err)
 	}
 	return nil
 }

--- a/pkg/infra/plugins/ratelimit/plugin.go
+++ b/pkg/infra/plugins/ratelimit/plugin.go
@@ -9,7 +9,6 @@ import (
 
 	appplugins "github.com/NeuralTrust/AgentGateway/pkg/app/plugins"
 	"github.com/NeuralTrust/AgentGateway/pkg/domain/policy"
-	infracontext "github.com/NeuralTrust/AgentGateway/pkg/infra/context"
 	"github.com/go-redis/redis/v8"
 	"github.com/google/uuid"
 )
@@ -71,83 +70,70 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 		return nil, fmt.Errorf("rate_limiter: %w", err)
 	}
 
+	dimension, subject, err := in.Scope.Subject()
+	if err != nil {
+		return nil, fmt.Errorf("rate_limiter: %w", err)
+	}
+
+	window, err := time.ParseDuration(cfg.Window)
+	if err != nil {
+		return nil, fmt.Errorf("rate_limiter: invalid window: %w", err)
+	}
+
+	now := p.now()
+	redisKey := fmt.Sprintf("ratelimit:%s:%s:%s", in.Config.ID, dimension, subject)
+	if group := in.Request.HeaderValue(cfg.GroupByHeader); group != "" {
+		redisKey += ":hdr:" + group
+	}
+	count, err := p.currentCount(ctx, redisKey, now, window)
+	if err != nil {
+		return nil, err
+	}
+
 	headers := make(map[string][]string)
+	setLimitHeaders(headers, dimension, cfg.Limit, count, now.Add(window))
 
-	var evaluated *RateLimiterData
-	var exceeded *RateLimiterData
-	var throttle time.Duration
+	data := RateLimiterData{
+		ExceededType: dimension,
+		CurrentCount: count,
+		Limit:        cfg.Limit,
+		Window:       cfg.Window,
+	}
 
-	for _, limitType := range limitOrder {
-		lc, ok := cfg.Limits[limitType]
-		if !ok {
-			continue
-		}
-		key := p.extractKey(ctx, in.Request, limitType)
-		if limitType == keyPerUser && key == "anonymous" {
-			continue
-		}
+	if count >= int64(cfg.Limit) {
+		data.RateLimitExceeded = true
+		data.RetryAfter = cfg.RetryAfter
 
-		window, err := time.ParseDuration(lc.Window)
-		if err != nil {
-			return nil, fmt.Errorf("rate_limiter: invalid window for %q: %w", limitType, err)
-		}
-
-		now := p.now()
-		redisKey := fmt.Sprintf("ratelimit:%s:%s:%s", in.Config.ID, limitType, key)
-		count, err := p.currentCount(ctx, redisKey, now, window)
-		if err != nil {
-			return nil, err
-		}
-
-		setLimitHeaders(headers, limitType, lc.Limit, count, now.Add(window))
-		evaluated = &RateLimiterData{
-			ExceededType: limitType,
-			CurrentCount: count,
-			Limit:        lc.Limit,
-			Window:       lc.Window,
-		}
-
-		if count >= int64(lc.Limit) {
-			evaluated.RateLimitExceeded = true
-			evaluated.RetryAfter = cfg.Actions.RetryAfter
-
-			if appplugins.Blocks(in.Mode) && !appplugins.Throttles(in.Mode) {
-				headers["Retry-After"] = []string{cfg.Actions.RetryAfter}
-				appplugins.SetDecision(in.Event, in.Mode)
-				if in.Event != nil {
-					in.Event.SetExtras(*evaluated)
-				}
-				return nil, &appplugins.PluginError{
-					StatusCode: http.StatusTooManyRequests,
-					Message:    fmt.Sprintf("%s rate limit exceeded", limitType),
-					Headers:    headers,
-				}
+		if appplugins.Blocks(in.Mode) && !appplugins.Throttles(in.Mode) {
+			headers["Retry-After"] = []string{cfg.RetryAfter}
+			appplugins.SetDecision(in.Event, in.Mode)
+			if in.Event != nil {
+				in.Event.SetExtras(data)
 			}
-
-			if exceeded == nil {
-				exceeded = evaluated
-				throttle = throttleDelay(window, lc.Limit)
+			return nil, &appplugins.PluginError{
+				StatusCode: http.StatusTooManyRequests,
+				Message:    fmt.Sprintf("%s rate limit exceeded", dimension),
+				Headers:    headers,
 			}
 		}
-		if err := p.record(ctx, redisKey, now, window); err != nil {
-			return nil, err
+
+		if appplugins.Throttles(in.Mode) {
+			if err := appplugins.Throttle(ctx, throttleDelay(window, cfg.Limit)); err != nil {
+				return nil, err
+			}
 		}
 	}
 
-	if exceeded != nil && appplugins.Throttles(in.Mode) {
-		if err := appplugins.Throttle(ctx, throttle); err != nil {
-			return nil, err
-		}
+	if err := p.record(ctx, redisKey, now, window); err != nil {
+		return nil, err
 	}
 
 	if in.Event != nil {
 		in.Event.SetStatusCode(http.StatusOK)
-		if exceeded != nil {
+		if data.RateLimitExceeded {
 			appplugins.SetDecision(in.Event, in.Mode)
-			in.Event.SetExtras(*exceeded)
-		} else if evaluated != nil {
-			in.Event.SetExtras(*evaluated)
 		}
+		in.Event.SetExtras(data)
 	}
 	return &appplugins.Result{StatusCode: http.StatusOK, Headers: headers}, nil
 }
@@ -187,48 +173,8 @@ func (p *Plugin) record(ctx context.Context, key string, now time.Time, window t
 	return nil
 }
 
-// extractKey resolves the rate-limit subject for a limit type.
-func (p *Plugin) extractKey(ctx context.Context, req *infracontext.RequestContext, limitType string) string {
-	switch limitType {
-	case keyGlobal:
-		return keyGlobal
-	case keyPerFingerprint:
-		if fp, ok := ctx.Value(infracontext.FingerprintIDContextKey).(string); ok && fp != "" {
-			return fp
-		}
-		return "unknown"
-	case keyPerIP:
-		if ip := firstHeader(req, "X-Real-IP", "X-Real-Ip", "X-Forwarded-For", "X-Original-Forwarded-For", "True-Client-IP", "CF-Connecting-IP"); ip != "" {
-			return ip
-		}
-		if req != nil && req.IP != "" {
-			return req.IP
-		}
-		return "unknown"
-	case keyPerUser:
-		if user := firstHeader(req, "X-User-ID", "X-User-Id", "X-UserID", "User-ID"); user != "" {
-			return user
-		}
-		return "anonymous"
-	default:
-		return limitType
-	}
-}
-
-func firstHeader(req *infracontext.RequestContext, names ...string) string {
-	if req == nil {
-		return ""
-	}
-	for _, name := range names {
-		if values := req.Headers[name]; len(values) > 0 && values[0] != "" {
-			return values[0]
-		}
-	}
-	return ""
-}
-
-func setLimitHeaders(headers map[string][]string, limitType string, limit int, count int64, reset time.Time) {
-	prefix := "X-RateLimit-" + limitType
+func setLimitHeaders(headers map[string][]string, dimension string, limit int, count int64, reset time.Time) {
+	prefix := "X-RateLimit-" + dimension
 	remaining := int64(limit) - count
 	if remaining < 0 {
 		remaining = 0

--- a/pkg/infra/plugins/ratelimit/plugin_test.go
+++ b/pkg/infra/plugins/ratelimit/plugin_test.go
@@ -30,13 +30,38 @@ func newTestPlugin(t *testing.T) (*Plugin, *miniredis.Miniredis) {
 	return p, mr
 }
 
-func execInput(settings map[string]any, req *infracontext.RequestContext) appplugins.ExecInput {
+func consumerScope(consumerID string) appplugins.RuntimeScope {
+	return appplugins.RuntimeScope{ConsumerID: consumerID, GatewayID: "gw-1"}
+}
+
+func globalScope() appplugins.RuntimeScope {
+	return appplugins.RuntimeScope{GatewayID: "gw-1", Global: true}
+}
+
+func execInput(settings map[string]any, scope appplugins.RuntimeScope) appplugins.ExecInput {
 	return appplugins.ExecInput{
 		Stage:    policy.StagePreRequest,
 		Config:   policy.PluginConfig{ID: "plugin-1", Slug: PluginName, Name: PluginName, Settings: settings},
-		Request:  req,
+		Scope:    scope,
+		Request:  &infracontext.RequestContext{},
 		Response: &infracontext.ResponseContext{},
 	}
+}
+
+func limitSettings(limit int, window string) map[string]any {
+	return map[string]any{"limit": limit, "window": window}
+}
+
+func headerSettings(limit int, window, header string) map[string]any {
+	s := limitSettings(limit, window)
+	s["group_by_header"] = header
+	return s
+}
+
+func execInputHdr(settings map[string]any, scope appplugins.RuntimeScope, headers map[string][]string) appplugins.ExecInput {
+	in := execInput(settings, scope)
+	in.Request = &infracontext.RequestContext{Headers: headers}
+	return in
 }
 
 func TestPlugin_Stages(t *testing.T) {
@@ -54,26 +79,36 @@ func TestPlugin_ValidateConfig(t *testing.T) {
 	}{
 		{
 			name:     "valid",
-			settings: map[string]any{"limits": map[string]any{"per_ip": map[string]any{"limit": 5, "window": "1m"}}},
+			settings: limitSettings(5, "1m"),
 		},
 		{
-			name:     "no limits",
-			settings: map[string]any{"limits": map[string]any{}},
+			name:     "missing limit",
+			settings: map[string]any{"window": "1m"},
 			wantErr:  true,
 		},
 		{
 			name:     "non-positive limit",
-			settings: map[string]any{"limits": map[string]any{"global": map[string]any{"limit": 0, "window": "1m"}}},
+			settings: limitSettings(0, "1m"),
+			wantErr:  true,
+		},
+		{
+			name:     "missing window",
+			settings: map[string]any{"limit": 5},
 			wantErr:  true,
 		},
 		{
 			name:     "bad window",
-			settings: map[string]any{"limits": map[string]any{"global": map[string]any{"limit": 5, "window": "nope"}}},
+			settings: limitSettings(5, "nope"),
 			wantErr:  true,
 		},
 		{
-			name:     "ignores deprecated action type",
-			settings: map[string]any{"limits": map[string]any{"global": map[string]any{"limit": 5, "window": "1m"}}, "actions": map[string]any{"type": "explode"}},
+			name:     "rejects legacy nested limits map",
+			settings: map[string]any{"limits": map[string]any{"global": map[string]any{"limit": 5, "window": "1m"}}},
+			wantErr:  true,
+		},
+		{
+			name:     "ignores unknown fields",
+			settings: map[string]any{"limit": 5, "window": "1m", "actions": map[string]any{"type": "explode"}},
 			wantErr:  false,
 		},
 	}
@@ -92,50 +127,84 @@ func TestPlugin_ValidateConfig(t *testing.T) {
 
 func TestPlugin_Execute_AllowsUnderLimit(t *testing.T) {
 	p, _ := newTestPlugin(t)
-	settings := map[string]any{"limits": map[string]any{"per_ip": map[string]any{"limit": 3, "window": "1m"}}}
-	req := &infracontext.RequestContext{IP: "1.2.3.4"}
 
-	res, err := p.Execute(context.Background(), execInput(settings, req))
+	res, err := p.Execute(context.Background(), execInput(limitSettings(3, "1m"), consumerScope("c-1")))
 	require.NoError(t, err)
 	require.NotNil(t, res)
-	assert.Equal(t, []string{"3"}, res.Headers["X-RateLimit-per_ip-Limit"])
-	assert.Equal(t, []string{"3"}, res.Headers["X-RateLimit-per_ip-Remaining"])
+	assert.Equal(t, []string{"3"}, res.Headers["X-RateLimit-consumer-Limit"])
+	assert.Equal(t, []string{"3"}, res.Headers["X-RateLimit-consumer-Remaining"])
 }
 
 func TestPlugin_Execute_RejectsOverLimit(t *testing.T) {
 	p, _ := newTestPlugin(t)
-	settings := map[string]any{
-		"limits":  map[string]any{"per_ip": map[string]any{"limit": 2, "window": "1m"}},
-		"actions": map[string]any{"type": "reject", "retry_after": "30"},
-	}
-	req := &infracontext.RequestContext{IP: "1.2.3.4"}
+	settings := map[string]any{"limit": 2, "window": "1m", "retry_after": "30"}
 
 	for i := 0; i < 2; i++ {
-		_, err := p.Execute(context.Background(), execInput(settings, req))
+		_, err := p.Execute(context.Background(), execInput(settings, consumerScope("c-1")))
 		require.NoError(t, err, "request %d should pass", i)
 	}
 
-	_, err := p.Execute(context.Background(), execInput(settings, req))
+	_, err := p.Execute(context.Background(), execInput(settings, consumerScope("c-1")))
 	require.Error(t, err)
 	pe, ok := appplugins.AsPluginError(err)
 	require.True(t, ok)
 	assert.Equal(t, 429, pe.StatusCode)
 	assert.Equal(t, []string{"30"}, pe.Headers["Retry-After"])
-	assert.Equal(t, []string{"0"}, pe.Headers["X-RateLimit-per_ip-Remaining"])
+	assert.Equal(t, []string{"0"}, pe.Headers["X-RateLimit-consumer-Remaining"])
+}
+
+// A non-global policy must give each consumer an independent budget even when
+// they share the same policy (same Config.ID).
+func TestPlugin_Execute_ConsumerScopeIsolatesBudgets(t *testing.T) {
+	p, _ := newTestPlugin(t)
+	settings := limitSettings(1, "1m")
+
+	_, err := p.Execute(context.Background(), execInput(settings, consumerScope("c-1")))
+	require.NoError(t, err)
+	// c-1 is now exhausted.
+	_, err = p.Execute(context.Background(), execInput(settings, consumerScope("c-1")))
+	require.Error(t, err)
+
+	// c-2 shares the policy but must have its own budget.
+	_, err = p.Execute(context.Background(), execInput(settings, consumerScope("c-2")))
+	require.NoError(t, err, "a sibling consumer must not be affected by another consumer's usage")
+}
+
+// A global policy shares one counter across every consumer of the gateway.
+func TestPlugin_Execute_GlobalScopeSharesBudget(t *testing.T) {
+	p, _ := newTestPlugin(t)
+	settings := limitSettings(1, "1m")
+
+	res, err := p.Execute(context.Background(), execInput(settings, globalScope()))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"1"}, res.Headers["X-RateLimit-global-Limit"])
+
+	// The single global counter is now exhausted for the whole gateway.
+	_, err = p.Execute(context.Background(), execInput(settings, globalScope()))
+	require.Error(t, err)
+	pe, ok := appplugins.AsPluginError(err)
+	require.True(t, ok)
+	assert.Equal(t, 429, pe.StatusCode)
+}
+
+// A non-global policy that reaches execution without a consumer id is a wiring
+// bug; the plugin must surface it instead of falling back to a shared bucket.
+func TestPlugin_Execute_ConsumerScopeRequiresConsumerID(t *testing.T) {
+	p, _ := newTestPlugin(t)
+	_, err := p.Execute(context.Background(), execInput(limitSettings(1, "1m"), appplugins.RuntimeScope{GatewayID: "gw-1"}))
+	require.Error(t, err)
+	_, ok := appplugins.AsPluginError(err)
+	assert.False(t, ok, "a missing consumer id is an internal error, not a client rejection")
 }
 
 func TestPlugin_Execute_ObserveDoesNotReject(t *testing.T) {
 	p, _ := newTestPlugin(t)
 	assert.Equal(t, []policy.Mode{policy.ModeEnforce, policy.ModeThrottle, policy.ModeObserve}, p.SupportedModes())
 
-	settings := map[string]any{
-		"limits":  map[string]any{"per_ip": map[string]any{"limit": 1, "window": "1m"}},
-		"actions": map[string]any{"type": "reject", "retry_after": "30"},
-	}
-	req := &infracontext.RequestContext{IP: "9.9.9.9"}
+	settings := map[string]any{"limit": 1, "window": "1m", "retry_after": "30"}
 
 	for i := 0; i < 5; i++ {
-		in := execInput(settings, req)
+		in := execInput(settings, consumerScope("c-1"))
 		in.Mode = policy.ModeObserve
 		res, err := p.Execute(context.Background(), in)
 		require.NoError(t, err, "observe request %d should never be rejected", i)
@@ -144,24 +213,18 @@ func TestPlugin_Execute_ObserveDoesNotReject(t *testing.T) {
 	}
 }
 
-func TestPlugin_Execute_ObserveReportsExceededLimitNotLastEvaluated(t *testing.T) {
+func TestPlugin_Execute_ObserveReportsExceeded(t *testing.T) {
 	p, _ := newTestPlugin(t)
-	settings := map[string]any{
-		"limits": map[string]any{
-			"per_ip": map[string]any{"limit": 1, "window": "1m"},
-			"global": map[string]any{"limit": 1000, "window": "1m"},
-		},
-	}
-	req := &infracontext.RequestContext{IP: "5.5.5.5"}
+	settings := limitSettings(1, "1m")
 
-	first := execInput(settings, req)
+	first := execInput(settings, consumerScope("c-1"))
 	first.Mode = policy.ModeObserve
 	_, err := p.Execute(context.Background(), first)
 	require.NoError(t, err)
 
 	rt := trace.New("t", trace.Metadata{})
 	span := rt.StartSpan(trace.SpanPlugin, PluginName)
-	second := execInput(settings, req)
+	second := execInput(settings, consumerScope("c-1"))
 	second.Mode = policy.ModeObserve
 	second.Event = metrics.NewEventContext(span)
 
@@ -174,19 +237,16 @@ func TestPlugin_Execute_ObserveReportsExceededLimitNotLastEvaluated(t *testing.T
 	assert.Equal(t, "observe", span.Plugin.Decision)
 	data, ok := span.Plugin.Extras.(RateLimiterData)
 	require.True(t, ok, "extras should carry rate limiter data")
-	assert.True(t, data.RateLimitExceeded, "must report the exceeded limit, not the last evaluated one")
-	assert.Equal(t, "per_ip", data.ExceededType)
+	assert.True(t, data.RateLimitExceeded, "must report the exceeded limit")
+	assert.Equal(t, "consumer", data.ExceededType)
 }
 
 func TestPlugin_Execute_ThrottleDelaysButAllows(t *testing.T) {
 	p, _ := newTestPlugin(t)
-	settings := map[string]any{
-		"limits": map[string]any{"per_ip": map[string]any{"limit": 1, "window": "200ms"}},
-	}
-	req := &infracontext.RequestContext{IP: "8.8.8.8"}
+	settings := limitSettings(1, "200ms")
 
 	for i := 0; i < 3; i++ {
-		in := execInput(settings, req)
+		in := execInput(settings, consumerScope("c-1"))
 		in.Mode = policy.ModeThrottle
 		res, err := p.Execute(context.Background(), in)
 		require.NoError(t, err, "throttle request %d should not be rejected", i)
@@ -195,46 +255,86 @@ func TestPlugin_Execute_ThrottleDelaysButAllows(t *testing.T) {
 	}
 }
 
+// With a group_by_header configured, the counter is sub-partitioned by header
+// value within the policy scope: distinct values get independent budgets.
+func TestPlugin_Execute_GroupByHeaderIsolatesByValue(t *testing.T) {
+	p, _ := newTestPlugin(t)
+	settings := headerSettings(1, "1m", "X-User-Id")
+
+	u1 := map[string][]string{"X-User-Id": {"user-1"}}
+	u2 := map[string][]string{"X-User-Id": {"user-2"}}
+
+	_, err := p.Execute(context.Background(), execInputHdr(settings, consumerScope("c-1"), u1))
+	require.NoError(t, err)
+	// user-1's bucket is exhausted.
+	_, err = p.Execute(context.Background(), execInputHdr(settings, consumerScope("c-1"), u1))
+	require.Error(t, err)
+	// user-2 has its own bucket within the same consumer.
+	_, err = p.Execute(context.Background(), execInputHdr(settings, consumerScope("c-1"), u2))
+	require.NoError(t, err, "a different header value must have an independent budget")
+}
+
+// Under a global policy the header partition is shared across consumers because
+// the scope subject is the gateway, not the consumer.
+func TestPlugin_Execute_GroupByHeaderSharedAcrossConsumersWhenGlobal(t *testing.T) {
+	p, _ := newTestPlugin(t)
+	settings := headerSettings(1, "1m", "X-User-Id")
+	u1 := map[string][]string{"X-User-Id": {"user-1"}}
+
+	// Same gateway, same header value, but two different consumers.
+	scopeA := appplugins.RuntimeScope{GatewayID: "gw-1", ConsumerID: "c-1", Global: true}
+	scopeB := appplugins.RuntimeScope{GatewayID: "gw-1", ConsumerID: "c-2", Global: true}
+
+	_, err := p.Execute(context.Background(), execInputHdr(settings, scopeA, u1))
+	require.NoError(t, err)
+	_, err = p.Execute(context.Background(), execInputHdr(settings, scopeB, u1))
+	require.Error(t, err, "global scope must share the header bucket across consumers of the gateway")
+}
+
+// When the header is configured but absent from the request, the counter falls
+// back to the scope subject (here, the consumer).
+func TestPlugin_Execute_GroupByHeaderFallsBackWhenAbsent(t *testing.T) {
+	p, _ := newTestPlugin(t)
+	settings := headerSettings(1, "1m", "X-User-Id")
+
+	noHeader := map[string][]string{"X-Other": {"x"}}
+	_, err := p.Execute(context.Background(), execInputHdr(settings, consumerScope("c-1"), noHeader))
+	require.NoError(t, err)
+	// The consumer-level fallback bucket is now exhausted.
+	_, err = p.Execute(context.Background(), execInputHdr(settings, consumerScope("c-1"), noHeader))
+	require.Error(t, err)
+	// A request that does carry the header gets its own bucket.
+	withHeader := map[string][]string{"X-User-Id": {"user-1"}}
+	_, err = p.Execute(context.Background(), execInputHdr(settings, consumerScope("c-1"), withHeader))
+	require.NoError(t, err)
+}
+
+// An empty header value is treated as if the header were absent: it falls back
+// to the scope subject instead of creating an "empty value" bucket.
+func TestPlugin_Execute_GroupByHeaderEmptyValueFallsBack(t *testing.T) {
+	p, _ := newTestPlugin(t)
+	settings := headerSettings(1, "1m", "X-User-Id")
+	empty := map[string][]string{"X-User-Id": {""}}
+
+	_, err := p.Execute(context.Background(), execInputHdr(settings, consumerScope("c-1"), empty))
+	require.NoError(t, err)
+	_, err = p.Execute(context.Background(), execInputHdr(settings, consumerScope("c-1"), empty))
+	require.Error(t, err, "an empty header value must share the consumer fallback bucket")
+}
+
 func TestThrottleDelay(t *testing.T) {
 	assert.Equal(t, time.Duration(0), throttleDelay(time.Minute, 0))
 	assert.Equal(t, time.Duration(0), throttleDelay(0, 10))
 	assert.Equal(t, 100*time.Millisecond, throttleDelay(time.Second, 10))
 }
 
-func TestPlugin_Execute_PerFingerprintFromContext(t *testing.T) {
-	p, _ := newTestPlugin(t)
-	settings := map[string]any{"limits": map[string]any{"per_fingerprint": map[string]any{"limit": 1, "window": "1m"}}}
-	ctx := context.WithValue(context.Background(), infracontext.FingerprintIDContextKey, "fp-123")
-	req := &infracontext.RequestContext{}
-
-	_, err := p.Execute(ctx, execInput(settings, req))
-	require.NoError(t, err)
-	_, err = p.Execute(ctx, execInput(settings, req))
-	require.Error(t, err)
-	pe, _ := appplugins.AsPluginError(err)
-	assert.Equal(t, 429, pe.StatusCode)
-}
-
-func TestPlugin_Execute_SkipsAnonymousPerUser(t *testing.T) {
-	p, _ := newTestPlugin(t)
-	settings := map[string]any{"limits": map[string]any{"per_user": map[string]any{"limit": 1, "window": "1m"}}}
-	req := &infracontext.RequestContext{}
-
-	// No user header -> anonymous -> limit skipped, so repeated calls always pass.
-	for i := 0; i < 5; i++ {
-		_, err := p.Execute(context.Background(), execInput(settings, req))
-		require.NoError(t, err)
-	}
-}
-
 func TestPlugin_Execute_DefaultRetryAfter(t *testing.T) {
 	p, _ := newTestPlugin(t)
-	settings := map[string]any{"limits": map[string]any{"global": map[string]any{"limit": 1, "window": "1m"}}}
-	req := &infracontext.RequestContext{}
+	settings := limitSettings(1, "1m")
 
-	_, err := p.Execute(context.Background(), execInput(settings, req))
+	_, err := p.Execute(context.Background(), execInput(settings, globalScope()))
 	require.NoError(t, err)
-	_, err = p.Execute(context.Background(), execInput(settings, req))
+	_, err = p.Execute(context.Background(), execInput(settings, globalScope()))
 	require.Error(t, err)
 	pe, _ := appplugins.AsPluginError(err)
 	assert.Equal(t, []string{"60"}, pe.Headers["Retry-After"])

--- a/pkg/infra/plugins/tokenratelimit/config.go
+++ b/pkg/infra/plugins/tokenratelimit/config.go
@@ -12,9 +12,17 @@ type windowConfig struct {
 	Max  int    `mapstructure:"max"`
 }
 
+// config is the token_rate_limiter settings. Whether the budget is enforced
+// gateway-wide or per consumer is decided by the policy scope (Policy.Global) at
+// runtime.
+//
+// GroupByHeader optionally sub-partitions the budget within the policy scope by
+// the value of a request header (e.g. a tenant or end-user id), so each distinct
+// header value gets its own budget. When empty (or the header is absent on a
+// request), the budget is keyed by the scope subject (gateway or consumer).
 type config struct {
-	IdentifierHeader string       `mapstructure:"identifier_header"`
-	Window           windowConfig `mapstructure:"window"`
+	Window        windowConfig `mapstructure:"window"`
+	GroupByHeader string       `mapstructure:"group_by_header"`
 }
 
 var validUnits = map[string]int{

--- a/pkg/infra/plugins/tokenratelimit/plugin.go
+++ b/pkg/infra/plugins/tokenratelimit/plugin.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	appplugins "github.com/NeuralTrust/AgentGateway/pkg/app/plugins"
@@ -79,8 +78,14 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 		return nil, fmt.Errorf("token_rate_limiter: %w", err)
 	}
 
-	identifier := extractIdentifier(in.Request, cfg.IdentifierHeader)
-	counterKey := fmt.Sprintf("%s:%s:%s", counterKeyPrefix, in.Config.ID, identifier)
+	dimension, subject, err := in.Scope.Subject()
+	if err != nil {
+		return nil, fmt.Errorf("token_rate_limiter: %w", err)
+	}
+	counterKey := fmt.Sprintf("%s:%s:%s:%s", counterKeyPrefix, in.Config.ID, dimension, subject)
+	if group := in.Request.HeaderValue(cfg.GroupByHeader); group != "" {
+		counterKey += ":hdr:" + group
+	}
 
 	switch in.Stage {
 	case policy.StagePreRequest:
@@ -248,24 +253,6 @@ func (p *Plugin) resetSeconds(ctx context.Context, counterKey string, cfg *confi
 		return int(ttl / time.Second)
 	}
 	return cfg.windowSeconds()
-}
-
-func extractIdentifier(req *infracontext.RequestContext, headerName string) string {
-	if req != nil && headerName != "" {
-		if values, ok := req.Headers[headerName]; ok && len(values) > 0 && values[0] != "" {
-			return values[0]
-		}
-		canonical := strings.ToLower(headerName)
-		for name, values := range req.Headers {
-			if strings.ToLower(name) == canonical && len(values) > 0 && values[0] != "" {
-				return values[0]
-			}
-		}
-	}
-	if req != nil && req.IP != "" {
-		return req.IP
-	}
-	return "_global"
 }
 
 func rateLimitHeaders(limit, remaining, resetSeconds int) map[string][]string {

--- a/pkg/infra/plugins/tokenratelimit/plugin_test.go
+++ b/pkg/infra/plugins/tokenratelimit/plugin_test.go
@@ -26,6 +26,7 @@ func input(stage policy.Stage, settings map[string]any, req *infracontext.Reques
 	return appplugins.ExecInput{
 		Stage:    stage,
 		Config:   policy.PluginConfig{ID: "tk-1", Slug: PluginName, Name: PluginName, Settings: settings},
+		Scope:    appplugins.RuntimeScope{ConsumerID: "c-1", GatewayID: "gw-1"},
 		Request:  req,
 		Response: resp,
 	}
@@ -145,4 +146,88 @@ func TestPlugin_PostResponse_NoTokensNoRecord(t *testing.T) {
 	res, err := p.Execute(context.Background(), input(policy.StagePostResponse, settings, req, resp))
 	require.NoError(t, err)
 	assert.Empty(t, res.Headers["X-Tokens-Consumed"])
+}
+
+func scopedInput(stage policy.Stage, settings map[string]any, req *infracontext.RequestContext, resp *infracontext.ResponseContext, scope appplugins.RuntimeScope) appplugins.ExecInput {
+	in := input(stage, settings, req, resp)
+	in.Scope = scope
+	return in
+}
+
+// A non-global policy must give each consumer an independent token budget even
+// when they share the same policy (same Config.ID).
+func TestPlugin_ConsumerScopeIsolatesBudgets(t *testing.T) {
+	p := newTestPlugin(t)
+	settings := map[string]any{"window": map[string]any{"unit": "minute", "max": 10}}
+	req := &infracontext.RequestContext{Provider: "openai", SourceFormat: "openai"}
+	body := []byte(`{"id":"x","model":"gpt","choices":[{"message":{"role":"assistant","content":"hi"}}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`)
+	resp := &infracontext.ResponseContext{StatusCode: 200, Body: body}
+
+	c1 := appplugins.RuntimeScope{ConsumerID: "c-1", GatewayID: "gw-1"}
+	c2 := appplugins.RuntimeScope{ConsumerID: "c-2", GatewayID: "gw-1"}
+
+	_, err := p.Execute(context.Background(), scopedInput(policy.StagePostResponse, settings, req, resp, c1))
+	require.NoError(t, err)
+
+	// c-1 is over budget now.
+	_, err = p.Execute(context.Background(), scopedInput(policy.StagePreRequest, settings, req, &infracontext.ResponseContext{}, c1))
+	require.Error(t, err)
+
+	// c-2 shares the policy but keeps its own budget.
+	_, err = p.Execute(context.Background(), scopedInput(policy.StagePreRequest, settings, req, &infracontext.ResponseContext{}, c2))
+	require.NoError(t, err, "a sibling consumer must not inherit another consumer's token usage")
+}
+
+// A global policy shares one token counter across consumers of the gateway.
+func TestPlugin_GlobalScopeSharesBudget(t *testing.T) {
+	p := newTestPlugin(t)
+	settings := map[string]any{"window": map[string]any{"unit": "minute", "max": 10}}
+	req := &infracontext.RequestContext{Provider: "openai", SourceFormat: "openai"}
+	body := []byte(`{"id":"x","model":"gpt","choices":[{"message":{"role":"assistant","content":"hi"}}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`)
+	resp := &infracontext.ResponseContext{StatusCode: 200, Body: body}
+
+	global := appplugins.RuntimeScope{GatewayID: "gw-1", Global: true}
+
+	_, err := p.Execute(context.Background(), scopedInput(policy.StagePostResponse, settings, req, resp, global))
+	require.NoError(t, err)
+
+	_, err = p.Execute(context.Background(), scopedInput(policy.StagePreRequest, settings, req, &infracontext.ResponseContext{}, global))
+	require.Error(t, err, "the shared global budget must gate the next request from any consumer")
+}
+
+// With a group_by_header configured, the token budget is sub-partitioned by
+// header value within the policy scope: distinct values get independent budgets.
+func TestPlugin_GroupByHeaderIsolatesBudgets(t *testing.T) {
+	p := newTestPlugin(t)
+	settings := map[string]any{
+		"window":          map[string]any{"unit": "minute", "max": 10},
+		"group_by_header": "X-User-Id",
+	}
+	scope := appplugins.RuntimeScope{ConsumerID: "c-1", GatewayID: "gw-1"}
+	body := []byte(`{"id":"x","model":"gpt","choices":[{"message":{"role":"assistant","content":"hi"}}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`)
+
+	reqU1 := &infracontext.RequestContext{Provider: "openai", SourceFormat: "openai", Headers: map[string][]string{"X-User-Id": {"user-1"}}}
+	reqU2 := &infracontext.RequestContext{Provider: "openai", SourceFormat: "openai", Headers: map[string][]string{"X-User-Id": {"user-2"}}}
+	resp := &infracontext.ResponseContext{StatusCode: 200, Body: body}
+
+	// user-1 consumes its whole budget.
+	_, err := p.Execute(context.Background(), scopedInput(policy.StagePostResponse, settings, reqU1, resp, scope))
+	require.NoError(t, err)
+
+	// user-1 is now over budget.
+	_, err = p.Execute(context.Background(), scopedInput(policy.StagePreRequest, settings, reqU1, &infracontext.ResponseContext{}, scope))
+	require.Error(t, err)
+
+	// user-2 has an independent budget within the same consumer.
+	_, err = p.Execute(context.Background(), scopedInput(policy.StagePreRequest, settings, reqU2, &infracontext.ResponseContext{}, scope))
+	require.NoError(t, err, "a different header value must have an independent token budget")
+}
+
+func TestPlugin_ConsumerScopeRequiresConsumerID(t *testing.T) {
+	p := newTestPlugin(t)
+	settings := map[string]any{"window": map[string]any{"unit": "minute", "max": 10}}
+	req := &infracontext.RequestContext{Provider: "openai"}
+
+	_, err := p.Execute(context.Background(), scopedInput(policy.StagePreRequest, settings, req, &infracontext.ResponseContext{}, appplugins.RuntimeScope{GatewayID: "gw-1"}))
+	require.Error(t, err)
 }

--- a/tests/functional/common_test.go
+++ b/tests/functional/common_test.go
@@ -72,9 +72,8 @@ func validPolicyPayload(name string) map[string]any {
 		"enabled":  true,
 		"priority": 0,
 		"settings": map[string]any{
-			"limits": map[string]any{
-				"global": map[string]any{"limit": 100, "window": "1m"},
-			},
+			"limit":  100,
+			"window": "1m",
 		},
 	}
 }

--- a/tests/functional/plugin_policy_composition_test.go
+++ b/tests/functional/plugin_policy_composition_test.go
@@ -29,14 +29,14 @@ import (
 
 // ---- payload builders -------------------------------------------------------
 
-// rateLimitSettings configures the rate_limiter plugin with a single global
-// limit over a 1-minute window, rejecting with 429 + Retry-After once exceeded.
+// rateLimitSettings configures the rate_limiter plugin with a single sliding
+// window over 1 minute, rejecting with 429 + Retry-After once exceeded. Whether
+// the limit is gateway-wide or per consumer is decided by the policy scope.
 func rateLimitSettings(limit int) map[string]any {
 	return map[string]any{
-		"limits": map[string]any{
-			"global": map[string]any{"limit": limit, "window": "1m"},
-		},
-		"actions": map[string]any{"type": "reject", "retry_after": "30"},
+		"limit":       limit,
+		"window":      "1m",
+		"retry_after": "30",
 	}
 }
 
@@ -208,7 +208,7 @@ func TestPolicyE2E_GlobalAndConsumerComposeDifferentSlugs(t *testing.T) {
 	status, headers, raw := proxyRequest(t, http.MethodPost, apiKey, path, allowed, body)
 	require.Equal(t, http.StatusOK, status, "body: %s", raw)
 	assert.Equal(t, "https://allowed.com", headers.Get("Access-Control-Allow-Origin"), "global CORS must run")
-	assert.Equal(t, "2", headers.Get("X-RateLimit-global-Limit"), "consumer rate limiter must run")
+	assert.Equal(t, "2", headers.Get("X-RateLimit-consumer-Limit"), "consumer rate limiter must run")
 
 	// The global CORS rejection still fires for a foreign origin.
 	statusBad, _, _ := proxyRequest(t, http.MethodPost, apiKey, path,
@@ -243,7 +243,7 @@ func TestPolicyE2E_ConsumerOverridesGlobalBySlug(t *testing.T) {
 		require.Equal(t, http.StatusOK, status,
 			"request %d must pass: the permissive consumer policy overrides the strict global one, body: %s", i, raw)
 		// The applied limit is the consumer's (100), proving the global was dropped.
-		assert.Equal(t, "100", headers.Get("X-RateLimit-global-Limit"))
+		assert.Equal(t, "100", headers.Get("X-RateLimit-consumer-Limit"))
 	}
 	assert.Equal(t, 3, up.Hits())
 }
@@ -309,7 +309,7 @@ func TestPolicyE2E_ParallelBatchBothApply(t *testing.T) {
 	status, headers, raw := proxyRequest(t, http.MethodPost, apiKey, path, allowed, body)
 	require.Equal(t, http.StatusOK, status, "body: %s", raw)
 	assert.Equal(t, "https://allowed.com", headers.Get("Access-Control-Allow-Origin"), "parallel CORS header must survive")
-	assert.Equal(t, "2", headers.Get("X-RateLimit-global-Limit"), "parallel rate-limiter header must survive")
+	assert.Equal(t, "2", headers.Get("X-RateLimit-consumer-Limit"), "parallel rate-limiter header must survive")
 
 	// A rejection from any plugin in the parallel batch still short-circuits.
 	statusBad, _, _ := proxyRequest(t, http.MethodPost, apiKey, path,
@@ -338,7 +338,7 @@ func TestPolicyE2E_MultiStagePluginComposesWithPreRequest(t *testing.T) {
 	for i := 1; i <= 2; i++ {
 		status, headers, raw := proxyRequest(t, http.MethodPost, apiKey, path, nil, body)
 		require.Equal(t, http.StatusOK, status, "request %d should pass, body: %s", i, raw)
-		assert.Equal(t, "2", headers.Get("X-RateLimit-global-Limit"),
+		assert.Equal(t, "2", headers.Get("X-RateLimit-consumer-Limit"),
 			"the pre_request rate limiter must run alongside the multi-stage token limiter")
 	}
 	status, _, _ := proxyRequest(t, http.MethodPost, apiKey, path, nil, body)

--- a/tests/functional/plugin_rate_limiter_test.go
+++ b/tests/functional/plugin_rate_limiter_test.go
@@ -10,17 +10,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPluginE2E_RateLimiter_Global(t *testing.T) {
+// A non-global rate_limiter policy partitions its budget per consumer: a single
+// guarded route is limited at its own budget and rejects once exceeded.
+func TestPluginE2E_RateLimiter_ConsumerScoped(t *testing.T) {
 	defer Track(t, "PluginRateLimiter")()
 
 	const limit = 5
 	up := newJSONUpstream(t, "rl-upstream")
 	apiKey, path := setupPolicyRoute(t, up,
 		policyPlugin("rate_limiter", map[string]any{
-			"limits": map[string]any{
-				"global": map[string]any{"limit": limit, "window": "1m"},
-			},
-			"actions": map[string]any{"type": "reject", "retry_after": "60"},
+			"limit":       limit,
+			"window":      "1m",
+			"retry_after": "60",
 		}),
 	)
 
@@ -29,7 +30,7 @@ func TestPluginE2E_RateLimiter_Global(t *testing.T) {
 	for i := 1; i <= limit; i++ {
 		status, headers, raw := proxyRequest(t, http.MethodPost, apiKey, path, nil, body)
 		require.Equal(t, http.StatusOK, status, "request %d should be allowed, body: %s", i, raw)
-		assert.Equal(t, "5", headers.Get("X-RateLimit-global-Limit"))
+		assert.Equal(t, "5", headers.Get("X-RateLimit-consumer-Limit"))
 	}
 
 	status, headers, _ := proxyRequest(t, http.MethodPost, apiKey, path, nil, body)
@@ -38,35 +39,61 @@ func TestPluginE2E_RateLimiter_Global(t *testing.T) {
 	assert.Equal(t, limit, up.Hits(), "rejected requests must not reach the upstream")
 }
 
-func TestPluginE2E_RateLimiter_PerUserIsolation(t *testing.T) {
+// A single non-global policy shared by two consumers must give each its own
+// budget: exhausting one consumer must not affect the other.
+func TestPluginE2E_RateLimiter_ConsumerIsolation(t *testing.T) {
 	defer Track(t, "PluginRateLimiter")()
 
-	const perUser = 3
-	up := newJSONUpstream(t, "rl-user-upstream")
+	up := newJSONUpstream(t, "rl-isolation")
+	gatewayID, backendID := setupGatewayBackend(t, up)
+	// One consumer-scoped policy (limit 2) attached to two distinct consumers.
+	rl := createScopedPolicy(t, gatewayID, "rate_limiter", rateLimitSettings(2), 0, false)
+	pathA, keyA := addConsumerRoute(t, gatewayID, backendID, rl)
+	pathB, keyB := addConsumerRoute(t, gatewayID, backendID, rl)
+
+	body := mustJSON(t, chatRequest(false))
+
+	// Exhaust consumer A's budget (2 allowed, 3rd rejected).
+	for i := 1; i <= 2; i++ {
+		status, _, raw := proxyRequest(t, http.MethodPost, keyA, pathA, nil, body)
+		require.Equal(t, http.StatusOK, status, "consumer A request %d should pass, body: %s", i, raw)
+	}
+	statusA, _, _ := proxyRequest(t, http.MethodPost, keyA, pathA, nil, body)
+	require.Equal(t, http.StatusTooManyRequests, statusA, "consumer A must be limited at its own budget")
+
+	// Consumer B shares the policy but keeps an independent budget.
+	for i := 1; i <= 2; i++ {
+		status, _, raw := proxyRequest(t, http.MethodPost, keyB, pathB, nil, body)
+		require.Equal(t, http.StatusOK, status,
+			"consumer B request %d must pass: a sibling consumer's usage must not count against it, body: %s", i, raw)
+	}
+}
+
+// With group_by_header set, the budget is counted per header value within the
+// consumer scope, so distinct header values get independent budgets.
+func TestPluginE2E_RateLimiter_GroupByHeader(t *testing.T) {
+	defer Track(t, "PluginRateLimiter")()
+
+	const limit = 2
+	up := newJSONUpstream(t, "rl-group-header")
 	apiKey, path := setupPolicyRoute(t, up,
 		policyPlugin("rate_limiter", map[string]any{
-			"limits": map[string]any{
-				"per_user": map[string]any{"limit": perUser, "window": "1m"},
-				"global":   map[string]any{"limit": 1000, "window": "1m"},
-			},
-			"actions": map[string]any{"type": "reject", "retry_after": "30"},
+			"limit":           limit,
+			"window":          "1m",
+			"group_by_header": "X-User-Id",
 		}),
 	)
 
 	body := mustJSON(t, chatRequest(false))
 
-	exhaust := func(user string) {
-		for i := 1; i <= perUser; i++ {
-			status, _, raw := proxyRequest(t, http.MethodPost, apiKey, path,
-				map[string]string{"X-User-ID": user}, body)
-			require.Equal(t, http.StatusOK, status, "user %s request %d, body: %s", user, i, raw)
-		}
-		status, _, _ := proxyRequest(t, http.MethodPost, apiKey, path,
-			map[string]string{"X-User-ID": user}, body)
-		assert.Equal(t, http.StatusTooManyRequests, status, "user %s should be limited after %d requests", user, perUser)
+	for i := 1; i <= limit; i++ {
+		status, _, raw := proxyRequest(t, http.MethodPost, apiKey, path, map[string]string{"X-User-Id": "user-1"}, body)
+		require.Equal(t, http.StatusOK, status, "user-1 request %d should pass, body: %s", i, raw)
 	}
+	status, _, _ := proxyRequest(t, http.MethodPost, apiKey, path, map[string]string{"X-User-Id": "user-1"}, body)
+	require.Equal(t, http.StatusTooManyRequests, status, "user-1 must be limited by its own header value")
 
-	exhaust("alice")
-	// Bob has an independent budget: alice being limited must not affect bob.
-	exhaust("bob")
+	// A different header value keeps an independent budget on the same route.
+	status, _, raw := proxyRequest(t, http.MethodPost, apiKey, path, map[string]string{"X-User-Id": "user-2"}, body)
+	require.Equal(t, http.StatusOK, status, "a different header value must not be limited, body: %s", raw)
 }

--- a/tests/functional/plugin_token_rate_limiter_test.go
+++ b/tests/functional/plugin_token_rate_limiter_test.go
@@ -32,22 +32,3 @@ func TestPluginE2E_TokenRateLimiter(t *testing.T) {
 	}
 	assert.Equal(t, 5, up.Hits())
 }
-
-func TestPluginE2E_TokenRateLimiter_WithIdentifierHeader(t *testing.T) {
-	defer Track(t, "PluginTokenRateLimiter")()
-
-	up := newUsageUpstream(t, "token-hdr-upstream", 8)
-	apiKey, path := setupPolicyRoute(t, up,
-		policyPlugin("token_rate_limiter", map[string]any{
-			"identifier_header": "X-Client-ID",
-			"window":            map[string]any{"unit": "hour", "max": 1000},
-		}),
-	)
-
-	body := mustJSON(t, chatRequest(false))
-	for _, clientID := range []string{"client-a", "client-b"} {
-		status, _, raw := proxyRequest(t, http.MethodPost, apiKey, path,
-			map[string]string{"X-Client-ID": clientID}, body)
-		assert.Equal(t, http.StatusOK, status, "client %s should pass through, body: %s", clientID, raw)
-	}
-}


### PR DESCRIPTION
## Summary
- Los límites de `rate_limiter` y `token_rate_limiter` ahora se particionan por el **scope de la policy**: gateway-wide cuando `Policy.Global` es true, y por consumer cuando es false. El scope se deriva en runtime de `Policy.Global` + el consumer resuelto, nunca de IP/user/identificadores de la request.
- Se propaga `GatewayID`/`ConsumerID`/`Policy.Global` hasta la ejecución del plugin (`ExecInput.RuntimeScope`) vía forwarder, executor y chain/plan.
- `rate_limiter`: settings aplanados a `limit`/`window`/`retry_after`; clave de contador por scope; eliminados los scopes legacy `per_ip`/`per_user`/`per_fingerprint`.
- `token_rate_limiter`: presupuesto por scope; eliminado `identifier_header`.
- Nuevo `group_by_header` opcional en ambos plugins: sub-particiona el contador por el valor de una cabecera dentro del scope. Una cabecera vacía o ausente cae al subject del scope (`gateway_id`/`consumer_id`).
- Catálogo (`catalog_metadata.go`) y `docs/policies.json` actualizados para que el frontend solo pida los campos necesarios.

Refs ENG-726

## Claves de Redis
- `rate_limiter`: `ratelimit:<policyID>:<global|consumer>:<scopeID>[:hdr:<valor>]`
- `token_rate_limiter`: `trl:<policyID>:<global|consumer>:<scopeID>[:hdr:<valor>]`

## Notas
- **Breaking**: las policies `rate_limiter` guardadas con el shape antiguo (`limits.global.{limit,window}`) ya no validan; hay que re-guardarlas con el shape plano.
- El frontend usa hoy un editor JSON libre para los settings; el catálogo queda como contrato/documentación de los campos.

## Test plan
- [x] `go build ./...` y `go build -tags functional ./...`
- [x] Unit tests: `ratelimit`, `tokenratelimit`, `app/plugins`, `infra/context`
- [x] `go vet -tags functional ./tests/functional/...` y `golangci-lint`
- [ ] Functional suite (requiere servicios) en CI

Made with [Cursor](https://cursor.com)