### PR TITLE
feat: add native DeepSeek provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 ## ✨ Features
 
 - 🚀 **High Performance** — Built in Go on top of [Fiber](https://gofiber.io), tuned for low latency and high concurrency.
-- 🌍 **Multi-Provider** — First-class adapters for OpenAI, Anthropic, Azure OpenAI, AWS Bedrock, Google Gemini, Vertex AI, Groq and Mistral.
+- 🌍 **Multi-Provider** — First-class adapters for OpenAI, Anthropic, Azure OpenAI, AWS Bedrock, Google Gemini, Vertex AI, Groq, Mistral and DeepSeek.
 - 🧭 **Smart Routing & Load Balancing** — Round-robin, weighted round-robin and IP-hash strategies with health checks and fallback targets.
 - 🔌 **Plugin System** — Policy stages with built-in plugins: rate limiting, token rate limiting, request size guard, semantic cache and CORS.
 - 🧠 **Semantic Cache** — Embedding-based response caching to cut cost and latency on repeated prompts.
@@ -305,6 +305,7 @@ Plugins run inside ordered **policy stages** and can execute sequentially or in 
 |----------|----------|----------|----------|
 | OpenAI | Anthropic | Azure OpenAI | AWS Bedrock |
 | Google Gemini | Vertex AI | Groq | Mistral |
+| DeepSeek | | | |
 
 ## ⚙️ Configuration
 

--- a/docs/AgentGateway.postman_collection.json
+++ b/docs/AgentGateway.postman_collection.json
@@ -116,6 +116,11 @@
       "type": "string"
     },
     {
+      "key": "deepseek_api_key",
+      "value": "replace-with-real-deepseek-api-key",
+      "type": "string"
+    },
+    {
       "key": "aws_region",
       "value": "us-east-1",
       "type": "string"
@@ -2446,6 +2451,49 @@
             "body": {
               "mode": "raw",
               "raw": "{\n  \"name\": \"groq-primary-{$guid}\",\n  \"provider\": \"groq\",\n  \"description\": \"Groq registry\",\n  \"auth\": {\n    \"type\": \"api_key\",\n    \"api_key\": {\n      \"api_key\": \"{{groq_api_key}}\"\n    }\n  }\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/gateways/{{gateway_id}}/registries",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "v1",
+                "gateways",
+                "{{gateway_id}}",
+                "registries"
+              ]
+            }
+          },
+          "description": "Optional provider payload. Does not overwrite registry_id used by later E2E steps.",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('registry created', () => pm.response.code === 201);",
+                  "if (pm.response.code === 201) {",
+                  "  pm.environment.set('registry_id', pm.response.json().id);",
+                  "}"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "2j. Create Registry (DeepSeek)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"deepseek-primary-{$guid}\",\n  \"provider\": \"deepseek\",\n  \"description\": \"DeepSeek registry\",\n  \"provider_options\": {},\n  \"auth\": {\n    \"type\": \"api_key\",\n    \"api_key\": {\n      \"api_key\": \"{{deepseek_api_key}}\"\n    }\n  }\n}"
             },
             "url": {
               "raw": "{{base_url}}/v1/gateways/{{gateway_id}}/registries",

--- a/pkg/app/catalog/provider_auth.go
+++ b/pkg/app/catalog/provider_auth.go
@@ -254,6 +254,7 @@ var providerAuthCatalog = map[string][]AuthTypeOption{
 	providers.ProviderAzure:            azureAuthOptions,
 	providers.ProviderMistral:          {apiKeyAuthOption},
 	providers.ProviderGroq:             {apiKeyAuthOption},
+	providers.ProviderDeepSeek:         {apiKeyAuthOption},
 }
 
 func ProviderAuthOptions(code string) []AuthTypeOption {

--- a/pkg/app/catalog/sync.go
+++ b/pkg/app/catalog/sync.go
@@ -41,6 +41,7 @@ var seedProviders = []seedProvider{
 	{providers.ProviderAzure, "Azure OpenAI", "openai"},
 	{providers.ProviderMistral, "Mistral", "openai"},
 	{providers.ProviderGroq, "Groq", "openai"},
+	{providers.ProviderDeepSeek, "DeepSeek", "openai"},
 }
 
 // modelsDevProviderToCode maps models.dev provider keys to the gateway provider
@@ -54,6 +55,7 @@ var modelsDevProviderToCode = map[string]string{
 	"azure":          providers.ProviderAzure,
 	"mistral":        providers.ProviderMistral,
 	"groq":           providers.ProviderGroq,
+	"deepseek":       providers.ProviderDeepSeek,
 }
 
 //go:generate mockery --name=Syncer --dir=. --output=./mocks --filename=catalog_syncer_mock.go --case=underscore --with-expecter

--- a/pkg/infra/providers/adapter/adapter_test.go
+++ b/pkg/infra/providers/adapter/adapter_test.go
@@ -167,6 +167,7 @@ func TestResolveAgentFormat_KnownProviders(t *testing.T) {
 		{"mistral", FormatMistral},
 		{"vertex", FormatVertex},
 		{"groq", FormatGroq},
+		{"deepseek", FormatDeepSeek},
 	}
 	for _, tt := range tests {
 		t.Run(tt.provider, func(t *testing.T) {

--- a/pkg/infra/providers/adapter/format.go
+++ b/pkg/infra/providers/adapter/format.go
@@ -32,6 +32,7 @@ const (
 	FormatGroq            Format = "groq"  // wire-compatible with OpenAI Chat Completions
 	FormatVertex          Format = "vertex"
 	FormatMistral         Format = "mistral"
+	FormatDeepSeek        Format = "deepseek" // wire-compatible with OpenAI Chat Completions
 )
 
 // GeminiModelsRoutePrefix is the fixed Gemini route segment that carries the
@@ -93,7 +94,7 @@ func DetectFormat(body []byte) Format {
 func SupportedSourceFormat(f Format) bool {
 	switch f {
 	case FormatOpenAI, FormatOpenAIResponses, FormatAnthropic, FormatGemini,
-		FormatAzure, FormatGroq, FormatVertex, FormatMistral:
+		FormatAzure, FormatGroq, FormatVertex, FormatMistral, FormatDeepSeek:
 		return true
 	default:
 		return false
@@ -114,6 +115,8 @@ func resolveProviderWireFormat(provider string) Format {
 	switch provider {
 	case string(FormatGroq):
 		return FormatGroq
+	case string(FormatDeepSeek):
+		return FormatDeepSeek
 	case "openai_compatible":
 		return FormatOpenAI
 	default:
@@ -141,7 +144,7 @@ func ResolveAgentFormat(provider, sourceFormat string, providerOptions map[strin
 		return Format(sourceFormat), nil
 	}
 	switch provider {
-	case "openai", "openai_compatible", "azure", "groq":
+	case "openai", "openai_compatible", "azure", "groq", "deepseek":
 		return ResolveTargetFormat(provider, providerOptions), nil
 	case "anthropic":
 		return FormatAnthropic, nil
@@ -166,7 +169,7 @@ func IsSameWireFormat(a, b Format) bool {
 
 func normalizeFormat(f Format) Format {
 	switch f {
-	case FormatAzure, FormatGroq:
+	case FormatAzure, FormatGroq, FormatDeepSeek:
 		return FormatOpenAI
 	case FormatVertex:
 		return FormatGemini

--- a/pkg/infra/providers/adapter/registry.go
+++ b/pkg/infra/providers/adapter/registry.go
@@ -96,6 +96,7 @@ func NewRegistry() *Registry {
 	}
 	r.Register(FormatOpenAI, &OpenAIAdapter{})
 	r.Register(FormatGroq, &OpenAIAdapter{})
+	r.Register(FormatDeepSeek, &OpenAIAdapter{})
 	r.Register(FormatOpenAIResponses, &OpenAIResponsesAdapter{})
 	r.Register(FormatAnthropic, &AnthropicAdapter{})
 	r.Register(FormatGemini, &GeminiAdapter{})

--- a/pkg/infra/providers/client.go
+++ b/pkg/infra/providers/client.go
@@ -31,6 +31,7 @@ const (
 	ProviderAzure            = "azure"
 	ProviderMistral          = "mistral"
 	ProviderGroq             = "groq"
+	ProviderDeepSeek         = "deepseek"
 )
 
 // SupportedProviders returns every provider name the gateway can route to.
@@ -45,6 +46,7 @@ func SupportedProviders() []string {
 		ProviderAzure,
 		ProviderMistral,
 		ProviderGroq,
+		ProviderDeepSeek,
 	}
 }
 
@@ -59,7 +61,8 @@ func IsValidProvider(name string) bool {
 		ProviderBedrock,
 		ProviderAzure,
 		ProviderMistral,
-		ProviderGroq:
+		ProviderGroq,
+		ProviderDeepSeek:
 		return true
 	default:
 		return false

--- a/pkg/infra/providers/deepseek/client.go
+++ b/pkg/infra/providers/deepseek/client.go
@@ -1,0 +1,97 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deepseek
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"iter"
+
+	"github.com/NeuralTrust/AgentGateway/pkg/infra/providers"
+	"github.com/NeuralTrust/AgentGateway/pkg/infra/providers/openai"
+)
+
+const (
+	chatCompletionsURL = "https://api.deepseek.com/chat/completions"
+	reasonerModelName  = "deepseek-reasoner"
+	reasonerMaxTokens  = 64000
+)
+
+type client struct {
+	chat *openai.ChatCompletionsClient
+}
+
+type chatCompletionsRequest struct {
+	Model               string `json:"model,omitempty"`
+	MaxTokens           *int   `json:"max_tokens,omitempty"`
+	MaxCompletionTokens *int   `json:"max_completion_tokens,omitempty"`
+}
+
+// NewDeepSeekClient returns a providers.Client for DeepSeek's OpenAI-compatible
+// Chat Completions API.
+func NewDeepSeekClient() providers.Client {
+	return &client{
+		chat: openai.NewChatCompletionsClient(providers.ProviderDeepSeek, nil),
+	}
+}
+
+func (c *client) Completions(
+	ctx context.Context,
+	config *providers.Config,
+	reqBody []byte,
+) ([]byte, error) {
+	if err := validateRequest(reqBody); err != nil {
+		return nil, err
+	}
+	return c.chat.Completions(ctx, chatCompletionsURL, config, reqBody, nil)
+}
+
+func (c *client) CompletionsStream(
+	ctx context.Context,
+	config *providers.Config,
+	reqBody []byte,
+) (iter.Seq2[[]byte, error], error) {
+	if err := validateRequest(reqBody); err != nil {
+		return nil, err
+	}
+	return c.chat.CompletionsStream(ctx, chatCompletionsURL, config, reqBody, nil)
+}
+
+// validateRequest rejects deepseek-reasoner requests whose max token budget
+// exceeds DeepSeek's published limit before the upstream call is made.
+func validateRequest(reqBody []byte) error {
+	var req chatCompletionsRequest
+	if err := json.Unmarshal(reqBody, &req); err != nil {
+		return nil
+	}
+
+	maxTokens := 0
+	if req.MaxCompletionTokens != nil {
+		maxTokens = *req.MaxCompletionTokens
+	} else if req.MaxTokens != nil {
+		maxTokens = *req.MaxTokens
+	}
+
+	if req.Model == reasonerModelName && maxTokens > reasonerMaxTokens {
+		return fmt.Errorf(
+			"invalid max tokens for model %q: %d exceeds DeepSeek limit %d",
+			reasonerModelName,
+			maxTokens,
+			reasonerMaxTokens,
+		)
+	}
+	return nil
+}

--- a/pkg/infra/providers/deepseek/client_test.go
+++ b/pkg/infra/providers/deepseek/client_test.go
@@ -1,0 +1,182 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deepseek
+
+import (
+	"context"
+	"encoding/json"
+	"iter"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/NeuralTrust/AgentGateway/pkg/domain/registry"
+	"github.com/NeuralTrust/AgentGateway/pkg/infra/providers"
+	"github.com/NeuralTrust/AgentGateway/pkg/infra/providers/openai"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// deepseekClientAt is a test-only wrapper that targets a custom URL so the
+// OpenAI-compatible round trip can be exercised against an httptest server
+// while preserving the reasoner validation guard.
+type deepseekClientAt struct {
+	chat *openai.ChatCompletionsClient
+	url  string
+}
+
+func newDeepSeekClientAt(url string) providers.Client {
+	return &deepseekClientAt{
+		chat: openai.NewChatCompletionsClient(providers.ProviderDeepSeek, nil),
+		url:  url,
+	}
+}
+
+func (c *deepseekClientAt) Completions(ctx context.Context, config *providers.Config, reqBody []byte) ([]byte, error) {
+	if err := validateRequest(reqBody); err != nil {
+		return nil, err
+	}
+	return c.chat.Completions(ctx, c.url, config, reqBody, nil)
+}
+
+func (c *deepseekClientAt) CompletionsStream(ctx context.Context, config *providers.Config, reqBody []byte) (iter.Seq2[[]byte, error], error) {
+	if err := validateRequest(reqBody); err != nil {
+		return nil, err
+	}
+	return c.chat.CompletionsStream(ctx, c.url, config, reqBody, nil)
+}
+
+func TestNewDeepSeekClient(t *testing.T) {
+	assert.NotNil(t, NewDeepSeekClient())
+}
+
+func TestCompletions_MissingAPIKey(t *testing.T) {
+	_, err := NewDeepSeekClient().Completions(context.Background(), &providers.Config{}, []byte(`{}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "API key is required")
+}
+
+func TestCompletions_NonStreamingRoundTrip(t *testing.T) {
+	const wantModel = "deepseek-chat"
+	var gotAuth, gotModel string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		gotAuth = r.Header.Get("Authorization")
+
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		gotModel, _ = body["model"].(string)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"model": wantModel,
+			"choices": []any{map[string]any{
+				"message": map[string]any{
+					"role":              "assistant",
+					"content":           "hi",
+					"reasoning_content": "let me think",
+				},
+			}},
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	resp, err := newDeepSeekClientAt(srv.URL+"/chat/completions").Completions(
+		context.Background(),
+		&providers.Config{Credentials: providers.Credentials{ApiKey: "deepseek-test-key"}},
+		[]byte(`{"model":"`+wantModel+`","messages":[{"role":"user","content":"hello"}]}`),
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Bearer deepseek-test-key", gotAuth)
+	assert.Equal(t, wantModel, gotModel)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(resp, &parsed))
+	assert.Equal(t, wantModel, parsed["model"])
+}
+
+func TestCompletionsStream_RoundTrip(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer deepseek-key", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	t.Cleanup(srv.Close)
+
+	seq, err := newDeepSeekClientAt(srv.URL+"/chat/completions").CompletionsStream(
+		context.Background(),
+		&providers.Config{Credentials: providers.Credentials{ApiKey: "deepseek-key"}},
+		[]byte(`{"model":"deepseek-chat","stream":true}`),
+	)
+	require.NoError(t, err)
+
+	var lines []string
+	for line, lerr := range seq {
+		require.NoError(t, lerr)
+		lines = append(lines, string(line))
+	}
+	require.NotEmpty(t, lines)
+	assert.Equal(t, `data: {"choices":[{"delta":{"content":"hi"}}]}`, lines[0])
+	assert.Equal(t, `data: [DONE]`, lines[len(lines)-1])
+}
+
+func TestCompletions_ReasonerMaxTokensValidation(t *testing.T) {
+	_, err := NewDeepSeekClient().Completions(
+		context.Background(),
+		&providers.Config{Credentials: providers.Credentials{ApiKey: "key"}},
+		[]byte(`{"model":"deepseek-reasoner","max_tokens":70000}`),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds DeepSeek limit")
+}
+
+func TestCompletions_ReasonerWithinLimit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"model": "deepseek-reasoner"})
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := newDeepSeekClientAt(srv.URL+"/chat/completions").Completions(
+		context.Background(),
+		&providers.Config{Credentials: providers.Credentials{ApiKey: "key"}},
+		[]byte(`{"model":"deepseek-reasoner","max_completion_tokens":64000,"messages":[{"role":"user","content":"hi"}]}`),
+	)
+	require.NoError(t, err)
+}
+
+func TestCompletions_RateLimitRetryAfter(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "2")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"rate limit exceeded"}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := newDeepSeekClientAt(srv.URL+"/chat/completions").Completions(
+		context.Background(),
+		&providers.Config{Credentials: providers.Credentials{ApiKey: "key"}},
+		[]byte(`{"model":"deepseek-chat","messages":[{"role":"user","content":"hi"}]}`),
+	)
+	require.Error(t, err)
+
+	be, ok := registry.IsBackendError(err)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusTooManyRequests, be.StatusCode)
+	assert.Equal(t, "2", be.RetryAfter)
+}

--- a/pkg/infra/providers/deepseek/connection.go
+++ b/pkg/infra/providers/deepseek/connection.go
@@ -1,0 +1,27 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deepseek
+
+import (
+	"context"
+
+	"github.com/NeuralTrust/AgentGateway/pkg/infra/providers"
+)
+
+const modelsURL = "https://api.deepseek.com/models"
+
+func (c *client) TestConnection(ctx context.Context, config *providers.Config) providers.ProbeResult {
+	return providers.RunBearerGETProbe(ctx, providers.ProviderDeepSeek, modelsURL, config.Credentials.ApiKey)
+}

--- a/pkg/infra/providers/factory/locator.go
+++ b/pkg/infra/providers/factory/locator.go
@@ -21,6 +21,7 @@ import (
 	"github.com/NeuralTrust/AgentGateway/pkg/infra/providers/anthropic"
 	"github.com/NeuralTrust/AgentGateway/pkg/infra/providers/azure"
 	"github.com/NeuralTrust/AgentGateway/pkg/infra/providers/bedrock"
+	"github.com/NeuralTrust/AgentGateway/pkg/infra/providers/deepseek"
 	"github.com/NeuralTrust/AgentGateway/pkg/infra/providers/google"
 	"github.com/NeuralTrust/AgentGateway/pkg/infra/providers/groq"
 	"github.com/NeuralTrust/AgentGateway/pkg/infra/providers/mistral"
@@ -41,6 +42,7 @@ const (
 	ProviderAzure            = providers.ProviderAzure
 	ProviderMistral          = providers.ProviderMistral
 	ProviderGroq             = providers.ProviderGroq
+	ProviderDeepSeek         = providers.ProviderDeepSeek
 )
 
 //go:generate mockery --name=ProviderLocator --dir=. --output=./mocks --filename=provider_locator_mock.go --case=underscore --with-expecter
@@ -70,6 +72,7 @@ func NewProviderLocator() ProviderLocator {
 			ProviderAzure:            azure.NewAzureClient(),
 			ProviderMistral:          mistral.NewMistralClient(),
 			ProviderGroq:             groq.NewGroqClient(),
+			ProviderDeepSeek:         deepseek.NewDeepSeekClient(),
 			ProviderVertex:           vertex.NewVertexClient(),
 		},
 	}

--- a/pkg/infra/providers/factory/locator_test.go
+++ b/pkg/infra/providers/factory/locator_test.go
@@ -34,6 +34,7 @@ func TestProviderLocator_Get(t *testing.T) {
 		ProviderAzure,
 		ProviderMistral,
 		ProviderGroq,
+		ProviderDeepSeek,
 	} {
 		t.Run(provider, func(t *testing.T) {
 			client, err := locator.Get(provider)


### PR DESCRIPTION
## Summary
- Add a first-class `deepseek` provider in `pkg/infra/providers/deepseek/` wrapping the OpenAI-compatible Chat Completions client (mirroring `groq`), with DeepSeek's fixed endpoint and a `max_tokens`/`max_completion_tokens` guard for `deepseek-reasoner` (limit 64000).
- Wire the provider through constants (`client.go`), factory locator, and the format/adapter layer (`FormatDeepSeek`, normalized to the OpenAI wire, registered with `OpenAIAdapter`, passthrough preserving `reasoning_content`).
- Seed the admin catalog (`sync.go` provider seed + models.dev mapping) and expose API-key auth (`provider_auth.go`).
- Add a `Create Registry (DeepSeek)` request + `deepseek_api_key` variable to the Postman E2E flow, and document the provider in the README.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/infra/providers/... ./pkg/app/catalog/...`
- [x] Pre-commit hook (golangci-lint, gosec, full test suite) green
- [x] Postman collection JSON validates
- [ ] Manual smoke test against the real DeepSeek API with a valid key

Made with [Cursor](https://cursor.com)