### PR TITLE
feat(proxy): pool-scoped LB, fallback authorization, and route tracing (Phase 4, ENG-771)

### DIFF
--- a/pkg/app/metrics/builder.go
+++ b/pkg/app/metrics/builder.go
@@ -100,6 +100,7 @@ func (b *Builder) foldLLMSpans(requestTrace *trace.RequestTrace) (*trace.LLMAttr
 			Provider:   attrs.Provider,
 			Attempt:    attrs.Attempt,
 			Fallback:   attrs.Fallback,
+			Route:      attrs.Route,
 			Outcome:    attrs.Outcome,
 			StatusCode: span.StatusCode(),
 			LatencyMs:  span.Latency().Milliseconds(),

--- a/pkg/app/proxy/forwarder.go
+++ b/pkg/app/proxy/forwarder.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"iter"
 	"log/slog"
+	"strings"
 	"time"
 
 	appconsumer "github.com/NeuralTrust/AgentGateway/pkg/app/consumer"
@@ -48,6 +49,7 @@ type ForwardResult struct {
 type forwardRequestDTO struct {
 	backend     *domain.Registry
 	candidates  *routingdomain.CandidateSet
+	routeSource string
 	request     *infracontext.RequestContext
 	response    *infracontext.ResponseContext
 	policies    []*policydomain.Policy
@@ -120,7 +122,7 @@ func (f *forwarder) Forward(ctx context.Context, in ForwardInput) (*ForwardResul
 	f.stampConsumerScope(in)
 	f.stampContinuation(ctx, in.Request)
 
-	route, err := f.routeBackend(in.Consumer, in.Request, candidates)
+	route, err := f.routeBackend(in.Consumer, in.Request, intent, candidates)
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +189,7 @@ func (f *forwarder) invokeWithFailover(
 			resp, err := f.invokeOnce(ctx, current, dto.request, stream)
 			elapsed := time.Since(startedAt)
 			outcome := classifyOutcome(resp, err, triggers)
-			span := f.recordSpan(ctx, current, fromFallback, budget.attempts, outcome, resp, elapsed)
+			span := f.recordSpan(ctx, current, fromFallback, dto.routeSource, budget.attempts, outcome, resp, elapsed)
 			switch outcome {
 			case OutcomeSuccess:
 				reportSuccess(lb, current)
@@ -264,6 +266,9 @@ func (f *forwarder) nextCandidate(
 	req *infracontext.RequestContext,
 	excluded map[ids.RegistryID]struct{},
 ) (*domain.Registry, bool) {
+	if isRoleBased(rc) {
+		return nil, false
+	}
 	if lb != nil {
 		if bk, err := lb.NextBackend(req, excluded); err == nil && bk != nil {
 			if _, seen := excluded[bk.ID]; !seen {
@@ -293,6 +298,7 @@ func (f *forwarder) recordSpan(
 	ctx context.Context,
 	bk *domain.Registry,
 	fromFallback bool,
+	route string,
 	attempt int,
 	outcome Outcome,
 	resp *ProviderResponse,
@@ -311,6 +317,7 @@ func (f *forwarder) recordSpan(
 			Provider:   bk.Provider,
 			Attempt:    attempt,
 			Fallback:   fromFallback,
+			Route:      route,
 			Outcome:    outcome.String(),
 		},
 	}
@@ -518,47 +525,60 @@ func (f *forwarder) finalizeBodyGated(
 	}, nil
 }
 
-func (f *forwarder) selectBackend(
-	rc *appconsumer.RoutableConsumer,
-	req *infracontext.RequestContext,
-	excluded map[ids.RegistryID]struct{},
-) (*loadbalancer.LoadBalancer, *domain.Registry, error) {
-	lb, err := f.loadBalancerFor(rc)
-	if err != nil {
-		return nil, nil, err
-	}
-	bk, err := lb.NextBackend(req, excluded)
-	if err != nil {
-		return lb, nil, fmt.Errorf("%w: %s", ErrNoBackendAvailable, err.Error())
-	}
-	return lb, bk, nil
-}
-
 func (f *forwarder) loadBalancerFor(rc *appconsumer.RoutableConsumer) (*loadbalancer.LoadBalancer, error) {
 	key := loadBalancerCacheKey(rc.Consumer.GatewayID, rc.Consumer.ID)
-	if lb, ok := f.cachedLoadBalancer(key); ok {
-		return lb, nil
-	}
-
-	built, err, _ := f.lbGroup.Do(key, func() (interface{}, error) {
-		if lb, ok := f.cachedLoadBalancer(key); ok {
-			return lb, nil
-		}
-		lbAlgorithm := algorithm.RoundRobin
-		var embeddingConfig *domain.EmbeddingConfig
-		if lbCfg := rc.Consumer.LBConfig; lbCfg != nil && lbCfg.Enabled {
-			if lbCfg.Algorithm != "" {
-				lbAlgorithm = lbCfg.Algorithm
-			}
-			embeddingConfig = lbCfg.EmbeddingConfig
-		}
-		pool := loadbalancer.Pool{
+	return f.cachedOrBuildLoadBalancer(key, func() loadbalancer.Pool {
+		lbAlgorithm, embeddingConfig := lbSettings(rc)
+		return loadbalancer.Pool{
 			ID:              key,
 			Registries:      rc.Registries,
 			Algorithm:       lbAlgorithm,
 			EmbeddingConfig: embeddingConfig,
 		}
-		lb, err := loadbalancer.NewLoadBalancer(f.factory, pool, f.logger, f.cache)
+	})
+}
+
+func (f *forwarder) poolLoadBalancerFor(
+	rc *appconsumer.RoutableConsumer,
+	alias string,
+	candidates *routingdomain.CandidateSet,
+) (*loadbalancer.LoadBalancer, error) {
+	key := poolLoadBalancerCacheKey(rc.Consumer.GatewayID, rc.Consumer.ID, alias)
+	return f.cachedOrBuildLoadBalancer(key, func() loadbalancer.Pool {
+		lbAlgorithm, embeddingConfig := lbSettings(rc)
+		return loadbalancer.Pool{
+			ID:              key,
+			Registries:      candidates.Registries(),
+			Algorithm:       lbAlgorithm,
+			EmbeddingConfig: embeddingConfig,
+		}
+	})
+}
+
+func lbSettings(rc *appconsumer.RoutableConsumer) (string, *domain.EmbeddingConfig) {
+	lbAlgorithm := algorithm.RoundRobin
+	var embeddingConfig *domain.EmbeddingConfig
+	if lbCfg := rc.Consumer.LBConfig; lbCfg != nil && lbCfg.Enabled {
+		if lbCfg.Algorithm != "" {
+			lbAlgorithm = lbCfg.Algorithm
+		}
+		embeddingConfig = lbCfg.EmbeddingConfig
+	}
+	return lbAlgorithm, embeddingConfig
+}
+
+func (f *forwarder) cachedOrBuildLoadBalancer(
+	key string,
+	buildPool func() loadbalancer.Pool,
+) (*loadbalancer.LoadBalancer, error) {
+	if lb, ok := f.cachedLoadBalancer(key); ok {
+		return lb, nil
+	}
+	built, err, _ := f.lbGroup.Do(key, func() (interface{}, error) {
+		if lb, ok := f.cachedLoadBalancer(key); ok {
+			return lb, nil
+		}
+		lb, err := loadbalancer.NewLoadBalancer(f.factory, buildPool(), f.logger, f.cache)
 		if err != nil {
 			return nil, err
 		}
@@ -588,4 +608,8 @@ func (f *forwarder) cachedLoadBalancer(key string) (*loadbalancer.LoadBalancer, 
 
 func loadBalancerCacheKey(gatewayID ids.GatewayID, consumerID ids.ConsumerID) string {
 	return gatewayID.String() + ":" + consumerID.String()
+}
+
+func poolLoadBalancerCacheKey(gatewayID ids.GatewayID, consumerID ids.ConsumerID, alias string) string {
+	return gatewayID.String() + ":" + consumerID.String() + ":pool:" + strings.ToLower(alias)
 }

--- a/pkg/app/proxy/routing.go
+++ b/pkg/app/proxy/routing.go
@@ -1,6 +1,9 @@
 package proxy
 
 import (
+	"fmt"
+	"strings"
+
 	appconsumer "github.com/NeuralTrust/AgentGateway/pkg/app/consumer"
 	approuting "github.com/NeuralTrust/AgentGateway/pkg/app/routing"
 	consumerdomain "github.com/NeuralTrust/AgentGateway/pkg/domain/consumer"
@@ -101,6 +104,7 @@ func registryLookup(data *appconsumer.Data) approuting.RegistryLookup {
 func (f *forwarder) routeBackend(
 	rc *appconsumer.RoutableConsumer,
 	req *infracontext.RequestContext,
+	intent routingdomain.RoutingIntent,
 	candidates *routingdomain.CandidateSet,
 ) (routedBackend, error) {
 	if isRoleBased(rc) {
@@ -112,15 +116,30 @@ func (f *forwarder) routeBackend(
 	if len(rc.Registries) == 0 {
 		return routedBackend{}, ErrNoBackendsInPool
 	}
+	lb, err := f.routeLoadBalancer(rc, intent, candidates)
+	if err != nil {
+		return routedBackend{}, err
+	}
 	excluded := nonCandidateRegistries(rc, candidates)
-	lb, bk, err := f.selectBackend(rc, req, excluded)
+	bk, err := lb.NextBackend(req, excluded)
 	if err != nil {
 		if fallback := firstAvailableFallback(rc, excluded); fallback != nil {
 			return routedBackend{lb: lb, backend: fallback, excluded: excluded, fromFallback: true}, nil
 		}
-		return routedBackend{}, err
+		return routedBackend{}, fmt.Errorf("%w: %s", ErrNoBackendAvailable, err.Error())
 	}
 	return routedBackend{lb: lb, backend: bk, excluded: excluded}, nil
+}
+
+func (f *forwarder) routeLoadBalancer(
+	rc *appconsumer.RoutableConsumer,
+	intent routingdomain.RoutingIntent,
+	candidates *routingdomain.CandidateSet,
+) (*loadbalancer.LoadBalancer, error) {
+	if intent.IsPool() {
+		return f.poolLoadBalancerFor(rc, intent.PoolAlias, candidates)
+	}
+	return f.loadBalancerFor(rc)
 }
 
 func nonCandidateRegistries(
@@ -160,6 +179,7 @@ func firstAvailableFallback(
 }
 
 func (f *forwarder) stampRoutingPolicy(dto *forwardRequestDTO, rc *appconsumer.RoutableConsumer, bk *domain.Registry) {
+	dto.routeSource = routeSourceFor(dto.candidates, bk)
 	if candidate, ok := dto.candidates.ForRegistry(bk.ID); ok {
 		dto.request.AllowedModels = candidate.Allowed
 		dto.request.DefaultModel = candidate.Default
@@ -173,4 +193,11 @@ func (f *forwarder) stampRoutingPolicy(dto *forwardRequestDTO, rc *appconsumer.R
 	}
 	dto.request.AllowedModels = policy.Allowed
 	dto.request.DefaultModel = policy.Default
+}
+
+func routeSourceFor(candidates *routingdomain.CandidateSet, bk *domain.Registry) string {
+	if candidate, ok := candidates.ForRegistry(bk.ID); ok && len(candidate.Sources) > 0 {
+		return strings.Join(candidate.Sources, ",")
+	}
+	return "consumer"
 }

--- a/pkg/app/proxy/routing_forwarder_test.go
+++ b/pkg/app/proxy/routing_forwarder_test.go
@@ -14,6 +14,7 @@ import (
 	roledomain "github.com/NeuralTrust/AgentGateway/pkg/domain/role"
 	routingdomain "github.com/NeuralTrust/AgentGateway/pkg/domain/routing"
 	infracontext "github.com/NeuralTrust/AgentGateway/pkg/infra/context"
+	"github.com/NeuralTrust/AgentGateway/pkg/infra/trace"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -304,6 +305,197 @@ func TestForward_ShortModelSingleProviderKeepsBalancing(t *testing.T) {
 	}
 	if res.StatusCode != 200 {
 		t.Fatalf("expected 200, got %d", res.StatusCode)
+	}
+}
+
+func TestForward_PoolAliasBalancesAcrossMembers(t *testing.T) {
+	gatewayID := ids.New[ids.GatewayKind]()
+	memberA := backendFor(gatewayID, "openai")
+	memberB := backendFor(gatewayID, "openai")
+	outside := backendFor(gatewayID, "anthropic")
+	rc := routableConsumerWith(gatewayID, memberA, memberB, outside)
+	rc.Consumer.LBConfig.Enabled = true
+	rc.Consumer.LBConfig.PoolAlias = "fast-chat"
+	rc.Consumer.LBConfig.Members = []domainconsumer.LBPoolMember{
+		{RegistryID: memberA.ID},
+		{RegistryID: memberB.ID},
+	}
+
+	invoked := make(map[ids.RegistryID]int)
+	invoker := proxymocks.NewProviderInvoker(t)
+	invoker.EXPECT().
+		Invoke(mock.Anything, mock.Anything, mock.Anything).
+		Run(func(_ context.Context, bk *registrydomain.Registry, _ *infracontext.RequestContext) {
+			invoked[bk.ID]++
+		}).
+		Return(&appproxy.ProviderResponse{StatusCode: 200, Body: []byte("ok")}, nil).
+		Times(4)
+
+	fwd := newTestForwarder(t, invoker)
+	for i := 0; i < 4; i++ {
+		_, err := fwd.Forward(context.Background(), appproxy.ForwardInput{
+			GatewayID: gatewayID,
+			Consumer:  rc,
+			Request: &infracontext.RequestContext{
+				Context: context.Background(),
+				Body:    []byte(`{"model":"pool:fast-chat"}`),
+			},
+		})
+		if err != nil {
+			t.Fatalf("Forward %d: %v", i, err)
+		}
+	}
+	if invoked[outside.ID] != 0 {
+		t.Fatalf("non-member registry must never be selected, got %d invocations", invoked[outside.ID])
+	}
+	if invoked[memberA.ID] != 2 || invoked[memberB.ID] != 2 {
+		t.Fatalf("expected round-robin 2/2 across pool members, got %d/%d", invoked[memberA.ID], invoked[memberB.ID])
+	}
+}
+
+func TestForward_RoleBasedNeverEntersLBOrFallback(t *testing.T) {
+	gatewayID := ids.New[ids.GatewayKind]()
+	openai := backendFor(gatewayID, "openai")
+	fallbackBk := backendFor(gatewayID, "anthropic")
+	role := &roledomain.Role{
+		ID:            ids.New[ids.RoleKind](),
+		GatewayID:     gatewayID,
+		Name:          "analyst",
+		RegistryIDs:   []ids.RegistryID{openai.ID},
+		ModelPolicies: roledomain.ModelPolicies{openai.ID: {Allowed: []string{"gpt-5"}, Default: "gpt-5"}},
+	}
+	rc := &appconsumer.RoutableConsumer{
+		Consumer: &domainconsumer.Consumer{
+			ID:          ids.New[ids.ConsumerKind](),
+			GatewayID:   gatewayID,
+			RoutingMode: domainconsumer.RoutingModeRoleBased,
+			RoleIDs:     []ids.RoleID{role.ID},
+			Fallback:    enabledFallback(fallbackBk.ID),
+		},
+		FallbackBackends: []*registrydomain.Registry{fallbackBk},
+	}
+	data := appconsumer.NewData(gatewayID, nil, []*roledomain.Role{role})
+	data.SetRegistryIndex(map[ids.RegistryID]*registrydomain.Registry{
+		openai.ID:     openai,
+		fallbackBk.ID: fallbackBk,
+	})
+
+	invoker := proxymocks.NewProviderInvoker(t)
+	invoker.EXPECT().
+		Invoke(mock.Anything, mock.MatchedBy(func(bk *registrydomain.Registry) bool {
+			return bk.ID == openai.ID
+		}), mock.Anything).
+		Return(&appproxy.ProviderResponse{StatusCode: 503, Body: []byte("down")}, nil).
+		Once()
+
+	fwd := newTestForwarder(t, invoker)
+	res, err := fwd.Forward(context.Background(), appproxy.ForwardInput{
+		GatewayID: gatewayID,
+		Consumer:  rc,
+		Data:      data,
+		RoleIDs:   []ids.RoleID{role.ID},
+		Request: &infracontext.RequestContext{
+			Context: context.Background(),
+			Body:    []byte(`{"model":"gpt-5"}`),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+	if res.StatusCode != 503 {
+		t.Fatalf("expected 503 relayed without fallback, got %d", res.StatusCode)
+	}
+}
+
+func TestForward_SpanRecordsRouteSource(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func(gatewayID ids.GatewayID, bk *registrydomain.Registry) (appproxy.ForwardInput, string)
+	}{
+		{
+			name: "pool alias",
+			setup: func(gatewayID ids.GatewayID, bk *registrydomain.Registry) (appproxy.ForwardInput, string) {
+				rc := routableConsumerWith(gatewayID, bk)
+				rc.Consumer.LBConfig.Enabled = true
+				rc.Consumer.LBConfig.PoolAlias = "fast-chat"
+				rc.Consumer.LBConfig.Members = []domainconsumer.LBPoolMember{{RegistryID: bk.ID}}
+				return appproxy.ForwardInput{
+					GatewayID: gatewayID,
+					Consumer:  rc,
+					Request:   &infracontext.RequestContext{Body: []byte(`{"model":"pool:fast-chat"}`)},
+				}, "pool:fast-chat"
+			},
+		},
+		{
+			name: "role based",
+			setup: func(gatewayID ids.GatewayID, bk *registrydomain.Registry) (appproxy.ForwardInput, string) {
+				role := &roledomain.Role{
+					ID:            ids.New[ids.RoleKind](),
+					GatewayID:     gatewayID,
+					Name:          "analyst",
+					RegistryIDs:   []ids.RegistryID{bk.ID},
+					ModelPolicies: roledomain.ModelPolicies{bk.ID: {Allowed: []string{"gpt-5"}, Default: "gpt-5"}},
+				}
+				rc := &appconsumer.RoutableConsumer{
+					Consumer: &domainconsumer.Consumer{
+						ID:          ids.New[ids.ConsumerKind](),
+						GatewayID:   gatewayID,
+						RoutingMode: domainconsumer.RoutingModeRoleBased,
+						RoleIDs:     []ids.RoleID{role.ID},
+					},
+				}
+				data := appconsumer.NewData(gatewayID, nil, []*roledomain.Role{role})
+				data.SetRegistryIndex(map[ids.RegistryID]*registrydomain.Registry{bk.ID: bk})
+				return appproxy.ForwardInput{
+					GatewayID: gatewayID,
+					Consumer:  rc,
+					Data:      data,
+					RoleIDs:   []ids.RoleID{role.ID},
+					Request:   &infracontext.RequestContext{Body: []byte(`{"model":"gpt-5"}`)},
+				}, "role:analyst"
+			},
+		},
+		{
+			name: "inline passthrough",
+			setup: func(gatewayID ids.GatewayID, bk *registrydomain.Registry) (appproxy.ForwardInput, string) {
+				rc := routableConsumerWith(gatewayID, bk)
+				return appproxy.ForwardInput{
+					GatewayID: gatewayID,
+					Consumer:  rc,
+					Request:   &infracontext.RequestContext{Body: []byte(`{}`)},
+				}, "consumer"
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gatewayID := ids.New[ids.GatewayKind]()
+			bk := backendFor(gatewayID, "openai")
+			in, wantRoute := tc.setup(gatewayID, bk)
+
+			invoker := proxymocks.NewProviderInvoker(t)
+			invoker.EXPECT().
+				Invoke(mock.Anything, mock.Anything, mock.Anything).
+				Return(&appproxy.ProviderResponse{StatusCode: 200, Body: []byte("ok")}, nil).
+				Once()
+
+			fwd := newTestForwarder(t, invoker)
+			rt := trace.New("trace-route", trace.Metadata{})
+			ctx := trace.NewContext(context.Background(), rt)
+			in.Request.Context = ctx
+
+			_, err := fwd.Forward(ctx, in)
+			if err != nil {
+				t.Fatalf("Forward: %v", err)
+			}
+			spans := rt.Spans()
+			if len(spans) != 1 || spans[0].LLM == nil {
+				t.Fatalf("expected one LLM span, got %d", len(spans))
+			}
+			if spans[0].LLM.Route != wantRoute {
+				t.Fatalf("expected route %q, got %q", wantRoute, spans[0].LLM.Route)
+			}
+		})
 	}
 }
 

--- a/pkg/infra/metrics/events/event.go
+++ b/pkg/infra/metrics/events/event.go
@@ -96,6 +96,7 @@ type Attempt struct {
 	Provider   string `json:"provider,omitempty"`
 	Attempt    int    `json:"attempt"`
 	Fallback   bool   `json:"fallback"`
+	Route      string `json:"route,omitempty"`
 	Outcome    string `json:"outcome,omitempty"`
 	StatusCode int    `json:"status_code"`
 	LatencyMs  int64  `json:"latency_ms"`

--- a/pkg/infra/trace/span.go
+++ b/pkg/infra/trace/span.go
@@ -25,6 +25,7 @@ type LLMAttrs struct {
 	TurnID       string
 	Attempt      int
 	Fallback     bool
+	Route        string
 	Outcome      string
 	Usage        *adapter.CanonicalUsage
 }

--- a/tests/functional/routing_intent_test.go
+++ b/tests/functional/routing_intent_test.go
@@ -155,6 +155,58 @@ func TestRoutingIntent_PoolAlias(t *testing.T) {
 	})
 }
 
+func TestRoutingIntent_FallbackAuthorization(t *testing.T) {
+	defer Track(t, "RoutingIntent")()
+
+	setupCrossProviderFallback := func(t *testing.T, primary, fallback *fakeUpstream) (string, string) {
+		t.Helper()
+		gatewayID := CreateGateway(t, map[string]any{"name": uniqueName("fbauth-gw")})
+		primaryID := CreateRegistry(t, gatewayID, openaiBackendPayload(uniqueName("be-primary"), primary.URL()))
+		fallbackID := CreateRegistry(t, gatewayID, openaiCompatibleBackendPayload(uniqueName("be-fallback"), fallback.URL()))
+		path := "/v1/" + uniqueName("route")
+		coID := CreateConsumer(t, gatewayID, map[string]any{
+			"name": uniqueName("cons"),
+			"path": path,
+			"registries": []map[string]any{
+				{"id": primaryID, "model_policies": map[string]any{"allowed": []string{"gpt-4o-mini"}, "default": "gpt-4o-mini"}},
+				{"id": fallbackID, "model_policies": map[string]any{"allowed": []string{"compat-model"}, "default": "compat-model"}},
+			},
+			"fallback": map[string]any{
+				"enabled":  true,
+				"triggers": []string{"http_5xx"},
+				"chain":    []string{fallbackID},
+			},
+		})
+		apiKey := createAndAttachAPIKey(t, gatewayID, coID)
+		return apiKey, path
+	}
+
+	t.Run("multi-provider chain rescues a request without intent", func(t *testing.T) {
+		primary := newFailingUpstream(t, http.StatusInternalServerError)
+		fallback := newJSONUpstream(t, "fallback-served")
+		apiKey, path := setupCrossProviderFallback(t, primary, fallback)
+
+		status, _, body := proxyPost(t, apiKey, path, chatRequestNoModel())
+
+		assert.Equal(t, http.StatusOK, status, "body: %s", body)
+		assert.Contains(t, string(body), "fallback-served")
+		assert.Equal(t, expectedAttempts(), primary.Hits(), "primary must exhaust its retry budget before failover")
+		assert.Equal(t, 1, fallback.Hits(), "the cross-provider fallback must serve exactly once")
+	})
+
+	t.Run("qualified intent excludes other-provider fallback and relays the error", func(t *testing.T) {
+		primary := newFailingUpstream(t, http.StatusInternalServerError)
+		fallback := newJSONUpstream(t, "must-not-serve")
+		apiKey, path := setupCrossProviderFallback(t, primary, fallback)
+
+		status, _, body := proxyPost(t, apiKey, path, chatRequestModel("openai/gpt-4o-mini"))
+
+		assert.Equal(t, http.StatusInternalServerError, status, "body: %s", body)
+		assert.Equal(t, expectedAttempts(), primary.Hits(), "the authorized candidate must be fully retried")
+		assert.Equal(t, 0, fallback.Hits(), "a fallback outside the requested provider must never serve")
+	})
+}
+
 func TestRoutingIntent_ShortModel(t *testing.T) {
 	defer Track(t, "RoutingIntent")()
 


### PR DESCRIPTION
## Summary

Phase 4 of the Auth & Roles refactor ([ENG-771](https://linear.app/neuraltrust/issue/ENG-771/phase-4-forwarder-lb-and-fallback-integration)): integrates the `CandidateSet` routing layer (Phase 3) with the proxy runtime so LB and fallback only ever operate on authorized candidates, and only for `inline` consumers.

### Pool-scoped load balancing (ENG-783)
- `pool:<alias>` intents now build a **dedicated load balancer** whose pool contains only the authorized pool members, running the consumer-configured algorithm — previously the alias reused the consumer-wide LB and skipped non-members via exclusions, which biased the algorithm.
- The pool LB is cached under a pool-scoped key (`<gateway>:<consumer>:pool:<alias>`); the existing gateway-prefix cache invalidation covers it.

### Fallback authorization & exhaustion (ENG-784)
- Explicit guard: `role_based` routing never enters the LB or the fallback failover chain (defense in depth on top of domain validation).
- E2E coverage for cross-provider chains: a multi-provider fallback rescues intent-less requests, but a qualified `provider/model` intent excludes other-provider fallbacks and relays the last error.

### Forwarder + CandidateSet (ENG-786)
- Backend selection is fully driven by the resolved routing view; `routeBackend` now receives the parsed intent and picks the LB accordingly.
- Unit asserts that pool traffic balances round-robin across members only, and that role-based requests pick directly with no LB/fallback.

### Retry, health, and tracing preserved (ENG-782)
- Retry budget, passive health reporting, and `Attempt`/`Fallback` span attributes are untouched (health reports flow to the pool-scoped LB when one is active).
- New `Route` attribute on LLM spans and telemetry attempts identifies the selected route source: `pool:<alias>`, `role:<name>`, or `consumer`.

## Test plan
- [x] `make lint` — 0 issues
- [x] `go test ./...` — 71 packages green
- [x] `make test-functional` — full E2E suite green, including new `TestRoutingIntent_FallbackAuthorization`
- [x] New unit tests: `TestForward_PoolAliasBalancesAcrossMembers`, `TestForward_RoleBasedNeverEntersLBOrFallback`, `TestForward_SpanRecordsRouteSource`

Closes ENG-771, ENG-782, ENG-783, ENG-784, ENG-786.

Made with [Cursor](https://cursor.com)