### PR TITLE
fix(proxy): coalesce streamed tool-call deltas for openai-wire clients

### DIFF
--- a/pkg/app/proxy/provider_stream.go
+++ b/pkg/app/proxy/provider_stream.go
@@ -120,7 +120,7 @@ func adaptStream(
 	// source they speak expects it. Other source formats use their own terminator.
 	forwardDone := crossFormat && adapter.IsSameWireFormat(source, adapter.FormatOpenAI)
 
-	return func(yield func([]byte, error) bool) {
+	stream := func(yield func([]byte, error) bool) {
 		emit := func(lines [][]byte) bool {
 			for _, l := range lines {
 				if !yield(l, nil) {
@@ -178,6 +178,11 @@ func adaptStream(
 			// TODO(B.3): plugin chunk forwarding hook here.
 		}
 	}
+
+	if source != adapter.FormatOpenAIResponses && adapter.IsSameWireFormat(source, adapter.FormatOpenAI) {
+		return coalesceOpenAIToolCallStream(stream)
+	}
+	return stream
 }
 
 // isSSEDone reports whether line is the SSE "data: [DONE]" end-of-stream marker.

--- a/pkg/app/proxy/stream_toolcall_coalesce.go
+++ b/pkg/app/proxy/stream_toolcall_coalesce.go
@@ -1,0 +1,202 @@
+package proxy
+
+import (
+	"encoding/json"
+	"iter"
+
+	"github.com/NeuralTrust/AgentGateway/pkg/infra/providers/adapter"
+)
+
+type coalesceAction int
+
+const (
+	coalescePass coalesceAction = iota
+	coalesceSuppress
+	coalesceFlushFirst
+)
+
+type toolCallCoalescer struct {
+	acc       toolCallAccumulator
+	envelope  map[string]any
+	choiceIdx any
+}
+
+func coalesceOpenAIToolCallStream(src iter.Seq2[[]byte, error]) iter.Seq2[[]byte, error] {
+	return func(yield func([]byte, error) bool) {
+		c := &toolCallCoalescer{}
+		emitFlush := func() bool {
+			for _, l := range c.flushLines() {
+				if !yield(l, nil) {
+					return false
+				}
+			}
+			return true
+		}
+		for line, err := range src {
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+			payload, ok := dataPayload(line)
+			if !ok {
+				if isSSEDone(line) && !emitFlush() {
+					return
+				}
+				if !yield(line, nil) {
+					return
+				}
+				continue
+			}
+			rewritten, action := c.absorb(payload)
+			if action == coalesceSuppress {
+				continue
+			}
+			if action == coalesceFlushFirst && !emitFlush() {
+				return
+			}
+			out := line
+			if rewritten != nil {
+				out = append([]byte("data: "), rewritten...)
+			}
+			if !yield(out, nil) {
+				return
+			}
+		}
+		emitFlush()
+	}
+}
+
+func (c *toolCallCoalescer) absorb(payload []byte) ([]byte, coalesceAction) {
+	var chunk map[string]any
+	if err := json.Unmarshal(payload, &chunk); err != nil {
+		return nil, coalescePass
+	}
+	choices, _ := chunk["choices"].([]any)
+	if len(choices) != 1 {
+		return nil, coalescePass
+	}
+	choice, _ := choices[0].(map[string]any)
+	if choice == nil {
+		return nil, coalescePass
+	}
+	finishReason := choice["finish_reason"]
+	delta, _ := choice["delta"].(map[string]any)
+
+	absorbed := false
+	if delta != nil {
+		if rawCalls, ok := delta["tool_calls"].([]any); ok && len(rawCalls) > 0 {
+			c.merge(rawCalls)
+			c.captureEnvelope(chunk, choice)
+			delete(delta, "tool_calls")
+			absorbed = true
+		}
+	}
+
+	flush := finishReason != nil && len(c.acc) > 0
+
+	if !absorbed {
+		if flush {
+			return nil, coalesceFlushFirst
+		}
+		return nil, coalescePass
+	}
+
+	if !deltaHasPayload(delta) && finishReason == nil {
+		return nil, coalesceSuppress
+	}
+	out, err := json.Marshal(chunk)
+	if err != nil {
+		return nil, coalesceSuppress
+	}
+	if flush {
+		return out, coalesceFlushFirst
+	}
+	return out, coalescePass
+}
+
+func (c *toolCallCoalescer) merge(rawCalls []any) {
+	deltas := make([]adapter.StreamToolCallDelta, 0, len(rawCalls))
+	for _, raw := range rawCalls {
+		m, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		var d adapter.StreamToolCallDelta
+		if idx, ok := m["index"].(float64); ok {
+			d.Index = int(idx)
+		}
+		if id, ok := m["id"].(string); ok {
+			d.ID = id
+		}
+		if fn, ok := m["function"].(map[string]any); ok {
+			if name, ok := fn["name"].(string); ok {
+				d.Name = name
+			}
+			if args, ok := fn["arguments"].(string); ok {
+				d.ArgumentsDelta = args
+			}
+		}
+		deltas = append(deltas, d)
+	}
+	c.acc.Merge(deltas)
+}
+
+func (c *toolCallCoalescer) captureEnvelope(chunk, choice map[string]any) {
+	if c.envelope != nil {
+		return
+	}
+	c.envelope = make(map[string]any, len(chunk))
+	for k, v := range chunk {
+		if k == "choices" || k == "usage" {
+			continue
+		}
+		c.envelope[k] = v
+	}
+	c.choiceIdx = choice["index"]
+}
+
+func (c *toolCallCoalescer) flushLines() [][]byte {
+	if len(c.acc) == 0 {
+		return nil
+	}
+	deltas := c.acc.Flush()
+	toolCalls := make([]any, 0, len(deltas))
+	for _, d := range deltas {
+		toolCalls = append(toolCalls, map[string]any{
+			"index": d.Index,
+			"id":    d.ID,
+			"type":  "function",
+			"function": map[string]any{
+				"name":      d.Name,
+				"arguments": d.ArgumentsDelta,
+			},
+		})
+	}
+	chunk := make(map[string]any, len(c.envelope)+1)
+	for k, v := range c.envelope {
+		chunk[k] = v
+	}
+	idx := c.choiceIdx
+	if idx == nil {
+		idx = 0
+	}
+	chunk["choices"] = []any{map[string]any{
+		"index":         idx,
+		"delta":         map[string]any{"tool_calls": toolCalls},
+		"finish_reason": nil,
+	}}
+	payload, err := json.Marshal(chunk)
+	if err != nil {
+		return nil
+	}
+	return [][]byte{append([]byte("data: "), payload...), {}}
+}
+
+func deltaHasPayload(delta map[string]any) bool {
+	for _, v := range delta {
+		if v != nil {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/app/proxy/stream_toolcall_coalesce_test.go
+++ b/pkg/app/proxy/stream_toolcall_coalesce_test.go
@@ -1,0 +1,184 @@
+package proxy
+
+import (
+	"encoding/json"
+	"iter"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func linesSeq(lines ...string) iter.Seq2[[]byte, error] {
+	return func(yield func([]byte, error) bool) {
+		for _, l := range lines {
+			if !yield([]byte(l), nil) {
+				return
+			}
+		}
+	}
+}
+
+func collectLines(t *testing.T, seq iter.Seq2[[]byte, error]) []string {
+	t.Helper()
+	var out []string
+	for line, err := range seq {
+		require.NoError(t, err)
+		out = append(out, string(line))
+	}
+	return out
+}
+
+func dataChunks(t *testing.T, lines []string) []map[string]any {
+	t.Helper()
+	var chunks []map[string]any
+	for _, l := range lines {
+		payload, ok := dataPayload([]byte(l))
+		if !ok {
+			continue
+		}
+		var m map[string]any
+		require.NoError(t, json.Unmarshal(payload, &m))
+		chunks = append(chunks, m)
+	}
+	return chunks
+}
+
+func chunkToolCalls(chunk map[string]any) []any {
+	choices, _ := chunk["choices"].([]any)
+	if len(choices) == 0 {
+		return nil
+	}
+	choice, _ := choices[0].(map[string]any)
+	delta, _ := choice["delta"].(map[string]any)
+	calls, _ := delta["tool_calls"].([]any)
+	return calls
+}
+
+func TestCoalesceOpenAIToolCallStream_MergesFragmentedArguments(t *testing.T) {
+	out := collectLines(t, coalesceOpenAIToolCallStream(linesSeq(
+		`data: {"id":"c1","object":"chat.completion.chunk","model":"gpt-4o","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"database_agent","arguments":""}}]},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"c1","object":"chat.completion.chunk","model":"gpt-4o","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"que"}}]},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"c1","object":"chat.completion.chunk","model":"gpt-4o","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"ry\":\"Juan\"}"}}]},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"c1","object":"chat.completion.chunk","model":"gpt-4o","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		``,
+		`data: [DONE]`,
+		``,
+	)))
+
+	chunks := dataChunks(t, out)
+	require.Len(t, chunks, 3)
+
+	assert.Equal(t, "assistant", chunks[0]["choices"].([]any)[0].(map[string]any)["delta"].(map[string]any)["role"])
+	assert.Empty(t, chunkToolCalls(chunks[0]))
+
+	calls := chunkToolCalls(chunks[1])
+	require.Len(t, calls, 1)
+	call := calls[0].(map[string]any)
+	assert.Equal(t, "call_1", call["id"])
+	assert.Equal(t, "function", call["type"])
+	fn := call["function"].(map[string]any)
+	assert.Equal(t, "database_agent", fn["name"])
+	assert.JSONEq(t, `{"query":"Juan"}`, fn["arguments"].(string))
+	assert.Equal(t, "c1", chunks[1]["id"])
+	assert.Equal(t, "gpt-4o", chunks[1]["model"])
+
+	finish := chunks[2]["choices"].([]any)[0].(map[string]any)
+	assert.Equal(t, "tool_calls", finish["finish_reason"])
+
+	assert.Contains(t, out, "data: [DONE]")
+}
+
+func TestCoalesceOpenAIToolCallStream_ContentOnlyPassthroughVerbatim(t *testing.T) {
+	in := []string{
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"content":"hola"},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}
+	out := collectLines(t, coalesceOpenAIToolCallStream(linesSeq(in...)))
+	assert.Equal(t, in, out)
+}
+
+func TestCoalesceOpenAIToolCallStream_FlushesOnDoneWithoutFinishChunk(t *testing.T) {
+	out := collectLines(t, coalesceOpenAIToolCallStream(linesSeq(
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"f","arguments":"{\"a\":1}"}}]},"finish_reason":null}]}`,
+		``,
+		`data: [DONE]`,
+		``,
+	)))
+
+	chunks := dataChunks(t, out)
+	require.Len(t, chunks, 1)
+	calls := chunkToolCalls(chunks[0])
+	require.Len(t, calls, 1)
+	fn := calls[0].(map[string]any)["function"].(map[string]any)
+	assert.JSONEq(t, `{"a":1}`, fn["arguments"].(string))
+
+	doneIdx, flushIdx := -1, -1
+	for i, l := range out {
+		if isSSEDone([]byte(l)) {
+			doneIdx = i
+		}
+		if _, ok := dataPayload([]byte(l)); ok {
+			flushIdx = i
+		}
+	}
+	require.GreaterOrEqual(t, flushIdx, 0)
+	require.GreaterOrEqual(t, doneIdx, 0)
+	assert.Less(t, flushIdx, doneIdx)
+}
+
+func TestCoalesceOpenAIToolCallStream_ParallelToolCallsSortedByIndex(t *testing.T) {
+	out := collectLines(t, coalesceOpenAIToolCallStream(linesSeq(
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"id":"call_b","function":{"name":"g","arguments":""}}]},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_a","function":{"name":"f","arguments":"{}"}}]},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"c1","choices":[{"index":1,"delta":{"tool_calls":[{"index":1,"function":{"arguments":"{\"x\":2}"}}]},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		``,
+		`data: [DONE]`,
+		``,
+	)))
+
+	chunks := dataChunks(t, out)
+	require.Len(t, chunks, 2)
+	calls := chunkToolCalls(chunks[0])
+	require.Len(t, calls, 2)
+	first := calls[0].(map[string]any)
+	second := calls[1].(map[string]any)
+	assert.Equal(t, "call_a", first["id"])
+	assert.Equal(t, "call_b", second["id"])
+	assert.JSONEq(t, `{"x":2}`, second["function"].(map[string]any)["arguments"].(string))
+}
+
+func TestCoalesceOpenAIToolCallStream_MultiChoiceUntouched(t *testing.T) {
+	in := []string{
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{"}}]},"finish_reason":null},{"index":1,"delta":{"content":"x"},"finish_reason":null}]}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}
+	out := collectLines(t, coalesceOpenAIToolCallStream(linesSeq(in...)))
+	assert.Equal(t, in, out)
+}
+
+func TestCoalesceOpenAIToolCallStream_FlushesAtSequenceEndWithoutDone(t *testing.T) {
+	out := collectLines(t, coalesceOpenAIToolCallStream(linesSeq(
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"f","arguments":"{}"}}]},"finish_reason":null}]}`,
+		``,
+	)))
+
+	chunks := dataChunks(t, out)
+	require.Len(t, chunks, 1)
+	require.Len(t, chunkToolCalls(chunks[0]), 1)
+}


### PR DESCRIPTION
## Summary

- Some OpenAI-compatible SDKs (e.g. `langchain-mistralai` 1.1.5) assume tool-call arguments arrive complete in a single streamed delta, because their native APIs never fragment them. The OpenAI wire streams arguments incrementally (`index: 0`, no `id` on continuations), so through the gateway those clients received tool calls with empty arguments.
- The proxy now wraps client-facing chat-completions streams (`openai`/`azure`/`groq` sources, both passthrough and cross-format paths): tool-call fragments are absorbed and re-emitted as **one complete `tool_calls` chunk** right before the `finish_reason` chunk (or `[DONE]`/end of stream). Content tokens keep streaming through verbatim.
- This hardens the "swap your SDK's base_url and it works" promise for lax OpenAI-compatible SDKs without client-side patches.

## Changes

| File | Change |
|------|--------|
| `pkg/app/proxy/stream_toolcall_coalesce.go` | New coalescer: accumulates per-index tool-call deltas, suppresses fragments, synthesizes the complete chunk reusing the native stream envelope |
| `pkg/app/proxy/provider_stream.go` | `adaptStream` wraps the resulting stream with the coalescer for OpenAI chat-completions sources (Responses API excluded) |
| `pkg/app/proxy/stream_toolcall_coalesce_test.go` | Unit tests: fragment merge, verbatim content passthrough, flush on `[DONE]`/end without finish, parallel tool calls ordering, multi-choice untouched |

## Test plan

- [x] `go test ./...` green
- [x] Wire-level check against the local proxy: OpenAI fragments arrive at the client as a single chunk with complete JSON arguments
- [x] E2E with the multi-agent matrix and the `langchain-mistralai` SDK **unpatched**: `openai -> mistral` cell passes in both stream and non-stream modes
- [x] Regression sweep over cross-format cells (`openai/openai_responses/anthropic/azure` upstreams x `openai_completions/openai_responses/anthropic` agents, stream and non-stream): 12/12 OK

Made with [Cursor](https://cursor.com)