### PR TITLE
refactor(providers): typed provider_options for openai and vertex

### DIFF
--- a/pkg/infra/providers/openai/client.go
+++ b/pkg/infra/providers/openai/client.go
@@ -6,27 +6,15 @@ import (
 	"strings"
 
 	"github.com/NeuralTrust/AgentGateway/pkg/infra/providers"
-	"github.com/mitchellh/mapstructure"
 )
 
 const (
-	CompletionsAPI = "completions"
-	ResponsesAPI   = "responses"
 	completionsURL = "https://api.openai.com/v1/chat/completions"
 	responsesURL   = "https://api.openai.com/v1/responses"
 
 	completionsPath = "/chat/completions"
 	responsesPath   = "/responses"
 )
-
-type openaiOptions struct {
-	API string `json:"api" mapstructure:"api"`
-	// BaseURL overrides the default api.openai.com host so a backend can target
-	// any OpenAI-compatible endpoint (self-hosted gateways, vLLM, LiteLLM, a test
-	// server, ...). It is the API base, e.g. "https://host/v1"; the endpoint path
-	// ("/chat/completions" or "/responses") is appended. Empty keeps the defaults.
-	BaseURL string `json:"base_url" mapstructure:"base_url"`
-}
 
 type client struct {
 	chat *ChatCompletionsClient
@@ -44,7 +32,11 @@ func (c *client) Completions(
 	config *providers.Config,
 	reqBody []byte,
 ) ([]byte, error) {
-	return c.chat.Completions(ctx, c.resolveURL(config), config, reqBody, nil)
+	endpointURL, err := c.resolveURL(config)
+	if err != nil {
+		return nil, err
+	}
+	return c.chat.Completions(ctx, endpointURL, config, reqBody, nil)
 }
 
 func (c *client) CompletionsStream(
@@ -52,32 +44,27 @@ func (c *client) CompletionsStream(
 	config *providers.Config,
 	reqBody []byte,
 ) (iter.Seq2[[]byte, error], error) {
-	return c.chat.CompletionsStream(ctx, c.resolveURL(config), config, reqBody, nil)
+	endpointURL, err := c.resolveURL(config)
+	if err != nil {
+		return nil, err
+	}
+	return c.chat.CompletionsStream(ctx, endpointURL, config, reqBody, nil)
 }
 
-func (c *client) resolveURL(config *providers.Config) string {
-	options := parseOptions(config)
-	base := strings.TrimRight(options.BaseURL, "/")
-	if options.API == ResponsesAPI {
+func (c *client) resolveURL(config *providers.Config) (string, error) {
+	opts, err := providers.DecodeOpenAIOptions(config.Options)
+	if err != nil {
+		return "", err
+	}
+	base := strings.TrimRight(opts.BaseURL, "/")
+	if opts.API == providers.OpenAIAPIResponses {
 		if base != "" {
-			return base + responsesPath
+			return base + responsesPath, nil
 		}
-		return responsesURL
+		return responsesURL, nil
 	}
 	if base != "" {
-		return base + completionsPath
+		return base + completionsPath, nil
 	}
-	return completionsURL
-}
-
-func parseOptions(config *providers.Config) openaiOptions {
-	var options openaiOptions
-	if len(config.Options) > 0 {
-		if err := mapstructure.Decode(config.Options, &options); err != nil {
-			options = openaiOptions{API: CompletionsAPI}
-		}
-	} else {
-		options = openaiOptions{API: CompletionsAPI}
-	}
-	return options
+	return completionsURL, nil
 }

--- a/pkg/infra/providers/openai/client_test.go
+++ b/pkg/infra/providers/openai/client_test.go
@@ -27,43 +27,32 @@ func TestNewOpenaiClient(t *testing.T) {
 	assert.NotNil(t, NewOpenaiClient())
 }
 
-func TestParseOptions(t *testing.T) {
-	tests := []struct {
-		name    string
-		options map[string]any
-		wantAPI string
-	}{
-		{name: "no options defaults to completions", options: nil, wantAPI: CompletionsAPI},
-		{name: "explicit completions", options: map[string]any{"api": "completions"}, wantAPI: CompletionsAPI},
-		{name: "responses api", options: map[string]any{"api": "responses"}, wantAPI: ResponsesAPI},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := parseOptions(&providers.Config{Options: tt.options})
-			assert.Equal(t, tt.wantAPI, got.API)
-		})
-	}
-}
-
 func TestResolveURL(t *testing.T) {
 	c := &client{}
-	assert.Equal(t, completionsURL, c.resolveURL(&providers.Config{}))
-	assert.Equal(t, responsesURL, c.resolveURL(&providers.Config{Options: map[string]any{"api": "responses"}}))
 
-	// base_url overrides the host for OpenAI-compatible endpoints; the endpoint
-	// path is appended and a trailing slash on the base is tolerated.
-	assert.Equal(t,
-		"http://127.0.0.1:9999/chat/completions",
-		c.resolveURL(&providers.Config{Options: map[string]any{"base_url": "http://127.0.0.1:9999"}}),
-	)
-	assert.Equal(t,
-		"https://host/v1/chat/completions",
-		c.resolveURL(&providers.Config{Options: map[string]any{"base_url": "https://host/v1/"}}),
-	)
-	assert.Equal(t,
-		"https://host/v1/responses",
-		c.resolveURL(&providers.Config{Options: map[string]any{"api": "responses", "base_url": "https://host/v1"}}),
-	)
+	cases := []struct {
+		name    string
+		options map[string]any
+		want    string
+	}{
+		{name: "defaults to completions", options: nil, want: completionsURL},
+		{name: "responses api", options: map[string]any{"api": "responses"}, want: responsesURL},
+		{name: "base_url completions", options: map[string]any{"base_url": "http://127.0.0.1:9999"}, want: "http://127.0.0.1:9999/chat/completions"},
+		{name: "base_url trailing slash", options: map[string]any{"base_url": "https://host/v1/"}, want: "https://host/v1/chat/completions"},
+		{name: "base_url responses", options: map[string]any{"api": "responses", "base_url": "https://host/v1"}, want: "https://host/v1/responses"},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := c.resolveURL(&providers.Config{Options: tt.options})
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	t.Run("invalid api errors", func(t *testing.T) {
+		_, err := c.resolveURL(&providers.Config{Options: map[string]any{"api": "chat"}})
+		require.Error(t, err)
+	})
 }
 
 func TestChatCompletions_MissingAPIKey(t *testing.T) {

--- a/pkg/infra/providers/openai/connection.go
+++ b/pkg/infra/providers/openai/connection.go
@@ -13,13 +13,25 @@ const (
 )
 
 func (c *client) TestConnection(ctx context.Context, config *providers.Config) providers.ProbeResult {
-	return providers.RunBearerGETProbe(ctx, providers.ProviderOpenAI, c.resolveModelsURL(config), config.Credentials.ApiKey)
+	endpointURL, err := c.resolveModelsURL(config)
+	if err != nil {
+		return providers.ProbeResult{
+			OK:      false,
+			Stage:   providers.StageProvider,
+			Message: err.Error(),
+		}
+	}
+	return providers.RunBearerGETProbe(ctx, providers.ProviderOpenAI, endpointURL, config.Credentials.ApiKey)
 }
 
-func (c *client) resolveModelsURL(config *providers.Config) string {
-	base := strings.TrimRight(parseOptions(config).BaseURL, "/")
-	if base != "" {
-		return base + modelsPath
+func (c *client) resolveModelsURL(config *providers.Config) (string, error) {
+	opts, err := providers.DecodeOpenAIOptions(config.Options)
+	if err != nil {
+		return "", err
 	}
-	return modelsURL
+	base := strings.TrimRight(opts.BaseURL, "/")
+	if base != "" {
+		return base + modelsPath, nil
+	}
+	return modelsURL, nil
 }

--- a/pkg/infra/providers/openai/connection_test.go
+++ b/pkg/infra/providers/openai/connection_test.go
@@ -13,11 +13,14 @@ import (
 
 func TestResolveModelsURL(t *testing.T) {
 	c := &client{}
-	assert.Equal(t, modelsURL, c.resolveModelsURL(&providers.Config{}))
-	assert.Equal(t,
-		"https://host/v1/models",
-		c.resolveModelsURL(&providers.Config{Options: map[string]any{"base_url": "https://host/v1/"}}),
-	)
+
+	got, err := c.resolveModelsURL(&providers.Config{})
+	require.NoError(t, err)
+	assert.Equal(t, modelsURL, got)
+
+	got, err = c.resolveModelsURL(&providers.Config{Options: map[string]any{"base_url": "https://host/v1/"}})
+	require.NoError(t, err)
+	assert.Equal(t, "https://host/v1/models", got)
 }
 
 func TestTestConnection_MissingAPIKey(t *testing.T) {

--- a/pkg/infra/providers/options.go
+++ b/pkg/infra/providers/options.go
@@ -8,6 +8,13 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
+const (
+	OpenAIAPICompletions = "completions"
+	OpenAIAPIResponses   = "responses"
+
+	vertexDefaultAPIVersion = "v1"
+)
+
 type OpenAICompatibleOptions struct {
 	BaseURL string            `mapstructure:"base_url"`
 	Headers map[string]string `mapstructure:"headers"`
@@ -25,11 +32,78 @@ func DecodeOpenAICompatibleOptions(options map[string]any) (OpenAICompatibleOpti
 	if opts.BaseURL == "" {
 		return OpenAICompatibleOptions{}, fmt.Errorf("openai_compatible: base_url is required")
 	}
-
-	parsed, err := url.Parse(opts.BaseURL)
-	if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
-		return OpenAICompatibleOptions{}, fmt.Errorf("openai_compatible: base_url must be a valid http(s) URL, got %q", opts.BaseURL)
+	if err := validateHTTPBaseURL(opts.BaseURL); err != nil {
+		return OpenAICompatibleOptions{}, fmt.Errorf("openai_compatible: %w", err)
 	}
 
 	return opts, nil
+}
+
+type OpenAIOptions struct {
+	API     string `mapstructure:"api"`
+	BaseURL string `mapstructure:"base_url"`
+}
+
+func DecodeOpenAIOptions(options map[string]any) (OpenAIOptions, error) {
+	var opts OpenAIOptions
+	if len(options) > 0 {
+		if err := mapstructure.Decode(options, &opts); err != nil {
+			return OpenAIOptions{}, fmt.Errorf("openai: invalid provider_options: %w", err)
+		}
+	}
+
+	opts.API = strings.TrimSpace(opts.API)
+	switch opts.API {
+	case "", OpenAIAPICompletions, OpenAIAPIResponses:
+	default:
+		return OpenAIOptions{}, fmt.Errorf("openai: provider_options.api must be %q or %q, got %q", OpenAIAPICompletions, OpenAIAPIResponses, opts.API)
+	}
+
+	opts.BaseURL = strings.TrimSpace(opts.BaseURL)
+	if opts.BaseURL != "" {
+		if err := validateHTTPBaseURL(opts.BaseURL); err != nil {
+			return OpenAIOptions{}, fmt.Errorf("openai: %w", err)
+		}
+	}
+
+	return opts, nil
+}
+
+type VertexOptions struct {
+	Project  string `mapstructure:"project"`
+	Location string `mapstructure:"location"`
+	Version  string `mapstructure:"version"`
+}
+
+func DecodeVertexOptions(options map[string]any) (VertexOptions, error) {
+	var opts VertexOptions
+	if len(options) > 0 {
+		if err := mapstructure.Decode(options, &opts); err != nil {
+			return VertexOptions{}, fmt.Errorf("vertex: invalid provider_options: %w", err)
+		}
+	}
+
+	opts.Project = strings.TrimSpace(opts.Project)
+	opts.Location = strings.TrimSpace(opts.Location)
+	opts.Version = strings.TrimSpace(opts.Version)
+
+	if opts.Project == "" {
+		return VertexOptions{}, fmt.Errorf("vertex: provider_options.project is required")
+	}
+	if opts.Location == "" {
+		return VertexOptions{}, fmt.Errorf("vertex: provider_options.location is required")
+	}
+	if opts.Version == "" {
+		opts.Version = vertexDefaultAPIVersion
+	}
+
+	return opts, nil
+}
+
+func validateHTTPBaseURL(raw string) error {
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return fmt.Errorf("base_url must be a valid http(s) URL, got %q", raw)
+	}
+	return nil
 }

--- a/pkg/infra/providers/validate.go
+++ b/pkg/infra/providers/validate.go
@@ -5,6 +5,12 @@ func ValidateProviderOptions(provider string, options map[string]any) error {
 	case ProviderOpenAICompatible:
 		_, err := DecodeOpenAICompatibleOptions(options)
 		return err
+	case ProviderOpenAI:
+		_, err := DecodeOpenAIOptions(options)
+		return err
+	case ProviderVertex:
+		_, err := DecodeVertexOptions(options)
+		return err
 	default:
 		return nil
 	}

--- a/pkg/infra/providers/validate_test.go
+++ b/pkg/infra/providers/validate_test.go
@@ -9,27 +9,43 @@ import (
 
 func TestValidateProviderOptions(t *testing.T) {
 	tests := []struct {
-		name     string
-		provider string
-		options  map[string]any
-		wantErr  bool
+		name        string
+		provider    string
+		options     map[string]any
+		errContains string
 	}{
-		{name: "openai has no required options", provider: ProviderOpenAI, options: nil},
+		{name: "unknown provider is not validated", provider: "anthropic", options: map[string]any{"foo": "bar"}},
+
 		{name: "openai_compatible with base_url", provider: ProviderOpenAICompatible, options: map[string]any{"base_url": "https://host/v1"}},
 		{name: "openai_compatible with http base_url", provider: ProviderOpenAICompatible, options: map[string]any{"base_url": "http://localhost:8080/v1"}},
-		{name: "openai_compatible missing base_url", provider: ProviderOpenAICompatible, options: nil, wantErr: true},
-		{name: "openai_compatible empty base_url", provider: ProviderOpenAICompatible, options: map[string]any{"base_url": ""}, wantErr: true},
-		{name: "openai_compatible whitespace base_url", provider: ProviderOpenAICompatible, options: map[string]any{"base_url": "   "}, wantErr: true},
-		{name: "openai_compatible base_url without scheme", provider: ProviderOpenAICompatible, options: map[string]any{"base_url": "host/v1"}, wantErr: true},
-		{name: "openai_compatible base_url with bad scheme", provider: ProviderOpenAICompatible, options: map[string]any{"base_url": "ftp://host/v1"}, wantErr: true},
-		{name: "openai_compatible non-string base_url", provider: ProviderOpenAICompatible, options: map[string]any{"base_url": 123}, wantErr: true},
+		{name: "openai_compatible missing base_url", provider: ProviderOpenAICompatible, options: nil, errContains: "base_url"},
+		{name: "openai_compatible empty base_url", provider: ProviderOpenAICompatible, options: map[string]any{"base_url": ""}, errContains: "base_url"},
+		{name: "openai_compatible whitespace base_url", provider: ProviderOpenAICompatible, options: map[string]any{"base_url": "   "}, errContains: "base_url"},
+		{name: "openai_compatible base_url without scheme", provider: ProviderOpenAICompatible, options: map[string]any{"base_url": "host/v1"}, errContains: "base_url"},
+		{name: "openai_compatible base_url with bad scheme", provider: ProviderOpenAICompatible, options: map[string]any{"base_url": "ftp://host/v1"}, errContains: "base_url"},
+		{name: "openai_compatible non-string base_url", provider: ProviderOpenAICompatible, options: map[string]any{"base_url": 123}, errContains: "openai_compatible"},
+
+		{name: "openai no options is valid", provider: ProviderOpenAI, options: nil},
+		{name: "openai explicit completions", provider: ProviderOpenAI, options: map[string]any{"api": "completions"}},
+		{name: "openai responses", provider: ProviderOpenAI, options: map[string]any{"api": "responses"}},
+		{name: "openai custom base_url", provider: ProviderOpenAI, options: map[string]any{"base_url": "https://host/v1"}},
+		{name: "openai invalid api", provider: ProviderOpenAI, options: map[string]any{"api": "chat"}, errContains: "api"},
+		{name: "openai invalid base_url", provider: ProviderOpenAI, options: map[string]any{"base_url": "host/v1"}, errContains: "base_url"},
+		{name: "openai non-string api", provider: ProviderOpenAI, options: map[string]any{"api": 123}, errContains: "openai"},
+
+		{name: "vertex valid", provider: ProviderVertex, options: map[string]any{"project": "p", "location": "us-central1"}},
+		{name: "vertex custom version", provider: ProviderVertex, options: map[string]any{"project": "p", "location": "eu-west1", "version": "v1beta1"}},
+		{name: "vertex missing project", provider: ProviderVertex, options: map[string]any{"location": "us-central1"}, errContains: "project"},
+		{name: "vertex missing location", provider: ProviderVertex, options: map[string]any{"project": "p"}, errContains: "location"},
+		{name: "vertex nil options", provider: ProviderVertex, options: nil, errContains: "project"},
+		{name: "vertex project wrong type", provider: ProviderVertex, options: map[string]any{"project": 123, "location": "l"}, errContains: "vertex"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := ValidateProviderOptions(tt.provider, tt.options)
-			if tt.wantErr {
+			if tt.errContains != "" {
 				require.Error(t, err)
-				assert.Contains(t, err.Error(), "base_url")
+				assert.Contains(t, err.Error(), tt.errContains)
 				return
 			}
 			require.NoError(t, err)

--- a/pkg/infra/providers/vertex/client.go
+++ b/pkg/infra/providers/vertex/client.go
@@ -17,19 +17,9 @@ import (
 const (
 	defaultAction = "generateContent"
 	streamAction  = "streamGenerateContent"
-	defaultAPIVer = "v1"
 
-	OptKeyProject  = "project"
-	OptKeyLocation = "location"
-	OptKeyVersion  = "version"
-	optKeyAction   = "action"
+	optKeyAction = "action"
 )
-
-type vertexOptions struct {
-	Project  string
-	Location string
-	Version  string
-}
 
 type client struct {
 	pool *providers.HTTPClientPool
@@ -105,7 +95,7 @@ func (c *client) buildRequestURL(config *providers.Config, reqBody []byte, strea
 		return "", fmt.Errorf("bearer token (api_key) is required for Vertex AI")
 	}
 
-	opts, err := parseOptions(config.Options)
+	opts, err := providers.DecodeVertexOptions(config.Options)
 	if err != nil {
 		return "", err
 	}
@@ -174,36 +164,7 @@ func isModelAllowed(model string, allowed []string) bool {
 	return false
 }
 
-func parseOptions(opts map[string]any) (vertexOptions, error) {
-	vo := vertexOptions{Version: defaultAPIVer}
-
-	vo.Project = stringOpt(opts, OptKeyProject)
-	if vo.Project == "" {
-		return vo, fmt.Errorf("vertex provider_options.%s is required", OptKeyProject)
-	}
-
-	vo.Location = stringOpt(opts, OptKeyLocation)
-	if vo.Location == "" {
-		return vo, fmt.Errorf("vertex provider_options.%s is required", OptKeyLocation)
-	}
-
-	if v := stringOpt(opts, OptKeyVersion); v != "" {
-		vo.Version = v
-	}
-
-	return vo, nil
-}
-
-func stringOpt(opts map[string]any, key string) string {
-	if v, ok := opts[key]; ok {
-		if s, ok := v.(string); ok {
-			return s
-		}
-	}
-	return ""
-}
-
-func buildVertexURL(opts vertexOptions, model, action string) string {
+func buildVertexURL(opts providers.VertexOptions, model, action string) string {
 	var sb strings.Builder
 	sb.WriteString("https://")
 	sb.WriteString(opts.Location)

--- a/pkg/infra/providers/vertex/client_test.go
+++ b/pkg/infra/providers/vertex/client_test.go
@@ -16,44 +16,8 @@ func TestNewVertexClient(t *testing.T) {
 	assert.NotNil(t, NewVertexClient())
 }
 
-func TestParseOptions(t *testing.T) {
-	tests := []struct {
-		name     string
-		opts     map[string]any
-		wantOpts vertexOptions
-		wantErr  bool
-	}{
-		{
-			name:     "valid options",
-			opts:     map[string]any{"project": "my-proj", "location": "us-central1"},
-			wantOpts: vertexOptions{Project: "my-proj", Location: "us-central1", Version: "v1"},
-		},
-		{
-			name:     "custom version",
-			opts:     map[string]any{"project": "p", "location": "eu-west1", "version": "v1beta1"},
-			wantOpts: vertexOptions{Project: "p", Location: "eu-west1", Version: "v1beta1"},
-		},
-		{name: "missing project", opts: map[string]any{"location": "us-central1"}, wantErr: true},
-		{name: "missing location", opts: map[string]any{"project": "p"}, wantErr: true},
-		{name: "nil options", opts: nil, wantErr: true},
-		{name: "empty options", opts: map[string]any{}, wantErr: true},
-		{name: "project wrong type", opts: map[string]any{"project": 123, "location": "us-central1"}, wantErr: true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseOptions(tt.opts)
-			if tt.wantErr {
-				require.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
-			assert.Equal(t, tt.wantOpts, got)
-		})
-	}
-}
-
 func TestBuildVertexURL(t *testing.T) {
-	opts := vertexOptions{Project: "my-proj", Location: "us-central1", Version: "v1"}
+	opts := providers.VertexOptions{Project: "my-proj", Location: "us-central1", Version: "v1"}
 
 	assert.Equal(t,
 		"https://us-central1-aiplatform.googleapis.com/v1/projects/my-proj/locations/us-central1/publishers/google/models/gemini-2.5-flash:generateContent",


### PR DESCRIPTION
## Summary

Follow-up to #32. Extends the typed `provider_options` decoder pattern (introduced for `openai_compatible`) to the `openai` and `vertex` providers, so each provider's option contract lives as a typed struct in the `providers` package and is validated up front via `ValidateProviderOptions`.

- **`options.go`**: new `OpenAIOptions` + `DecodeOpenAIOptions` (validates `api ∈ {"", completions, responses}` and an `http(s)` `base_url`) and `VertexOptions` + `DecodeVertexOptions` (requires `project` and `location`, defaults `version` to `v1`). Shared `validateHTTPBaseURL` helper reused by `openai` and `openai_compatible`.
- **`validate.go`**: `ValidateProviderOptions` now delegates to the per-provider decoders for `openai` and `vertex` (previously only `openai_compatible`).
- **`openai` / `vertex` clients**: dropped their private `*Options` structs and `parseOptions`/`stringOpt` helpers; both now consume the shared decoders. The `openai` client propagates decode errors (consistent with `openai_compatible`) instead of silently defaulting.
- Moved the `completions`/`responses` API constants into the `providers` package (they were not referenced outside `openai`).

## Behavior change (intended)

Validation is now stricter and happens at persist time rather than at request time:
- A `vertex` backend missing `project`/`location`, or an `openai` backend with an invalid `api` value or malformed `base_url`, is now rejected when the backend is created/updated.
- At runtime, the `openai` client returns an error on invalid options instead of silently falling back to completions. Valid configs are unaffected; only legacy data with invalid options (created before this validation existed) would now fail fast.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./pkg/infra/providers/...`
- [x] `go test ./pkg/infra/providers/...` (openai, vertex, openaicompat, validate)
- [x] `gofmt` clean on changed files
- [ ] Confirm no existing `openai`/`vertex` backends in target envs rely on invalid stored options

Made with [Cursor](https://cursor.com)