### PR TITLE
fix(metrics): emit occurred_on so gateway_metrics TTL works

### DIFF
--- a/pkg/app/metrics/builder.go
+++ b/pkg/app/metrics/builder.go
@@ -38,16 +38,16 @@ func (b *Builder) Build(
 	}
 
 	evt := &events.Event{
-		SchemaVersion:  events.SchemaVersion,
-		TraceID:        traceID,
-		GatewayID:      meta.GatewayID,
-		Timestamp:      startTime.UTC().Format(time.RFC3339),
-		StartTimestamp: startTime.UnixMilli(),
-		EndTimestamp:   endTime.UnixMilli(),
-		Consumer:       events.Consumer{ID: meta.ConsumerID, Name: meta.ConsumerName},
-		SessionID:      meta.SessionID,
-		FingerprintID:  meta.FingerprintID,
-		IP:             meta.IP,
+		SchemaVersion: events.SchemaVersion,
+		TraceID:       traceID,
+		GatewayID:     meta.GatewayID,
+		Timestamp:     startTime.UTC().Format(time.RFC3339),
+		OccurredOn:    startTime.UnixMilli(),
+		EndTimestamp:  endTime.UnixMilli(),
+		Consumer:      events.Consumer{ID: meta.ConsumerID, Name: meta.ConsumerName},
+		SessionID:     meta.SessionID,
+		FingerprintID: meta.FingerprintID,
+		IP:            meta.IP,
 	}
 
 	served, attempts := b.foldLLMSpans(requestTrace)

--- a/pkg/infra/metrics/events/event.go
+++ b/pkg/infra/metrics/events/event.go
@@ -8,9 +8,9 @@ type Event struct {
 	GatewayID     string `json:"gateway_id"`
 	TeamID        string `json:"team_id,omitempty"`
 
-	Timestamp      string `json:"timestamp"`
-	StartTimestamp int64  `json:"start_timestamp"`
-	EndTimestamp   int64  `json:"end_timestamp"`
+	Timestamp    string `json:"timestamp"`
+	OccurredOn   int64  `json:"occurred_on"`
+	EndTimestamp int64  `json:"end_timestamp"`
 
 	Consumer      Consumer `json:"consumer"`
 	SessionID     string   `json:"session_id,omitempty"`


### PR DESCRIPTION
## Summary

- The ClickHouse Kafka sink (`ClickHouseSinkConnector`) maps JSON keys to columns **by name**. The gateway request event published to `agentgateway.requests` had no `occurred_on` key, so the `gateway_metrics.occurred_on` column fell back to `DEFAULT 0` (1970).
- The table TTL `TTL toDate(occurred_on) + INTERVAL 12 MONTH` then evaluated `toDate(0) + 12 MONTH` (~1971), already expired, so rows were dropped on the next merge — inserts worked but data vanished.
- Fix: emit `occurred_on` as the request start time in epoch milliseconds (matching the column comment "arrives as epoch milliseconds"), and drop the now-unused `start_timestamp` field (no column consumes it).

## Test plan

- [ ] Send a request through the gateway and confirm the published Kafka event includes `occurred_on` with the epoch-ms start time.
- [ ] Verify rows persist in `gateway_metrics` with a correct `occurred_on` and are no longer expired by the TTL.

Made with [Cursor](https://cursor.com)