### PR TITLE
fix(oauth): scope IdP fallback per gateway and require a single IdP auth for role_based consumers

### DIFF
--- a/pkg/api/handler/http/oauth/handlers_test.go
+++ b/pkg/api/handler/http/oauth/handlers_test.go
@@ -23,6 +23,7 @@ import (
 
 	appoauth "github.com/NeuralTrust/AgentGateway/pkg/app/oauth"
 	authdomain "github.com/NeuralTrust/AgentGateway/pkg/domain/auth"
+	"github.com/NeuralTrust/AgentGateway/pkg/domain/ids"
 	"github.com/gofiber/fiber/v2"
 )
 
@@ -32,6 +33,16 @@ type fakeCredentialFinder struct {
 
 func (f *fakeCredentialFinder) OAuth2Auths(context.Context) ([]*authdomain.Auth, error) {
 	return f.oauth2, nil
+}
+
+func (f *fakeCredentialFinder) OAuth2AuthsForGateway(_ context.Context, gatewayID ids.GatewayID) ([]*authdomain.Auth, error) {
+	out := make([]*authdomain.Auth, 0, len(f.oauth2))
+	for _, a := range f.oauth2 {
+		if a.GatewayID == gatewayID {
+			out = append(out, a)
+		}
+	}
+	return out, nil
 }
 
 func (f *fakeCredentialFinder) MTLSAuths(context.Context) ([]*authdomain.Auth, error) {

--- a/pkg/api/middleware/auth_chain_test.go
+++ b/pkg/api/middleware/auth_chain_test.go
@@ -51,6 +51,16 @@ func (f fakeCredentialFinder) OAuth2Auths(context.Context) ([]*authdomain.Auth, 
 	return f.oauth2, nil
 }
 
+func (f fakeCredentialFinder) OAuth2AuthsForGateway(_ context.Context, gatewayID ids.GatewayID) ([]*authdomain.Auth, error) {
+	out := make([]*authdomain.Auth, 0, len(f.oauth2))
+	for _, a := range f.oauth2 {
+		if a.GatewayID == gatewayID {
+			out = append(out, a)
+		}
+	}
+	return out, nil
+}
+
 func (f fakeCredentialFinder) MTLSAuths(context.Context) ([]*authdomain.Auth, error) {
 	return f.mtls, nil
 }

--- a/pkg/app/auth/credential_finder.go
+++ b/pkg/app/auth/credential_finder.go
@@ -19,20 +19,23 @@ import (
 	"log/slog"
 
 	domain "github.com/NeuralTrust/AgentGateway/pkg/domain/auth"
+	"github.com/NeuralTrust/AgentGateway/pkg/domain/ids"
 	"github.com/NeuralTrust/AgentGateway/pkg/infra/cache"
 )
 
 //go:generate mockery --name=CredentialFinder --dir=. --output=./mocks --filename=auth_credential_finder_mock.go --case=underscore --with-expecter
 type CredentialFinder interface {
 	OAuth2Auths(ctx context.Context) ([]*domain.Auth, error)
+	OAuth2AuthsForGateway(ctx context.Context, gatewayID ids.GatewayID) ([]*domain.Auth, error)
 	MTLSAuths(ctx context.Context) ([]*domain.Auth, error)
 }
 
 var _ CredentialFinder = (*credentialFinder)(nil)
 
 const (
-	oauth2CacheKey = "enabled:oauth2"
-	mtlsCacheKey   = "enabled:mtls"
+	oauth2CacheKey           = "enabled:oauth2"
+	oauth2GatewayCachePrefix = "enabled:oauth2:gw:"
+	mtlsCacheKey             = "enabled:mtls"
 )
 
 type credentialFinder struct {
@@ -51,6 +54,23 @@ func NewCredentialFinder(repo domain.Repository, manager *cache.TTLMapManager, l
 
 func (f *credentialFinder) OAuth2Auths(ctx context.Context) ([]*domain.Auth, error) {
 	return f.findByType(ctx, oauth2CacheKey, domain.TypeOAuth2)
+}
+
+func (f *credentialFinder) OAuth2AuthsForGateway(ctx context.Context, gatewayID ids.GatewayID) ([]*domain.Auth, error) {
+	key := oauth2GatewayCachePrefix + gatewayID.String()
+	if cached, ok := f.cache.Get(key); ok {
+		if auths, ok := cached.([]*domain.Auth); ok {
+			return auths, nil
+		}
+		f.logger.Warn("credential cache entry failed type assertion; falling back to database")
+		f.cache.Delete(key)
+	}
+	auths, err := f.repo.ListEnabledByGatewayAndType(ctx, gatewayID, domain.TypeOAuth2)
+	if err != nil {
+		return nil, err
+	}
+	f.cache.Set(key, auths)
+	return auths, nil
 }
 
 func (f *credentialFinder) MTLSAuths(ctx context.Context) ([]*domain.Auth, error) {

--- a/pkg/app/auth/mocks/auth_credential_finder_mock.go
+++ b/pkg/app/auth/mocks/auth_credential_finder_mock.go
@@ -6,6 +6,7 @@ import (
 	context "context"
 
 	auth "github.com/NeuralTrust/AgentGateway/pkg/domain/auth"
+	ids "github.com/NeuralTrust/AgentGateway/pkg/domain/ids"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -108,6 +109,65 @@ func (_m *CredentialFinder) OAuth2Auths(ctx context.Context) ([]*auth.Auth, erro
 	}
 
 	return r0, r1
+}
+
+// OAuth2AuthsForGateway provides a mock function with given fields: ctx, gatewayID
+func (_m *CredentialFinder) OAuth2AuthsForGateway(ctx context.Context, gatewayID ids.GatewayID) ([]*auth.Auth, error) {
+	ret := _m.Called(ctx, gatewayID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for OAuth2AuthsForGateway")
+	}
+
+	var r0 []*auth.Auth
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, ids.GatewayID) ([]*auth.Auth, error)); ok {
+		return rf(ctx, gatewayID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, ids.GatewayID) []*auth.Auth); ok {
+		r0 = rf(ctx, gatewayID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*auth.Auth)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, ids.GatewayID) error); ok {
+		r1 = rf(ctx, gatewayID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// CredentialFinder_OAuth2AuthsForGateway_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'OAuth2AuthsForGateway'
+type CredentialFinder_OAuth2AuthsForGateway_Call struct {
+	*mock.Call
+}
+
+// OAuth2AuthsForGateway is a helper method to define mock.On call
+//   - ctx context.Context
+//   - gatewayID ids.GatewayID
+func (_e *CredentialFinder_Expecter) OAuth2AuthsForGateway(ctx interface{}, gatewayID interface{}) *CredentialFinder_OAuth2AuthsForGateway_Call {
+	return &CredentialFinder_OAuth2AuthsForGateway_Call{Call: _e.mock.On("OAuth2AuthsForGateway", ctx, gatewayID)}
+}
+
+func (_c *CredentialFinder_OAuth2AuthsForGateway_Call) Run(run func(ctx context.Context, gatewayID ids.GatewayID)) *CredentialFinder_OAuth2AuthsForGateway_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(ids.GatewayID))
+	})
+	return _c
+}
+
+func (_c *CredentialFinder_OAuth2AuthsForGateway_Call) Return(_a0 []*auth.Auth, _a1 error) *CredentialFinder_OAuth2AuthsForGateway_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *CredentialFinder_OAuth2AuthsForGateway_Call) RunAndReturn(run func(context.Context, ids.GatewayID) ([]*auth.Auth, error)) *CredentialFinder_OAuth2AuthsForGateway_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // CredentialFinder_OAuth2Auths_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'OAuth2Auths'

--- a/pkg/app/consumer/associator.go
+++ b/pkg/app/consumer/associator.go
@@ -145,13 +145,40 @@ func (a *associator) AttachAuth(ctx context.Context, gatewayID ids.GatewayID, co
 	if err != nil {
 		return err
 	}
-	if err := a.authInGateway(ctx, gatewayID, authID); err != nil {
+	au, err := a.authInGateway(ctx, gatewayID, authID)
+	if err != nil {
 		return err
+	}
+	if cons.RoutingMode == domain.RoutingModeRoleBased {
+		if err := validateRoleBasedAuth(cons, au); err != nil {
+			return err
+		}
 	}
 	if err := a.repo.AttachAuth(ctx, consumerID, authID); err != nil {
 		return err
 	}
 	a.invalidate(ctx, cons)
+	return nil
+}
+
+// validateRoleBasedAuth enforces that a role_based consumer is backed by exactly
+// one identity-provider credential: the IdP whose token claims map to the
+// consumer's roles. Re-attaching the already-linked auth stays idempotent.
+func validateRoleBasedAuth(cons *domain.Consumer, au *authdomain.Auth) error {
+	if !au.Type.IsIdentityProvider() {
+		return fmt.Errorf(
+			"%w: a role_based consumer requires an identity-provider auth (oauth2 or idp), got %q",
+			commonerrors.ErrConflict, au.Type,
+		)
+	}
+	for _, existing := range cons.AuthIDs {
+		if existing != au.ID {
+			return fmt.Errorf(
+				"%w: a role_based consumer can have at most one auth",
+				commonerrors.ErrConflict,
+			)
+		}
+	}
 	return nil
 }
 
@@ -229,15 +256,15 @@ func (a *associator) roleInGateway(ctx context.Context, gatewayID ids.GatewayID,
 	return nil
 }
 
-func (a *associator) authInGateway(ctx context.Context, gatewayID ids.GatewayID, authID ids.AuthID) error {
+func (a *associator) authInGateway(ctx context.Context, gatewayID ids.GatewayID, authID ids.AuthID) (*authdomain.Auth, error) {
 	au, err := a.authRepo.FindByID(ctx, authID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if au.GatewayID != gatewayID {
-		return authdomain.ErrNotFound
+		return nil, authdomain.ErrNotFound
 	}
-	return nil
+	return au, nil
 }
 
 func (a *associator) policyInGateway(ctx context.Context, gatewayID ids.GatewayID, policyID ids.PolicyID) error {

--- a/pkg/app/consumer/associator_test.go
+++ b/pkg/app/consumer/associator_test.go
@@ -245,6 +245,101 @@ func TestAssociator_AttachAuth_Success(t *testing.T) {
 	}
 }
 
+func TestAssociator_AttachAuth_RoleBasedAcceptsIdP(t *testing.T) {
+	t.Parallel()
+	gwID := ids.New[ids.GatewayKind]()
+	consumerID := ids.New[ids.ConsumerKind]()
+	authID := ids.New[ids.AuthKind]()
+
+	repo := repomocks.NewRepository(t)
+	repo.EXPECT().FindByID(mock.Anything, consumerID).
+		Return(&domain.Consumer{ID: consumerID, GatewayID: gwID, RoutingMode: domain.RoutingModeRoleBased}, nil).Once()
+	repo.EXPECT().AttachAuth(mock.Anything, consumerID, authID).Return(nil).Once()
+
+	authRepo := authmocks.NewRepository(t)
+	authRepo.EXPECT().FindByID(mock.Anything, authID).
+		Return(&authdomain.Auth{ID: authID, GatewayID: gwID, Type: authdomain.TypeOAuth2}, nil).Once()
+
+	a := newAssociator(repo, backendmocks.NewRepository(t), authRepo, policymocks.NewRepository(t))
+	if err := a.AttachAuth(context.Background(), gwID, consumerID, authID); err != nil {
+		t.Fatalf("AttachAuth error: %v", err)
+	}
+}
+
+func TestAssociator_AttachAuth_RoleBasedRejectsNonIdP(t *testing.T) {
+	t.Parallel()
+	gwID := ids.New[ids.GatewayKind]()
+	consumerID := ids.New[ids.ConsumerKind]()
+	authID := ids.New[ids.AuthKind]()
+
+	repo := repomocks.NewRepository(t)
+	repo.EXPECT().FindByID(mock.Anything, consumerID).
+		Return(&domain.Consumer{ID: consumerID, GatewayID: gwID, RoutingMode: domain.RoutingModeRoleBased}, nil).Once()
+
+	authRepo := authmocks.NewRepository(t)
+	authRepo.EXPECT().FindByID(mock.Anything, authID).
+		Return(&authdomain.Auth{ID: authID, GatewayID: gwID, Type: authdomain.TypeAPIKey}, nil).Once()
+
+	a := newAssociator(repo, backendmocks.NewRepository(t), authRepo, policymocks.NewRepository(t))
+	err := a.AttachAuth(context.Background(), gwID, consumerID, authID)
+	if !errors.Is(err, commonerrors.ErrConflict) {
+		t.Fatalf("err = %v, want ErrConflict", err)
+	}
+}
+
+func TestAssociator_AttachAuth_RoleBasedRejectsSecondAuth(t *testing.T) {
+	t.Parallel()
+	gwID := ids.New[ids.GatewayKind]()
+	consumerID := ids.New[ids.ConsumerKind]()
+	existingAuthID := ids.New[ids.AuthKind]()
+	authID := ids.New[ids.AuthKind]()
+
+	repo := repomocks.NewRepository(t)
+	repo.EXPECT().FindByID(mock.Anything, consumerID).
+		Return(&domain.Consumer{
+			ID:          consumerID,
+			GatewayID:   gwID,
+			RoutingMode: domain.RoutingModeRoleBased,
+			AuthIDs:     []ids.AuthID{existingAuthID},
+		}, nil).Once()
+
+	authRepo := authmocks.NewRepository(t)
+	authRepo.EXPECT().FindByID(mock.Anything, authID).
+		Return(&authdomain.Auth{ID: authID, GatewayID: gwID, Type: authdomain.TypeOAuth2}, nil).Once()
+
+	a := newAssociator(repo, backendmocks.NewRepository(t), authRepo, policymocks.NewRepository(t))
+	err := a.AttachAuth(context.Background(), gwID, consumerID, authID)
+	if !errors.Is(err, commonerrors.ErrConflict) {
+		t.Fatalf("err = %v, want ErrConflict", err)
+	}
+}
+
+func TestAssociator_AttachAuth_RoleBasedReattachIsIdempotent(t *testing.T) {
+	t.Parallel()
+	gwID := ids.New[ids.GatewayKind]()
+	consumerID := ids.New[ids.ConsumerKind]()
+	authID := ids.New[ids.AuthKind]()
+
+	repo := repomocks.NewRepository(t)
+	repo.EXPECT().FindByID(mock.Anything, consumerID).
+		Return(&domain.Consumer{
+			ID:          consumerID,
+			GatewayID:   gwID,
+			RoutingMode: domain.RoutingModeRoleBased,
+			AuthIDs:     []ids.AuthID{authID},
+		}, nil).Once()
+	repo.EXPECT().AttachAuth(mock.Anything, consumerID, authID).Return(nil).Once()
+
+	authRepo := authmocks.NewRepository(t)
+	authRepo.EXPECT().FindByID(mock.Anything, authID).
+		Return(&authdomain.Auth{ID: authID, GatewayID: gwID, Type: authdomain.TypeIDP}, nil).Once()
+
+	a := newAssociator(repo, backendmocks.NewRepository(t), authRepo, policymocks.NewRepository(t))
+	if err := a.AttachAuth(context.Background(), gwID, consumerID, authID); err != nil {
+		t.Fatalf("AttachAuth error: %v", err)
+	}
+}
+
 func TestAssociator_DetachPolicy_Success(t *testing.T) {
 	t.Parallel()
 	gwID := ids.New[ids.GatewayKind]()

--- a/pkg/app/identity/sts/exchanger_test.go
+++ b/pkg/app/identity/sts/exchanger_test.go
@@ -25,6 +25,7 @@ import (
 
 	authdomain "github.com/NeuralTrust/AgentGateway/pkg/domain/auth"
 	"github.com/NeuralTrust/AgentGateway/pkg/domain/identity"
+	"github.com/NeuralTrust/AgentGateway/pkg/domain/ids"
 	registrydomain "github.com/NeuralTrust/AgentGateway/pkg/domain/registry"
 	"github.com/golang-jwt/jwt/v5"
 )
@@ -35,6 +36,16 @@ type stubCredentials struct {
 
 func (s *stubCredentials) OAuth2Auths(context.Context) ([]*authdomain.Auth, error) {
 	return s.auths, nil
+}
+
+func (s *stubCredentials) OAuth2AuthsForGateway(_ context.Context, gatewayID ids.GatewayID) ([]*authdomain.Auth, error) {
+	out := make([]*authdomain.Auth, 0, len(s.auths))
+	for _, a := range s.auths {
+		if a.GatewayID == gatewayID {
+			out = append(out, a)
+		}
+	}
+	return out, nil
 }
 
 func (s *stubCredentials) MTLSAuths(context.Context) ([]*authdomain.Auth, error) { return nil, nil }

--- a/pkg/app/oauth/metadata_test.go
+++ b/pkg/app/oauth/metadata_test.go
@@ -22,6 +22,7 @@ import (
 
 	appconsumer "github.com/NeuralTrust/AgentGateway/pkg/app/consumer"
 	authdomain "github.com/NeuralTrust/AgentGateway/pkg/domain/auth"
+	"github.com/NeuralTrust/AgentGateway/pkg/domain/ids"
 )
 
 type fakeCredentialFinder struct {
@@ -31,6 +32,19 @@ type fakeCredentialFinder struct {
 
 func (f *fakeCredentialFinder) OAuth2Auths(context.Context) ([]*authdomain.Auth, error) {
 	return f.oauth2, f.err
+}
+
+func (f *fakeCredentialFinder) OAuth2AuthsForGateway(_ context.Context, gatewayID ids.GatewayID) ([]*authdomain.Auth, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	out := make([]*authdomain.Auth, 0, len(f.oauth2))
+	for _, a := range f.oauth2 {
+		if a.GatewayID == gatewayID {
+			out = append(out, a)
+		}
+	}
+	return out, nil
 }
 
 func (f *fakeCredentialFinder) MTLSAuths(context.Context) ([]*authdomain.Auth, error) {

--- a/pkg/app/oauth/proxy_auth_selection.go
+++ b/pkg/app/oauth/proxy_auth_selection.go
@@ -22,11 +22,24 @@ import (
 	"net/url"
 
 	authdomain "github.com/NeuralTrust/AgentGateway/pkg/domain/auth"
+	"github.com/NeuralTrust/AgentGateway/pkg/domain/ids"
 )
 
 func (p *authProxy) authForResource(ctx context.Context, resource string) (*authdomain.Auth, error) {
-	if a := p.resourceAuth(ctx, resource); a != nil {
-		return a, nil
+	auth, gatewayID, matched := p.resourceAuth(ctx, resource)
+	if auth != nil {
+		return auth, nil
+	}
+	// The resource pinned a consumer but it has no OAuth2 identity provider of
+	// its own: fall back to the single IdP configured on that consumer's
+	// gateway instead of scanning every tenant on the platform.
+	if matched {
+		a, err := p.singleOAuth2AuthForGateway(ctx, gatewayID)
+		if errors.Is(err, ErrAmbiguousAuthorizationServer) {
+			return nil, oauthErr("invalid_target",
+				"multiple identity providers configured for this gateway; attach a single oauth2 identity provider to the MCP consumer")
+		}
+		return a, err
 	}
 	a, err := p.singleOAuth2Auth(ctx)
 	if errors.Is(err, ErrAmbiguousAuthorizationServer) {
@@ -36,28 +49,35 @@ func (p *authProxy) authForResource(ctx context.Context, resource string) (*auth
 	return a, err
 }
 
-func (p *authProxy) resourceAuth(ctx context.Context, resource string) *authdomain.Auth {
+// resourceAuth resolves the RFC 8707 resource indicator to the OAuth2 auth
+// attached to the addressed consumer. When the consumer is found but exposes no
+// usable OAuth2 auth, it still reports the consumer's gateway so the caller can
+// scope the identity-provider fallback to that tenant.
+func (p *authProxy) resourceAuth(ctx context.Context, resource string) (*authdomain.Auth, ids.GatewayID, bool) {
 	if p.paths == nil || resource == "" {
-		return nil
+		return nil, ids.GatewayID{}, false
 	}
 	u, err := url.Parse(resource)
 	if err != nil || u.Path == "" {
-		return nil
+		return nil, ids.GatewayID{}, false
 	}
 	matches, err := p.paths.Match(ctx, u.Host, u.Path)
 	if err != nil {
 		slog.Warn("oauth: resource lookup failed; falling back to single-issuer selection",
 			"resource", resource, "error", err)
-		return nil
+		return nil, ids.GatewayID{}, false
 	}
 	for _, m := range matches {
 		for _, a := range m.Auths {
 			if a.Enabled && a.Type == authdomain.TypeOAuth2 && a.Config.OAuth2 != nil {
-				return a
+				return a, m.GatewayID, true
 			}
 		}
 	}
-	return nil
+	if len(matches) > 0 {
+		return nil, matches[0].GatewayID, true
+	}
+	return nil, ids.GatewayID{}, false
 }
 
 func (p *authProxy) pendingAuth(ctx context.Context, pending *PendingAuthorization) (*authdomain.Auth, error) {
@@ -75,7 +95,6 @@ func (p *authProxy) pendingAuth(ctx context.Context, pending *PendingAuthorizati
 	}
 	return p.authForResource(ctx, pending.Resource)
 }
-
 
 func (p *authProxy) validateClientRedirect(ctx context.Context, clientID, redirectURI string) error {
 	if clientID != "" && p.store != nil {
@@ -128,6 +147,18 @@ func (p *authProxy) singleOAuth2Auth(ctx context.Context) (*authdomain.Auth, err
 	if err != nil {
 		return nil, fmt.Errorf("oauth: load oauth2 auths: %w", err)
 	}
+	return pickSingleOAuth2(auths)
+}
+
+func (p *authProxy) singleOAuth2AuthForGateway(ctx context.Context, gatewayID ids.GatewayID) (*authdomain.Auth, error) {
+	auths, err := p.credentials.OAuth2AuthsForGateway(ctx, gatewayID)
+	if err != nil {
+		return nil, fmt.Errorf("oauth: load oauth2 auths for gateway: %w", err)
+	}
+	return pickSingleOAuth2(auths)
+}
+
+func pickSingleOAuth2(auths []*authdomain.Auth) (*authdomain.Auth, error) {
 	issuers := issuersOf(auths)
 	if len(issuers) == 0 {
 		return nil, ErrNoAuthorizationServer

--- a/pkg/app/oauth/proxy_test.go
+++ b/pkg/app/oauth/proxy_test.go
@@ -461,6 +461,79 @@ func TestResourceScopedFacadeSelectsIdPPerTenant(t *testing.T) {
 	}
 }
 
+// When the resource pins a consumer that has no OAuth2 auth of its own, the
+// fallback is scoped to that consumer's gateway: a different tenant's IdP must
+// not turn the lookup ambiguous.
+func TestAuthorizeResourceFallsBackToGatewayScopedIdP(t *testing.T) {
+	t.Parallel()
+	idpGateway, _ := fakeIdP(t)
+	idpOtherTenant, capturedOther := fakeIdP(t)
+	gatewayID := ids.New[ids.GatewayKind]()
+
+	gatewayAuth := enabledOAuth2Auth(t, authdomain.OAuth2Config{Issuer: idpGateway.URL, ClientID: "client-gw"})
+	gatewayAuth.GatewayID = gatewayID
+	otherTenantAuth := enabledOAuth2Auth(t, authdomain.OAuth2Config{Issuer: idpOtherTenant.URL, ClientID: "client-other"})
+
+	finder := &fakeCredentialFinder{oauth2: []*authdomain.Auth{gatewayAuth, otherTenantAuth}}
+	paths := &fakePathResolver{byPath: map[string][]appconsumer.PathMatch{
+		"/cons/mcp": {{GatewayID: gatewayID, Auths: nil}},
+	}}
+	proxy := NewAuthProxy(finder, paths, http.DefaultClient, newMemFlowStore(), nil)
+
+	location, err := proxy.Authorize(context.Background(), "http://gw.example.com", AuthorizeRequest{
+		ResponseType:        "code",
+		ClientID:            "client-gw",
+		RedirectURI:         "cursor://anysphere.cursor-mcp/oauth/callback",
+		CodeChallenge:       s256("v"),
+		CodeChallengeMethod: "S256",
+		Resource:            "http://gw.example.com/cons/mcp",
+	})
+	if err != nil {
+		t.Fatalf("authorize must resolve the gateway's single IdP, got %v", err)
+	}
+	loc, err := url.Parse(location)
+	if err != nil {
+		t.Fatalf("parse redirect: %v", err)
+	}
+	if got := loc.Scheme + "://" + loc.Host; got != idpGateway.URL {
+		t.Fatalf("authorize must redirect to the gateway IdP, got %s (want %s)", got, idpGateway.URL)
+	}
+	if len(*capturedOther) != 0 {
+		t.Fatalf("another tenant's IdP must never be contacted, got %v", *capturedOther)
+	}
+}
+
+// A consumer without its own OAuth2 auth on a gateway that hosts several IdPs
+// is genuinely ambiguous: the client gets invalid_target, not a cross-tenant
+// leak.
+func TestAuthorizeResourceAmbiguousWithinGateway(t *testing.T) {
+	t.Parallel()
+	gatewayID := ids.New[ids.GatewayKind]()
+	authA := enabledOAuth2Auth(t, authdomain.OAuth2Config{Issuer: "https://idp-a.example.com", ClientID: "client-a"})
+	authA.GatewayID = gatewayID
+	authB := enabledOAuth2Auth(t, authdomain.OAuth2Config{Issuer: "https://idp-b.example.com", ClientID: "client-b"})
+	authB.GatewayID = gatewayID
+
+	finder := &fakeCredentialFinder{oauth2: []*authdomain.Auth{authA, authB}}
+	paths := &fakePathResolver{byPath: map[string][]appconsumer.PathMatch{
+		"/cons/mcp": {{GatewayID: gatewayID, Auths: nil}},
+	}}
+	proxy := NewAuthProxy(finder, paths, http.DefaultClient, newMemFlowStore(), nil)
+
+	_, err := proxy.Authorize(context.Background(), "http://gw.example.com", AuthorizeRequest{
+		ResponseType:        "code",
+		ClientID:            "client-a",
+		RedirectURI:         "cursor://cb",
+		CodeChallenge:       s256("v"),
+		CodeChallengeMethod: "S256",
+		Resource:            "http://gw.example.com/cons/mcp",
+	})
+	var oe *OAuthError
+	if !errors.As(err, &oe) || oe.Code != "invalid_target" {
+		t.Fatalf("expected invalid_target within an ambiguous gateway, got %v", err)
+	}
+}
+
 // Multiple IdPs without a resource indicator cannot be disambiguated: the
 // client gets a structured invalid_target error.
 func TestAuthorizeMultiIssuerRequiresResource(t *testing.T) {

--- a/pkg/domain/auth/auth.go
+++ b/pkg/domain/auth/auth.go
@@ -51,6 +51,14 @@ func IsValidType(t Type) bool {
 	return false
 }
 
+func (t Type) IsIdentityProvider() bool {
+	switch t {
+	case TypeOAuth2, TypeIDP:
+		return true
+	}
+	return false
+}
+
 type Auth struct {
 	ID        ids.AuthID    `json:"id"`
 	GatewayID ids.GatewayID `json:"gateway_id"`

--- a/pkg/domain/consumer/consumer.go
+++ b/pkg/domain/consumer/consumer.go
@@ -284,6 +284,9 @@ func (c *Consumer) validateRoleBased() error {
 	if c.MCP != nil {
 		return fmt.Errorf("%w: mcp policy is only valid in inline mode", ErrInvalidRoutingMode)
 	}
+	if len(c.AuthIDs) > 1 {
+		return fmt.Errorf("%w: a role_based consumer can have at most one auth", ErrInvalidRoutingMode)
+	}
 	if err := validateUniqueIDs(c.RoleIDs, ErrInvalidRoutingMode, "role"); err != nil {
 		return err
 	}

--- a/tests/functional/mcp_e2e_test.go
+++ b/tests/functional/mcp_e2e_test.go
@@ -602,15 +602,16 @@ func TestMCPServer_RoleBasedConsumerRejectsIdentityWithoutMatchingRole(t *testin
 	status, body := mcpRPC(t, gatewayID, consumerID, bearerHeaders(denied), "tools/list", nil)
 	require.Equal(t, http.StatusForbidden, status, "identity without a matching role must be rejected: %v", body)
 
-	apiKeyAuthID, key := CreateAPIKeyAuth(t, gatewayID, uniqueName("mcp-key"))
-	AttachAuth(t, gatewayID, consumerID, apiKeyAuthID)
-	// The freshly attached API key only reaches the MCP process after the admin
-	// plane's cache-invalidation event propagates across processes via Redis, so
-	// poll until the role_based consumer rejects the claimless credential.
-	require.Eventually(t, func() bool {
-		s, _ := mcpRPC(t, gatewayID, consumerID, apiKeyHeaders(key), "tools/list", nil)
-		return s == http.StatusForbidden
-	}, 5*time.Second, 100*time.Millisecond, "claimless credentials cannot satisfy role_based consumers")
+	// A role_based consumer is backed by a single identity-provider auth, so a
+	// claimless API key cannot be attached in the first place: the association is
+	// rejected before any request can reach the MCP process.
+	apiKeyAuthID, _ := CreateAPIKeyAuth(t, gatewayID, uniqueName("mcp-key"))
+	status, body = sendRequest(t, http.MethodPost,
+		fmt.Sprintf("%s/v1/gateways/%s/consumers/%s/auths/%s", AdminURL, gatewayID, consumerID, apiKeyAuthID),
+		nil, nil,
+	)
+	require.Equal(t, http.StatusConflict, status,
+		"a role_based consumer must reject a non-IdP auth at attach time: %v", body)
 }
 
 func TestMCPServer_RoleBasedConsumerMergesMultipleRoles(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes the misleading `invalid_target` returned by `/oauth/authorize` for MCP consumers, and tightens `role_based` consumer auth configuration.

- **Per-gateway IdP fallback.** The OAuth authorize fallback scanned *every* enabled OAuth2 credential on the whole platform. When a request carried an RFC 8707 `resource` indicator that pinned a consumer with no OAuth2 auth of its own, the global scan surfaced *other tenants'* identity providers and failed with `invalid_target` ("multiple identity providers configured"). The fallback is now scoped to the addressed consumer's gateway via a new `CredentialFinder.OAuth2AuthsForGateway` (backed by the existing `ListEnabledByGatewayAndType`), so it can never leak across tenants. Results are cached per gateway (`enabled:oauth2:gw:<id>`) and the existing `InvalidateGatewayDataEvent` already clears the whole auth cache, so an attach/detach drops these entries on every process.
- **`role_based` consumer validations.** A `role_based` consumer must be backed by exactly one identity-provider auth. `AttachAuth` now rejects (409 Conflict):
  1. attaching an auth whose type is not an IdP (`oauth2` or `idp`), and
  2. attaching a second auth when one is already linked (re-attaching the same auth stays idempotent).
  The domain also enforces the "at most one auth" invariant for `role_based` (covers create and routing-mode switch on update).

## Changes

- `pkg/domain/auth/auth.go`: `Type.IsIdentityProvider()` (oauth2/idp).
- `pkg/domain/consumer/consumer.go`: role_based ≤ 1 auth invariant.
- `pkg/app/consumer/associator.go`: validate IdP type + single auth on `AttachAuth`.
- `pkg/app/auth/credential_finder.go` (+ mock): `OAuth2AuthsForGateway` with per-gateway cache.
- `pkg/app/oauth/proxy_auth_selection.go`: resource match returns gateway id; gateway-scoped fallback; shared `pickSingleOAuth2`.
- Tests: unit tests for the validations and the gateway-scoped fallback; functional `mcp_e2e` test adapted (attaching a non-IdP auth to a role_based consumer now returns 409).

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/app/oauth/... ./pkg/app/auth/... ./pkg/app/consumer/... ./pkg/api/middleware/... ./pkg/api/handler/http/oauth/... ./pkg/domain/...`
- [x] `go vet -tags functional ./tests/functional/...` (compile)
- [x] pre-commit `golangci-lint`
- [ ] Functional suite (`tests/functional`) against Postgres+Redis in CI

Made with [Cursor](https://cursor.com)