### PR TITLE
feat(registry): add enabled flag to toggle registries out of live traffic

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -4166,6 +4166,12 @@ const docTemplate = `{
                 "domain": {
                     "type": "string"
                 },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
                 "name": {
                     "type": "string"
                 },
@@ -4188,6 +4194,12 @@ const docTemplate = `{
                 },
                 "domain": {
                     "type": "string"
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "name": {
                     "type": "string"
@@ -4218,8 +4230,17 @@ const docTemplate = `{
                 "domain": {
                     "type": "string"
                 },
+                "host": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "name": {
                     "type": "string"
@@ -4507,6 +4528,9 @@ const docTemplate = `{
                 "description": {
                     "type": "string"
                 },
+                "enabled": {
+                    "type": "boolean"
+                },
                 "health_checks": {
                     "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_registry_request.HealthChecksRequest"
                 },
@@ -4738,6 +4762,9 @@ const docTemplate = `{
                 "description": {
                     "type": "string"
                 },
+                "enabled": {
+                    "type": "boolean"
+                },
                 "health_checks": {
                     "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_registry_request.HealthChecksRequest"
                 },
@@ -4968,6 +4995,9 @@ const docTemplate = `{
                 },
                 "description": {
                     "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
                 },
                 "gateway_id": {
                     "type": "string"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4972,6 +4972,12 @@
                     "domain": {
                         "type": "string"
                     },
+                    "metadata": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
                     "name": {
                         "type": "string"
                     },
@@ -4994,6 +5000,12 @@
                     },
                     "domain": {
                         "type": "string"
+                    },
+                    "metadata": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
                     },
                     "name": {
                         "type": "string"
@@ -5024,8 +5036,17 @@
                     "domain": {
                         "type": "string"
                     },
+                    "host": {
+                        "type": "string"
+                    },
                     "id": {
                         "type": "string"
+                    },
+                    "metadata": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
                     },
                     "name": {
                         "type": "string"
@@ -5313,6 +5334,9 @@
                     "description": {
                         "type": "string"
                     },
+                    "enabled": {
+                        "type": "boolean"
+                    },
                     "health_checks": {
                         "$ref": "#/components/schemas/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_registry_request.HealthChecksRequest"
                     },
@@ -5544,6 +5568,9 @@
                     "description": {
                         "type": "string"
                     },
+                    "enabled": {
+                        "type": "boolean"
+                    },
                     "health_checks": {
                         "$ref": "#/components/schemas/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_registry_request.HealthChecksRequest"
                     },
@@ -5774,6 +5801,9 @@
                     },
                     "description": {
                         "type": "string"
+                    },
+                    "enabled": {
+                        "type": "boolean"
                     },
                     "gateway_id": {
                         "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -4159,6 +4159,12 @@
                 "domain": {
                     "type": "string"
                 },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
                 "name": {
                     "type": "string"
                 },
@@ -4181,6 +4187,12 @@
                 },
                 "domain": {
                     "type": "string"
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "name": {
                     "type": "string"
@@ -4211,8 +4223,17 @@
                 "domain": {
                     "type": "string"
                 },
+                "host": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "name": {
                     "type": "string"
@@ -4500,6 +4521,9 @@
                 "description": {
                     "type": "string"
                 },
+                "enabled": {
+                    "type": "boolean"
+                },
                 "health_checks": {
                     "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_registry_request.HealthChecksRequest"
                 },
@@ -4731,6 +4755,9 @@
                 "description": {
                     "type": "string"
                 },
+                "enabled": {
+                    "type": "boolean"
+                },
                 "health_checks": {
                     "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_registry_request.HealthChecksRequest"
                 },
@@ -4961,6 +4988,9 @@
                 },
                 "description": {
                     "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
                 },
                 "gateway_id": {
                     "type": "string"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -631,6 +631,10 @@ definitions:
         $ref: '#/definitions/github_com_NeuralTrust_AgentGateway_pkg_domain_gateway.ClientTLSConfig'
       domain:
         type: string
+      metadata:
+        additionalProperties:
+          type: string
+        type: object
       name:
         type: string
       session_config:
@@ -646,6 +650,10 @@ definitions:
         $ref: '#/definitions/github_com_NeuralTrust_AgentGateway_pkg_domain_gateway.ClientTLSConfig'
       domain:
         type: string
+      metadata:
+        additionalProperties:
+          type: string
+        type: object
       name:
         type: string
       session_config:
@@ -665,8 +673,14 @@ definitions:
         type: string
       domain:
         type: string
+      host:
+        type: string
       id:
         type: string
+      metadata:
+        additionalProperties:
+          type: string
+        type: object
       name:
         type: string
       session_config:
@@ -857,6 +871,8 @@ definitions:
         $ref: '#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_registry_request.TargetAuthRequest'
       description:
         type: string
+      enabled:
+        type: boolean
       health_checks:
         $ref: '#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_registry_request.HealthChecksRequest'
       mcp_target:
@@ -1011,6 +1027,8 @@ definitions:
         $ref: '#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_registry_request.TargetAuthRequest'
       description:
         type: string
+      enabled:
+        type: boolean
       health_checks:
         $ref: '#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_registry_request.HealthChecksRequest'
       mcp_target:
@@ -1165,6 +1183,8 @@ definitions:
         type: string
       description:
         type: string
+      enabled:
+        type: boolean
       gateway_id:
         type: string
       health_checks:

--- a/pkg/api/handler/http/registry/create_registry_handler.go
+++ b/pkg/api/handler/http/registry/create_registry_handler.go
@@ -52,6 +52,7 @@ func (h *CreateRegistryHandler) Handle(c *fiber.Ctx) error {
 		GatewayID:   gatewayID,
 		Name:        req.Name,
 		Type:        req.ToType(),
+		Enabled:     req.Enabled,
 		Description: req.Description,
 		LLMTarget:   req.ToLLMTarget(),
 		MCPTarget:   req.ToMCPTarget(),

--- a/pkg/api/handler/http/registry/request/create_registry_request.go
+++ b/pkg/api/handler/http/registry/request/create_registry_request.go
@@ -11,6 +11,7 @@ import (
 type CreateRegistryRequest struct {
 	Name            string               `json:"name"`
 	Type            string               `json:"type,omitempty"`
+	Enabled         *bool                `json:"enabled,omitempty"`
 	Provider        string               `json:"provider,omitempty"`
 	ProviderOptions map[string]any       `json:"provider_options,omitempty"`
 	Description     string               `json:"description,omitempty"`

--- a/pkg/api/handler/http/registry/request/update_registry_request.go
+++ b/pkg/api/handler/http/registry/request/update_registry_request.go
@@ -10,6 +10,7 @@ import (
 
 type UpdateRegistryRequest struct {
 	Name            *string              `json:"name,omitempty"`
+	Enabled         *bool                `json:"enabled,omitempty"`
 	Provider        *string              `json:"provider,omitempty"`
 	ProviderOptions *map[string]any      `json:"provider_options,omitempty"`
 	Description     *string              `json:"description,omitempty"`

--- a/pkg/api/handler/http/registry/response/registry_response.go
+++ b/pkg/api/handler/http/registry/response/registry_response.go
@@ -13,6 +13,7 @@ type RegistryResponse struct {
 	GatewayID       ids.GatewayID         `json:"gateway_id"`
 	Name            string                `json:"name"`
 	Type            string                `json:"type"`
+	Enabled         bool                  `json:"enabled"`
 	Provider        string                `json:"provider,omitempty"`
 	ProviderOptions map[string]any        `json:"provider_options,omitempty"`
 	Description     string                `json:"description,omitempty"`
@@ -130,6 +131,7 @@ func FromRegistry(b *domain.Registry) RegistryResponse {
 		GatewayID:       b.GatewayID,
 		Name:            b.Name,
 		Type:            string(regType),
+		Enabled:         b.Enabled,
 		Provider:        b.Provider(),
 		ProviderOptions: b.ProviderOptions(),
 		Description:     b.Description,

--- a/pkg/api/handler/http/registry/response/registry_response_test.go
+++ b/pkg/api/handler/http/registry/response/registry_response_test.go
@@ -4,8 +4,28 @@ import (
 	"testing"
 
 	"github.com/NeuralTrust/AgentGateway/pkg/common/secret"
+	"github.com/NeuralTrust/AgentGateway/pkg/domain/ids"
 	domain "github.com/NeuralTrust/AgentGateway/pkg/domain/registry"
 )
+
+func TestFromRegistry_IncludesEnabled(t *testing.T) {
+	t.Parallel()
+
+	for _, enabled := range []bool{true, false} {
+		reg := &domain.Registry{
+			ID:        ids.New[ids.RegistryKind](),
+			GatewayID: ids.New[ids.GatewayKind](),
+			Name:      "r",
+			Type:      domain.TypeLLM,
+			Enabled:   enabled,
+			LLMTarget: &domain.LLMTarget{Provider: "openai"},
+		}
+		got := FromRegistry(reg)
+		if got.Enabled != enabled {
+			t.Fatalf("Enabled = %v, want %v", got.Enabled, enabled)
+		}
+	}
+}
 
 func TestFromAuth_MasksAzureSecretsAndReturnsIdentifiers(t *testing.T) {
 	t.Parallel()

--- a/pkg/api/handler/http/registry/update_registry_handler.go
+++ b/pkg/api/handler/http/registry/update_registry_handler.go
@@ -54,6 +54,7 @@ func (h *UpdateRegistryHandler) Handle(c *fiber.Ctx) error {
 		ID:              id,
 		GatewayID:       gatewayID,
 		Name:            req.Name,
+		Enabled:         req.Enabled,
 		Provider:        req.Provider,
 		ProviderOptions: req.ProviderOptions,
 		Description:     req.Description,

--- a/pkg/app/consumer/data_finder.go
+++ b/pkg/app/consumer/data_finder.go
@@ -159,6 +159,9 @@ func (f *dataFinder) loadBackends(
 	}
 	byID := make(map[ids.RegistryID]*registrydomain.Registry, len(found))
 	for _, b := range found {
+		if !b.Enabled {
+			continue
+		}
 		byID[b.ID] = b
 	}
 	return byID, nil
@@ -256,7 +259,7 @@ func (f *dataFinder) warnUnresolvedFallbackChain(c *domain.Consumer, resolved []
 	if len(chain) == len(resolved) {
 		return
 	}
-	f.logger.Warn("consumer fallback chain references unknown backend(s); skipping them",
+	f.logger.Warn("consumer fallback chain has unresolved or disabled backend(s); skipping them",
 		slog.String("consumer_id", c.ID.String()),
 		slog.Int("chain_size", len(chain)),
 		slog.Int("resolved", len(resolved)),

--- a/pkg/app/consumer/data_finder_test.go
+++ b/pkg/app/consumer/data_finder_test.go
@@ -174,9 +174,9 @@ func TestDataFinder_FindByGateway_ResolvesFallbackChainInOrder(t *testing.T) {
 			return len(bids) == 3
 		})).
 		Return([]*registrydomain.Registry{
-			{ID: poolID, GatewayID: gwID, LLMTarget: &registrydomain.LLMTarget{Provider: "openai"}},
-			{ID: fb1, GatewayID: gwID, LLMTarget: &registrydomain.LLMTarget{Provider: "anthropic"}},
-			{ID: fb2, GatewayID: gwID, LLMTarget: &registrydomain.LLMTarget{Provider: "mistral"}},
+			{ID: poolID, GatewayID: gwID, Enabled: true, LLMTarget: &registrydomain.LLMTarget{Provider: "openai"}},
+			{ID: fb1, GatewayID: gwID, Enabled: true, LLMTarget: &registrydomain.LLMTarget{Provider: "anthropic"}},
+			{ID: fb2, GatewayID: gwID, Enabled: true, LLMTarget: &registrydomain.LLMTarget{Provider: "mistral"}},
 		}, nil).Once()
 
 	policyRepo := policymocks.NewRepository(t)
@@ -201,6 +201,76 @@ func TestDataFinder_FindByGateway_ResolvesFallbackChainInOrder(t *testing.T) {
 	}
 	if rc.FallbackBackends[0].ID != fb2 || rc.FallbackBackends[1].ID != fb1 {
 		t.Fatal("fallback chain order was not preserved")
+	}
+}
+
+func TestDataFinder_FindByGateway_ExcludesDisabledRegistries(t *testing.T) {
+	t.Parallel()
+	gwID := ids.New[ids.GatewayKind]()
+	poolID := ids.New[ids.RegistryKind]()
+	disabledPoolID := ids.New[ids.RegistryKind]()
+	fbEnabled, fbDisabled := ids.New[ids.RegistryKind](), ids.New[ids.RegistryKind]()
+	now := time.Now().UTC()
+	cons := domain.Rehydrate(domain.RehydrateParams{
+		ID:          ids.New[ids.ConsumerKind](),
+		GatewayID:   gwID,
+		Name:        "c",
+		Type:        domain.TypeLLM,
+		Slug:        "X84Yhsy8",
+		RoutingMode: domain.RoutingModeInline,
+		Fallback: &domain.Fallback{
+			Enabled:  true,
+			Triggers: []domain.FallbackTrigger{domain.TriggerHTTP5xx},
+			Budget:   domain.FallbackBudget{MaxAttempts: 9},
+			Chain:    []ids.RegistryID{fbDisabled, fbEnabled},
+		},
+		Active:      true,
+		RegistryIDs: []ids.RegistryID{poolID, disabledPoolID},
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	})
+
+	repo := repomocks.NewRepository(t)
+	repo.EXPECT().ListByGateway(mock.Anything, gwID).Return([]*domain.Consumer{cons}, nil).Once()
+
+	registryRepo := backendmocks.NewRepository(t)
+	registryRepo.EXPECT().
+		FindByIDs(mock.Anything, gwID, mock.Anything).
+		Return([]*registrydomain.Registry{
+			{ID: poolID, GatewayID: gwID, Enabled: true, LLMTarget: &registrydomain.LLMTarget{Provider: "openai"}},
+			{ID: disabledPoolID, GatewayID: gwID, Enabled: false, LLMTarget: &registrydomain.LLMTarget{Provider: "anthropic"}},
+			{ID: fbEnabled, GatewayID: gwID, Enabled: true, LLMTarget: &registrydomain.LLMTarget{Provider: "mistral"}},
+			{ID: fbDisabled, GatewayID: gwID, Enabled: false, LLMTarget: &registrydomain.LLMTarget{Provider: "google"}},
+		}, nil).Once()
+
+	policyRepo := policymocks.NewRepository(t)
+	policyRepo.EXPECT().ListByGateway(mock.Anything, gwID).Return(nil, nil).Once()
+
+	finder := appconsumer.NewDataFinder(
+		repo, registryRepo,
+		policyRepo, authmocks.NewRepository(t),
+		nil, nil, newCacheManager(), newTestLogger(),
+	)
+
+	data, err := finder.FindByGateway(context.Background(), gwID)
+	if err != nil {
+		t.Fatalf("FindByGateway error: %v", err)
+	}
+	rc := data.Consumers[0]
+	if len(rc.Registries) != 1 || rc.Registries[0].ID != poolID {
+		t.Fatalf("disabled pool registry not excluded: %+v", rc.Registries)
+	}
+	if len(rc.FallbackBackends) != 1 || rc.FallbackBackends[0].ID != fbEnabled {
+		t.Fatalf("disabled fallback registry not excluded: %+v", rc.FallbackBackends)
+	}
+	if _, ok := data.RegistryByID(disabledPoolID); ok {
+		t.Fatal("disabled registry must not be in the RegistryByID index")
+	}
+	if _, ok := data.RegistryByID(fbDisabled); ok {
+		t.Fatal("disabled fallback registry must not be in the RegistryByID index")
+	}
+	if _, ok := data.RegistryByID(poolID); !ok {
+		t.Fatal("enabled registry must be in the RegistryByID index")
 	}
 }
 

--- a/pkg/app/registry/creator.go
+++ b/pkg/app/registry/creator.go
@@ -13,6 +13,7 @@ type CreateInput struct {
 	GatewayID   ids.GatewayID
 	Name        string
 	Type        domain.Type
+	Enabled     *bool
 	Description string
 	LLMTarget   *domain.LLMTarget
 	MCPTarget   *domain.MCPTarget
@@ -59,6 +60,9 @@ func (c *creator) Create(ctx context.Context, in CreateInput) (*domain.Registry,
 	}
 	if err != nil {
 		return nil, err
+	}
+	if in.Enabled != nil {
+		b.Enabled = *in.Enabled
 	}
 	if err := c.repo.Save(ctx, b); err != nil {
 		return nil, err

--- a/pkg/app/registry/creator_test.go
+++ b/pkg/app/registry/creator_test.go
@@ -63,6 +63,69 @@ func TestCreator_Create_Success(t *testing.T) {
 	}
 }
 
+func TestCreator_Create_EnabledFlag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		enabled bool
+	}{
+		{name: "enabled", enabled: true},
+		{name: "disabled", enabled: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			repo := repomocks.NewRepository(t)
+			gwID := ids.New[ids.GatewayKind]()
+			repo.EXPECT().
+				Save(mock.Anything, mock.MatchedBy(func(b *domain.Registry) bool {
+					return b.Enabled == tt.enabled
+				})).
+				Return(nil).
+				Once()
+
+			creator := appregistry.NewCreator(repo, newCacheManager(), newTestLogger())
+			in := validCreateInput(gwID, "backend-"+tt.name)
+			in.Enabled = ptr(tt.enabled)
+			got, err := creator.Create(context.Background(), in)
+			if err != nil {
+				t.Fatalf("Create error: %v", err)
+			}
+			if got.Enabled != tt.enabled {
+				t.Fatalf("Enabled = %v, want %v", got.Enabled, tt.enabled)
+			}
+		})
+	}
+}
+
+func TestCreator_Create_EnabledDefaultsTrueWhenNil(t *testing.T) {
+	t.Parallel()
+	repo := repomocks.NewRepository(t)
+	gwID := ids.New[ids.GatewayKind]()
+	repo.EXPECT().
+		Save(mock.Anything, mock.MatchedBy(func(b *domain.Registry) bool {
+			return b.Enabled
+		})).
+		Return(nil).
+		Once()
+
+	creator := appregistry.NewCreator(repo, newCacheManager(), newTestLogger())
+	in := validCreateInput(gwID, "backend-default")
+	if in.Enabled != nil {
+		t.Fatal("precondition: Enabled should be unset in validCreateInput")
+	}
+	got, err := creator.Create(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Create error: %v", err)
+	}
+	if !got.Enabled {
+		t.Fatal("Enabled should default to true when not provided")
+	}
+}
+
 func TestCreator_Create_AzureModes(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/app/registry/updater.go
+++ b/pkg/app/registry/updater.go
@@ -15,6 +15,7 @@ type UpdateInput struct {
 	ID              ids.RegistryID
 	GatewayID       ids.GatewayID
 	Name            *string
+	Enabled         *bool
 	Provider        *string
 	ProviderOptions *map[string]any
 	Description     *string
@@ -64,6 +65,9 @@ func (u *updater) Update(ctx context.Context, in UpdateInput) (*domain.Registry,
 	}
 	if in.Description != nil {
 		existing.Description = *in.Description
+	}
+	if in.Enabled != nil {
+		existing.Enabled = *in.Enabled
 	}
 	applyLLMTargetUpdate(existing, in)
 	applyMCPTargetUpdate(existing, in)

--- a/pkg/app/registry/updater_test.go
+++ b/pkg/app/registry/updater_test.go
@@ -39,6 +39,53 @@ func TestUpdater_Update_Success(t *testing.T) {
 	}
 }
 
+func TestUpdater_Update_TogglesEnabled(t *testing.T) {
+	t.Parallel()
+	repo := repomocks.NewRepository(t)
+	existing, _ := domain.NewLLMRegistry(ids.New[ids.GatewayKind](), "old", "", &domain.LLMTarget{Provider: "openai", Auth: domain.NewAPIKeyAuth("sk-1")})
+	if !existing.Enabled {
+		t.Fatal("precondition: freshly created registry should be enabled")
+	}
+	repo.EXPECT().FindByID(mock.Anything, existing.ID).Return(existing, nil).Once()
+	repo.EXPECT().Update(mock.Anything, mock.MatchedBy(func(b *domain.Registry) bool {
+		return b.ID == existing.ID && !b.Enabled
+	})).Return(nil).Once()
+
+	updater := appregistry.NewUpdater(repo, newCacheManager(), cachetest.NoopPublisher(), newTestLogger())
+	got, err := updater.Update(context.Background(), appregistry.UpdateInput{
+		ID:      existing.ID,
+		Enabled: ptr(false),
+	})
+	if err != nil {
+		t.Fatalf("Update error: %v", err)
+	}
+	if got.Enabled {
+		t.Fatal("Enabled should be false after toggle")
+	}
+}
+
+func TestUpdater_Update_EnabledUnchangedWhenNil(t *testing.T) {
+	t.Parallel()
+	repo := repomocks.NewRepository(t)
+	existing, _ := domain.NewLLMRegistry(ids.New[ids.GatewayKind](), "old", "", &domain.LLMTarget{Provider: "openai", Auth: domain.NewAPIKeyAuth("sk-1")})
+	repo.EXPECT().FindByID(mock.Anything, existing.ID).Return(existing, nil).Once()
+	repo.EXPECT().Update(mock.Anything, mock.MatchedBy(func(b *domain.Registry) bool {
+		return b.Enabled
+	})).Return(nil).Once()
+
+	updater := appregistry.NewUpdater(repo, newCacheManager(), cachetest.NoopPublisher(), newTestLogger())
+	got, err := updater.Update(context.Background(), appregistry.UpdateInput{
+		ID:   existing.ID,
+		Name: ptr("renamed"),
+	})
+	if err != nil {
+		t.Fatalf("Update error: %v", err)
+	}
+	if !got.Enabled {
+		t.Fatal("Enabled should remain true when not provided")
+	}
+}
+
 func TestUpdater_Update_Partial_PreservesProviderOptionsAndHealthChecks(t *testing.T) {
 	t.Parallel()
 	repo := repomocks.NewRepository(t)

--- a/pkg/domain/registry/registry.go
+++ b/pkg/domain/registry/registry.go
@@ -12,6 +12,7 @@ type Registry struct {
 	GatewayID   ids.GatewayID  `json:"gateway_id"`
 	Name        string         `json:"name"`
 	Type        Type           `json:"type"`
+	Enabled     bool           `json:"enabled"`
 	Description string         `json:"description,omitempty"`
 	LLMTarget   *LLMTarget     `json:"llm_target,omitempty"`
 	MCPTarget   *MCPTarget     `json:"mcp_target,omitempty"`
@@ -34,6 +35,7 @@ func NewLLMRegistry(
 		GatewayID:   gatewayID,
 		Name:        name,
 		Type:        TypeLLM,
+		Enabled:     true,
 		Description: description,
 		LLMTarget:   target,
 		CreatedAt:   now,
@@ -60,6 +62,7 @@ func NewMCPRegistry(
 		GatewayID:   gatewayID,
 		Name:        name,
 		Type:        TypeMCP,
+		Enabled:     true,
 		Description: description,
 		MCPTarget:   target,
 		CreatedAt:   now,
@@ -108,6 +111,7 @@ type RehydrateParams struct {
 	GatewayID   ids.GatewayID
 	Name        string
 	Type        Type
+	Enabled     bool
 	Description string
 	LLMTarget   *LLMTarget
 	MCPTarget   *MCPTarget
@@ -125,6 +129,7 @@ func Rehydrate(params RehydrateParams) *Registry {
 		GatewayID:   params.GatewayID,
 		Name:        params.Name,
 		Type:        regType,
+		Enabled:     params.Enabled,
 		Description: params.Description,
 		LLMTarget:   params.LLMTarget,
 		MCPTarget:   params.MCPTarget,

--- a/pkg/infra/database/migrations/20260616130000_add_registry_enabled.go
+++ b/pkg/infra/database/migrations/20260616130000_add_registry_enabled.go
@@ -1,0 +1,25 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/NeuralTrust/AgentGateway/pkg/infra/database"
+	"github.com/jackc/pgx/v5"
+)
+
+func init() {
+	database.RegisterMigration(database.Migration{
+		ID:   "20260616130000_add_registry_enabled",
+		Name: "add registries.enabled to toggle registries out of live traffic",
+		Up: func(ctx context.Context, tx pgx.Tx) error {
+			const ddl = `ALTER TABLE registries ADD COLUMN IF NOT EXISTS enabled BOOLEAN NOT NULL DEFAULT true;`
+			_, err := tx.Exec(ctx, ddl)
+			return err
+		},
+		Down: func(ctx context.Context, tx pgx.Tx) error {
+			const ddl = `ALTER TABLE registries DROP COLUMN IF EXISTS enabled;`
+			_, err := tx.Exec(ctx, ddl)
+			return err
+		},
+	})
+}

--- a/pkg/infra/repository/registry/repository.go
+++ b/pkg/infra/repository/registry/repository.go
@@ -50,11 +50,11 @@ func (r *Repository) Save(ctx context.Context, b *domain.Registry) error {
 		return fmt.Errorf("registry repository: marshal mcp_target: %w", err)
 	}
 	const query = `
-		INSERT INTO registries (id, gateway_id, name, type, provider, provider_options, auth, description, health_checks, mcp_target, created_at, updated_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`
+		INSERT INTO registries (id, gateway_id, name, type, enabled, provider, provider_options, auth, description, health_checks, mcp_target, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`
 	return database.WithTx(ctx, r.conn, func(tx pgx.Tx) error {
 		if _, err := tx.Exec(ctx, query,
-			b.ID, b.GatewayID, b.Name, registryType(b), b.Provider(), providerOptionsBytes, authBytes, b.Description, healthChecksBytes, mcpTargetBytes, b.CreatedAt, b.UpdatedAt,
+			b.ID, b.GatewayID, b.Name, registryType(b), b.Enabled, b.Provider(), providerOptionsBytes, authBytes, b.Description, healthChecksBytes, mcpTargetBytes, b.CreatedAt, b.UpdatedAt,
 		); err != nil {
 			return mapPgError(err)
 		}
@@ -86,17 +86,18 @@ func (r *Repository) Update(ctx context.Context, b *domain.Registry) error {
 		UPDATE registries
 		   SET name             = $2,
 		       type             = $3,
-		       provider         = $4,
-		       provider_options = $5,
-		       auth             = $6,
-		       description      = $7,
-		       health_checks    = $8,
-		       mcp_target       = $9,
-		       updated_at       = $10
+		       enabled          = $4,
+		       provider         = $5,
+		       provider_options = $6,
+		       auth             = $7,
+		       description      = $8,
+		       health_checks    = $9,
+		       mcp_target       = $10,
+		       updated_at       = $11
 		 WHERE id = $1`
 	return database.WithTx(ctx, r.conn, func(tx pgx.Tx) error {
 		cmd, err := tx.Exec(ctx, query,
-			b.ID, b.Name, registryType(b), b.Provider(), providerOptionsBytes, authBytes, b.Description, healthChecksBytes, mcpTargetBytes, b.UpdatedAt,
+			b.ID, b.Name, registryType(b), b.Enabled, b.Provider(), providerOptionsBytes, authBytes, b.Description, healthChecksBytes, mcpTargetBytes, b.UpdatedAt,
 		)
 		if err != nil {
 			return mapPgError(err)
@@ -145,7 +146,7 @@ func ensureNotInFallbackChain(ctx context.Context, tx pgx.Tx, id ids.RegistryID)
 
 func (r *Repository) FindByID(ctx context.Context, id ids.RegistryID) (*domain.Registry, error) {
 	const query = `
-		SELECT id, gateway_id, name, type, provider, provider_options, auth, description, health_checks, mcp_target, created_at, updated_at
+		SELECT id, gateway_id, name, type, enabled, provider, provider_options, auth, description, health_checks, mcp_target, created_at, updated_at
 		  FROM registries
 		 WHERE id = $1`
 	row := r.conn.Pool.QueryRow(ctx, query, id)
@@ -164,7 +165,7 @@ func (r *Repository) FindByIDs(ctx context.Context, gatewayID ids.GatewayID, reg
 		return nil, nil
 	}
 	const query = `
-		SELECT id, gateway_id, name, type, provider, provider_options, auth, description, health_checks, mcp_target, created_at, updated_at
+		SELECT id, gateway_id, name, type, enabled, provider, provider_options, auth, description, health_checks, mcp_target, created_at, updated_at
 		  FROM registries
 		 WHERE gateway_id = $1
 		   AND id = ANY($2::uuid[])`
@@ -211,7 +212,7 @@ func (r *Repository) List(ctx context.Context, filter domain.ListFilter) ([]*dom
 	}
 
 	const listQuery = `
-		SELECT id, gateway_id, name, type, provider, provider_options, auth, description, health_checks, mcp_target, created_at, updated_at
+		SELECT id, gateway_id, name, type, enabled, provider, provider_options, auth, description, health_checks, mcp_target, created_at, updated_at
 		  FROM registries
 		 WHERE ($1::uuid IS NULL OR gateway_id = $1)
 		   AND ($2 = '' OR lower(name) LIKE '%' || lower($2) || '%')
@@ -247,7 +248,7 @@ func scanRegistry(s rowScanner) (*domain.Registry, error) {
 	var providerRaw *string
 	var typeRaw string
 	if err := s.Scan(
-		&b.ID, &b.GatewayID, &b.Name, &typeRaw, &providerRaw,
+		&b.ID, &b.GatewayID, &b.Name, &typeRaw, &b.Enabled, &providerRaw,
 		&providerOptionsRaw, &authRaw, &b.Description, &healthChecksRaw, &mcpTargetRaw,
 		&b.CreatedAt, &b.UpdatedAt,
 	); err != nil {


### PR DESCRIPTION
## Summary

- Add an `enabled` boolean to the registry entity, DB (`registries.enabled`, `BOOLEAN NOT NULL DEFAULT true`, existing rows backfill to `true`), create/update API and swagger.
- A disabled registry stays fully visible and editable for admins (GET/LIST, attach-to-consumer, test-connection, list-tools keep working), but is excluded from **live traffic** via a single chokepoint at gateway-data hydration (`data_finder.loadBackends`). Disabled registries never enter LLM pools, fallback chains, MCP federation, or the role-based routing index.
- `enabled` defaults to `true` when omitted on create (`*bool`); update is a partial toggle (`*bool`, unchanged when nil). Toggling reuses the existing registry cache-invalidation so it takes effect on the next request.

## Corner cases

- Consumer whose every registry is disabled: pool + fallback end up empty and the request returns the existing `ErrNoBackendsInPool` (verified: no panic on role-based/qualified paths).
- Fallback chain referencing a disabled registry: skipped; the hydration warning was reworded to "unresolved or disabled".

## Test plan

- [x] `go build ./...`, `go vet ./pkg/...`, `golangci-lint` (0 issues)
- [x] Unit tests: domain default, repository column wiring, creator (default-true + explicit), updater (toggle on/off + unchanged-when-nil), `data_finder` exclusion (pool + fallback + `RegistryByID` index), response mapping
- [x] `go test ./...` green
- [ ] Apply migration `20260616130000_add_registry_enabled` in target environments

Made with [Cursor](https://cursor.com)