### PR TITLE
docs(playground): document trace endpoint in swagger and postman

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,8 @@ linters:
       - vendor
       - ".*\\.pb\\.go$"
       - ".*_gen\\.go$"
+      - ".*_mock\\.go$"
+      - ".*/mocks/.*"
     rules:
       - linters:
           - errcheck

--- a/docs/AgentGateway.postman_collection.json
+++ b/docs/AgentGateway.postman_collection.json
@@ -27,6 +27,11 @@
       "type": "string"
     },
     {
+      "key": "trace_id",
+      "value": "",
+      "type": "string"
+    },
+    {
       "key": "admin_token",
       "value": "",
       "type": "string"
@@ -382,6 +387,31 @@
                 "version"
               ]
             }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Playground",
+      "item": [
+        {
+          "name": "Get Playground Trace",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/v1/playground/traces/{{trace_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "v1",
+                "playground",
+                "traces",
+                "{{trace_id}}"
+              ]
+            },
+            "description": "Fetch the metrics Event stored for a playground request, keyed by the X-AG-Trace-Id header returned in the proxy response. Requires an admin Bearer token. Traces expire after a short TTL (default 10m)."
           }
         }
       ]

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -3050,6 +3050,58 @@ const docTemplate = `{
                 }
             }
         },
+        "/v1/playground/traces/{trace_id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the metrics Event captured for a playground request, keyed by the X-AG-Trace-Id returned in the proxy response. Traces expire after a short TTL.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "playground"
+                ],
+                "summary": "Get a playground trace",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Trace id (X-AG-Trace-Id from the proxy response)",
+                        "name": "trace_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Event"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_helpers.ErrorBody"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_helpers.ErrorBody"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_helpers.ErrorBody"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/policies-catalog": {
             "get": {
                 "security": [
@@ -5865,6 +5917,318 @@ const docTemplate = `{
                     "additionalProperties": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Attempt": {
+            "type": "object",
+            "properties": {
+                "attempt": {
+                    "type": "integer"
+                },
+                "fallback": {
+                    "type": "boolean"
+                },
+                "latency_ms": {
+                    "type": "integer"
+                },
+                "outcome": {
+                    "type": "string"
+                },
+                "pinned": {
+                    "type": "boolean"
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "registry_id": {
+                    "type": "string"
+                },
+                "route": {
+                    "type": "string"
+                },
+                "status_code": {
+                    "type": "integer"
+                }
+            }
+        },
+        "github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Consumer": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Cost": {
+            "type": "object",
+            "properties": {
+                "completion_usd": {
+                    "type": "number"
+                },
+                "currency": {
+                    "type": "string"
+                },
+                "prompt_usd": {
+                    "type": "number"
+                },
+                "total_usd": {
+                    "type": "number"
+                }
+            }
+        },
+        "github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Event": {
+            "type": "object",
+            "properties": {
+                "attempts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Attempt"
+                    }
+                },
+                "consumer": {
+                    "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Consumer"
+                },
+                "cost": {
+                    "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Cost"
+                },
+                "end_timestamp": {
+                    "type": "integer"
+                },
+                "fingerprint_id": {
+                    "type": "string"
+                },
+                "gateway_id": {
+                    "type": "string"
+                },
+                "ip": {
+                    "type": "string"
+                },
+                "is_flagged": {
+                    "type": "boolean"
+                },
+                "latency": {
+                    "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Latency"
+                },
+                "occurred_on": {
+                    "type": "integer"
+                },
+                "policy_chain": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.PolicyEntry"
+                    }
+                },
+                "request": {
+                    "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Request"
+                },
+                "response": {
+                    "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Response"
+                },
+                "schema_version": {
+                    "type": "integer"
+                },
+                "security": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "session_id": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Status"
+                },
+                "team_id": {
+                    "type": "string"
+                },
+                "timestamp": {
+                    "type": "string"
+                },
+                "trace_id": {
+                    "type": "string"
+                },
+                "turn_id": {
+                    "type": "string"
+                },
+                "usage": {
+                    "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Usage"
+                }
+            }
+        },
+        "github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Latency": {
+            "type": "object",
+            "properties": {
+                "gateway_ms": {
+                    "type": "integer"
+                },
+                "policies_ms": {
+                    "type": "integer"
+                },
+                "provider_ms": {
+                    "type": "integer"
+                },
+                "routing_ms": {
+                    "type": "integer"
+                },
+                "total_ms": {
+                    "type": "integer"
+                }
+            }
+        },
+        "github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.PolicyEntry": {
+            "type": "object",
+            "properties": {
+                "decision": {
+                    "type": "string"
+                },
+                "error": {
+                    "type": "boolean"
+                },
+                "extras": {},
+                "flagged": {
+                    "type": "boolean"
+                },
+                "latency_ms": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "score": {
+                    "type": "number"
+                },
+                "score_label": {
+                    "type": "string"
+                },
+                "stage": {
+                    "type": "string"
+                },
+                "status_code": {
+                    "type": "integer"
+                }
+            }
+        },
+        "github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Request": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "string"
+                },
+                "headers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "max_tokens": {
+                    "type": "integer"
+                },
+                "method": {
+                    "type": "string"
+                },
+                "model": {
+                    "type": "string"
+                },
+                "model_label": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "prompt_tokens": {
+                    "type": "integer"
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "registry_id": {
+                    "type": "string"
+                },
+                "requested_model": {
+                    "type": "string"
+                },
+                "stream": {
+                    "type": "boolean"
+                },
+                "temperature": {
+                    "type": "number"
+                }
+            }
+        },
+        "github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Response": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "string"
+                },
+                "completion_tokens": {
+                    "type": "integer"
+                },
+                "finish_reason": {
+                    "type": "string"
+                },
+                "headers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "latency_ms": {
+                    "type": "integer"
+                },
+                "status_code": {
+                    "type": "integer"
+                },
+                "streaming": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Status": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "integer"
+                },
+                "is_timeout": {
+                    "type": "boolean"
+                },
+                "outcome": {
+                    "type": "string"
+                },
+                "reason": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Usage": {
+            "type": "object",
+            "properties": {
+                "cached_input_tokens": {
+                    "type": "integer"
+                },
+                "completion_tokens": {
+                    "type": "integer"
+                },
+                "prompt_tokens": {
+                    "type": "integer"
+                },
+                "reasoning_output_tokens": {
+                    "type": "integer"
+                },
+                "total_tokens": {
+                    "type": "integer"
                 }
             }
         },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3805,6 +3805,73 @@
                 }
             }
         },
+        "/v1/playground/traces/{trace_id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the metrics Event captured for a playground request, keyed by the X-AG-Trace-Id returned in the proxy response. Traces expire after a short TTL.",
+                "tags": [
+                    "playground"
+                ],
+                "summary": "Get a playground trace",
+                "parameters": [
+                    {
+                        "description": "Trace id (X-AG-Trace-Id from the proxy response)",
+                        "name": "trace_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Event"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_helpers.ErrorBody"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_helpers.ErrorBody"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_helpers.ErrorBody"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/v1/policies-catalog": {
             "get": {
                 "security": [
@@ -6671,6 +6738,318 @@
                         "additionalProperties": {
                             "type": "string"
                         }
+                    }
+                }
+            },
+            "github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Attempt": {
+                "type": "object",
+                "properties": {
+                    "attempt": {
+                        "type": "integer"
+                    },
+                    "fallback": {
+                        "type": "boolean"
+                    },
+                    "latency_ms": {
+                        "type": "integer"
+                    },
+                    "outcome": {
+                        "type": "string"
+                    },
+                    "pinned": {
+                        "type": "boolean"
+                    },
+                    "provider": {
+                        "type": "string"
+                    },
+                    "registry_id": {
+                        "type": "string"
+                    },
+                    "route": {
+                        "type": "string"
+                    },
+                    "status_code": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Consumer": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                }
+            },
+            "github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Cost": {
+                "type": "object",
+                "properties": {
+                    "completion_usd": {
+                        "type": "number"
+                    },
+                    "currency": {
+                        "type": "string"
+                    },
+                    "prompt_usd": {
+                        "type": "number"
+                    },
+                    "total_usd": {
+                        "type": "number"
+                    }
+                }
+            },
+            "github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Event": {
+                "type": "object",
+                "properties": {
+                    "attempts": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Attempt"
+                        }
+                    },
+                    "consumer": {
+                        "$ref": "#/components/schemas/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Consumer"
+                    },
+                    "cost": {
+                        "$ref": "#/components/schemas/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Cost"
+                    },
+                    "end_timestamp": {
+                        "type": "integer"
+                    },
+                    "fingerprint_id": {
+                        "type": "string"
+                    },
+                    "gateway_id": {
+                        "type": "string"
+                    },
+                    "ip": {
+                        "type": "string"
+                    },
+                    "is_flagged": {
+                        "type": "boolean"
+                    },
+                    "latency": {
+                        "$ref": "#/components/schemas/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Latency"
+                    },
+                    "occurred_on": {
+                        "type": "integer"
+                    },
+                    "policy_chain": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.PolicyEntry"
+                        }
+                    },
+                    "request": {
+                        "$ref": "#/components/schemas/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Request"
+                    },
+                    "response": {
+                        "$ref": "#/components/schemas/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Response"
+                    },
+                    "schema_version": {
+                        "type": "integer"
+                    },
+                    "security": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "session_id": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "$ref": "#/components/schemas/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Status"
+                    },
+                    "team_id": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string"
+                    },
+                    "trace_id": {
+                        "type": "string"
+                    },
+                    "turn_id": {
+                        "type": "string"
+                    },
+                    "usage": {
+                        "$ref": "#/components/schemas/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Usage"
+                    }
+                }
+            },
+            "github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Latency": {
+                "type": "object",
+                "properties": {
+                    "gateway_ms": {
+                        "type": "integer"
+                    },
+                    "policies_ms": {
+                        "type": "integer"
+                    },
+                    "provider_ms": {
+                        "type": "integer"
+                    },
+                    "routing_ms": {
+                        "type": "integer"
+                    },
+                    "total_ms": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.PolicyEntry": {
+                "type": "object",
+                "properties": {
+                    "decision": {
+                        "type": "string"
+                    },
+                    "error": {
+                        "type": "boolean"
+                    },
+                    "extras": {},
+                    "flagged": {
+                        "type": "boolean"
+                    },
+                    "latency_ms": {
+                        "type": "integer"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "score": {
+                        "type": "number"
+                    },
+                    "score_label": {
+                        "type": "string"
+                    },
+                    "stage": {
+                        "type": "string"
+                    },
+                    "status_code": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Request": {
+                "type": "object",
+                "properties": {
+                    "body": {
+                        "type": "string"
+                    },
+                    "headers": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "max_tokens": {
+                        "type": "integer"
+                    },
+                    "method": {
+                        "type": "string"
+                    },
+                    "model": {
+                        "type": "string"
+                    },
+                    "model_label": {
+                        "type": "string"
+                    },
+                    "path": {
+                        "type": "string"
+                    },
+                    "prompt_tokens": {
+                        "type": "integer"
+                    },
+                    "provider": {
+                        "type": "string"
+                    },
+                    "registry_id": {
+                        "type": "string"
+                    },
+                    "requested_model": {
+                        "type": "string"
+                    },
+                    "stream": {
+                        "type": "boolean"
+                    },
+                    "temperature": {
+                        "type": "number"
+                    }
+                }
+            },
+            "github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Response": {
+                "type": "object",
+                "properties": {
+                    "body": {
+                        "type": "string"
+                    },
+                    "completion_tokens": {
+                        "type": "integer"
+                    },
+                    "finish_reason": {
+                        "type": "string"
+                    },
+                    "headers": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "latency_ms": {
+                        "type": "integer"
+                    },
+                    "status_code": {
+                        "type": "integer"
+                    },
+                    "streaming": {
+                        "type": "boolean"
+                    }
+                }
+            },
+            "github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Status": {
+                "type": "object",
+                "properties": {
+                    "code": {
+                        "type": "integer"
+                    },
+                    "is_timeout": {
+                        "type": "boolean"
+                    },
+                    "outcome": {
+                        "type": "string"
+                    },
+                    "reason": {
+                        "type": "string"
+                    }
+                }
+            },
+            "github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Usage": {
+                "type": "object",
+                "properties": {
+                    "cached_input_tokens": {
+                        "type": "integer"
+                    },
+                    "completion_tokens": {
+                        "type": "integer"
+                    },
+                    "prompt_tokens": {
+                        "type": "integer"
+                    },
+                    "reasoning_output_tokens": {
+                        "type": "integer"
+                    },
+                    "total_tokens": {
+                        "type": "integer"
                     }
                 }
             },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -3043,6 +3043,58 @@
                 }
             }
         },
+        "/v1/playground/traces/{trace_id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the metrics Event captured for a playground request, keyed by the X-AG-Trace-Id returned in the proxy response. Traces expire after a short TTL.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "playground"
+                ],
+                "summary": "Get a playground trace",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Trace id (X-AG-Trace-Id from the proxy response)",
+                        "name": "trace_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Event"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_helpers.ErrorBody"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_helpers.ErrorBody"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_helpers.ErrorBody"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/policies-catalog": {
             "get": {
                 "security": [
@@ -5858,6 +5910,318 @@
                     "additionalProperties": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Attempt": {
+            "type": "object",
+            "properties": {
+                "attempt": {
+                    "type": "integer"
+                },
+                "fallback": {
+                    "type": "boolean"
+                },
+                "latency_ms": {
+                    "type": "integer"
+                },
+                "outcome": {
+                    "type": "string"
+                },
+                "pinned": {
+                    "type": "boolean"
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "registry_id": {
+                    "type": "string"
+                },
+                "route": {
+                    "type": "string"
+                },
+                "status_code": {
+                    "type": "integer"
+                }
+            }
+        },
+        "github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Consumer": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Cost": {
+            "type": "object",
+            "properties": {
+                "completion_usd": {
+                    "type": "number"
+                },
+                "currency": {
+                    "type": "string"
+                },
+                "prompt_usd": {
+                    "type": "number"
+                },
+                "total_usd": {
+                    "type": "number"
+                }
+            }
+        },
+        "github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Event": {
+            "type": "object",
+            "properties": {
+                "attempts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Attempt"
+                    }
+                },
+                "consumer": {
+                    "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Consumer"
+                },
+                "cost": {
+                    "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Cost"
+                },
+                "end_timestamp": {
+                    "type": "integer"
+                },
+                "fingerprint_id": {
+                    "type": "string"
+                },
+                "gateway_id": {
+                    "type": "string"
+                },
+                "ip": {
+                    "type": "string"
+                },
+                "is_flagged": {
+                    "type": "boolean"
+                },
+                "latency": {
+                    "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Latency"
+                },
+                "occurred_on": {
+                    "type": "integer"
+                },
+                "policy_chain": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.PolicyEntry"
+                    }
+                },
+                "request": {
+                    "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Request"
+                },
+                "response": {
+                    "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Response"
+                },
+                "schema_version": {
+                    "type": "integer"
+                },
+                "security": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "session_id": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Status"
+                },
+                "team_id": {
+                    "type": "string"
+                },
+                "timestamp": {
+                    "type": "string"
+                },
+                "trace_id": {
+                    "type": "string"
+                },
+                "turn_id": {
+                    "type": "string"
+                },
+                "usage": {
+                    "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Usage"
+                }
+            }
+        },
+        "github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Latency": {
+            "type": "object",
+            "properties": {
+                "gateway_ms": {
+                    "type": "integer"
+                },
+                "policies_ms": {
+                    "type": "integer"
+                },
+                "provider_ms": {
+                    "type": "integer"
+                },
+                "routing_ms": {
+                    "type": "integer"
+                },
+                "total_ms": {
+                    "type": "integer"
+                }
+            }
+        },
+        "github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.PolicyEntry": {
+            "type": "object",
+            "properties": {
+                "decision": {
+                    "type": "string"
+                },
+                "error": {
+                    "type": "boolean"
+                },
+                "extras": {},
+                "flagged": {
+                    "type": "boolean"
+                },
+                "latency_ms": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "score": {
+                    "type": "number"
+                },
+                "score_label": {
+                    "type": "string"
+                },
+                "stage": {
+                    "type": "string"
+                },
+                "status_code": {
+                    "type": "integer"
+                }
+            }
+        },
+        "github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Request": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "string"
+                },
+                "headers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "max_tokens": {
+                    "type": "integer"
+                },
+                "method": {
+                    "type": "string"
+                },
+                "model": {
+                    "type": "string"
+                },
+                "model_label": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "prompt_tokens": {
+                    "type": "integer"
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "registry_id": {
+                    "type": "string"
+                },
+                "requested_model": {
+                    "type": "string"
+                },
+                "stream": {
+                    "type": "boolean"
+                },
+                "temperature": {
+                    "type": "number"
+                }
+            }
+        },
+        "github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Response": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "string"
+                },
+                "completion_tokens": {
+                    "type": "integer"
+                },
+                "finish_reason": {
+                    "type": "string"
+                },
+                "headers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "latency_ms": {
+                    "type": "integer"
+                },
+                "status_code": {
+                    "type": "integer"
+                },
+                "streaming": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Status": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "integer"
+                },
+                "is_timeout": {
+                    "type": "boolean"
+                },
+                "outcome": {
+                    "type": "string"
+                },
+                "reason": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Usage": {
+            "type": "object",
+            "properties": {
+                "cached_input_tokens": {
+                    "type": "integer"
+                },
+                "completion_tokens": {
+                    "type": "integer"
+                },
+                "prompt_tokens": {
+                    "type": "integer"
+                },
+                "reasoning_output_tokens": {
+                    "type": "integer"
+                },
+                "total_tokens": {
+                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1805,6 +1805,211 @@ definitions:
           type: string
         type: object
     type: object
+  github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Attempt:
+    properties:
+      attempt:
+        type: integer
+      fallback:
+        type: boolean
+      latency_ms:
+        type: integer
+      outcome:
+        type: string
+      pinned:
+        type: boolean
+      provider:
+        type: string
+      registry_id:
+        type: string
+      route:
+        type: string
+      status_code:
+        type: integer
+    type: object
+  github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Consumer:
+    properties:
+      id:
+        type: string
+      name:
+        type: string
+    type: object
+  github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Cost:
+    properties:
+      completion_usd:
+        type: number
+      currency:
+        type: string
+      prompt_usd:
+        type: number
+      total_usd:
+        type: number
+    type: object
+  github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Event:
+    properties:
+      attempts:
+        items:
+          $ref: '#/definitions/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Attempt'
+        type: array
+      consumer:
+        $ref: '#/definitions/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Consumer'
+      cost:
+        $ref: '#/definitions/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Cost'
+      end_timestamp:
+        type: integer
+      fingerprint_id:
+        type: string
+      gateway_id:
+        type: string
+      ip:
+        type: string
+      is_flagged:
+        type: boolean
+      latency:
+        $ref: '#/definitions/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Latency'
+      occurred_on:
+        type: integer
+      policy_chain:
+        items:
+          $ref: '#/definitions/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.PolicyEntry'
+        type: array
+      request:
+        $ref: '#/definitions/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Request'
+      response:
+        $ref: '#/definitions/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Response'
+      schema_version:
+        type: integer
+      security:
+        items:
+          type: string
+        type: array
+      session_id:
+        type: string
+      status:
+        $ref: '#/definitions/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Status'
+      team_id:
+        type: string
+      timestamp:
+        type: string
+      trace_id:
+        type: string
+      turn_id:
+        type: string
+      usage:
+        $ref: '#/definitions/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Usage'
+    type: object
+  github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Latency:
+    properties:
+      gateway_ms:
+        type: integer
+      policies_ms:
+        type: integer
+      provider_ms:
+        type: integer
+      routing_ms:
+        type: integer
+      total_ms:
+        type: integer
+    type: object
+  github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.PolicyEntry:
+    properties:
+      decision:
+        type: string
+      error:
+        type: boolean
+      extras: {}
+      flagged:
+        type: boolean
+      latency_ms:
+        type: integer
+      name:
+        type: string
+      score:
+        type: number
+      score_label:
+        type: string
+      stage:
+        type: string
+      status_code:
+        type: integer
+    type: object
+  github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Request:
+    properties:
+      body:
+        type: string
+      headers:
+        additionalProperties:
+          items:
+            type: string
+          type: array
+        type: object
+      max_tokens:
+        type: integer
+      method:
+        type: string
+      model:
+        type: string
+      model_label:
+        type: string
+      path:
+        type: string
+      prompt_tokens:
+        type: integer
+      provider:
+        type: string
+      registry_id:
+        type: string
+      requested_model:
+        type: string
+      stream:
+        type: boolean
+      temperature:
+        type: number
+    type: object
+  github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Response:
+    properties:
+      body:
+        type: string
+      completion_tokens:
+        type: integer
+      finish_reason:
+        type: string
+      headers:
+        additionalProperties:
+          items:
+            type: string
+          type: array
+        type: object
+      latency_ms:
+        type: integer
+      status_code:
+        type: integer
+      streaming:
+        type: boolean
+    type: object
+  github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Status:
+    properties:
+      code:
+        type: integer
+      is_timeout:
+        type: boolean
+      outcome:
+        type: string
+      reason:
+        type: string
+    type: object
+  github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Usage:
+    properties:
+      cached_input_tokens:
+        type: integer
+      completion_tokens:
+        type: integer
+      prompt_tokens:
+        type: integer
+      reasoning_output_tokens:
+        type: integer
+      total_tokens:
+        type: integer
+    type: object
   github_com_NeuralTrust_AgentGateway_pkg_version.Info:
     properties:
       app_name:
@@ -3903,6 +4108,41 @@ paths:
       summary: List model catalog
       tags:
       - catalog
+  /v1/playground/traces/{trace_id}:
+    get:
+      description: Returns the metrics Event captured for a playground request, keyed
+        by the X-AG-Trace-Id returned in the proxy response. Traces expire after a
+        short TTL.
+      parameters:
+      - description: Trace id (X-AG-Trace-Id from the proxy response)
+        in: path
+        name: trace_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Event'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_helpers.ErrorBody'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_helpers.ErrorBody'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_helpers.ErrorBody'
+      security:
+      - BearerAuth: []
+      summary: Get a playground trace
+      tags:
+      - playground
   /v1/policies-catalog:
     get:
       description: Returns the catalog of available policies grouped by type. Each


### PR DESCRIPTION
## Summary
- Regenerate the Swagger 2.0 / OpenAPI 3 specs (`docs/swagger.json`, `docs/swagger.yaml`, `docs/docs.go`, `docs/openapi.json`) so `GET /v1/playground/traces/{trace_id}` is documented from its existing handler annotations (the spec had not been regenerated when PR #84 merged).
- Add a **Playground** folder with a **Get Playground Trace** request and a `trace_id` collection variable to `docs/AgentGateway.postman_collection.json`.

## Context
The playground trace store and the admin endpoint shipped in PR #84 (merged), but the generated API docs and the Postman collection were not updated. This is a docs-only change; no code behavior is affected.

## Test plan
- [ ] `make swagger` / `make openapi` run clean and regenerate the same specs.
- [ ] Import `docs/AgentGateway.postman_collection.json` and confirm the **Playground → Get Playground Trace** request hits `{{base_url}}/v1/playground/traces/{{trace_id}}` with the admin Bearer token.

Made with [Cursor](https://cursor.com)