### PR TITLE
fix(metrics): resolve cost pricing slugs and proxy trace headers

### DIFF
--- a/pkg/api/handler/http/proxy/proxy_handler.go
+++ b/pkg/api/handler/http/proxy/proxy_handler.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 
 	"github.com/NeuralTrust/AgentGateway/pkg/api/handler/http/helpers"
+	"github.com/NeuralTrust/AgentGateway/pkg/api/middleware"
 	apiresolver "github.com/NeuralTrust/AgentGateway/pkg/api/resolver"
 	appauth "github.com/NeuralTrust/AgentGateway/pkg/app/auth"
 	appconsumer "github.com/NeuralTrust/AgentGateway/pkg/app/consumer"
@@ -131,7 +132,11 @@ func (h *ForwardedHandler) Handle(c *fiber.Ctx) error {
 
 func relayHeaders(c *fiber.Ctx, headers map[string][]string) {
 	for name, values := range headers {
-		if _, skip := hopByHopHeaders[textproto.CanonicalMIMEHeaderKey(name)]; skip {
+		canonical := textproto.CanonicalMIMEHeaderKey(name)
+		if _, skip := hopByHopHeaders[canonical]; skip {
+			continue
+		}
+		if _, skip := middleware.StrippedProxyResponseHeaders[canonical]; skip {
 			continue
 		}
 		for _, v := range values {

--- a/pkg/api/handler/http/proxy/proxy_handler_test.go
+++ b/pkg/api/handler/http/proxy/proxy_handler_test.go
@@ -379,6 +379,7 @@ func TestHandle_Success_RelaysResponse(t *testing.T) {
 			Headers: map[string][]string{
 				"Content-Type":        {"application/json"},
 				"X-Selected-Provider": {"openai"},
+				"X-Request-Id":        {"upstream-request-id"},
 				"Transfer-Encoding":   {"chunked"},
 			},
 			Body: []byte(`{"ok":true}`),
@@ -394,6 +395,9 @@ func TestHandle_Success_RelaysResponse(t *testing.T) {
 	}
 	if got := resp.Header.Get("X-Selected-Provider"); got != "openai" {
 		t.Fatalf("X-Selected-Provider = %q, want openai", got)
+	}
+	if got := resp.Header.Get("X-Request-Id"); got != "" {
+		t.Fatalf("X-Request-Id = %q, want empty", got)
 	}
 	if got := resp.Header.Get("Transfer-Encoding"); got == "chunked" {
 		t.Fatal("hop-by-hop Transfer-Encoding header should not be relayed")

--- a/pkg/api/middleware/access_log.go
+++ b/pkg/api/middleware/access_log.go
@@ -36,6 +36,9 @@ func (m *AccessLogMiddleware) Middleware() fiber.Handler {
 		start := time.Now()
 		err := c.Next()
 		requestID, _ := c.Locals(requestid.ConfigDefault.ContextKey).(string)
+		if requestID == "" {
+			requestID = c.Get(HeaderTraceID)
+		}
 
 		// For streamed responses the body is a lazy fasthttp body stream
 		// (registered via SetBodyStreamWriter). Calling Response.Body() here

--- a/pkg/api/middleware/auth.go
+++ b/pkg/api/middleware/auth.go
@@ -127,7 +127,7 @@ func (m *AuthMiddleware) debug(c *fiber.Ctx) *slog.Logger {
 		logger = slog.Default()
 	}
 	return logger.With(
-		slog.String("request_id", c.GetRespHeader(fiber.HeaderXRequestID)),
+		slog.String("trace_id", c.Get(HeaderTraceID)),
 		slog.String("path", c.Path()),
 	)
 }

--- a/pkg/api/middleware/metrics.go
+++ b/pkg/api/middleware/metrics.go
@@ -28,7 +28,6 @@ import (
 	infracontext "github.com/NeuralTrust/AgentGateway/pkg/infra/context"
 	"github.com/NeuralTrust/AgentGateway/pkg/infra/trace"
 	"github.com/gofiber/fiber/v2"
-	"github.com/gofiber/fiber/v2/middleware/requestid"
 	"github.com/google/uuid"
 )
 
@@ -124,17 +123,10 @@ func (m *MetricsMiddleware) enabled() bool {
 }
 
 func (m *MetricsMiddleware) resolveTraceID(c *fiber.Ctx) string {
-	if rid, ok := c.Locals(requestid.ConfigDefault.ContextKey).(string); ok && rid != "" {
-		return rid
-	}
 	if tid := c.Get(HeaderTraceID); tid != "" {
 		return tid
 	}
-	traceID := c.Get(fiber.HeaderXRequestID)
-	if traceID == "" {
-		traceID = uuid.New().String()
-	}
-	return traceID
+	return uuid.New().String()
 }
 
 func (m *MetricsMiddleware) attachTrace(c *fiber.Ctx, requestTrace *trace.RequestTrace) {

--- a/pkg/api/middleware/metrics_test.go
+++ b/pkg/api/middleware/metrics_test.go
@@ -33,7 +33,6 @@ import (
 	infracontext "github.com/NeuralTrust/AgentGateway/pkg/infra/context"
 	"github.com/NeuralTrust/AgentGateway/pkg/infra/trace"
 	"github.com/gofiber/fiber/v2"
-	"github.com/gofiber/fiber/v2/middleware/requestid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -116,7 +115,6 @@ func TestMetricsMiddleware_TraceIDMatchesTraceIDHeader(t *testing.T) {
 
 	gatewayID := ids.New[ids.GatewayKind]()
 	app := fiber.New()
-	app.Use(requestid.New())
 	app.Use(func(c *fiber.Ctx) error {
 		c.SetUserContext(appconsumer.WithGatewayID(c.UserContext(), gatewayID))
 		return c.Next()
@@ -133,8 +131,7 @@ func TestMetricsMiddleware_TraceIDMatchesTraceIDHeader(t *testing.T) {
 
 	respTraceID := resp.Header.Get(middleware.HeaderTraceID)
 	require.NotEmpty(t, respTraceID, "metrics middleware must echo X-AG-Trace-Id")
-	assert.Equal(t, resp.Header.Get(fiber.HeaderXRequestID), respTraceID,
-		"the echoed trace id must equal the request id so logs and traces share it")
+	assert.Empty(t, resp.Header.Get(fiber.HeaderXRequestID), "proxy must not set X-Request-Id")
 
 	mu.Lock()
 	defer mu.Unlock()

--- a/pkg/api/middleware/trace_id.go
+++ b/pkg/api/middleware/trace_id.go
@@ -17,3 +17,8 @@ package middleware
 // HeaderTraceID is the response header the proxy sets with the request trace id.
 // A gateway-specific name avoids the upstream X-Request-Id some providers emit.
 const HeaderTraceID = "X-AG-Trace-Id"
+
+// StrippedProxyResponseHeaders lists upstream headers that must not be forwarded to clients.
+var StrippedProxyResponseHeaders = map[string]struct{}{
+	"X-Request-Id": {},
+}

--- a/pkg/app/metrics/builder.go
+++ b/pkg/app/metrics/builder.go
@@ -17,7 +17,6 @@ package metrics
 import (
 	"context"
 	"net/http"
-	"strings"
 	"time"
 
 	appcatalog "github.com/NeuralTrust/AgentGateway/pkg/app/catalog"
@@ -290,23 +289,40 @@ func (b *Builder) fillUsageAndCost(ctx context.Context, evt *events.Event, serve
 	}
 }
 
+// pricingSlugs returns catalog lookup candidates, against served.Provider,
+// ordered by how reliably each identifies the model that was actually billed:
+//
+//  1. SentModel: the model the gateway put on the outbound request after
+//     routing-ref parsing, pool/LB resolution and model enforcement. It already
+//     matches the models.dev catalog slug, so it is the primary source.
+//  2. Model: the model echoed by the provider response (precise, may carry a
+//     date suffix that is stripped to match the catalog; empty for providers
+//     such as Bedrock Titan/Llama/Mistral that do not echo it).
+//  3. The client-requested model (qualified @provider/model or a bare string;
+//     pools contribute nothing) as a last resort.
+//
+// Each candidate is tried raw and with its -YYYY-MM-DD deployment suffix stripped.
 func pricingSlugs(evt *events.Event, served *trace.LLMAttrs) []string {
-	requestedRef := requestedModelRef(evt, served)
-	resolved := servedModel(evt, served)
-
-	intent, _ := routingdomain.ParseModelRef(requestedRef)
 	var slugs []string
-	switch {
-	case intent.IsPool() || (intent.IsZero() && requestedRef == ""):
-		slugs = []string{resolved}
-	case intent.Model == "":
-		slugs = []string{resolved, requestedRef}
-	case resolved == "" || modelsCompatibleForPricing(intent.Model, resolved):
-		slugs = []string{intent.Model, resolved}
-	default:
-		slugs = []string{resolved, intent.Model}
+	if served != nil {
+		slugs = appendModelSlugs(slugs, served.SentModel)
+		slugs = appendModelSlugs(slugs, served.Model)
 	}
-	return expandDeploymentPricingSlugs(slugs...)
+	slugs = appendModelSlugs(slugs, servedModel(evt, served))
+	intent, _ := routingdomain.ParseModelRef(requestedModelRef(evt, served))
+	slugs = appendModelSlugs(slugs, intent.Model)
+	return uniqueNonEmptySlugs(slugs...)
+}
+
+func appendModelSlugs(dst []string, model string) []string {
+	if model == "" {
+		return dst
+	}
+	dst = append(dst, model)
+	if base := deploymentCatalogSlug(model); base != model {
+		dst = append(dst, base)
+	}
+	return dst
 }
 
 func requestedModelRef(evt *events.Event, served *trace.LLMAttrs) string {
@@ -327,27 +343,6 @@ func servedModel(evt *events.Event, served *trace.LLMAttrs) string {
 		return served.Model
 	}
 	return ""
-}
-
-func modelsCompatibleForPricing(requested, served string) bool {
-	if requested == "" || served == "" {
-		return false
-	}
-	if requested == served {
-		return true
-	}
-	return strings.HasPrefix(served, requested+"-")
-}
-
-func expandDeploymentPricingSlugs(slugs ...string) []string {
-	expanded := make([]string, 0, len(slugs)*2)
-	expanded = append(expanded, slugs...)
-	for _, slug := range slugs {
-		if base := deploymentCatalogSlug(slug); base != slug {
-			expanded = append(expanded, base)
-		}
-	}
-	return uniqueNonEmptySlugs(expanded...)
 }
 
 func deploymentCatalogSlug(model string) string {

--- a/pkg/app/metrics/builder.go
+++ b/pkg/app/metrics/builder.go
@@ -17,9 +17,11 @@ package metrics
 import (
 	"context"
 	"net/http"
+	"strings"
 	"time"
 
 	appcatalog "github.com/NeuralTrust/AgentGateway/pkg/app/catalog"
+	routingdomain "github.com/NeuralTrust/AgentGateway/pkg/domain/routing"
 	infracontext "github.com/NeuralTrust/AgentGateway/pkg/infra/context"
 	"github.com/NeuralTrust/AgentGateway/pkg/infra/metrics/events"
 	"github.com/NeuralTrust/AgentGateway/pkg/infra/providers/adapter"
@@ -262,10 +264,16 @@ func (b *Builder) fillUsageAndCost(ctx context.Context, evt *events.Event, serve
 	evt.Request.PromptTokens = u.InputTokens
 	evt.Response.CompletionTokens = u.OutputTokens
 
-	if b.pricing == nil || served.Provider == "" || evt.Request.Model == "" {
+	if b.pricing == nil || served.Provider == "" {
 		return
 	}
-	price := b.pricing.Resolve(ctx, served.Provider, evt.Request.Model)
+	var price appcatalog.Pricing
+	for _, slug := range pricingSlugs(evt, served) {
+		price = b.pricing.Resolve(ctx, served.Provider, slug)
+		if price.Found {
+			break
+		}
+	}
 	if !price.Found {
 		return
 	}
@@ -275,11 +283,104 @@ func (b *Builder) fillUsageAndCost(ctx context.Context, evt *events.Event, serve
 	promptUsd := float64(u.InputTokens) * price.InputPrice
 	completionUsd := float64(u.OutputTokens) * price.OutputPrice
 	evt.Cost = &events.Cost{
-		PromptUsd:     promptUsd,
-		CompletionUsd: completionUsd,
-		TotalUsd:      promptUsd + completionUsd,
+		PromptUsd:     events.DecimalFloat(promptUsd),
+		CompletionUsd: events.DecimalFloat(completionUsd),
+		TotalUsd:      events.DecimalFloat(promptUsd + completionUsd),
 		Currency:      costCurrencyUSD,
 	}
+}
+
+func pricingSlugs(evt *events.Event, served *trace.LLMAttrs) []string {
+	requestedRef := requestedModelRef(evt, served)
+	resolved := servedModel(evt, served)
+
+	intent, _ := routingdomain.ParseModelRef(requestedRef)
+	var slugs []string
+	switch {
+	case intent.IsPool() || (intent.IsZero() && requestedRef == ""):
+		slugs = []string{resolved}
+	case intent.Model == "":
+		slugs = []string{resolved, requestedRef}
+	case resolved == "" || modelsCompatibleForPricing(intent.Model, resolved):
+		slugs = []string{intent.Model, resolved}
+	default:
+		slugs = []string{resolved, intent.Model}
+	}
+	return expandDeploymentPricingSlugs(slugs...)
+}
+
+func requestedModelRef(evt *events.Event, served *trace.LLMAttrs) string {
+	if evt != nil && evt.Request.RequestedModel != "" {
+		return evt.Request.RequestedModel
+	}
+	if served != nil {
+		return served.RequestedModel
+	}
+	return ""
+}
+
+func servedModel(evt *events.Event, served *trace.LLMAttrs) string {
+	if evt != nil && evt.Request.Model != "" {
+		return evt.Request.Model
+	}
+	if served != nil {
+		return served.Model
+	}
+	return ""
+}
+
+func modelsCompatibleForPricing(requested, served string) bool {
+	if requested == "" || served == "" {
+		return false
+	}
+	if requested == served {
+		return true
+	}
+	return strings.HasPrefix(served, requested+"-")
+}
+
+func expandDeploymentPricingSlugs(slugs ...string) []string {
+	expanded := make([]string, 0, len(slugs)*2)
+	expanded = append(expanded, slugs...)
+	for _, slug := range slugs {
+		if base := deploymentCatalogSlug(slug); base != slug {
+			expanded = append(expanded, base)
+		}
+	}
+	return uniqueNonEmptySlugs(expanded...)
+}
+
+func deploymentCatalogSlug(model string) string {
+	const dateSuffixLen = 10
+	if len(model) <= dateSuffixLen+1 {
+		return model
+	}
+	suffix := model[len(model)-dateSuffixLen:]
+	if suffix[4] != '-' || suffix[7] != '-' {
+		return model
+	}
+	for _, ch := range suffix {
+		if ch != '-' && (ch < '0' || ch > '9') {
+			return model
+		}
+	}
+	return model[:len(model)-dateSuffixLen-1]
+}
+
+func uniqueNonEmptySlugs(slugs ...string) []string {
+	seen := make(map[string]struct{}, len(slugs))
+	out := make([]string, 0, len(slugs))
+	for _, slug := range slugs {
+		if slug == "" {
+			continue
+		}
+		if _, dup := seen[slug]; dup {
+			continue
+		}
+		seen[slug] = struct{}{}
+		out = append(out, slug)
+	}
+	return out
 }
 
 func sumAttemptLatency(attempts []events.Attempt) int64 {

--- a/pkg/app/metrics/builder_test.go
+++ b/pkg/app/metrics/builder_test.go
@@ -29,10 +29,24 @@ import (
 
 type stubPricing struct {
 	price appcatalog.Pricing
+	byKey map[string]appcatalog.Pricing
 }
 
-func (s stubPricing) Resolve(_ context.Context, _ string, _ string) appcatalog.Pricing {
+func (s stubPricing) Resolve(_ context.Context, providerCode, slug string) appcatalog.Pricing {
+	if s.byKey != nil {
+		if p, ok := s.byKey[providerCode+":"+slug]; ok {
+			return p
+		}
+	}
 	return s.price
+}
+
+func newBuilder(price appcatalog.Pricing) *Builder {
+	return NewBuilder(adapter.NewRegistry(), stubPricing{price: price})
+}
+
+func newBuilderWithPricing(byKey map[string]appcatalog.Pricing) *Builder {
+	return NewBuilder(adapter.NewRegistry(), stubPricing{byKey: byKey})
 }
 
 func llmSpan(name string, attrs *trace.LLMAttrs, statusCode int, latency time.Duration, errMsg string) *trace.Span {
@@ -53,10 +67,6 @@ func pluginSpan(name string, attrs *trace.PluginAttrs, statusCode int, latency t
 		span.SetError(errMsg)
 	}
 	return span
-}
-
-func newBuilder(price appcatalog.Pricing) *Builder {
-	return NewBuilder(adapter.NewRegistry(), stubPricing{price: price})
 }
 
 const openAIRequestBody = `{"model":"gpt-4o","temperature":0.7,"max_tokens":100,"stream":false,` +
@@ -145,9 +155,9 @@ func TestBuilder_SyncSuccessFoldsCostAndLatency(t *testing.T) {
 	assert.Equal(t, 30, evt.Usage.TotalTokens)
 
 	require.NotNil(t, evt.Cost)
-	assert.InDelta(t, 10*0.0000025, evt.Cost.PromptUsd, 1e-12)
-	assert.InDelta(t, 20*0.00001, evt.Cost.CompletionUsd, 1e-12)
-	assert.InDelta(t, 10*0.0000025+20*0.00001, evt.Cost.TotalUsd, 1e-12)
+	assert.InDelta(t, 10*0.0000025, float64(evt.Cost.PromptUsd), 1e-12)
+	assert.InDelta(t, 20*0.00001, float64(evt.Cost.CompletionUsd), 1e-12)
+	assert.InDelta(t, 10*0.0000025+20*0.00001, float64(evt.Cost.TotalUsd), 1e-12)
 	assert.Equal(t, "USD", evt.Cost.Currency)
 
 	assert.Equal(t, int64(320), evt.Latency.TotalMs)
@@ -162,6 +172,118 @@ func TestBuilder_SyncSuccessFoldsCostAndLatency(t *testing.T) {
 	assert.Equal(t, "rate_limiter", evt.PolicyChain[0].Name)
 	assert.False(t, evt.PolicyChain[0].Flagged)
 	assert.False(t, evt.IsFlagged)
+}
+
+func TestBuilder_CostUsesRequestedModelForPricingLookup(t *testing.T) {
+	rt := trace.New("trace-pricing", trace.Metadata{GatewayID: "gw-1"})
+	_ = rt.AddSpan(llmSpan("openai",
+		&trace.LLMAttrs{
+			Provider:       "openai",
+			Model:          "gpt-4o-mini-2024-07-18",
+			RequestedModel: "gpt-4o-mini",
+			FinishReason:   "stop",
+			Attempt:        1,
+			Outcome:        "success",
+			Usage:          &adapter.CanonicalUsage{InputTokens: 11, OutputTokens: 12, TotalTokens: 23},
+		}, 200, 300*time.Millisecond, ""))
+
+	req := &infracontext.RequestContext{
+		GatewayID:      "gw-1",
+		Method:         "POST",
+		Path:           "/v1/chat/completions",
+		RequestedModel: "gpt-4o-mini",
+		Body:           []byte(openAIRequestBody),
+		SourceFormat:   string(adapter.FormatOpenAI),
+	}
+	resp := &infracontext.ResponseContext{StatusCode: 200, Body: []byte(`{"id":"x","choices":[]}`)}
+
+	start := time.UnixMilli(1_000_000)
+	end := start.Add(320 * time.Millisecond)
+
+	b := newBuilder(appcatalog.Pricing{
+		InputPrice:  0.00000015,
+		OutputPrice: 0.0000006,
+		Found:       true,
+	})
+	evt := b.Build(context.Background(), rt, req, resp, start, end)
+
+	require.NotNil(t, evt.Cost)
+	assert.InDelta(t, 11*0.00000015, float64(evt.Cost.PromptUsd), 1e-12)
+	assert.InDelta(t, 12*0.0000006, float64(evt.Cost.CompletionUsd), 1e-12)
+	assert.Equal(t, "gpt-4o-mini-2024-07-18", evt.Request.Model)
+	assert.Equal(t, "gpt-4o-mini", evt.Request.RequestedModel)
+}
+
+func TestBuilder_CostUsesServedModelWhenLBChangesModel(t *testing.T) {
+	rt := trace.New("trace-lb", trace.Metadata{GatewayID: "gw-1"})
+	_ = rt.AddSpan(llmSpan("openai",
+		&trace.LLMAttrs{
+			Provider:       "openai",
+			Model:          "gpt-4o-2024-08-06",
+			RequestedModel: "gpt-4o-mini",
+			FinishReason:   "stop",
+			Attempt:        1,
+			Outcome:        "success",
+			Usage:          &adapter.CanonicalUsage{InputTokens: 10, OutputTokens: 20, TotalTokens: 30},
+		}, 200, 300*time.Millisecond, ""))
+
+	req := &infracontext.RequestContext{
+		GatewayID:      "gw-1",
+		RequestedModel: "gpt-4o-mini",
+		Body:           []byte(openAIRequestBody),
+		SourceFormat:   string(adapter.FormatOpenAI),
+	}
+	resp := &infracontext.ResponseContext{StatusCode: 200, Body: []byte(`{"id":"x","choices":[]}`)}
+
+	b := newBuilderWithPricing(map[string]appcatalog.Pricing{
+		"openai:gpt-4o-mini": {Found: false},
+		"openai:gpt-4o-2024-08-06": {
+			Found:       true,
+			InputPrice:  0.0000025,
+			OutputPrice: 0.00001,
+		},
+	})
+	evt := b.Build(context.Background(), rt, req, resp, time.UnixMilli(1), time.UnixMilli(2))
+
+	require.NotNil(t, evt.Cost)
+	assert.InDelta(t, 10*0.0000025, float64(evt.Cost.PromptUsd), 1e-12)
+	assert.InDelta(t, 20*0.00001, float64(evt.Cost.CompletionUsd), 1e-12)
+}
+
+func TestBuilder_CostUsesServedModelForPoolRouting(t *testing.T) {
+	rt := trace.New("trace-pool", trace.Metadata{GatewayID: "gw-1"})
+	_ = rt.AddSpan(llmSpan("openai",
+		&trace.LLMAttrs{
+			Provider:       "openai",
+			Model:          "gpt-4o-mini-2024-07-18",
+			RequestedModel: "pool:fast-chat",
+			FinishReason:   "stop",
+			Attempt:        1,
+			Outcome:        "success",
+			Usage:          &adapter.CanonicalUsage{InputTokens: 11, OutputTokens: 12, TotalTokens: 23},
+		}, 200, 300*time.Millisecond, ""))
+
+	req := &infracontext.RequestContext{
+		GatewayID:      "gw-1",
+		RequestedModel: "pool:fast-chat",
+		Body:           []byte(openAIRequestBody),
+		SourceFormat:   string(adapter.FormatOpenAI),
+	}
+	resp := &infracontext.ResponseContext{StatusCode: 200, Body: []byte(`{"id":"x","choices":[]}`)}
+
+	b := newBuilderWithPricing(map[string]appcatalog.Pricing{
+		"openai:pool:fast-chat": {Found: false},
+		"openai:gpt-4o-mini-2024-07-18": {Found: false},
+		"openai:gpt-4o-mini": {
+			Found:       true,
+			InputPrice:  0.00000015,
+			OutputPrice: 0.0000006,
+		},
+	})
+	evt := b.Build(context.Background(), rt, req, resp, time.UnixMilli(1), time.UnixMilli(2))
+
+	require.NotNil(t, evt.Cost)
+	assert.InDelta(t, 11*0.00000015, float64(evt.Cost.PromptUsd), 1e-12)
 }
 
 func TestBuilder_TimeoutHasNilBody(t *testing.T) {

--- a/pkg/app/metrics/builder_test.go
+++ b/pkg/app/metrics/builder_test.go
@@ -214,6 +214,47 @@ func TestBuilder_CostUsesRequestedModelForPricingLookup(t *testing.T) {
 	assert.Equal(t, "gpt-4o-mini", evt.Request.RequestedModel)
 }
 
+func TestBuilder_CostPrefersSentModelOverResponseModel(t *testing.T) {
+	rt := trace.New("trace-sent", trace.Metadata{GatewayID: "gw-1"})
+	_ = rt.AddSpan(llmSpan("openai",
+		&trace.LLMAttrs{
+			Provider:       "openai",
+			SentModel:      "gpt-4o-mini",
+			Model:          "gpt-4o-mini-2024-07-18",
+			RequestedModel: "pool:fast-chat",
+			FinishReason:   "stop",
+			Attempt:        1,
+			Outcome:        "success",
+			Usage:          &adapter.CanonicalUsage{InputTokens: 11, OutputTokens: 12, TotalTokens: 23},
+		}, 200, 300*time.Millisecond, ""))
+
+	req := &infracontext.RequestContext{
+		GatewayID:      "gw-1",
+		RequestedModel: "pool:fast-chat",
+		Body:           []byte(openAIRequestBody),
+		SourceFormat:   string(adapter.FormatOpenAI),
+	}
+	resp := &infracontext.ResponseContext{StatusCode: 200, Body: []byte(`{"id":"x","choices":[]}`)}
+
+	b := newBuilderWithPricing(map[string]appcatalog.Pricing{
+		"openai:gpt-4o-mini": {
+			Found:       true,
+			InputPrice:  0.00000015,
+			OutputPrice: 0.0000006,
+		},
+		"openai:gpt-4o-mini-2024-07-18": {
+			Found:       true,
+			InputPrice:  9,
+			OutputPrice: 9,
+		},
+	})
+	evt := b.Build(context.Background(), rt, req, resp, time.UnixMilli(1), time.UnixMilli(2))
+
+	require.NotNil(t, evt.Cost)
+	assert.InDelta(t, 11*0.00000015, float64(evt.Cost.PromptUsd), 1e-12)
+	assert.InDelta(t, 12*0.0000006, float64(evt.Cost.CompletionUsd), 1e-12)
+}
+
 func TestBuilder_CostUsesServedModelWhenLBChangesModel(t *testing.T) {
 	rt := trace.New("trace-lb", trace.Metadata{GatewayID: "gw-1"})
 	_ = rt.AddSpan(llmSpan("openai",

--- a/pkg/app/proxy/forwarder.go
+++ b/pkg/app/proxy/forwarder.go
@@ -353,6 +353,7 @@ func (f *forwarder) recordSpan(
 		span.SetStatusCode(resp.StatusCode)
 		span.ObserveUsage(resp.Usage)
 		span.LLM.Model = resp.Model
+		span.LLM.SentModel = resp.SentModel
 		span.LLM.FinishReason = resp.FinishReason
 		span.LLM.TurnID = resp.ResponseID
 	}

--- a/pkg/app/proxy/provider.go
+++ b/pkg/app/proxy/provider.go
@@ -61,9 +61,15 @@ type ProviderResponse struct {
 	// adapted to the client's source format. The consumer writes each line + "\n"
 	// and is responsible for draining the sequence (which closes the backend
 	// body). The second value carries mid-stream errors.
-	Stream       iter.Seq2[[]byte, error]
-	Usage        *adapter.CanonicalUsage
-	Model        string
+	Stream iter.Seq2[[]byte, error]
+	Usage  *adapter.CanonicalUsage
+	// Model is the model echoed by the provider in its response. Some providers
+	// (e.g. Bedrock Titan/Llama/Mistral) leave it empty.
+	Model string
+	// SentModel is the model the gateway actually put on the outbound request to
+	// the provider, after routing-ref parsing, pool/LB resolution and model
+	// enforcement. It is the most reliable identifier for cost attribution.
+	SentModel    string
 	FinishReason string
 	ResponseID   string
 }
@@ -101,6 +107,7 @@ type preparedInvocation struct {
 	client       providers.Client
 	cfg          *providers.Config
 	body         []byte
+	sentModel    string
 	sourceFormat adapter.Format
 	targetFormat adapter.Format
 	crossFormat  bool
@@ -148,6 +155,7 @@ func (p *providerInvoker) Invoke(
 		Body:         respBody,
 		Usage:        usage,
 		Model:        model,
+		SentModel:    prep.sentModel,
 		FinishReason: finishReason,
 		ResponseID:   responseID,
 	}, nil
@@ -199,6 +207,7 @@ func (p *providerInvoker) InvokeStream(
 		StatusCode: http.StatusOK,
 		Headers:    streamHeaders(bk.Provider()),
 		Stream:     stream,
+		SentModel:  prep.sentModel,
 	}, nil
 }
 
@@ -251,6 +260,8 @@ func (p *providerInvoker) prepare(
 
 	body = injectPreviousResponseID(body, targetFormat, req.PreviousResponseID)
 
+	sentModel, _ := adapter.ExtractModel(body)
+
 	return &preparedInvocation{
 		client: client,
 		cfg: &providers.Config{
@@ -258,6 +269,7 @@ func (p *providerInvoker) prepare(
 			Credentials: bk.Auth().ProviderCredentials(),
 		},
 		body:         body,
+		sentModel:    sentModel,
 		sourceFormat: sourceFormat,
 		targetFormat: targetFormat,
 		crossFormat:  crossFormat,

--- a/pkg/container/modules/server_proxy.go
+++ b/pkg/container/modules/server_proxy.go
@@ -30,7 +30,6 @@ import (
 
 type proxyMiddlewares struct {
 	dig.In
-	RequestID       *middleware.RequestIDMiddleware
 	PanicRecover    *middleware.PanicRecoverMiddleware
 	AccessLog       *middleware.AccessLogMiddleware
 	SecurityHeaders *middleware.SecurityHeadersMiddleware
@@ -41,7 +40,6 @@ type proxyMiddlewares struct {
 
 func proxyTransport(m proxyMiddlewares) *middleware.Transport {
 	return middleware.NewTransport(
-		m.RequestID,
 		m.SecurityHeaders,
 		m.PanicRecover,
 		m.AccessLog,

--- a/pkg/infra/metrics/events/cost_test.go
+++ b/pkg/infra/metrics/events/cost_test.go
@@ -1,3 +1,17 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package events_test
 
 import (

--- a/pkg/infra/metrics/events/cost_test.go
+++ b/pkg/infra/metrics/events/cost_test.go
@@ -1,0 +1,33 @@
+package events_test
+
+import (
+	"encoding/json"
+	"regexp"
+	"testing"
+
+	"github.com/NeuralTrust/AgentGateway/pkg/infra/metrics/events"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCost_MarshalJSON_UsesDecimalNotation(t *testing.T) {
+	cost := events.Cost{
+		PromptUsd:     events.DecimalFloat(2.4e-6),
+		CompletionUsd: events.DecimalFloat(1.44e-5),
+		TotalUsd:      events.DecimalFloat(1.68e-5),
+		Currency:      "USD",
+	}
+
+	data, err := json.Marshal(cost)
+	require.NoError(t, err)
+
+	s := string(data)
+	scientific := regexp.MustCompile(`[0-9]e[+-]?[0-9]`)
+	assert.False(t, scientific.MatchString(s), "cost JSON must not use scientific notation: %s", s)
+	assert.JSONEq(t, `{
+		"prompt_usd": 0.0000024,
+		"completion_usd": 0.0000144,
+		"total_usd": 0.0000168,
+		"currency": "USD"
+	}`, s)
+}

--- a/pkg/infra/metrics/events/decimal_float.go
+++ b/pkg/infra/metrics/events/decimal_float.go
@@ -1,3 +1,17 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package events
 
 import (

--- a/pkg/infra/metrics/events/decimal_float.go
+++ b/pkg/infra/metrics/events/decimal_float.go
@@ -1,0 +1,22 @@
+package events
+
+import (
+	"encoding/json"
+	"strconv"
+)
+
+// DecimalFloat is a float64 that JSON-encodes as a decimal number, never in scientific notation.
+type DecimalFloat float64
+
+func (f DecimalFloat) MarshalJSON() ([]byte, error) {
+	return []byte(strconv.FormatFloat(float64(f), 'f', -1, 64)), nil
+}
+
+func (f *DecimalFloat) UnmarshalJSON(data []byte) error {
+	var v float64
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	*f = DecimalFloat(v)
+	return nil
+}

--- a/pkg/infra/metrics/events/event.go
+++ b/pkg/infra/metrics/events/event.go
@@ -93,10 +93,10 @@ type Usage struct {
 }
 
 type Cost struct {
-	PromptUsd     float64 `json:"prompt_usd"`
-	CompletionUsd float64 `json:"completion_usd"`
-	TotalUsd      float64 `json:"total_usd"`
-	Currency      string  `json:"currency"`
+	PromptUsd     DecimalFloat `json:"prompt_usd"`
+	CompletionUsd DecimalFloat `json:"completion_usd"`
+	TotalUsd      DecimalFloat `json:"total_usd"`
+	Currency      string       `json:"currency"`
 }
 
 type Latency struct {

--- a/pkg/infra/telemetry/otlp/mapping.go
+++ b/pkg/infra/telemetry/otlp/mapping.go
@@ -138,9 +138,9 @@ func eventToRecord(evt *events.Event, maxBodyBytes int) otellog.Record {
 	}
 	if evt.Cost != nil {
 		attrs = append(attrs,
-			otellog.Float64(attrCostTotalUsd, evt.Cost.TotalUsd),
-			otellog.Float64(attrCostPromptUsd, evt.Cost.PromptUsd),
-			otellog.Float64(attrCostCompletionUsd, evt.Cost.CompletionUsd),
+			otellog.Float64(attrCostTotalUsd, float64(evt.Cost.TotalUsd)),
+			otellog.Float64(attrCostPromptUsd, float64(evt.Cost.PromptUsd)),
+			otellog.Float64(attrCostCompletionUsd, float64(evt.Cost.CompletionUsd)),
 		)
 		appendStr(attrCostCurrency, evt.Cost.Currency)
 	}

--- a/pkg/infra/telemetry/otlp/mapping_test.go
+++ b/pkg/infra/telemetry/otlp/mapping_test.go
@@ -66,7 +66,7 @@ func fullEvent() *events.Event {
 			CachedInputTokens:     2,
 			ReasoningOutputTokens: 1,
 		},
-		Cost:    &events.Cost{PromptUsd: 0.002, CompletionUsd: 0.008, TotalUsd: 0.01, Currency: "USD"},
+		Cost:    &events.Cost{PromptUsd: events.DecimalFloat(0.002), CompletionUsd: events.DecimalFloat(0.008), TotalUsd: events.DecimalFloat(0.01), Currency: "USD"},
 		Latency: events.Latency{TotalMs: 120, ProviderMs: 100, PoliciesMs: 10, RoutingMs: 5, GatewayMs: 5},
 		Attempts: []events.Attempt{
 			{Provider: "openai", Attempt: 1, StatusCode: 200},

--- a/pkg/infra/trace/span.go
+++ b/pkg/infra/trace/span.go
@@ -35,6 +35,7 @@ type LLMAttrs struct {
 	RegistryID     string
 	Provider       string
 	Model          string
+	SentModel      string
 	RequestedModel string
 	FinishReason   string
 	TurnID         string


### PR DESCRIPTION
## Summary

- **Cost is priced by the model actually sent to the provider.** The gateway now captures the model it puts on the outbound request (after `@provider/model` parsing, pool/LB resolution and model enforcement) and uses it as the primary key for catalog pricing. This matches the models.dev slug directly and fixes empty `cost` for versioned deployments (e.g. `gpt-4o-mini-2024-07-18`) and pool routing. It falls back to the provider response model (date-stripped) and then the client-requested model, since some providers (Bedrock Titan/Llama/Mistral) do not echo the model in their response.
- Serialize cost fields as plain decimal floats instead of scientific notation in metric events.
- Proxy responses now expose only `X-AG-Trace-Id`; `X-Request-Id` is no longer set by the gateway and upstream `X-Request-Id` headers are stripped.

## Test plan

- [x] `go test ./pkg/app/metrics/... ./pkg/app/proxy/... ./pkg/infra/trace/... ./pkg/infra/metrics/events/... ./pkg/api/middleware/... ./pkg/api/handler/http/proxy/... ./pkg/infra/telemetry/otlp/...`
- [ ] Deploy to dev and verify new `gateway_metrics` rows include populated `cost` for versioned OpenAI models and pool-routed requests
- [ ] Confirm proxy responses carry `X-AG-Trace-Id` and no `X-Request-Id`

## Known limitation

- Bedrock native models (Titan/Llama/Mistral) carry the model as `modelId` in the request path, not the body, so `SentModel` is empty for them and pricing falls back to the client-requested model.