### PR TITLE
fix(metrics): request stream usage for OpenAI Chat Completions

### DIFF
--- a/pkg/app/proxy/provider.go
+++ b/pkg/app/proxy/provider.go
@@ -189,6 +189,10 @@ func (p *providerInvoker) InvokeStream(
 		body = injectStreamTrue(body)
 	}
 
+	if adapter.IsSameWireFormat(prep.targetFormat, adapter.FormatOpenAI) {
+		body = injectStreamIncludeUsage(body)
+	}
+
 	seq, err := prep.client.CompletionsStream(ctx, prep.cfg, body)
 	if err != nil {
 		if be, ok := registry.IsBackendError(err); ok {

--- a/pkg/app/proxy/provider_stream.go
+++ b/pkg/app/proxy/provider_stream.go
@@ -45,6 +45,34 @@ func injectStreamTrue(body []byte) []byte {
 	return out
 }
 
+// injectStreamIncludeUsage forces "stream_options.include_usage": true on an
+// OpenAI Chat Completions request body. Without it OpenAI-wire backends omit the
+// final usage chunk while streaming, leaving the request metrics without token
+// usage. Existing stream_options keys are preserved. It must only be applied to
+// the OpenAI Chat Completions wire format: the Responses API, Anthropic and
+// Mistral stream usage by default and reject (or ignore) this field.
+func injectStreamIncludeUsage(body []byte) []byte {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(body, &m); err != nil {
+		return body
+	}
+	opts := map[string]json.RawMessage{}
+	if raw, ok := m["stream_options"]; ok {
+		_ = json.Unmarshal(raw, &opts)
+	}
+	opts["include_usage"] = json.RawMessage("true")
+	encodedOpts, err := json.Marshal(opts)
+	if err != nil {
+		return body
+	}
+	m["stream_options"] = encodedOpts
+	out, err := json.Marshal(m)
+	if err != nil {
+		return body
+	}
+	return out
+}
+
 // toolCallEntry holds accumulated tool call data for a single index.
 type toolCallEntry struct {
 	ID   string

--- a/pkg/app/proxy/stream_include_usage_test.go
+++ b/pkg/app/proxy/stream_include_usage_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func decodeStreamOptions(t *testing.T, body []byte) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatalf("body is not valid JSON: %v", err)
+	}
+	opts, ok := m["stream_options"].(map[string]any)
+	if !ok {
+		t.Fatalf("stream_options missing or not an object: %v", m["stream_options"])
+	}
+	return opts
+}
+
+func TestInjectStreamIncludeUsage_AddsWhenAbsent(t *testing.T) {
+	body := []byte(`{"model":"gpt-4o-mini","stream":true}`)
+	out := injectStreamIncludeUsage(body)
+	opts := decodeStreamOptions(t, out)
+	if opts["include_usage"] != true {
+		t.Fatalf("include_usage should be true, got %v", opts["include_usage"])
+	}
+}
+
+func TestInjectStreamIncludeUsage_PreservesExistingOptions(t *testing.T) {
+	body := []byte(`{"model":"gpt-4o-mini","stream":true,"stream_options":{"some_flag":"x"}}`)
+	out := injectStreamIncludeUsage(body)
+	opts := decodeStreamOptions(t, out)
+	if opts["include_usage"] != true {
+		t.Fatalf("include_usage should be true, got %v", opts["include_usage"])
+	}
+	if opts["some_flag"] != "x" {
+		t.Fatalf("existing stream_options keys must be preserved, got %v", opts["some_flag"])
+	}
+}
+
+func TestInjectStreamIncludeUsage_OverridesFalse(t *testing.T) {
+	body := []byte(`{"model":"gpt-4o-mini","stream":true,"stream_options":{"include_usage":false}}`)
+	out := injectStreamIncludeUsage(body)
+	opts := decodeStreamOptions(t, out)
+	if opts["include_usage"] != true {
+		t.Fatalf("include_usage should be forced to true, got %v", opts["include_usage"])
+	}
+}
+
+func TestInjectStreamIncludeUsage_InvalidJSONUnchanged(t *testing.T) {
+	body := []byte(`{not json`)
+	out := injectStreamIncludeUsage(body)
+	if string(out) != string(body) {
+		t.Fatalf("invalid JSON body must be returned unchanged, got %s", out)
+	}
+}


### PR DESCRIPTION
## Summary
- OpenAI-wire backends omit the final usage chunk while streaming unless `stream_options.include_usage` is set. Without it, streamed requests produced metrics with no token usage.
- `InvokeStream` now injects `stream_options.include_usage=true` strictly for the OpenAI Chat Completions wire (`openai`, `azure`, `groq`, `deepseek`), preserving any existing `stream_options` keys.
- Other wire formats are intentionally excluded — Responses, Anthropic, Gemini, Bedrock and Mistral already stream usage by default (and Mistral does not support `stream_options`).

## Behaviour note
On the passthrough path (OpenAI client → OpenAI-wire upstream) the client now receives the standard final usage chunk even if it did not request it. This is standard OpenAI behaviour when `include_usage` is on.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/app/proxy/...`
- [x] New unit tests: adds when absent, preserves existing options, forces over `false`, leaves invalid JSON unchanged

Made with [Cursor](https://cursor.com)