### PR TITLE
feat: dual gateway hosts (proxy+mcp), llm base domain & one-line installer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,26 +4,17 @@ APP_ENV=dev
 # Server Configuration (HTTP listeners)
 SERVER_ADMIN_PORT=8080
 SERVER_PROXY_PORT=8081
-SERVER_MCP_PORT=8082
 SERVER_READ_TIMEOUT=60s
 SERVER_WRITE_TIMEOUT=60s
 SERVER_IDLE_TIMEOUT=120s
-# SERVER_SECRET_KEY signs admin-plane JWTs and derives the vault at-rest
-# encryption key (forwarded third-party tokens). Required in production.
-SERVER_SECRET_KEY=
-
-# Security Token Service (Phase 4: downstream impersonation/delegation).
-# STS_ISSUER is the iss claim of gateway-minted tokens; STS_SIGNING_KEY is an
-# RSA private key in PEM (empty = ephemeral dev key, not shared across replicas).
-# JWKS is published at {mcp}/.well-known/jwks.json.
-STS_ISSUER=trustgate
-STS_SIGNING_KEY=
 
 # Gateway Discovery
 # GATEWAY_DISCOVERY_MODE: header (X-AG-Gateway-Slug with host fallback, self-hosted default) | subdomain (host only, cloud)
-# GATEWAY_BASE_DOMAIN: suffix to resolve {slug}.<base-domain> hosts (gw.neuraltrust.sandbox for local dev, see make local-dns)
+# GATEWAY_BASE_DOMAIN: suffix to resolve {slug}.<base-domain> proxy hosts (gw.neuraltrust.sandbox for local dev, see make local-dns)
+# MCP_BASE_DOMAIN: suffix to resolve {slug}.<base-domain> MCP hosts returned in the gateway response
 GATEWAY_DISCOVERY_MODE=header
-GATEWAY_BASE_DOMAIN=gw.neuraltrust.ai
+GATEWAY_BASE_DOMAIN=gw.neuraltrust.sandbox
+MCP_BASE_DOMAIN=mcp.neuraltrust.sandbox
 
 # Logging Configuration
 LOG_LEVEL=INFO

--- a/.env.functional.example
+++ b/.env.functional.example
@@ -16,9 +16,9 @@ SERVER_IDLE_TIMEOUT=120s
 SERVER_SECRET_KEY=functional-test-secret-0123456789abcdef
 
 # Gateway discovery: the suite boots in header mode and covers the subdomain
-# fallback against {slug}.gw.neuraltrust.ai hosts.
+# fallback against {slug}.llm.neuraltrust.ai hosts.
 GATEWAY_DISCOVERY_MODE=header
-GATEWAY_BASE_DOMAIN=gw.neuraltrust.ai
+GATEWAY_BASE_DOMAIN=llm.neuraltrust.ai
 
 LOG_LEVEL=WARN
 LOG_FORMAT=text

--- a/README.md
+++ b/README.md
@@ -37,6 +37,23 @@
 
 ## 🚀 Quick Start
 
+### One-line install
+
+Clones the repo, seeds `.env`, brings up the full stack in Docker and — when Go
+is installed — compiles the `trustgate` binary and installs it on your `PATH`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/NeuralTrust/AgentGateway/main/scripts/install.sh | bash
+```
+
+Requires `git`, `docker` and Docker Compose (plus Go to build the CLI). Re-running
+updates the checkout and never overwrites your `.env`. Useful overrides:
+
+- `AG_REF=develop` — install a different branch/tag/commit
+- `AG_DIR=/path/to/dir` — where to clone
+- `AG_BIN_DIR=~/.local/bin` — where to install the `trustgate` CLI
+- `AG_INSTALL_CLI=0` — skip building the CLI · `AG_NO_START=1` — skip `docker compose up`
+
 ### Using Docker Compose
 
 ```bash
@@ -300,6 +317,10 @@ to `.env` and `godotenv` loads it automatically. Production deployments inject e
 SERVER_ADMIN_PORT=8080
 SERVER_PROXY_PORT=8081
 SERVER_MCP_PORT=8082
+
+# Host suffixes returned in the gateway response ({slug}.<base-domain>)
+GATEWAY_BASE_DOMAIN=llm.neuraltrust.ai  # proxy plane host
+MCP_BASE_DOMAIN=mcp.neuraltrust.ai      # mcp plane host
 
 # Database (Postgres via pgx/pgxpool)
 DB_HOST=localhost

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -4218,6 +4218,17 @@ const docTemplate = `{
                 }
             }
         },
+        "github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_gateway_response.GatewayHosts": {
+            "type": "object",
+            "properties": {
+                "mcp": {
+                    "type": "string"
+                },
+                "proxy": {
+                    "type": "string"
+                }
+            }
+        },
         "github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_gateway_response.GatewayResponse": {
             "type": "object",
             "properties": {
@@ -4230,8 +4241,8 @@ const docTemplate = `{
                 "domain": {
                     "type": "string"
                 },
-                "host": {
-                    "type": "string"
+                "hosts": {
+                    "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_gateway_response.GatewayHosts"
                 },
                 "id": {
                     "type": "string"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -5024,6 +5024,17 @@
                     }
                 }
             },
+            "github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_gateway_response.GatewayHosts": {
+                "type": "object",
+                "properties": {
+                    "mcp": {
+                        "type": "string"
+                    },
+                    "proxy": {
+                        "type": "string"
+                    }
+                }
+            },
             "github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_gateway_response.GatewayResponse": {
                 "type": "object",
                 "properties": {
@@ -5036,8 +5047,8 @@
                     "domain": {
                         "type": "string"
                     },
-                    "host": {
-                        "type": "string"
+                    "hosts": {
+                        "$ref": "#/components/schemas/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_gateway_response.GatewayHosts"
                     },
                     "id": {
                         "type": "string"

--- a/docs/payload-routing.md
+++ b/docs/payload-routing.md
@@ -4,7 +4,7 @@ The proxy exposes fixed routes per wire format, prefixed by the consumer's auto-
 
 ## Fixed proxy routes
 
-A client points its SDK at `https://{gateway_slug}.gw.neuraltrust.ai/{consumer_slug}` and the SDK completes the path:
+A client points its SDK at `https://{gateway_slug}.llm.neuraltrust.ai/{consumer_slug}` and the SDK completes the path:
 
 | Route | Source format |
 | --- | --- |

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -4211,6 +4211,17 @@
                 }
             }
         },
+        "github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_gateway_response.GatewayHosts": {
+            "type": "object",
+            "properties": {
+                "mcp": {
+                    "type": "string"
+                },
+                "proxy": {
+                    "type": "string"
+                }
+            }
+        },
         "github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_gateway_response.GatewayResponse": {
             "type": "object",
             "properties": {
@@ -4223,8 +4234,8 @@
                 "domain": {
                     "type": "string"
                 },
-                "host": {
-                    "type": "string"
+                "hosts": {
+                    "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_gateway_response.GatewayHosts"
                 },
                 "id": {
                     "type": "string"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -665,6 +665,13 @@ definitions:
       telemetry:
         $ref: '#/definitions/github_com_NeuralTrust_AgentGateway_pkg_domain_telemetry.Telemetry'
     type: object
+  github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_gateway_response.GatewayHosts:
+    properties:
+      mcp:
+        type: string
+      proxy:
+        type: string
+    type: object
   github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_gateway_response.GatewayResponse:
     properties:
       client_tls:
@@ -673,8 +680,8 @@ definitions:
         type: string
       domain:
         type: string
-      host:
-        type: string
+      hosts:
+        $ref: '#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_gateway_response.GatewayHosts'
       id:
         type: string
       metadata:

--- a/pkg/api/handler/http/gateway/create_gateway_handler.go
+++ b/pkg/api/handler/http/gateway/create_gateway_handler.go
@@ -26,12 +26,13 @@ import (
 )
 
 type CreateGatewayHandler struct {
-	creator    appgateway.Creator
-	baseDomain string
+	creator       appgateway.Creator
+	baseDomain    string
+	mcpBaseDomain string
 }
 
-func NewCreateGatewayHandler(creator appgateway.Creator, baseDomain string) *CreateGatewayHandler {
-	return &CreateGatewayHandler{creator: creator, baseDomain: baseDomain}
+func NewCreateGatewayHandler(creator appgateway.Creator, baseDomain, mcpBaseDomain string) *CreateGatewayHandler {
+	return &CreateGatewayHandler{creator: creator, baseDomain: baseDomain, mcpBaseDomain: mcpBaseDomain}
 }
 
 // Handle godoc
@@ -68,5 +69,5 @@ func (h *CreateGatewayHandler) Handle(c *fiber.Ctx) error {
 	if err != nil {
 		return helpers.WriteError(c, err)
 	}
-	return helpers.WriteCreated(c, response.FromDomain(g, h.baseDomain))
+	return helpers.WriteCreated(c, response.FromDomain(g, h.baseDomain, h.mcpBaseDomain))
 }

--- a/pkg/api/handler/http/gateway/get_gateway_handler.go
+++ b/pkg/api/handler/http/gateway/get_gateway_handler.go
@@ -23,12 +23,13 @@ import (
 )
 
 type GetGatewayHandler struct {
-	finder     appgateway.Finder
-	baseDomain string
+	finder        appgateway.Finder
+	baseDomain    string
+	mcpBaseDomain string
 }
 
-func NewGetGatewayHandler(finder appgateway.Finder, baseDomain string) *GetGatewayHandler {
-	return &GetGatewayHandler{finder: finder, baseDomain: baseDomain}
+func NewGetGatewayHandler(finder appgateway.Finder, baseDomain, mcpBaseDomain string) *GetGatewayHandler {
+	return &GetGatewayHandler{finder: finder, baseDomain: baseDomain, mcpBaseDomain: mcpBaseDomain}
 }
 
 // Handle godoc
@@ -52,5 +53,5 @@ func (h *GetGatewayHandler) Handle(c *fiber.Ctx) error {
 	if err != nil {
 		return helpers.WriteError(c, err)
 	}
-	return helpers.WriteOK(c, response.FromDomain(g, h.baseDomain))
+	return helpers.WriteOK(c, response.FromDomain(g, h.baseDomain, h.mcpBaseDomain))
 }

--- a/pkg/api/handler/http/gateway/list_gateway_handler.go
+++ b/pkg/api/handler/http/gateway/list_gateway_handler.go
@@ -24,12 +24,13 @@ import (
 )
 
 type ListGatewayHandler struct {
-	finder     appgateway.Finder
-	baseDomain string
+	finder        appgateway.Finder
+	baseDomain    string
+	mcpBaseDomain string
 }
 
-func NewListGatewayHandler(finder appgateway.Finder, baseDomain string) *ListGatewayHandler {
-	return &ListGatewayHandler{finder: finder, baseDomain: baseDomain}
+func NewListGatewayHandler(finder appgateway.Finder, baseDomain, mcpBaseDomain string) *ListGatewayHandler {
+	return &ListGatewayHandler{finder: finder, baseDomain: baseDomain, mcpBaseDomain: mcpBaseDomain}
 }
 
 // Handle godoc
@@ -76,7 +77,7 @@ func (h *ListGatewayHandler) Handle(c *fiber.Ctx) error {
 		Total: total,
 	}
 	for _, g := range items {
-		out.Items = append(out.Items, response.FromDomain(g, h.baseDomain))
+		out.Items = append(out.Items, response.FromDomain(g, h.baseDomain, h.mcpBaseDomain))
 	}
 	return helpers.WriteOK(c, out)
 }

--- a/pkg/api/handler/http/gateway/response/gateway_response.go
+++ b/pkg/api/handler/http/gateway/response/gateway_response.go
@@ -29,7 +29,7 @@ type GatewayResponse struct {
 	Slug            string                 `json:"slug"`
 	Status          string                 `json:"status"`
 	Domain          string                 `json:"domain,omitempty"`
-	Host            string                 `json:"host,omitempty"`
+	Hosts           GatewayHosts           `json:"hosts"`
 	Metadata        map[string]string      `json:"metadata,omitempty"`
 	Telemetry       *telemetry.Telemetry   `json:"telemetry,omitempty"`
 	ClientTLSConfig domain.ClientTLSConfig `json:"client_tls,omitempty"`
@@ -38,17 +38,27 @@ type GatewayResponse struct {
 	UpdatedAt       time.Time              `json:"updated_at"`
 }
 
-func FromDomain(g *domain.Gateway, baseDomain string) GatewayResponse {
+// GatewayHosts holds the hostnames clients use to reach the gateway on each
+// plane: Proxy for the LLM proxy and MCP for the Model Context Protocol server.
+type GatewayHosts struct {
+	Proxy string `json:"proxy,omitempty"`
+	MCP   string `json:"mcp,omitempty"`
+}
+
+func FromDomain(g *domain.Gateway, proxyBaseDomain, mcpBaseDomain string) GatewayResponse {
 	if g == nil {
 		return GatewayResponse{}
 	}
 	return GatewayResponse{
-		ID:              g.ID,
-		Name:            g.Name,
-		Slug:            g.Slug,
-		Status:          g.Status,
-		Domain:          g.Domain,
-		Host:            gatewayHost(g, baseDomain),
+		ID:     g.ID,
+		Name:   g.Name,
+		Slug:   g.Slug,
+		Status: g.Status,
+		Domain: g.Domain,
+		Hosts: GatewayHosts{
+			Proxy: proxyHost(g, proxyBaseDomain),
+			MCP:   subdomainHost(g.Slug, mcpBaseDomain),
+		},
 		Metadata:        g.Metadata,
 		Telemetry:       g.Telemetry,
 		ClientTLSConfig: g.ClientTLSConfig,
@@ -58,15 +68,17 @@ func FromDomain(g *domain.Gateway, baseDomain string) GatewayResponse {
 	}
 }
 
-// gatewayHost returns the hostname clients use to reach the gateway: the custom
-// domain when set, otherwise the {slug}.{baseDomain} subdomain.
-func gatewayHost(g *domain.Gateway, baseDomain string) string {
+func proxyHost(g *domain.Gateway, baseDomain string) string {
 	if g.Domain != "" {
 		return g.Domain
 	}
+	return subdomainHost(g.Slug, baseDomain)
+}
+
+func subdomainHost(slug, baseDomain string) string {
 	baseDomain = strings.Trim(strings.TrimSpace(baseDomain), ".")
-	if baseDomain == "" || g.Slug == "" {
+	if baseDomain == "" || slug == "" {
 		return ""
 	}
-	return g.Slug + "." + baseDomain
+	return slug + "." + baseDomain
 }

--- a/pkg/api/handler/http/gateway/response/gateway_response_test.go
+++ b/pkg/api/handler/http/gateway/response/gateway_response_test.go
@@ -27,12 +27,15 @@ func TestFromDomain_IncludesSlug(t *testing.T) {
 	now := time.Now().UTC()
 	gw := domain.RehydrateWithSlug(ids.New[ids.GatewayKind](), "Acme", "acme", "active", nil, nil, nil, now, now)
 
-	got := FromDomain(gw, "gw.neuraltrust.ai")
+	got := FromDomain(gw, "llm.neuraltrust.ai", "mcp.neuraltrust.ai")
 	if got.Slug != "acme" {
 		t.Fatalf("Slug = %q, want acme", got.Slug)
 	}
-	if got.Host != "acme.gw.neuraltrust.ai" {
-		t.Fatalf("Host = %q, want acme.gw.neuraltrust.ai", got.Host)
+	if got.Hosts.Proxy != "acme.llm.neuraltrust.ai" {
+		t.Fatalf("Hosts.Proxy = %q, want acme.llm.neuraltrust.ai", got.Hosts.Proxy)
+	}
+	if got.Hosts.MCP != "acme.mcp.neuraltrust.ai" {
+		t.Fatalf("Hosts.MCP = %q, want acme.mcp.neuraltrust.ai", got.Hosts.MCP)
 	}
 }
 
@@ -42,8 +45,11 @@ func TestFromDomain_CustomDomainHost(t *testing.T) {
 	gw := domain.RehydrateWithSlug(ids.New[ids.GatewayKind](), "Acme", "acme", "active", nil, nil, nil, now, now)
 	gw.Domain = "api.acme.com"
 
-	got := FromDomain(gw, "gw.neuraltrust.ai")
-	if got.Host != "api.acme.com" {
-		t.Fatalf("Host = %q, want api.acme.com", got.Host)
+	got := FromDomain(gw, "llm.neuraltrust.ai", "mcp.neuraltrust.ai")
+	if got.Hosts.Proxy != "api.acme.com" {
+		t.Fatalf("Hosts.Proxy = %q, want api.acme.com", got.Hosts.Proxy)
+	}
+	if got.Hosts.MCP != "acme.mcp.neuraltrust.ai" {
+		t.Fatalf("Hosts.MCP = %q, want acme.mcp.neuraltrust.ai", got.Hosts.MCP)
 	}
 }

--- a/pkg/api/handler/http/gateway/update_gateway_handler.go
+++ b/pkg/api/handler/http/gateway/update_gateway_handler.go
@@ -27,12 +27,13 @@ import (
 )
 
 type UpdateGatewayHandler struct {
-	updater    appgateway.Updater
-	baseDomain string
+	updater       appgateway.Updater
+	baseDomain    string
+	mcpBaseDomain string
 }
 
-func NewUpdateGatewayHandler(updater appgateway.Updater, baseDomain string) *UpdateGatewayHandler {
-	return &UpdateGatewayHandler{updater: updater, baseDomain: baseDomain}
+func NewUpdateGatewayHandler(updater appgateway.Updater, baseDomain, mcpBaseDomain string) *UpdateGatewayHandler {
+	return &UpdateGatewayHandler{updater: updater, baseDomain: baseDomain, mcpBaseDomain: mcpBaseDomain}
 }
 
 // Handle godoc
@@ -78,5 +79,5 @@ func (h *UpdateGatewayHandler) Handle(c *fiber.Ctx) error {
 	if err != nil {
 		return helpers.WriteError(c, err)
 	}
-	return helpers.WriteOK(c, response.FromDomain(g, h.baseDomain))
+	return helpers.WriteOK(c, response.FromDomain(g, h.baseDomain, h.mcpBaseDomain))
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,7 +35,8 @@ const (
 	defaultServerReadTimeout  = 60 * time.Second
 	defaultServerWriteTimeout = 60 * time.Second
 	defaultServerIdleTimeout  = 120 * time.Second
-	defaultGatewayBaseDomain  = "gw.neuraltrust.ai"
+	defaultGatewayBaseDomain  = "llm.neuraltrust.ai"
+	defaultMCPBaseDomain      = "mcp.neuraltrust.ai"
 
 	GatewayDiscoveryModeHeader    = "header"
 	GatewayDiscoveryModeSubdomain = "subdomain"
@@ -122,6 +123,7 @@ type ServerConfig struct {
 	// token acceptance (every token is rejected).
 	SecretKey            string
 	GatewayBaseDomain    string
+	MCPBaseDomain        string
 	GatewayDiscoveryMode string
 	STSIssuer            string
 	STSSigningKey        string
@@ -251,6 +253,10 @@ func getServerConfig() ServerConfig {
 		GatewayBaseDomain: getEnv(
 			"GATEWAY_BASE_DOMAIN",
 			defaultGatewayBaseDomain,
+		),
+		MCPBaseDomain: getEnv(
+			"MCP_BASE_DOMAIN",
+			defaultMCPBaseDomain,
 		),
 		GatewayDiscoveryMode: strings.ToLower(strings.TrimSpace(getEnv(
 			"GATEWAY_DISCOVERY_MODE",

--- a/pkg/container/modules/gateway.go
+++ b/pkg/container/modules/gateway.go
@@ -47,22 +47,22 @@ func Gateway(c *container.Container) error {
 	}
 
 	if err := c.Provide(func(creator appgateway.Creator, cfg *config.Config) *gatewayhttp.CreateGatewayHandler {
-		return gatewayhttp.NewCreateGatewayHandler(creator, cfg.Server.GatewayBaseDomain)
+		return gatewayhttp.NewCreateGatewayHandler(creator, cfg.Server.GatewayBaseDomain, cfg.Server.MCPBaseDomain)
 	}); err != nil {
 		return err
 	}
 	if err := c.Provide(func(finder appgateway.Finder, cfg *config.Config) *gatewayhttp.GetGatewayHandler {
-		return gatewayhttp.NewGetGatewayHandler(finder, cfg.Server.GatewayBaseDomain)
+		return gatewayhttp.NewGetGatewayHandler(finder, cfg.Server.GatewayBaseDomain, cfg.Server.MCPBaseDomain)
 	}); err != nil {
 		return err
 	}
 	if err := c.Provide(func(finder appgateway.Finder, cfg *config.Config) *gatewayhttp.ListGatewayHandler {
-		return gatewayhttp.NewListGatewayHandler(finder, cfg.Server.GatewayBaseDomain)
+		return gatewayhttp.NewListGatewayHandler(finder, cfg.Server.GatewayBaseDomain, cfg.Server.MCPBaseDomain)
 	}); err != nil {
 		return err
 	}
 	if err := c.Provide(func(updater appgateway.Updater, cfg *config.Config) *gatewayhttp.UpdateGatewayHandler {
-		return gatewayhttp.NewUpdateGatewayHandler(updater, cfg.Server.GatewayBaseDomain)
+		return gatewayhttp.NewUpdateGatewayHandler(updater, cfg.Server.GatewayBaseDomain, cfg.Server.MCPBaseDomain)
 	}); err != nil {
 		return err
 	}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# One-line installer for AgentGateway.
+#
+#   curl -fsSL https://raw.githubusercontent.com/NeuralTrust/AgentGateway/main/scripts/install.sh | bash
+#
+# It clones the repository, seeds the .env file, and brings up the full stack
+# (Postgres, Redis, Kafka + admin, proxy & MCP planes) in Docker. Re-running is
+# safe: it updates an existing checkout and never clobbers your .env.
+#
+# When Go is installed it also compiles the `trustgate` binary and installs it
+# on your PATH so you can run `trustgate <subcommand>` from anywhere.
+#
+# Environment overrides:
+#   AG_REPO_URL     Git URL to clone     (default: https://github.com/NeuralTrust/AgentGateway.git)
+#   AG_REF          Branch/tag/commit    (default: main)
+#   AG_DIR          Target directory     (default: ./AgentGateway)
+#   AG_BIN_DIR      Where to install the CLI (default: /usr/local/bin if writable, else ~/.local/bin)
+#   AG_INSTALL_CLI  Set to 0 to skip building/installing the trustgate binary
+#   AG_NO_START     Set to 1 to skip bringing the Docker stack up
+set -euo pipefail
+
+AG_REPO_URL="${AG_REPO_URL:-https://github.com/NeuralTrust/AgentGateway.git}"
+AG_REF="${AG_REF:-main}"
+AG_DIR="${AG_DIR:-AgentGateway}"
+CLI_BIN=""
+
+if [[ -t 1 ]]; then
+  BOLD="$(printf '\033[1m')"; BLUE="$(printf '\033[34m')"; GREEN="$(printf '\033[32m')"
+  YELLOW="$(printf '\033[33m')"; RED="$(printf '\033[31m')"; RESET="$(printf '\033[0m')"
+else
+  BOLD=""; BLUE=""; GREEN=""; YELLOW=""; RED=""; RESET=""
+fi
+
+info()  { echo "${BLUE}${BOLD}==>${RESET} $*"; }
+ok()    { echo "${GREEN}${BOLD} ✓${RESET} $*"; }
+warn()  { echo "${YELLOW}${BOLD} !${RESET} $*" >&2; }
+die()   { echo "${RED}${BOLD}error:${RESET} $*" >&2; exit 1; }
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || die "$1 is required but not installed. $2"
+}
+
+detect_compose() {
+  if docker compose version >/dev/null 2>&1; then
+    COMPOSE=(docker compose)
+  elif command -v docker-compose >/dev/null 2>&1; then
+    COMPOSE=(docker-compose)
+  else
+    die "Docker Compose is required (Docker Desktop bundles it, or install the compose plugin)."
+  fi
+}
+
+install_cli() {
+  if ! command -v go >/dev/null 2>&1; then
+    warn "Go not found, skipping the trustgate CLI build (the Docker stack still runs)."
+    warn "Install Go from https://go.dev/dl/ and re-run, or set AG_INSTALL_CLI=0 to silence this."
+    return
+  fi
+
+  info "Building the trustgate CLI from source ..."
+  if command -v make >/dev/null 2>&1; then
+    if ! make build; then
+      warn "CLI build failed (check your Go toolchain against go.mod). Skipping CLI install."
+      return
+    fi
+  else
+    mkdir -p bin
+    if ! go build -o bin/trustgate ./cmd/trustgate; then
+      warn "CLI build failed. Skipping CLI install."
+      return
+    fi
+  fi
+
+  local bin_dir="${AG_BIN_DIR:-}"
+  if [[ -z "$bin_dir" ]]; then
+    if [[ -w /usr/local/bin ]]; then bin_dir=/usr/local/bin; else bin_dir="$HOME/.local/bin"; fi
+  fi
+  mkdir -p "$bin_dir" 2>/dev/null || true
+  if ! install -m 0755 bin/trustgate "$bin_dir/trustgate" 2>/dev/null; then
+    warn "Could not install to $bin_dir. Set AG_BIN_DIR to a writable directory and re-run."
+    return
+  fi
+  CLI_BIN="$bin_dir/trustgate"
+  ok "Installed trustgate CLI -> $CLI_BIN"
+  case ":$PATH:" in
+    *":$bin_dir:"*) : ;;
+    *) warn "$bin_dir is not on your PATH. Add it with: export PATH=\"$bin_dir:\$PATH\"" ;;
+  esac
+}
+
+info "Checking prerequisites ..."
+require git "Install it from https://git-scm.com/downloads"
+require docker "Install Docker from https://docs.docker.com/get-docker/"
+docker info >/dev/null 2>&1 || die "Docker daemon is not running. Start Docker and re-run."
+detect_compose
+ok "git, docker and compose are available"
+
+if [[ -d "$AG_DIR/.git" ]]; then
+  info "Updating existing checkout in $AG_DIR ..."
+  git -C "$AG_DIR" fetch --depth 1 origin "$AG_REF"
+  git -C "$AG_DIR" checkout -q FETCH_HEAD
+  ok "Repository updated to $AG_REF"
+else
+  [[ -e "$AG_DIR" ]] && die "$AG_DIR already exists and is not a git checkout. Remove it or set AG_DIR."
+  info "Cloning $AG_REPO_URL ($AG_REF) into $AG_DIR ..."
+  git clone --depth 1 --branch "$AG_REF" "$AG_REPO_URL" "$AG_DIR" 2>/dev/null \
+    || git clone --depth 1 "$AG_REPO_URL" "$AG_DIR"
+  ok "Repository cloned"
+fi
+
+cd "$AG_DIR"
+
+if [[ -f .env ]]; then
+  ok ".env already present, keeping it"
+else
+  [[ -f .env.example ]] || die ".env.example not found in the repository."
+  cp .env.example .env
+  ok "Created .env from .env.example"
+fi
+
+if [[ "${AG_INSTALL_CLI:-1}" != "0" ]]; then
+  install_cli
+fi
+
+if [[ "${AG_NO_START:-}" == "1" ]]; then
+  warn "AG_NO_START=1 set, skipping Docker startup."
+  echo "Start the stack later with: ${BOLD}cd $AG_DIR && make up${RESET}"
+else
+  info "Bringing up the AgentGateway stack (this builds images on first run) ..."
+  "${COMPOSE[@]}" -f docker-compose.yaml -f docker-compose.api.yaml up -d --build
+
+  cat <<EOF
+
+${GREEN}${BOLD}AgentGateway is up.${RESET}
+
+  Admin  -> ${BOLD}http://localhost:8080${RESET}  (healthz: /healthz)
+  Proxy  -> ${BOLD}http://localhost:8081${RESET}  (healthz: /healthz)
+  MCP    -> ${BOLD}http://localhost:8082${RESET}  (healthz: /healthz)
+
+Next steps (from the ${BOLD}$AG_DIR${RESET} directory):
+  make logs     # tail logs
+  make down     # stop everything and remove volumes
+
+See the "Your first request" section in README.md to mint an admin token and
+make your first proxied LLM call.
+EOF
+fi
+
+if [[ -n "$CLI_BIN" ]]; then
+  cat <<EOF
+
+${GREEN}${BOLD}trustgate CLI installed${RESET} -> $CLI_BIN
+  Subcommands: ${BOLD}trustgate admin|proxy|mcp|run${RESET}
+  Running natively needs an .env plus Postgres/Redis/Kafka (the Docker stack provides them).
+  Note: the dockerized planes already bind :8080/:8081/:8082, so 'make down' those first to run the CLI on the same ports.
+EOF
+fi

--- a/tests/functional/common_test.go
+++ b/tests/functional/common_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const functionalGatewayBaseDomain = "gw.neuraltrust.ai"
+const functionalGatewayBaseDomain = "llm.neuraltrust.ai"
 
 var (
 	gatewayHosts  sync.Map


### PR DESCRIPTION
## Summary

- **Two gateway hosts in the API response**: the gateway response now returns a `hosts` object with `proxy` and `mcp` hostnames instead of the single `host` field. Adds a new `MCP_BASE_DOMAIN` config (default `mcp.neuraltrust.ai`) and threads both base domains through the create/get/list/update handlers and DI wiring.
- **Default base domain** `GATEWAY_BASE_DOMAIN` changed from `gw.neuraltrust.ai` to `llm.neuraltrust.ai` (config, docs and functional fixtures).
- **One-line installer** (`scripts/install.sh`): clones the repo, seeds `.env`, brings up the full Docker stack and — when Go is installed — compiles the `trustgate` binary and installs it on `PATH`. Idempotent and documented in the README.
- Regenerated swagger/openapi docs for the new `GatewayHosts` shape.

### Response shape

```json
{
  "slug": "demo",
  "hosts": { "proxy": "demo.llm.neuraltrust.ai", "mcp": "demo.mcp.neuraltrust.ai" },
  ...
}
```

A custom `domain` still overrides the proxy host; the MCP host is always derived from the slug.

## Test plan

- [ ] `go build ./...`, `go vet ./pkg/...` (green locally)
- [ ] `go test ./pkg/api/handler/http/gateway/... ./pkg/config/... ./pkg/container/...`
- [ ] `bash -n scripts/install.sh`
- [ ] CI license-check + full suite

Made with [Cursor](https://cursor.com)