### PR TITLE
feat(consumer): allow registries and model policies on create

### DIFF
--- a/docs/AgentGateway.postman_collection.json
+++ b/docs/AgentGateway.postman_collection.json
@@ -383,7 +383,36 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"openai-primary-{{$guid}}\",\n  \"provider\": \"openai\",\n  \"description\": \"Primary OpenAI target\",\n  \"weight\": 1,\n  \"provider_options\": {},\n  \"auth\": {\n    \"type\": \"api_key\",\n    \"api_key\": { \"api_key\": \"sk-replace-me\" }\n  },\n  \"health_checks\": {\n    \"passive\": true,\n    \"threshold\": 3,\n    \"interval\": 30\n  }\n}"
+              "raw": "{\n  \"name\": \"openai-primary-{{$guid}}\",\n  \"provider\": \"openai\",\n  \"description\": \"Primary OpenAI target\",\n  \"weight\": 1,\n  \"provider_options\": {},\n  \"auth\": {\n    \"type\": \"api_key\",\n    \"api_key\": { \"api_key\": \"{{openai_api_key}}\" }\n  },\n  \"health_checks\": {\n    \"passive\": true,\n    \"threshold\": 3,\n    \"interval\": 30\n  }\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/gateways/{{gateway_id}}/registries",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "v1",
+                "gateways",
+                "{{gateway_id}}",
+                "registries"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Create Azure Registry (OAuth Service Principal)",
+          "description": "Default Azure auth mode: OAuth via service principal. Requires auth.type=azure, azure.endpoint, azure.tenant_id, azure.client_id, and azure.client_secret. It is not generic auth.type=oauth2.",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"azure-primary-{{$guid}}\",\n  \"provider\": \"azure\",\n  \"description\": \"Azure OpenAI registry using OAuth service principal auth\",\n  \"weight\": 1,\n  \"auth\": {\n    \"type\": \"azure\",\n    \"azure\": {\n      \"endpoint\": \"{{azure_openai_endpoint}}\",\n      \"version\": \"2024-10-21\",\n      \"tenant_id\": \"{{azure_tenant_id}}\",\n      \"client_id\": \"{{azure_client_id}}\",\n      \"client_secret\": \"{{azure_client_secret}}\"\n    }\n  }\n}"
             },
             "url": {
               "raw": "{{base_url}}/v1/gateways/{{gateway_id}}/registries",
@@ -413,35 +442,6 @@
             "body": {
               "mode": "raw",
               "raw": "{\n  \"name\": \"azure-api-key-{{$guid}}\",\n  \"provider\": \"azure\",\n  \"description\": \"Azure OpenAI using api-key auth\",\n  \"weight\": 1,\n  \"auth\": {\n    \"type\": \"azure\",\n    \"azure\": {\n      \"endpoint\": \"{{azure_openai_endpoint}}\",\n      \"version\": \"2024-10-21\",\n      \"api_key\": \"{{azure_openai_api_key}}\"\n    }\n  }\n}"
-            },
-            "url": {
-              "raw": "{{base_url}}/v1/gateways/{{gateway_id}}/registries",
-              "host": [
-                "{{base_url}}"
-              ],
-              "path": [
-                "v1",
-                "gateways",
-                "{{gateway_id}}",
-                "registries"
-              ]
-            }
-          }
-        },
-        {
-          "name": "Create Azure Registry (Service Principal)",
-          "description": "Azure service principal mode requires auth.type=azure, azure.endpoint, azure.tenant_id, azure.client_id, and azure.client_secret. It is not generic auth.type=oauth2.",
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"name\": \"azure-service-principal-{{$guid}}\",\n  \"provider\": \"azure\",\n  \"description\": \"Azure OpenAI using service principal auth\",\n  \"weight\": 1,\n  \"auth\": {\n    \"type\": \"azure\",\n    \"azure\": {\n      \"endpoint\": \"{{azure_openai_endpoint}}\",\n      \"version\": \"2024-10-21\",\n      \"tenant_id\": \"{{azure_tenant_id}}\",\n      \"client_id\": \"{{azure_client_id}}\",\n      \"client_secret\": \"{{azure_client_secret}}\"\n    }\n  }\n}"
             },
             "url": {
               "raw": "{{base_url}}/v1/gateways/{{gateway_id}}/registries",
@@ -552,7 +552,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"openai-primary\",\n  \"provider\": \"openai\",\n  \"description\": \"Updated description\",\n  \"weight\": 2,\n  \"auth\": {\n    \"type\": \"api_key\",\n    \"api_key\": { \"api_key\": \"sk-replace-me\" }\n  }\n}"
+              "raw": "{\n  \"name\": \"openai-primary\",\n  \"provider\": \"openai\",\n  \"description\": \"Updated description\",\n  \"weight\": 2,\n  \"auth\": {\n    \"type\": \"api_key\",\n    \"api_key\": { \"api_key\": \"{{openai_api_key}}\" }\n  }\n}"
             },
             "url": {
               "raw": "{{base_url}}/v1/gateways/{{gateway_id}}/registries/{{registry_id}}",

--- a/docs/AgentGateway.postman_collection.json
+++ b/docs/AgentGateway.postman_collection.json
@@ -960,7 +960,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"team-a-{{$guid}}\",\n  \"type\": \"LLM\",\n  \"path\": \"/v1/team-a-{{$guid}}\",\n  \"algorithm\": \"round-robin\",\n  \"active\": true,\n  \"headers\": {}\n}"
+              "raw": "{\n  \"name\": \"team-a-{{$guid}}\",\n  \"type\": \"LLM\",\n  \"path\": \"/v1/team-a-{{$guid}}\",\n  \"algorithm\": \"round-robin\",\n  \"active\": true,\n  \"headers\": {},\n  \"registries\": [\n    {\n      \"id\": \"{{registry_id}}\",\n      \"model_policies\": {\n        \"allowed\": [\"gpt-4o\"],\n        \"default\": \"gpt-4o\"\n      }\n    }\n  ]\n}"
             },
             "url": {
               "raw": "{{base_url}}/v1/gateways/{{gateway_id}}/consumers",
@@ -1042,7 +1042,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"team-a-{{$guid}}\",\n  \"type\": \"LLM\",\n  \"path\": \"/v1/team-a-{{$guid}}\",\n  \"algorithm\": \"round-robin\",\n  \"active\": true,\n  \"model_policies\": [\n    {\n      \"registry_id\": \"{{registry_id}}\",\n      \"allowed\": [\"gpt-4o\"],\n      \"default\": \"gpt-4o\"\n    }\n  ],\n  \"fallback\": {\n    \"enabled\": true,\n    \"triggers\": [\"5xx\"],\n    \"chain\": [\"{{registry_id}}\"],\n    \"budget\": {\n      \"max_attempts\": 2,\n      \"max_total_latency_ms\": 5000,\n      \"max_cost_usd\": 0.5\n    }\n  }\n}"
+              "raw": "{\n  \"name\": \"team-a-{{$guid}}\",\n  \"type\": \"LLM\",\n  \"path\": \"/v1/team-a-{{$guid}}\",\n  \"algorithm\": \"round-robin\",\n  \"active\": true,\n  \"registries\": [\n    {\n      \"id\": \"{{registry_id}}\",\n      \"model_policies\": {\n        \"allowed\": [\"gpt-4o\"],\n        \"default\": \"gpt-4o\"\n      }\n    }\n  ],\n  \"fallback\": {\n    \"enabled\": true,\n    \"triggers\": [\"http_5xx\"],\n    \"chain\": [\"{{registry_id}}\"],\n    \"budget\": {\n      \"max_attempts\": 2,\n      \"max_total_latency_ms\": 5000,\n      \"max_cost_usd\": 0.5\n    }\n  }\n}"
             },
             "url": {
               "raw": "{{base_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}",

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2820,22 +2820,16 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
-                "model_policies": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_request.ModelPolicyRequest"
-                    }
-                },
                 "name": {
                     "type": "string"
                 },
                 "path": {
                     "type": "string"
                 },
-                "registry_ids": {
+                "registries": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_request.RegistryBindingRequest"
                     }
                 },
                 "type": {
@@ -2905,9 +2899,17 @@ const docTemplate = `{
                 },
                 "default": {
                     "type": "string"
-                },
-                "registry_id": {
+                }
+            }
+        },
+        "github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_request.RegistryBindingRequest": {
+            "type": "object",
+            "properties": {
+                "id": {
                     "type": "string"
+                },
+                "model_policies": {
+                    "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_request.ModelPolicyRequest"
                 }
             }
         },
@@ -2932,17 +2934,17 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
-                "model_policies": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_request.ModelPolicyRequest"
-                    }
-                },
                 "name": {
                     "type": "string"
                 },
                 "path": {
                     "type": "string"
+                },
+                "registries": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_request.RegistryBindingRequest"
+                    }
                 },
                 "type": {
                     "type": "string"
@@ -2985,22 +2987,16 @@ const docTemplate = `{
                 "id": {
                     "type": "string"
                 },
-                "model_policies": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_response.ModelPolicyResponse"
-                    }
-                },
                 "name": {
                     "type": "string"
                 },
                 "path": {
                     "type": "string"
                 },
-                "registry_ids": {
+                "registries": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_response.RegistryBindingResponse"
                     }
                 },
                 "type": {
@@ -3117,9 +3113,17 @@ const docTemplate = `{
                 },
                 "default": {
                     "type": "string"
-                },
-                "registry_id": {
+                }
+            }
+        },
+        "github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_response.RegistryBindingResponse": {
+            "type": "object",
+            "properties": {
+                "id": {
                     "type": "string"
+                },
+                "model_policies": {
+                    "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_response.ModelPolicyResponse"
                 }
             }
         },

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2820,11 +2820,23 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
+                "model_policies": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_request.ModelPolicyRequest"
+                    }
+                },
                 "name": {
                     "type": "string"
                 },
                 "path": {
                     "type": "string"
+                },
+                "registry_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "type": {
                     "type": "string"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3437,22 +3437,16 @@
                             "type": "string"
                         }
                     },
-                    "model_policies": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_request.ModelPolicyRequest"
-                        }
-                    },
                     "name": {
                         "type": "string"
                     },
                     "path": {
                         "type": "string"
                     },
-                    "registry_ids": {
+                    "registries": {
                         "type": "array",
                         "items": {
-                            "type": "string"
+                            "$ref": "#/components/schemas/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_request.RegistryBindingRequest"
                         }
                     },
                     "type": {
@@ -3522,9 +3516,17 @@
                     },
                     "default": {
                         "type": "string"
-                    },
-                    "registry_id": {
+                    }
+                }
+            },
+            "github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_request.RegistryBindingRequest": {
+                "type": "object",
+                "properties": {
+                    "id": {
                         "type": "string"
+                    },
+                    "model_policies": {
+                        "$ref": "#/components/schemas/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_request.ModelPolicyRequest"
                     }
                 }
             },
@@ -3549,17 +3551,17 @@
                             "type": "string"
                         }
                     },
-                    "model_policies": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_request.ModelPolicyRequest"
-                        }
-                    },
                     "name": {
                         "type": "string"
                     },
                     "path": {
                         "type": "string"
+                    },
+                    "registries": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_request.RegistryBindingRequest"
+                        }
                     },
                     "type": {
                         "type": "string"
@@ -3602,22 +3604,16 @@
                     "id": {
                         "type": "string"
                     },
-                    "model_policies": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_response.ModelPolicyResponse"
-                        }
-                    },
                     "name": {
                         "type": "string"
                     },
                     "path": {
                         "type": "string"
                     },
-                    "registry_ids": {
+                    "registries": {
                         "type": "array",
                         "items": {
-                            "type": "string"
+                            "$ref": "#/components/schemas/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_response.RegistryBindingResponse"
                         }
                     },
                     "type": {
@@ -3734,9 +3730,17 @@
                     },
                     "default": {
                         "type": "string"
-                    },
-                    "registry_id": {
+                    }
+                }
+            },
+            "github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_response.RegistryBindingResponse": {
+                "type": "object",
+                "properties": {
+                    "id": {
                         "type": "string"
+                    },
+                    "model_policies": {
+                        "$ref": "#/components/schemas/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_response.ModelPolicyResponse"
                     }
                 }
             },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3437,11 +3437,23 @@
                             "type": "string"
                         }
                     },
+                    "model_policies": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_request.ModelPolicyRequest"
+                        }
+                    },
                     "name": {
                         "type": "string"
                     },
                     "path": {
                         "type": "string"
+                    },
+                    "registry_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "type": {
                         "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2813,22 +2813,16 @@
                         "type": "string"
                     }
                 },
-                "model_policies": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_request.ModelPolicyRequest"
-                    }
-                },
                 "name": {
                     "type": "string"
                 },
                 "path": {
                     "type": "string"
                 },
-                "registry_ids": {
+                "registries": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_request.RegistryBindingRequest"
                     }
                 },
                 "type": {
@@ -2898,9 +2892,17 @@
                 },
                 "default": {
                     "type": "string"
-                },
-                "registry_id": {
+                }
+            }
+        },
+        "github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_request.RegistryBindingRequest": {
+            "type": "object",
+            "properties": {
+                "id": {
                     "type": "string"
+                },
+                "model_policies": {
+                    "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_request.ModelPolicyRequest"
                 }
             }
         },
@@ -2925,17 +2927,17 @@
                         "type": "string"
                     }
                 },
-                "model_policies": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_request.ModelPolicyRequest"
-                    }
-                },
                 "name": {
                     "type": "string"
                 },
                 "path": {
                     "type": "string"
+                },
+                "registries": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_request.RegistryBindingRequest"
+                    }
                 },
                 "type": {
                     "type": "string"
@@ -2978,22 +2980,16 @@
                 "id": {
                     "type": "string"
                 },
-                "model_policies": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_response.ModelPolicyResponse"
-                    }
-                },
                 "name": {
                     "type": "string"
                 },
                 "path": {
                     "type": "string"
                 },
-                "registry_ids": {
+                "registries": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_response.RegistryBindingResponse"
                     }
                 },
                 "type": {
@@ -3110,9 +3106,17 @@
                 },
                 "default": {
                     "type": "string"
-                },
-                "registry_id": {
+                }
+            }
+        },
+        "github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_response.RegistryBindingResponse": {
+            "type": "object",
+            "properties": {
+                "id": {
                     "type": "string"
+                },
+                "model_policies": {
+                    "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_response.ModelPolicyResponse"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2813,11 +2813,23 @@
                         "type": "string"
                     }
                 },
+                "model_policies": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_request.ModelPolicyRequest"
+                    }
+                },
                 "name": {
                     "type": "string"
                 },
                 "path": {
                     "type": "string"
+                },
+                "registry_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "type": {
                     "type": "string"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -229,17 +229,13 @@ definitions:
         additionalProperties:
           type: string
         type: object
-      model_policies:
-        items:
-          $ref: '#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_request.ModelPolicyRequest'
-        type: array
       name:
         type: string
       path:
         type: string
-      registry_ids:
+      registries:
         items:
-          type: string
+          $ref: '#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_request.RegistryBindingRequest'
         type: array
       type:
         type: string
@@ -285,8 +281,13 @@ definitions:
         type: array
       default:
         type: string
-      registry_id:
+    type: object
+  github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_request.RegistryBindingRequest:
+    properties:
+      id:
         type: string
+      model_policies:
+        $ref: '#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_request.ModelPolicyRequest'
     type: object
   github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_request.UpdateConsumerRequest:
     properties:
@@ -302,14 +303,14 @@ definitions:
         additionalProperties:
           type: string
         type: object
-      model_policies:
-        items:
-          $ref: '#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_request.ModelPolicyRequest'
-        type: array
       name:
         type: string
       path:
         type: string
+      registries:
+        items:
+          $ref: '#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_request.RegistryBindingRequest'
+        type: array
       type:
         type: string
     type: object
@@ -337,17 +338,13 @@ definitions:
         type: object
       id:
         type: string
-      model_policies:
-        items:
-          $ref: '#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_response.ModelPolicyResponse'
-        type: array
       name:
         type: string
       path:
         type: string
-      registry_ids:
+      registries:
         items:
-          type: string
+          $ref: '#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_response.RegistryBindingResponse'
         type: array
       type:
         type: string
@@ -424,8 +421,13 @@ definitions:
         type: array
       default:
         type: string
-      registry_id:
+    type: object
+  github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_response.RegistryBindingResponse:
+    properties:
+      id:
         type: string
+      model_policies:
+        $ref: '#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_response.ModelPolicyResponse'
     type: object
   github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_gateway_request.CreateGatewayRequest:
     properties:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -229,10 +229,18 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      model_policies:
+        items:
+          $ref: '#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_consumer_request.ModelPolicyRequest'
+        type: array
       name:
         type: string
       path:
         type: string
+      registry_ids:
+        items:
+          type: string
+        type: array
       type:
         type: string
     type: object

--- a/frontend/src/components/entities/consumer-detail.tsx
+++ b/frontend/src/components/entities/consumer-detail.tsx
@@ -153,7 +153,7 @@ function BindingsTab({ consumer }: { consumer: Consumer }) {
         kind="registries"
         title="Registries"
         icon={<Server className="h-4 w-4" />}
-        boundIds={consumer.registry_ids}
+        boundIds={consumer.registries.map((r) => r.id)}
         useItems={() => useList<Registry>("registries")}
       />
       <BindingSection
@@ -281,7 +281,7 @@ function RoutingTab({ consumer, onClose }: { consumer: Consumer; onClose: () => 
   const { toast } = useToast();
   const { data: registries } = useList<Registry>("registries");
 
-  const attached = (registries ?? []).filter((r) => consumer.registry_ids.includes(r.id));
+  const attached = (registries ?? []).filter((r) => consumer.registries.some((b) => b.id === r.id));
 
   const [strategy, setStrategy] = useState<Strategy>(strategyOf(consumer));
   const [embProvider, setEmbProvider] = useState(consumer.embedding_config?.provider ?? "");
@@ -607,13 +607,14 @@ function ModelPoliciesTab({ consumer, onClose }: { consumer: Consumer; onClose: 
   const { toast } = useToast();
   const { data: registries } = useList<Registry>("registries");
 
-  const attached = (registries ?? []).filter((r) => consumer.registry_ids.includes(r.id));
+  const attached = (registries ?? []).filter((r) => consumer.registries.some((b) => b.id === r.id));
 
   const initial: Record<string, { allowed: string; default: string }> = {};
-  for (const mp of consumer.model_policies ?? []) {
-    initial[mp.registry_id] = {
-      allowed: (mp.allowed ?? []).join(", "),
-      default: mp.default ?? "",
+  for (const binding of consumer.registries) {
+    if (!binding.model_policies) continue;
+    initial[binding.id] = {
+      allowed: (binding.model_policies.allowed ?? []).join(", "),
+      default: binding.model_policies.default ?? "",
     };
   }
   const [state, setState] = useState(initial);
@@ -627,15 +628,12 @@ function ModelPoliciesTab({ consumer, onClose }: { consumer: Consumer; onClose: 
   }
 
   async function save() {
-    const modelPolicies = attached
-      .map((r) => {
-        const entry = state[r.id];
-        if (!entry) return null;
-        const allowed = entry.allowed.split(",").map((s) => s.trim()).filter(Boolean);
-        if (allowed.length === 0 && !entry.default) return null;
-        return { registry_id: r.id, allowed, default: entry.default || undefined };
-      })
-      .filter(Boolean);
+    const registryBindings = attached.map((r) => {
+      const entry = state[r.id];
+      const allowed = entry ? entry.allowed.split(",").map((s) => s.trim()).filter(Boolean) : [];
+      if (allowed.length === 0 && !entry?.default) return { id: r.id };
+      return { id: r.id, model_policies: { allowed, default: entry?.default || undefined } };
+    });
 
     const body = consumerBaseBody(consumer);
     if (consumer.fallback) {
@@ -650,7 +648,7 @@ function ModelPoliciesTab({ consumer, onClose }: { consumer: Consumer; onClose: 
         },
       };
     }
-    body.model_policies = modelPolicies;
+    body.registries = registryBindings;
 
     setSaving(true);
     try {

--- a/frontend/src/components/entities/consumers-view.tsx
+++ b/frontend/src/components/entities/consumers-view.tsx
@@ -103,7 +103,7 @@ export function ConsumersView() {
                 </TD>
                 <TD>
                   <span className="text-[12px] text-muted">
-                    {c.registry_ids.length}r · {c.auth_ids.length}a
+                    {c.registries.length}r · {c.auth_ids.length}a
                   </span>
                 </TD>
                 <TD>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -123,9 +123,13 @@ export interface Fallback {
 }
 
 export interface ModelPolicy {
-  registry_id: string;
   allowed?: string[];
   default?: string;
+}
+
+export interface RegistryBinding {
+  id: string;
+  model_policies?: ModelPolicy | null;
 }
 
 export interface ConsumerWeight {
@@ -143,11 +147,10 @@ export interface Consumer {
   embedding_config?: EmbeddingConfig | null;
   headers?: Record<string, string>;
   active: boolean;
-  registry_ids: string[];
+  registries: RegistryBinding[];
   auth_ids: string[];
   fallback?: Fallback | null;
   weights?: ConsumerWeight[];
-  model_policies?: ModelPolicy[];
   created_at: string;
   updated_at: string;
 }

--- a/pkg/api/handler/http/consumer/create_consumer_handler.go
+++ b/pkg/api/handler/http/consumer/create_consumer_handler.go
@@ -51,11 +51,7 @@ func (h *CreateConsumerHandler) Handle(c *fiber.Ctx) error {
 	if err != nil {
 		return helpers.WriteError(c, err)
 	}
-	registryIDs, err := req.ToRegistryIDs()
-	if err != nil {
-		return helpers.WriteError(c, err)
-	}
-	modelPolicies, err := req.ToModelPolicies()
+	registryIDs, modelPolicies, err := req.ToRegistryBindings()
 	if err != nil {
 		return helpers.WriteError(c, err)
 	}

--- a/pkg/api/handler/http/consumer/create_consumer_handler.go
+++ b/pkg/api/handler/http/consumer/create_consumer_handler.go
@@ -51,6 +51,14 @@ func (h *CreateConsumerHandler) Handle(c *fiber.Ctx) error {
 	if err != nil {
 		return helpers.WriteError(c, err)
 	}
+	registryIDs, err := req.ToRegistryIDs()
+	if err != nil {
+		return helpers.WriteError(c, err)
+	}
+	modelPolicies, err := req.ToModelPolicies()
+	if err != nil {
+		return helpers.WriteError(c, err)
+	}
 
 	cons, err := h.creator.Create(c.UserContext(), appconsumer.CreateInput{
 		GatewayID:       gatewayID,
@@ -62,6 +70,8 @@ func (h *CreateConsumerHandler) Handle(c *fiber.Ctx) error {
 		Headers:         req.Headers,
 		Active:          req.Active,
 		Fallback:        fallback,
+		RegistryIDs:     registryIDs,
+		ModelPolicies:   modelPolicies,
 	})
 	if err != nil {
 		return helpers.WriteError(c, err)

--- a/pkg/api/handler/http/consumer/request/create_consumer_request.go
+++ b/pkg/api/handler/http/consumer/request/create_consumer_request.go
@@ -12,22 +12,28 @@ import (
 )
 
 type CreateConsumerRequest struct {
-	Name            string                  `json:"name"`
-	Type            string                  `json:"type,omitempty"`
-	Path            string                  `json:"path"`
-	Algorithm       string                  `json:"algorithm,omitempty"`
-	EmbeddingConfig *EmbeddingConfigRequest `json:"embedding_config,omitempty"`
-	Headers         map[string]string       `json:"headers,omitempty"`
-	Active          *bool                   `json:"active,omitempty"`
-	Fallback        *FallbackRequest        `json:"fallback,omitempty"`
-	RegistryIDs     []string                `json:"registry_ids,omitempty"`
-	ModelPolicies   []ModelPolicyRequest    `json:"model_policies,omitempty"`
+	Name            string                   `json:"name"`
+	Type            string                   `json:"type,omitempty"`
+	Path            string                   `json:"path"`
+	Algorithm       string                   `json:"algorithm,omitempty"`
+	EmbeddingConfig *EmbeddingConfigRequest  `json:"embedding_config,omitempty"`
+	Headers         map[string]string        `json:"headers,omitempty"`
+	Active          *bool                    `json:"active,omitempty"`
+	Fallback        *FallbackRequest         `json:"fallback,omitempty"`
+	Registries      []RegistryBindingRequest `json:"registries,omitempty"`
+}
+
+// RegistryBindingRequest binds a registry to the consumer and optionally scopes
+// which models may be used on it. The policy applies to the registry whether it
+// is reached as a pool member or through the fallback chain.
+type RegistryBindingRequest struct {
+	ID            string              `json:"id"`
+	ModelPolicies *ModelPolicyRequest `json:"model_policies,omitempty"`
 }
 
 type ModelPolicyRequest struct {
-	RegistryID string   `json:"registry_id"`
-	Allowed    []string `json:"allowed,omitempty"`
-	Default    string   `json:"default,omitempty"`
+	Allowed []string `json:"allowed,omitempty"`
+	Default string   `json:"default,omitempty"`
 }
 
 type FallbackRequest struct {
@@ -130,30 +136,36 @@ func (r CreateConsumerRequest) ToFallback() (*domain.Fallback, error) {
 	return r.Fallback.ToFallback()
 }
 
-func (r CreateConsumerRequest) ToRegistryIDs() ([]ids.RegistryID, error) {
-	return parseUUIDList[ids.RegistryKind](r.RegistryIDs, "registry_ids")
+func (r CreateConsumerRequest) ToRegistryBindings() ([]ids.RegistryID, domain.ModelPolicies, error) {
+	return parseRegistryBindings(r.Registries)
 }
 
-func (r CreateConsumerRequest) ToModelPolicies() (domain.ModelPolicies, error) {
-	return parseModelPolicies(r.ModelPolicies)
-}
-
-func parseModelPolicies(raw []ModelPolicyRequest) (domain.ModelPolicies, error) {
+func parseRegistryBindings(raw []RegistryBindingRequest) ([]ids.RegistryID, domain.ModelPolicies, error) {
 	if len(raw) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
-	out := make(domain.ModelPolicies, len(raw))
-	for i, mp := range raw {
-		id, err := ids.Parse[ids.RegistryKind](mp.RegistryID)
+	registryIDs := make([]ids.RegistryID, 0, len(raw))
+	seen := make(map[ids.RegistryID]struct{}, len(raw))
+	var policies domain.ModelPolicies
+	for i, binding := range raw {
+		id, err := ids.Parse[ids.RegistryKind](binding.ID)
 		if err != nil {
-			return nil, fmt.Errorf("model_policies[%d]: invalid registry_id %q: %w", i, mp.RegistryID, commonerrors.ErrValidation)
+			return nil, nil, fmt.Errorf("registries[%d]: invalid id %q: %w", i, binding.ID, commonerrors.ErrValidation)
 		}
-		if _, dup := out[id]; dup {
-			return nil, fmt.Errorf("model_policies[%d]: duplicate registry_id %q: %w", i, mp.RegistryID, commonerrors.ErrValidation)
+		if _, dup := seen[id]; dup {
+			return nil, nil, fmt.Errorf("registries[%d]: duplicate id %q: %w", i, binding.ID, commonerrors.ErrValidation)
 		}
-		out[id] = domain.ModelPolicy{Allowed: mp.Allowed, Default: mp.Default}
+		seen[id] = struct{}{}
+		registryIDs = append(registryIDs, id)
+		if binding.ModelPolicies == nil {
+			continue
+		}
+		if policies == nil {
+			policies = make(domain.ModelPolicies, len(raw))
+		}
+		policies[id] = domain.ModelPolicy{Allowed: binding.ModelPolicies.Allowed, Default: binding.ModelPolicies.Default}
 	}
-	return out, nil
+	return registryIDs, policies, nil
 }
 
 func parseUUIDList[K ids.Kind](raw []string, field string) ([]ids.ID[K], error) {

--- a/pkg/api/handler/http/consumer/request/create_consumer_request.go
+++ b/pkg/api/handler/http/consumer/request/create_consumer_request.go
@@ -20,6 +20,8 @@ type CreateConsumerRequest struct {
 	Headers         map[string]string       `json:"headers,omitempty"`
 	Active          *bool                   `json:"active,omitempty"`
 	Fallback        *FallbackRequest        `json:"fallback,omitempty"`
+	RegistryIDs     []string                `json:"registry_ids,omitempty"`
+	ModelPolicies   []ModelPolicyRequest    `json:"model_policies,omitempty"`
 }
 
 type ModelPolicyRequest struct {
@@ -126,6 +128,14 @@ func (r CreateConsumerRequest) ToEmbeddingConfig() *registrydomain.EmbeddingConf
 
 func (r CreateConsumerRequest) ToFallback() (*domain.Fallback, error) {
 	return r.Fallback.ToFallback()
+}
+
+func (r CreateConsumerRequest) ToRegistryIDs() ([]ids.RegistryID, error) {
+	return parseUUIDList[ids.RegistryKind](r.RegistryIDs, "registry_ids")
+}
+
+func (r CreateConsumerRequest) ToModelPolicies() (domain.ModelPolicies, error) {
+	return parseModelPolicies(r.ModelPolicies)
 }
 
 func parseModelPolicies(raw []ModelPolicyRequest) (domain.ModelPolicies, error) {

--- a/pkg/api/handler/http/consumer/request/create_consumer_request_test.go
+++ b/pkg/api/handler/http/consumer/request/create_consumer_request_test.go
@@ -1,0 +1,96 @@
+package request
+
+import (
+	"errors"
+	"testing"
+
+	commonerrors "github.com/NeuralTrust/AgentGateway/pkg/common/errors"
+	"github.com/NeuralTrust/AgentGateway/pkg/domain/ids"
+	"github.com/google/uuid"
+)
+
+func TestCreateConsumerRequest_ToRegistryBindings(t *testing.T) {
+	t.Parallel()
+	reg1 := uuid.NewString()
+	reg2 := uuid.NewString()
+
+	req := CreateConsumerRequest{Registries: []RegistryBindingRequest{
+		{ID: reg1, ModelPolicies: &ModelPolicyRequest{Allowed: []string{"gpt-4o", "gpt-4o-mini"}, Default: "gpt-4o"}},
+		{ID: reg2},
+	}}
+
+	registryIDs, policies, err := req.ToRegistryBindings()
+	if err != nil {
+		t.Fatalf("ToRegistryBindings() error = %v", err)
+	}
+	if len(registryIDs) != 2 {
+		t.Fatalf("expected 2 registry ids, got %d", len(registryIDs))
+	}
+	if len(policies) != 1 {
+		t.Fatalf("expected 1 policy, got %d", len(policies))
+	}
+	id1, _ := ids.Parse[ids.RegistryKind](reg1)
+	policy, ok := policies.For(id1)
+	if !ok {
+		t.Fatalf("policy for %s missing", reg1)
+	}
+	if policy.Default != "gpt-4o" {
+		t.Fatalf("policy default = %q, want gpt-4o", policy.Default)
+	}
+}
+
+func TestCreateConsumerRequest_ToRegistryBindings_Empty(t *testing.T) {
+	t.Parallel()
+	registryIDs, policies, err := CreateConsumerRequest{}.ToRegistryBindings()
+	if err != nil {
+		t.Fatalf("ToRegistryBindings() error = %v", err)
+	}
+	if registryIDs != nil || policies != nil {
+		t.Fatalf("expected nil outputs, got ids=%v policies=%v", registryIDs, policies)
+	}
+}
+
+func TestCreateConsumerRequest_ToRegistryBindings_InvalidID(t *testing.T) {
+	t.Parallel()
+	req := CreateConsumerRequest{Registries: []RegistryBindingRequest{{ID: "not-a-uuid"}}}
+	if _, _, err := req.ToRegistryBindings(); !errors.Is(err, commonerrors.ErrValidation) {
+		t.Fatalf("expected validation error, got %v", err)
+	}
+}
+
+func TestCreateConsumerRequest_ToRegistryBindings_DuplicateID(t *testing.T) {
+	t.Parallel()
+	reg := uuid.NewString()
+	req := CreateConsumerRequest{Registries: []RegistryBindingRequest{{ID: reg}, {ID: reg}}}
+	if _, _, err := req.ToRegistryBindings(); !errors.Is(err, commonerrors.ErrValidation) {
+		t.Fatalf("expected validation error for duplicate id, got %v", err)
+	}
+}
+
+func TestUpdateConsumerRequest_ToModelPolicies_NestedRegistries(t *testing.T) {
+	t.Parallel()
+	if got, err := (UpdateConsumerRequest{}).ToModelPolicies(); err != nil || got != nil {
+		t.Fatalf("omitted registries: got=%v err=%v, want nil,nil", got, err)
+	}
+
+	reg := uuid.NewString()
+	bindings := []RegistryBindingRequest{
+		{ID: reg, ModelPolicies: &ModelPolicyRequest{Allowed: []string{"gpt-4o"}, Default: "gpt-4o"}},
+	}
+	got, err := (UpdateConsumerRequest{Registries: &bindings}).ToModelPolicies()
+	if err != nil {
+		t.Fatalf("ToModelPolicies() error = %v", err)
+	}
+	if got == nil || len(*got) != 1 {
+		t.Fatalf("expected 1 policy, got %v", got)
+	}
+
+	empty := []RegistryBindingRequest{{ID: reg}}
+	got, err = (UpdateConsumerRequest{Registries: &empty}).ToModelPolicies()
+	if err != nil {
+		t.Fatalf("ToModelPolicies() error = %v", err)
+	}
+	if got == nil || len(*got) != 0 {
+		t.Fatalf("registries without policies must clear the map, got %v", got)
+	}
+}

--- a/pkg/api/handler/http/consumer/request/update_consumer_request.go
+++ b/pkg/api/handler/http/consumer/request/update_consumer_request.go
@@ -10,15 +10,15 @@ import (
 )
 
 type UpdateConsumerRequest struct {
-	Name            *string                 `json:"name,omitempty"`
-	Type            *string                 `json:"type,omitempty"`
-	Path            *string                 `json:"path,omitempty"`
-	Algorithm       *string                 `json:"algorithm,omitempty"`
-	EmbeddingConfig *EmbeddingConfigRequest `json:"embedding_config,omitempty"`
-	Headers         *map[string]string      `json:"headers,omitempty"`
-	Active          *bool                   `json:"active,omitempty"`
-	Fallback        *FallbackRequest        `json:"fallback,omitempty"`
-	ModelPolicies   *[]ModelPolicyRequest   `json:"model_policies,omitempty"`
+	Name            *string                   `json:"name,omitempty"`
+	Type            *string                   `json:"type,omitempty"`
+	Path            *string                   `json:"path,omitempty"`
+	Algorithm       *string                   `json:"algorithm,omitempty"`
+	EmbeddingConfig *EmbeddingConfigRequest   `json:"embedding_config,omitempty"`
+	Headers         *map[string]string        `json:"headers,omitempty"`
+	Active          *bool                     `json:"active,omitempty"`
+	Fallback        *FallbackRequest          `json:"fallback,omitempty"`
+	Registries      *[]RegistryBindingRequest `json:"registries,omitempty"`
 }
 
 func (r UpdateConsumerRequest) Validate() error {
@@ -60,12 +60,15 @@ func (r UpdateConsumerRequest) ToFallback() (*domain.Fallback, error) {
 }
 
 func (r UpdateConsumerRequest) ToModelPolicies() (*domain.ModelPolicies, error) {
-	if r.ModelPolicies == nil {
+	if r.Registries == nil {
 		return nil, nil
 	}
-	mp, err := parseModelPolicies(*r.ModelPolicies)
+	_, mp, err := parseRegistryBindings(*r.Registries)
 	if err != nil {
 		return nil, err
+	}
+	if mp == nil {
+		mp = domain.ModelPolicies{}
 	}
 	return &mp, nil
 }

--- a/pkg/api/handler/http/consumer/response/consumer_response.go
+++ b/pkg/api/handler/http/consumer/response/consumer_response.go
@@ -11,27 +11,30 @@ import (
 )
 
 type ConsumerResponse struct {
-	ID              ids.ConsumerID           `json:"id"`
-	GatewayID       ids.GatewayID            `json:"gateway_id"`
-	Name            string                   `json:"name"`
-	Type            string                   `json:"type"`
-	Path            string                   `json:"path"`
-	Algorithm       string                   `json:"algorithm"`
-	EmbeddingConfig *EmbeddingConfigResponse `json:"embedding_config,omitempty"`
-	Headers         map[string]string        `json:"headers,omitempty"`
-	Active          bool                     `json:"active"`
-	RegistryIDs     []ids.RegistryID         `json:"registry_ids"`
-	AuthIDs         []ids.AuthID             `json:"auth_ids"`
-	Fallback        *FallbackResponse        `json:"fallback,omitempty"`
-	ModelPolicies   []ModelPolicyResponse    `json:"model_policies,omitempty"`
-	CreatedAt       time.Time                `json:"created_at"`
-	UpdatedAt       time.Time                `json:"updated_at"`
+	ID              ids.ConsumerID            `json:"id"`
+	GatewayID       ids.GatewayID             `json:"gateway_id"`
+	Name            string                    `json:"name"`
+	Type            string                    `json:"type"`
+	Path            string                    `json:"path"`
+	Algorithm       string                    `json:"algorithm"`
+	EmbeddingConfig *EmbeddingConfigResponse  `json:"embedding_config,omitempty"`
+	Headers         map[string]string         `json:"headers,omitempty"`
+	Active          bool                      `json:"active"`
+	Registries      []RegistryBindingResponse `json:"registries"`
+	AuthIDs         []ids.AuthID              `json:"auth_ids"`
+	Fallback        *FallbackResponse         `json:"fallback,omitempty"`
+	CreatedAt       time.Time                 `json:"created_at"`
+	UpdatedAt       time.Time                 `json:"updated_at"`
+}
+
+type RegistryBindingResponse struct {
+	ID            ids.RegistryID       `json:"id"`
+	ModelPolicies *ModelPolicyResponse `json:"model_policies,omitempty"`
 }
 
 type ModelPolicyResponse struct {
-	RegistryID ids.RegistryID `json:"registry_id"`
-	Allowed    []string       `json:"allowed,omitempty"`
-	Default    string         `json:"default,omitempty"`
+	Allowed []string `json:"allowed,omitempty"`
+	Default string   `json:"default,omitempty"`
 }
 
 type EmbeddingConfigResponse struct {
@@ -66,10 +69,6 @@ func FromConsumer(c *domain.Consumer) ConsumerResponse {
 	if c == nil {
 		return ConsumerResponse{}
 	}
-	registryIDs := []ids.RegistryID(c.RegistryIDs)
-	if registryIDs == nil {
-		registryIDs = []ids.RegistryID{}
-	}
 	authIDs := c.AuthIDs
 	if authIDs == nil {
 		authIDs = []ids.AuthID{}
@@ -92,13 +91,27 @@ func FromConsumer(c *domain.Consumer) ConsumerResponse {
 		EmbeddingConfig: embedding,
 		Headers:         c.Headers,
 		Active:          c.Active,
-		RegistryIDs:     registryIDs,
+		Registries:      fromRegistryBindings(c.RegistryIDs, c.ModelPolicies),
 		AuthIDs:         authIDs,
 		Fallback:        fromFallback(c.Fallback),
-		ModelPolicies:   fromModelPolicies(c.ModelPolicies),
 		CreatedAt:       c.CreatedAt,
 		UpdatedAt:       c.UpdatedAt,
 	}
+}
+
+func fromRegistryBindings(registryIDs []ids.RegistryID, policies domain.ModelPolicies) []RegistryBindingResponse {
+	out := make([]RegistryBindingResponse, 0, len(registryIDs))
+	for _, id := range registryIDs {
+		binding := RegistryBindingResponse{ID: id}
+		if policy, ok := policies.For(id); ok {
+			binding.ModelPolicies = &ModelPolicyResponse{Allowed: policy.Allowed, Default: policy.Default}
+		}
+		out = append(out, binding)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].ID.String() < out[j].ID.String()
+	})
+	return out
 }
 
 func fromEmbeddingAuth(a *registrydomain.APIKeyAuth) *EmbeddingAuthResponse {
@@ -113,24 +126,6 @@ func fromEmbeddingAuth(a *registrydomain.APIKeyAuth) *EmbeddingAuthResponse {
 		ParamValue:    secret.Mask(a.ParamValue),
 		ParamLocation: a.ParamLocation,
 	}
-}
-
-func fromModelPolicies(m domain.ModelPolicies) []ModelPolicyResponse {
-	if len(m) == 0 {
-		return nil
-	}
-	out := make([]ModelPolicyResponse, 0, len(m))
-	for backendID, policy := range m {
-		out = append(out, ModelPolicyResponse{
-			RegistryID: backendID,
-			Allowed:    policy.Allowed,
-			Default:    policy.Default,
-		})
-	}
-	sort.Slice(out, func(i, j int) bool {
-		return out[i].RegistryID.String() < out[j].RegistryID.String()
-	})
-	return out
 }
 
 func fromFallback(f *domain.Fallback) *FallbackResponse {

--- a/pkg/app/consumer/creator.go
+++ b/pkg/app/consumer/creator.go
@@ -2,6 +2,7 @@ package consumer
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	domain "github.com/NeuralTrust/AgentGateway/pkg/domain/consumer"
@@ -20,6 +21,8 @@ type CreateInput struct {
 	Headers         map[string]string
 	Active          *bool
 	Fallback        *domain.Fallback
+	RegistryIDs     []ids.RegistryID
+	ModelPolicies   domain.ModelPolicies
 }
 
 //go:generate mockery --name=Creator --dir=. --output=./mocks --filename=consumer_creator_mock.go --case=underscore --with-expecter
@@ -30,23 +33,26 @@ type Creator interface {
 var _ Creator = (*creator)(nil)
 
 type creator struct {
-	repo        domain.Repository
-	memoryCache *cache.TTLMap
-	publisher   cache.EventPublisher
-	logger      *slog.Logger
+	repo         domain.Repository
+	registryRepo registrydomain.Repository
+	memoryCache  *cache.TTLMap
+	publisher    cache.EventPublisher
+	logger       *slog.Logger
 }
 
 func NewCreator(
 	repo domain.Repository,
+	registryRepo registrydomain.Repository,
 	manager *cache.TTLMapManager,
 	publisher cache.EventPublisher,
 	logger *slog.Logger,
 ) Creator {
 	return &creator{
-		repo:        repo,
-		memoryCache: manager.GetTTLMap(cache.ConsumerTTLName),
-		publisher:   publisher,
-		logger:      logger,
+		repo:         repo,
+		registryRepo: registryRepo,
+		memoryCache:  manager.GetTTLMap(cache.ConsumerTTLName),
+		publisher:    publisher,
+		logger:       logger,
 	}
 }
 
@@ -60,9 +66,14 @@ func (c *creator) Create(ctx context.Context, in CreateInput) (*domain.Consumer,
 		EmbeddingConfig: in.EmbeddingConfig,
 		Headers:         in.Headers,
 		Active:          in.Active,
+		RegistryIDs:     in.RegistryIDs,
 		Fallback:        in.Fallback,
+		ModelPolicies:   in.ModelPolicies,
 	})
 	if err != nil {
+		return nil, err
+	}
+	if err := c.ensureRegistriesInGateway(ctx, in.GatewayID, in.RegistryIDs); err != nil {
 		return nil, err
 	}
 	if err := c.repo.Save(ctx, cons); err != nil {
@@ -71,4 +82,21 @@ func (c *creator) Create(ctx context.Context, in CreateInput) (*domain.Consumer,
 	c.memoryCache.Set(cons.ID.String(), cons)
 	publishGatewayDataInvalidation(ctx, c.publisher, c.logger, cons.GatewayID)
 	return cons, nil
+}
+
+// ensureRegistriesInGateway guards against attaching registries that belong to a
+// different gateway: the consumer_registry FK only proves the registry exists, not
+// that it is owned by this gateway.
+func (c *creator) ensureRegistriesInGateway(ctx context.Context, gatewayID ids.GatewayID, registryIDs []ids.RegistryID) error {
+	if len(registryIDs) == 0 {
+		return nil
+	}
+	found, err := c.registryRepo.FindByIDs(ctx, gatewayID, registryIDs)
+	if err != nil {
+		return err
+	}
+	if len(found) != len(registryIDs) {
+		return fmt.Errorf("%w: one or more registries do not belong to the gateway", registrydomain.ErrInvalidRegistryID)
+	}
+	return nil
 }

--- a/pkg/app/consumer/creator_test.go
+++ b/pkg/app/consumer/creator_test.go
@@ -13,6 +13,7 @@ import (
 	repomocks "github.com/NeuralTrust/AgentGateway/pkg/domain/consumer/mocks"
 	"github.com/NeuralTrust/AgentGateway/pkg/domain/ids"
 	registrydomain "github.com/NeuralTrust/AgentGateway/pkg/domain/registry"
+	registrymocks "github.com/NeuralTrust/AgentGateway/pkg/domain/registry/mocks"
 	"github.com/NeuralTrust/AgentGateway/pkg/infra/cache"
 	"github.com/NeuralTrust/AgentGateway/pkg/infra/cache/cachetest"
 	"github.com/stretchr/testify/mock"
@@ -39,7 +40,7 @@ func TestCreator_Create_Success(t *testing.T) {
 		Once()
 
 	mgr := newCacheManager()
-	creator := appconsumer.NewCreator(repo, mgr, cachetest.NoopPublisher(), newTestLogger())
+	creator := appconsumer.NewCreator(repo, registrymocks.NewRepository(t), mgr, cachetest.NoopPublisher(), newTestLogger())
 
 	c, err := creator.Create(context.Background(), appconsumer.CreateInput{
 		GatewayID: gwID,
@@ -86,7 +87,7 @@ func TestCreator_Create_WithFallback(t *testing.T) {
 		Return(nil).
 		Once()
 
-	creator := appconsumer.NewCreator(repo, newCacheManager(), cachetest.NoopPublisher(), newTestLogger())
+	creator := appconsumer.NewCreator(repo, registrymocks.NewRepository(t), newCacheManager(), cachetest.NoopPublisher(), newTestLogger())
 
 	created, err := creator.Create(context.Background(), appconsumer.CreateInput{
 		GatewayID: gwID,
@@ -105,7 +106,7 @@ func TestCreator_Create_WithFallback(t *testing.T) {
 
 func TestCreator_Create_RejectsInvalidDomain(t *testing.T) {
 	t.Parallel()
-	creator := appconsumer.NewCreator(repomocks.NewRepository(t), newCacheManager(), cachetest.NoopPublisher(), newTestLogger())
+	creator := appconsumer.NewCreator(repomocks.NewRepository(t), registrymocks.NewRepository(t), newCacheManager(), cachetest.NoopPublisher(), newTestLogger())
 
 	_, err := creator.Create(context.Background(), appconsumer.CreateInput{
 		GatewayID: ids.New[ids.GatewayKind](),
@@ -123,7 +124,7 @@ func TestCreator_Create_PropagatesRepoError(t *testing.T) {
 	repo := repomocks.NewRepository(t)
 	repo.EXPECT().Save(mock.Anything, mock.Anything).Return(domain.ErrAlreadyExists).Once()
 
-	creator := appconsumer.NewCreator(repo, newCacheManager(), cachetest.NoopPublisher(), newTestLogger())
+	creator := appconsumer.NewCreator(repo, registrymocks.NewRepository(t), newCacheManager(), cachetest.NoopPublisher(), newTestLogger())
 
 	_, err := creator.Create(context.Background(), appconsumer.CreateInput{
 		GatewayID: ids.New[ids.GatewayKind](),
@@ -133,5 +134,113 @@ func TestCreator_Create_PropagatesRepoError(t *testing.T) {
 	})
 	if !errors.Is(err, domain.ErrAlreadyExists) {
 		t.Fatalf("err = %v, want ErrAlreadyExists", err)
+	}
+}
+
+func TestCreator_Create_WithRegistriesAndModelPolicies(t *testing.T) {
+	t.Parallel()
+	gwID := ids.New[ids.GatewayKind]()
+	reg1 := ids.New[ids.RegistryKind]()
+	reg2 := ids.New[ids.RegistryKind]()
+
+	repo := repomocks.NewRepository(t)
+	repo.EXPECT().
+		Save(mock.Anything, mock.MatchedBy(func(c *domain.Consumer) bool {
+			return len(c.RegistryIDs) == 2 &&
+				c.RegistryIDs.Contains(reg1) &&
+				c.RegistryIDs.Contains(reg2) &&
+				len(c.ModelPolicies) == 1
+		})).
+		Return(nil).
+		Once()
+
+	registryRepo := registrymocks.NewRepository(t)
+	registryRepo.EXPECT().
+		FindByIDs(mock.Anything, gwID, mock.Anything).
+		Return([]*registrydomain.Registry{
+			{ID: reg1, GatewayID: gwID},
+			{ID: reg2, GatewayID: gwID},
+		}, nil).
+		Once()
+
+	creator := appconsumer.NewCreator(repo, registryRepo, newCacheManager(), cachetest.NoopPublisher(), newTestLogger())
+
+	created, err := creator.Create(context.Background(), appconsumer.CreateInput{
+		GatewayID:   gwID,
+		Name:        "chat",
+		Type:        domain.TypeLLM,
+		Path:        "/v1/chat/completions",
+		RegistryIDs: []ids.RegistryID{reg1, reg2},
+		ModelPolicies: domain.ModelPolicies{
+			reg1: {Allowed: []string{"gpt-4o", "gpt-4o-mini"}, Default: "gpt-4o"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create error: %v", err)
+	}
+	if len(created.RegistryIDs) != 2 {
+		t.Fatalf("RegistryIDs = %v, want 2 entries", created.RegistryIDs)
+	}
+	if _, ok := created.ModelPolicies.For(reg1); !ok {
+		t.Fatalf("ModelPolicies missing entry for %s", reg1)
+	}
+}
+
+func TestCreator_Create_RejectsRegistryFromAnotherGateway(t *testing.T) {
+	t.Parallel()
+	gwID := ids.New[ids.GatewayKind]()
+	reg1 := ids.New[ids.RegistryKind]()
+	reg2 := ids.New[ids.RegistryKind]()
+
+	repo := repomocks.NewRepository(t)
+
+	registryRepo := registrymocks.NewRepository(t)
+	registryRepo.EXPECT().
+		FindByIDs(mock.Anything, gwID, mock.Anything).
+		Return([]*registrydomain.Registry{
+			{ID: reg1, GatewayID: gwID},
+		}, nil).
+		Once()
+
+	creator := appconsumer.NewCreator(repo, registryRepo, newCacheManager(), cachetest.NoopPublisher(), newTestLogger())
+
+	_, err := creator.Create(context.Background(), appconsumer.CreateInput{
+		GatewayID:   gwID,
+		Name:        "chat",
+		Type:        domain.TypeLLM,
+		Path:        "/v1/chat/completions",
+		RegistryIDs: []ids.RegistryID{reg1, reg2},
+	})
+	if !errors.Is(err, registrydomain.ErrInvalidRegistryID) {
+		t.Fatalf("err = %v, want registrydomain.ErrInvalidRegistryID", err)
+	}
+}
+
+func TestCreator_Create_RejectsModelPolicyForUnboundRegistry(t *testing.T) {
+	t.Parallel()
+	gwID := ids.New[ids.GatewayKind]()
+	reg1 := ids.New[ids.RegistryKind]()
+	unbound := ids.New[ids.RegistryKind]()
+
+	creator := appconsumer.NewCreator(
+		repomocks.NewRepository(t),
+		registrymocks.NewRepository(t),
+		newCacheManager(),
+		cachetest.NoopPublisher(),
+		newTestLogger(),
+	)
+
+	_, err := creator.Create(context.Background(), appconsumer.CreateInput{
+		GatewayID:   gwID,
+		Name:        "chat",
+		Type:        domain.TypeLLM,
+		Path:        "/v1/chat/completions",
+		RegistryIDs: []ids.RegistryID{reg1},
+		ModelPolicies: domain.ModelPolicies{
+			unbound: {Default: "gpt-4o"},
+		},
+	})
+	if !errors.Is(err, domain.ErrInvalidModelPolicy) {
+		t.Fatalf("err = %v, want domain.ErrInvalidModelPolicy", err)
 	}
 }

--- a/pkg/infra/repository/consumer/repository.go
+++ b/pkg/infra/repository/consumer/repository.go
@@ -28,6 +28,8 @@ const (
 	consumerPathUniqueIndex      = "consumers_gateway_path_unique"
 )
 
+const insertConsumerRegistry = `INSERT INTO consumer_registry (consumer_id, registry_id) VALUES ($1, $2) ON CONFLICT DO NOTHING`
+
 const consumerSelectColumns = `
 		SELECT c.id, c.gateway_id, c.name, c.type, c.path, c.algorithm, c.embedding_config, c.fallback, c.model_policies, c.headers, c.active,
 		       c.created_at, c.updated_at,
@@ -72,13 +74,20 @@ func (r *Repository) Save(ctx context.Context, c *domain.Consumer) error {
 		) VALUES (
 			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13
 		)`
-	if _, err := r.conn.Pool.Exec(ctx, insertConsumer,
-		c.ID, c.GatewayID, c.Name, string(c.Type), c.Path, c.Algorithm, embeddingBytes, fallbackBytes, modelPoliciesBytes,
-		headersBytes, c.Active, c.CreatedAt, c.UpdatedAt,
-	); err != nil {
-		return mapPgError(err)
-	}
-	return nil
+	return database.WithTx(ctx, r.conn, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, insertConsumer,
+			c.ID, c.GatewayID, c.Name, string(c.Type), c.Path, c.Algorithm, embeddingBytes, fallbackBytes, modelPoliciesBytes,
+			headersBytes, c.Active, c.CreatedAt, c.UpdatedAt,
+		); err != nil {
+			return mapPgError(err)
+		}
+		for _, registryID := range c.RegistryIDs {
+			if _, err := tx.Exec(ctx, insertConsumerRegistry, c.ID, registryID); err != nil {
+				return mapPgError(err)
+			}
+		}
+		return nil
+	})
 }
 
 func (r *Repository) Update(ctx context.Context, c *domain.Consumer) error {
@@ -128,8 +137,7 @@ func (r *Repository) Update(ctx context.Context, c *domain.Consumer) error {
 }
 
 func (r *Repository) AttachRegistry(ctx context.Context, consumerID ids.ConsumerID, registryID ids.RegistryID) error {
-	const query = `INSERT INTO consumer_registry (consumer_id, registry_id) VALUES ($1, $2) ON CONFLICT DO NOTHING`
-	if _, err := r.conn.Pool.Exec(ctx, query, consumerID, registryID); err != nil {
+	if _, err := r.conn.Pool.Exec(ctx, insertConsumerRegistry, consumerID, registryID); err != nil {
 		return mapPgError(err)
 	}
 	return nil

--- a/tests/functional/common_test.go
+++ b/tests/functional/common_test.go
@@ -104,16 +104,17 @@ func validConsumerPayload(name string) map[string]any {
 	}
 }
 
-// CreateConsumerWithRegistries creates a base consumer and attaches each
-// registry through the association endpoint, returning the consumer id. This is
-// the common multi-step setup now that registries live outside the create body.
+// CreateConsumerWithRegistries creates a consumer with the given registries
+// bound atomically through the nested registries array of the create body.
 func CreateConsumerWithRegistries(t *testing.T, gatewayID, name string, registryIDs ...string) string {
 	t.Helper()
-	id := CreateConsumer(t, gatewayID, validConsumerPayload(name))
+	payload := validConsumerPayload(name)
+	bindings := make([]map[string]any, 0, len(registryIDs))
 	for _, registryID := range registryIDs {
-		AttachRegistry(t, gatewayID, id, registryID)
+		bindings = append(bindings, map[string]any{"id": registryID})
 	}
-	return id
+	payload["registries"] = bindings
+	return CreateConsumer(t, gatewayID, payload)
 }
 
 // AttachRegistry links a registry to a consumer via the association endpoint,
@@ -156,8 +157,8 @@ func SetPolicyGlobal(t *testing.T, gatewayID, policyID string) {
 }
 
 // UpdateConsumer issues a PUT /v1/gateways/:gateway_id/consumers/:id, asserting
-// the 200 contract. Registry-referencing config (model_policies, fallback) is
-// configured here, after the registries have been attached.
+// the 200 contract. Registry-referencing config (nested registries policies,
+// fallback) must reference registries already attached to the consumer.
 func UpdateConsumer(t *testing.T, gatewayID, consumerID string, payload map[string]any) {
 	t.Helper()
 	url := fmt.Sprintf("%s/v1/gateways/%s/consumers/%s", AdminURL, gatewayID, consumerID)

--- a/tests/functional/consumer_associations_test.go
+++ b/tests/functional/consumer_associations_test.go
@@ -47,6 +47,20 @@ func idSet(t *testing.T, body map[string]any, key string) map[string]struct{} {
 	return out
 }
 
+// registryIDSet extracts the bound registry ids from the nested registries
+// array of a consumer response.
+func registryIDSet(t *testing.T, body map[string]any) map[string]struct{} {
+	t.Helper()
+	raw, _ := body["registries"].([]any)
+	out := make(map[string]struct{}, len(raw))
+	for _, v := range raw {
+		entry, _ := v.(map[string]any)
+		s, _ := entry["id"].(string)
+		out[s] = struct{}{}
+	}
+	return out
+}
+
 func TestAttachRegistry_RoundTrip(t *testing.T) {
 	defer Track(t, "ConsumerAssociations")()
 	gwID := CreateGateway(t, map[string]any{"name": uniqueName("assoc-be-gw")})
@@ -57,7 +71,7 @@ func TestAttachRegistry_RoundTrip(t *testing.T) {
 	// Re-attach must be idempotent (204, no duplicate).
 	AttachRegistry(t, gwID, coID, beID)
 
-	got := idSet(t, getConsumer(t, gwID, coID), "registry_ids")
+	got := registryIDSet(t, getConsumer(t, gwID, coID))
 	require.Len(t, got, 1)
 	assert.Contains(t, got, beID)
 
@@ -67,7 +81,7 @@ func TestAttachRegistry_RoundTrip(t *testing.T) {
 	)
 	require.Equal(t, http.StatusNoContent, status)
 
-	got = idSet(t, getConsumer(t, gwID, coID), "registry_ids")
+	got = registryIDSet(t, getConsumer(t, gwID, coID))
 	assert.Empty(t, got, "registry should be detached")
 }
 

--- a/tests/functional/create_consumer_test.go
+++ b/tests/functional/create_consumer_test.go
@@ -30,10 +30,69 @@ func TestCreateConsumer_Success(t *testing.T) {
 	assert.Equal(t, "LLM", body["type"])
 	assert.Equal(t, true, body["active"])
 
-	// A freshly created consumer carries no associations until they are linked.
-	beIDs, ok := body["registry_ids"].([]any)
-	require.True(t, ok, "registry_ids missing: %v", body)
-	assert.Empty(t, beIDs)
+	// A consumer created without registries carries no associations.
+	bindings, ok := body["registries"].([]any)
+	require.True(t, ok, "registries missing: %v", body)
+	assert.Empty(t, bindings)
+}
+
+// TestCreateConsumer_WithRegistriesAndModelPolicies covers the atomic create
+// path: associations and per-registry model policies are accepted in a single
+// POST through the nested registries array.
+func TestCreateConsumer_WithRegistriesAndModelPolicies(t *testing.T) {
+	defer Track(t, "CreateConsumer")()
+	gwID := CreateGateway(t, map[string]any{"name": uniqueName("co-create-bind-gw")})
+	be1 := CreateRegistry(t, gwID, validRegistryPayload(uniqueName("co-create-bind-be1")))
+	be2 := CreateRegistry(t, gwID, validRegistryPayload(uniqueName("co-create-bind-be2")))
+	name := uniqueName("co-create-bind")
+
+	payload := validConsumerPayload(name)
+	payload["registries"] = []map[string]any{
+		{"id": be1, "model_policies": map[string]any{"allowed": []string{"gpt-4o", "gpt-4o-mini"}, "default": "gpt-4o"}},
+		{"id": be2},
+	}
+	status, body := sendRequest(t, http.MethodPost,
+		fmt.Sprintf("%s/v1/gateways/%s/consumers", AdminURL, gwID),
+		nil, payload,
+	)
+	require.Equal(t, http.StatusCreated, status, "body=%v", body)
+
+	got := registryIDSet(t, body)
+	require.Len(t, got, 2)
+	assert.Contains(t, got, be1)
+	assert.Contains(t, got, be2)
+
+	bindings := body["registries"].([]any)
+	for _, raw := range bindings {
+		binding := raw.(map[string]any)
+		policy, hasPolicy := binding["model_policies"].(map[string]any)
+		switch binding["id"] {
+		case be1:
+			require.True(t, hasPolicy, "policy missing for %s: %v", be1, binding)
+			assert.Equal(t, "gpt-4o", policy["default"])
+		case be2:
+			assert.False(t, hasPolicy, "unexpected policy for %s: %v", be2, binding)
+		}
+	}
+}
+
+// TestCreateConsumer_RejectsRegistryFromAnotherGateway ensures ownership is
+// validated before persisting anything: a registry created under a different
+// gateway cannot be bound at create time.
+func TestCreateConsumer_RejectsRegistryFromAnotherGateway(t *testing.T) {
+	defer Track(t, "CreateConsumer")()
+	gwA := CreateGateway(t, map[string]any{"name": uniqueName("co-create-xgw-a")})
+	gwB := CreateGateway(t, map[string]any{"name": uniqueName("co-create-xgw-b")})
+	foreignBE := CreateRegistry(t, gwB, validRegistryPayload(uniqueName("co-create-xgw-be")))
+
+	payload := validConsumerPayload(uniqueName("co-create-xgw"))
+	payload["registries"] = []map[string]any{{"id": foreignBE}}
+	status, body := sendRequest(t, http.MethodPost,
+		fmt.Sprintf("%s/v1/gateways/%s/consumers", AdminURL, gwA),
+		nil, payload,
+	)
+	require.Equal(t, http.StatusUnprocessableEntity, status, "body=%v", body)
+	assert.Equal(t, "validation_failed", body["error"])
 }
 
 func TestCreateConsumer_ConflictSameGateway(t *testing.T) {

--- a/tests/functional/proxy_e2e_test.go
+++ b/tests/functional/proxy_e2e_test.go
@@ -365,19 +365,17 @@ func setupModelPolicyRoute(t *testing.T, up *fakeUpstream, allowed []string, def
 	backendID := CreateRegistry(t, gatewayID, openaiBackendPayload(uniqueName("be"), up.URL()))
 	name := uniqueName("cons")
 	path := "/v1/" + uniqueName("route")
-	coID := CreateConsumer(t, gatewayID, map[string]any{"name": name, "path": path})
-	AttachRegistry(t, gatewayID, coID, backendID)
-
-	policy := map[string]any{"registry_id": backendID, "allowed": allowed}
+	policy := map[string]any{"allowed": allowed}
 	if defaultModel != "" {
 		policy["default"] = defaultModel
 	}
-	// model_policies reference an already-attached registry, so they are set on
-	// update once the association exists.
-	UpdateConsumer(t, gatewayID, coID, map[string]any{
-		"name":           name,
-		"path":           path,
-		"model_policies": []map[string]any{policy},
+	// The atomic create path binds the registry and its model policy in one POST.
+	coID := CreateConsumer(t, gatewayID, map[string]any{
+		"name": name,
+		"path": path,
+		"registries": []map[string]any{
+			{"id": backendID, "model_policies": policy},
+		},
 	})
 	apiKey := createAndAttachAPIKey(t, gatewayID, coID)
 	return apiKey, path

--- a/tests/functional/repositories/consumer/repository_test.go
+++ b/tests/functional/repositories/consumer/repository_test.go
@@ -158,6 +158,44 @@ func TestRepository_SaveAndFindByID(t *testing.T) {
 	}
 }
 
+func TestRepository_Save_PersistsRegistriesAtomically(t *testing.T) {
+	f := setupRepo(t)
+	ctx := context.Background()
+	gwID := seedGateway(t, f.gw, "pool-atomic")
+	be1 := seedRegistry(t, f.be, gwID, "be-atomic-1")
+	be2 := seedRegistry(t, f.be, gwID, "be-atomic-2")
+
+	c := validConsumer(t, gwID, "atomic-consumer", be1, be2)
+	if err := f.repo.Save(ctx, c); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := f.repo.FindByID(ctx, c.ID)
+	if err != nil {
+		t.Fatalf("FindByID: %v", err)
+	}
+	if len(got.RegistryIDs) != 2 {
+		t.Fatalf("RegistryIDs = %v, want 2 entries persisted by Save", got.RegistryIDs)
+	}
+	if !got.RegistryIDs.Contains(be1) || !got.RegistryIDs.Contains(be2) {
+		t.Fatalf("RegistryIDs = %v, want [%s, %s]", got.RegistryIDs, be1, be2)
+	}
+}
+
+func TestRepository_Save_RollsBackConsumerWhenRegistryInvalid(t *testing.T) {
+	f := setupRepo(t)
+	ctx := context.Background()
+	gwID := seedGateway(t, f.gw, "pool-rollback")
+
+	c := validConsumer(t, gwID, "rollback-consumer", ids.New[ids.RegistryKind]())
+	if err := f.repo.Save(ctx, c); !errors.Is(err, registrydomain.ErrInvalidRegistryID) {
+		t.Fatalf("Save err = %v, want registrydomain.ErrInvalidRegistryID", err)
+	}
+	if _, err := f.repo.FindByID(ctx, c.ID); !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("FindByID err = %v, want ErrNotFound (consumer insert must roll back)", err)
+	}
+}
+
 func TestRepository_SaveAndFindByID_RoundTripsFallback(t *testing.T) {
 	f := setupRepo(t)
 	ctx := context.Background()

--- a/tests/functional/update_consumer_test.go
+++ b/tests/functional/update_consumer_test.go
@@ -56,7 +56,7 @@ func TestUpdateConsumer_PreservesAssociations(t *testing.T) {
 	)
 	require.Equal(t, http.StatusOK, status, "body=%v", body)
 
-	got := idSet(t, getConsumer(t, gwID, coID), "registry_ids")
+	got := registryIDSet(t, getConsumer(t, gwID, coID))
 	require.Len(t, got, 2, "update must not drop associations")
 	assert.Contains(t, got, be1)
 	assert.Contains(t, got, be2)
@@ -72,8 +72,8 @@ func TestUpdateConsumer_SetsModelPolicies(t *testing.T) {
 	coID := CreateConsumerWithRegistries(t, gwID, name, beID)
 
 	payload := validConsumerPayload(name)
-	payload["model_policies"] = []map[string]any{
-		{"registry_id": beID, "allowed": []string{"gpt-4o-mini"}, "default": "gpt-4o-mini"},
+	payload["registries"] = []map[string]any{
+		{"id": beID, "model_policies": map[string]any{"allowed": []string{"gpt-4o-mini"}, "default": "gpt-4o-mini"}},
 	}
 	status, body := sendRequest(t, http.MethodPut,
 		fmt.Sprintf("%s/v1/gateways/%s/consumers/%s", AdminURL, gwID, coID),
@@ -87,12 +87,14 @@ func TestUpdateConsumer_SetsModelPolicies(t *testing.T) {
 	)
 	require.Equal(t, http.StatusOK, status)
 
-	policies, ok := body["model_policies"].([]any)
-	require.True(t, ok, "model_policies missing after update: %v", body)
-	require.Len(t, policies, 1)
-	policy, ok := policies[0].(map[string]any)
-	require.True(t, ok, "model policy entry malformed: %v", policies[0])
-	assert.Equal(t, beID, policy["registry_id"])
+	registries, ok := body["registries"].([]any)
+	require.True(t, ok, "registries missing after update: %v", body)
+	require.Len(t, registries, 1)
+	binding, ok := registries[0].(map[string]any)
+	require.True(t, ok, "registry binding malformed: %v", registries[0])
+	assert.Equal(t, beID, binding["id"])
+	policy, ok := binding["model_policies"].(map[string]any)
+	require.True(t, ok, "model_policies missing on binding: %v", binding)
 	assert.Equal(t, "gpt-4o-mini", policy["default"])
 }
 
@@ -106,8 +108,8 @@ func TestUpdateConsumer_RejectsModelPolicyForUnassociatedRegistry(t *testing.T) 
 	coID := CreateConsumer(t, gwID, validConsumerPayload(name)) // registry NOT attached
 
 	payload := validConsumerPayload(name)
-	payload["model_policies"] = []map[string]any{
-		{"registry_id": beID, "allowed": []string{"gpt-4o-mini"}},
+	payload["registries"] = []map[string]any{
+		{"id": beID, "model_policies": map[string]any{"allowed": []string{"gpt-4o-mini"}}},
 	}
 	status, body := sendRequest(t, http.MethodPut,
 		fmt.Sprintf("%s/v1/gateways/%s/consumers/%s", AdminURL, gwID, coID),


### PR DESCRIPTION
## Summary

- A consumer can now be created **atomically** with its registries and model policies in a single `POST /v1/gateways/{gateway_id}/consumers`.
- The API contract nests model policies under each registry binding (same shape on POST, PUT and GET):

```json
{
  "name": "chat",
  "path": "/v1/chat/completions",
  "registries": [
    { "id": "<reg-1>", "model_policies": { "allowed": ["gpt-4o", "gpt-4o-mini"], "default": "gpt-4o" } },
    { "id": "<reg-2>" }
  ]
}
```

- By construction a policy can no longer reference an unbound registry; registry ownership (same gateway) is validated in the app layer before persisting.
- `Save` is now transactional: the consumer row and its `consumer_registry` associations commit or roll back together.
- `PUT` keeps its current semantics: `registries` rebuilds the policy map for already-attached registries; membership is still managed via the attach/detach endpoints.
- `GET` groups the response the same way (`registries: [{id, model_policies}]`), replacing the flat `registry_ids` + `model_policies` fields.
- Frontend dashboard updated to the new contract.

## Test plan

- [x] Unit tests: request parsing (nested bindings, duplicates, invalid ids), creator ownership validation
- [x] Functional API tests: atomic create with policies, cross-gateway rejection, update round-trip, associations round-trip
- [x] Functional repository tests: transactional save + rollback
- [x] Proxy e2e: model policies enforced when bound at create time
- [x] `make swagger openapi` regenerated, frontend typecheck clean