### PR TITLE
feat(telemetry): register otlp exporter template + docs (4/4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,15 @@ TELEMETRY_KAFKA_TOPIC=agentgateway.requests
 TELEMETRY_TRUSTLENS_ENABLED=false
 TELEMETRY_TRUSTLENS_URL=
 
+# OTLP exporter defaults (opt-in per gateway via telemetry.exporters; per-gateway
+# settings override these). Timeout uses Go duration format (e.g. 10s).
+OTEL_EXPORTER_OTLP_ENDPOINT=
+OTEL_EXPORTER_OTLP_PROTOCOL=
+OTEL_EXPORTER_OTLP_HEADERS=
+OTEL_EXPORTER_OTLP_TIMEOUT=
+OTEL_EXPORTER_OTLP_INSECURE=
+OTEL_EXPORTER_OTLP_COMPRESSION=
+
 # Metrics Configuration
 METRICS_ENABLED=true
 METRICS_QUEUE_SIZE=1000

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 - 🔌 **Plugin System** — Policy stages with built-in plugins: rate limiting, token rate limiting, request size guard, semantic cache and CORS.
 - 🧠 **Semantic Cache** — Embedding-based response caching to cut cost and latency on repeated prompts.
 - 🔒 **Security & Multi-Tenancy** — Per-gateway consumers, API-key auth, and policies scoped globally or per consumer.
-- 📊 **Observability** — Built-in metrics, request telemetry streamed to Kafka and optional [TrustLens](https://neuraltrust.ai) integration.
+- 📊 **Observability** — Built-in metrics, request telemetry streamed to Kafka by default, with an opt-in per-gateway [OpenTelemetry](https://opentelemetry.io) (OTLP) exporter and optional [TrustLens](https://neuraltrust.ai) integration.
 - ⚙️ **Two Independent Planes** — Admin and Proxy run as separate processes so you can scale them independently.
 - ☁️ **Cloud Agnostic** — Single static binary, Docker image and Kubernetes manifests. Deploy anywhere.
 
@@ -335,9 +335,72 @@ KAFKA_BROKERS=localhost:9092
 TELEMETRY_ENABLED=true
 TELEMETRY_KAFKA_TOPIC=agentgateway.requests
 METRICS_ENABLED=true
+
+# OTLP exporter defaults (opt-in per gateway; per-gateway settings override these)
+OTEL_EXPORTER_OTLP_ENDPOINT=collector:4317
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 ```
 
 See [`.env.example`](.env.example) for the full set with safe defaults.
+
+### Telemetry exporters (Kafka default + OTLP opt-in)
+
+Every completed request is turned into a sanitized business event and fanned out
+to one or more exporters. **Kafka is the config-driven default** (feeds
+`kafka-connect → ClickHouse → data-plane-api`). A gateway can additionally opt
+into the **`otlp`** exporter, which ships the same event to an external
+[OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) as a single
+OTLP **log record** per request (`event.name="gateway.request"`); the Collector
+fans out to any vendor backend. Enabling `otlp` does not replace Kafka — both
+fire (explicit exporters merge with the global defaults).
+
+Add it to a gateway's `telemetry.exporters`:
+
+```json
+{
+  "telemetry": {
+    "exporters": [
+      {
+        "name": "otlp",
+        "settings": {
+          "endpoint": "collector:4317",
+          "protocol": "grpc",
+          "headers": { "authorization": "Bearer <token>" },
+          "compression": "gzip",
+          "timeout": "10s",
+          "insecure": false
+        }
+      }
+    ]
+  }
+}
+```
+
+With Kafka still configured, the event is delivered to the Collector **and**
+Kafka (the ClickHouse path keeps populating with `schema_version=2` intact).
+
+**`otlp` settings**
+
+| Key | Type | Default | Notes |
+|-----|------|---------|-------|
+| `endpoint` | string | — (required unless env fallback) | `host:port` or full URL of the Collector |
+| `protocol` | string | `grpc` | `grpc` (`:4317`) or `http/protobuf` (`:4318`) |
+| `signal` | string | `logs` | `logs`; `traces` is reserved and rejected |
+| `headers` | map | `{}` | auth/tenant headers |
+| `insecure` | bool | `false` | plaintext, no TLS (cannot combine with `tls`) |
+| `tls` | object | — | `{ ca_file, cert_file, key_file, skip_verify }` |
+| `timeout` | duration | `10s` | export + graceful-shutdown bound; must be `> 0` |
+| `compression` | string | `gzip` | `gzip` or `none` |
+| `max_body_bytes` | int | `4096` | request/response body truncation cap |
+
+Any key absent from a gateway's settings falls back to the process-level
+`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`,
+`OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_EXPORTER_OTLP_TIMEOUT`,
+`OTEL_EXPORTER_OTLP_INSECURE`, and `OTEL_EXPORTER_OTLP_COMPRESSION` env vars
+(per-gateway settings win). `OTEL_EXPORTER_OTLP_TIMEOUT` uses Go duration format
+(e.g. `10s`). Settings are validated structurally on gateway create/update with
+no network I/O; export is non-blocking (bounded queue, drop-on-full) so a slow
+or unreachable Collector never affects request latency or the Kafka path.
 
 ### Migrations
 
@@ -370,7 +433,7 @@ pkg/infra/providers/   # provider adapters (openai, anthropic, bedrock, …)
 pkg/infra/plugins/     # policy plugins (ratelimit, semanticcache, …)
 pkg/infra/loadbalancer/# routing strategies + health checks
 pkg/infra/database/    # pgxpool + in-code Go migrations registry
-pkg/infra/telemetry/   # Kafka + TrustLens telemetry
+pkg/infra/telemetry/   # Kafka (default) + OTLP exporters; TrustLens flag
 pkg/api/handler/http/  # per-route HTTP handlers
 pkg/server/            # Server interface + admin / proxy routers
 pkg/container/         # dig DI container + one module per context

--- a/pkg/container/modules/telemetry.go
+++ b/pkg/container/modules/telemetry.go
@@ -23,6 +23,7 @@ import (
 	telemetrydomain "github.com/NeuralTrust/AgentGateway/pkg/domain/telemetry"
 	infratelemetry "github.com/NeuralTrust/AgentGateway/pkg/infra/telemetry"
 	"github.com/NeuralTrust/AgentGateway/pkg/infra/telemetry/kafka"
+	"github.com/NeuralTrust/AgentGateway/pkg/infra/telemetry/otlp"
 	"go.uber.org/dig"
 )
 
@@ -45,6 +46,7 @@ func Telemetry(c *container.Container) error {
 func newExporterFactory(logger *slog.Logger, cfg *config.Config) appmetrics.ExporterFactory {
 	return infratelemetry.NewExporterLocator(
 		infratelemetry.WithExporter(kafka.ExporterName, kafka.NewKafkaTemplate(logger, cfg.Kafka)),
+		infratelemetry.WithExporter(otlp.ExporterName, otlp.NewTemplate(logger, cfg.Telemetry.OTLP)),
 	)
 }
 

--- a/pkg/infra/telemetry/otlp/template.go
+++ b/pkg/infra/telemetry/otlp/template.go
@@ -1,0 +1,71 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlp
+
+import (
+	"context"
+	"log/slog"
+
+	appmetrics "github.com/NeuralTrust/AgentGateway/pkg/app/metrics"
+	"github.com/NeuralTrust/AgentGateway/pkg/config"
+	infratelemetry "github.com/NeuralTrust/AgentGateway/pkg/infra/telemetry"
+)
+
+var _ infratelemetry.ExporterTemplate = (*Template)(nil)
+
+// Template builds otlp.Exporter instances from per-gateway settings, falling
+// back to process-level OTEL_EXPORTER_OTLP_* defaults.
+type Template struct {
+	logger *slog.Logger
+	envCfg config.OTLPConfig
+}
+
+// NewTemplate returns an OTLP ExporterTemplate bound to the given logger and
+// process-level OTEL_EXPORTER_OTLP_* defaults.
+func NewTemplate(logger *slog.Logger, envCfg config.OTLPConfig) *Template {
+	return &Template{logger: logger, envCfg: envCfg}
+}
+
+func (t *Template) Name() string {
+	return ExporterName
+}
+
+// ValidateConfig performs structural validation only; it never connects to the
+// Collector.
+func (t *Template) ValidateConfig(settings map[string]interface{}) error {
+	s, err := parseSettings(settings, t.envCfg)
+	if err != nil {
+		return err
+	}
+	return s.validate()
+}
+
+// WithSettings validates the settings then builds a dedicated provider and
+// exporter. The OTLP client connects lazily, so an unreachable Collector does
+// not fail construction.
+func (t *Template) WithSettings(settings map[string]interface{}) (appmetrics.Exporter, error) {
+	s, err := parseSettings(settings, t.envCfg)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.validate(); err != nil {
+		return nil, err
+	}
+	provider, err := newLoggerProvider(context.Background(), s)
+	if err != nil {
+		return nil, err
+	}
+	return newExporterWithProvider(provider, t.logger, s.MaxBodyBytes, s.Timeout), nil
+}


### PR DESCRIPTION
## Summary
Slice final 4/4 de la cadena del exporter `otlp`. Expone el exporter a la factory y documenta el opt-in.

- `pkg/infra/telemetry/otlp/template.go`: `ExporterTemplate` (`Name`, `ValidateConfig`, `WithSettings`).
- `pkg/container/modules/telemetry.go`: **1 línea** `WithExporter(otlp.ExporterName, otlp.NewTemplate(...))` en `newExporterFactory`.
- `README.md` + `.env.example`: documentan los `Settings` del exporter y las env `OTEL_EXPORTER_OTLP_*`.

Con esto, un gateway que incluya `{"name":"otlp","settings":{...}}` en `telemetry.exporters` hace **fan-out** (OTLP + Kafka) vía `Pipeline.resolveTargets` **sin cambios en el pipeline**; sin esa entrada, sigue solo Kafka. Añadir un futuro exporter = 1 template + 1 línea (extensibilidad preservada).

## Stack
- 1/4 (#79) · 2/4 · 3/4
- **4/4 (este)** → base 3/4

## Acceptance criteria
- [x] Sin `telemetry.exporters` → solo Kafka (sin regresión)
- [x] `{name:"otlp",settings}` → fan-out OTLP+Kafka
- [x] Settings inválidos → rechazo en `ValidateConfig` sin I/O de red
- [x] Collector caído → hot path intacto; shutdown hace flush
- [x] Contrato downstream (Event v2 / Kafka / ClickHouse) intacto

## Test plan
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues), `make build`
- [x] `go test -race ./pkg/...` (85 pkgs ok)

Made with [Cursor](https://cursor.com)