### PR TITLE
fix(mcp-oauth): resolve role_based registries in the connect plane

### DIFF
--- a/pkg/api/handler/http/oauth/connect_handler.go
+++ b/pkg/api/handler/http/oauth/connect_handler.go
@@ -16,15 +16,18 @@ package oauth
 
 import (
 	"errors"
+	"strings"
 
 	appoauth "github.com/NeuralTrust/AgentGateway/pkg/app/oauth"
 	"github.com/gofiber/fiber/v2"
 )
 
+// Provider keys can contain slashes (e.g. "app.linear/mcp"), so these routes
+// use a greedy wildcard segment instead of a single-segment :provider param.
 const (
-	ConnectStartPath    = "/oauth/connect/:provider"
-	ConnectCallbackPath = "/oauth/callback/:provider"
-	DisconnectPath      = "/oauth/disconnect/:provider"
+	ConnectStartPath    = "/oauth/connect/*"
+	ConnectCallbackPath = "/oauth/callback/*"
+	DisconnectPath      = "/oauth/disconnect/*"
 )
 
 type ConnectHandler struct {
@@ -44,7 +47,7 @@ func (h *ConnectHandler) Page(c *fiber.Ctx) error {
 }
 
 func (h *ConnectHandler) Start(c *fiber.Ctx) error {
-	location, err := h.connect.Start(c.UserContext(), c.BaseURL(), c.Query("ticket"), c.Params("provider"))
+	location, err := h.connect.Start(c.UserContext(), c.BaseURL(), c.Query("ticket"), providerParam(c))
 	if err != nil {
 		return h.pageError(c, err)
 	}
@@ -53,7 +56,7 @@ func (h *ConnectHandler) Start(c *fiber.Ctx) error {
 
 func (h *ConnectHandler) Callback(c *fiber.Ctx) error {
 	ticketID, err := h.connect.Callback(
-		c.UserContext(), c.BaseURL(), c.Params("provider"),
+		c.UserContext(), c.BaseURL(), providerParam(c),
 		c.Query("state"), c.Query("code"), c.Query("error"), c.Query("error_description"),
 	)
 	if err != nil {
@@ -67,10 +70,14 @@ func (h *ConnectHandler) Callback(c *fiber.Ctx) error {
 
 func (h *ConnectHandler) Disconnect(c *fiber.Ctx) error {
 	ticket := c.Query("ticket")
-	if err := h.connect.Disconnect(c.UserContext(), ticket, c.Params("provider")); err != nil {
+	if err := h.connect.Disconnect(c.UserContext(), ticket, providerParam(c)); err != nil {
 		return h.pageError(c, err)
 	}
 	return h.showPage(c, ticket, "")
+}
+
+func providerParam(c *fiber.Ctx) string {
+	return strings.TrimPrefix(c.Params("*"), "/")
 }
 
 func (h *ConnectHandler) showPage(c *fiber.Ctx, ticket, flash string) error {

--- a/pkg/api/handler/http/oauth/connect_handler_test.go
+++ b/pkg/api/handler/http/oauth/connect_handler_test.go
@@ -28,8 +28,9 @@ import (
 )
 
 type stubConnectService struct {
-	page *appoauth.ConnectPage
-	err  error
+	page        *appoauth.ConnectPage
+	err         error
+	gotProvider string
 }
 
 func (s *stubConnectService) CreateTicket(context.Context, ids.GatewayID, string, string) (string, error) {
@@ -40,7 +41,8 @@ func (s *stubConnectService) Page(context.Context, string) (*appoauth.ConnectPag
 	return s.page, s.err
 }
 
-func (s *stubConnectService) Start(context.Context, string, string, string) (string, error) {
+func (s *stubConnectService) Start(_ context.Context, _, _, provider string) (string, error) {
+	s.gotProvider = provider
 	return "https://github.com/login/oauth/authorize?x=1", nil
 }
 
@@ -122,5 +124,23 @@ func TestConnectStart_RedirectsToProvider(t *testing.T) {
 	}
 	if loc := res.Header.Get("Location"); !strings.HasPrefix(loc, "https://github.com/") {
 		t.Fatalf("Location = %q", loc)
+	}
+}
+
+func TestConnectStart_ProviderWithSlash(t *testing.T) {
+	t.Parallel()
+	stub := &stubConnectService{}
+	h := NewConnectHandler(stub)
+	app := fiber.New()
+	app.Get(ConnectStartPath, h.Start)
+	res, err := app.Test(httptest.NewRequest("GET", "/oauth/connect/app.linear/mcp?ticket=abc", nil))
+	if err != nil {
+		t.Fatalf("route test: %v", err)
+	}
+	if res.StatusCode != fiber.StatusFound {
+		t.Fatalf("status = %d, want 302", res.StatusCode)
+	}
+	if stub.gotProvider != "app.linear/mcp" {
+		t.Fatalf("provider = %q, want app.linear/mcp", stub.gotProvider)
 	}
 }

--- a/pkg/api/handler/http/oauth/pages.go
+++ b/pkg/api/handler/http/oauth/pages.go
@@ -111,7 +111,7 @@ var connectPageTmpl = template.Must(template.New("connect").Parse(`<!doctype htm
 {{if .Flash}}<div class="flash">{{.Flash}}</div>{{end}}
 {{if not .Providers}}<p class="empty">No third-party providers are configured for this virtual MCP.</p>{{end}}
 {{range .Providers}}<div class="row">
-  <div><div class="name">{{.Provider}}</div><div class="reg">{{.Registry}}</div></div>
+  <div><div class="name">{{.Registry}}</div><div class="reg">{{.Provider}}</div></div>
   <div class="actions">{{if .Linked}}
     <span class="status"><span class="dot"></span>Connected</span>
     <form method="post" action="/oauth/disconnect/{{.Provider}}?ticket={{$.Ticket}}"><button class="btn revoke">Revoke</button></form>

--- a/pkg/app/consumer/consumer_data.go
+++ b/pkg/app/consumer/consumer_data.go
@@ -78,6 +78,41 @@ func (d *Data) indexRegistries() {
 	}
 }
 
+func (d *Data) EffectiveRegistries(rc *RoutableConsumer) []*registrydomain.Registry {
+	if rc == nil || rc.Consumer == nil {
+		return nil
+	}
+	if rc.Consumer.RoutingMode != domain.RoutingModeRoleBased {
+		return rc.Registries
+	}
+	assigned := make(map[ids.RoleID]struct{}, len(rc.Consumer.RoleIDs))
+	for _, id := range rc.Consumer.RoleIDs {
+		assigned[id] = struct{}{}
+	}
+	seen := make(map[ids.RegistryID]struct{})
+	out := make([]*registrydomain.Registry, 0)
+	for _, role := range d.Roles {
+		if role == nil {
+			continue
+		}
+		if _, ok := assigned[role.ID]; !ok {
+			continue
+		}
+		for _, id := range role.RegistryIDs {
+			reg, ok := d.RegistryByID(id)
+			if !ok || !reg.IsMCP() {
+				continue
+			}
+			if _, dup := seen[reg.ID]; dup {
+				continue
+			}
+			seen[reg.ID] = struct{}{}
+			out = append(out, reg)
+		}
+	}
+	return out
+}
+
 func (d *Data) MatchSlug(slug string) (*RoutableConsumer, bool) {
 	if d == nil || d.bySlug == nil {
 		return nil, false

--- a/pkg/app/consumer/consumer_data_test.go
+++ b/pkg/app/consumer/consumer_data_test.go
@@ -19,6 +19,8 @@ import (
 
 	domain "github.com/NeuralTrust/AgentGateway/pkg/domain/consumer"
 	"github.com/NeuralTrust/AgentGateway/pkg/domain/ids"
+	registrydomain "github.com/NeuralTrust/AgentGateway/pkg/domain/registry"
+	roledomain "github.com/NeuralTrust/AgentGateway/pkg/domain/role"
 )
 
 func routable(slug string, active bool) RoutableConsumer {
@@ -50,5 +52,86 @@ func TestData_MatchSlug_SkipsInactiveConsumers(t *testing.T) {
 
 	if _, ok := d.MatchSlug("X84Yhsy8"); ok {
 		t.Fatal("inactive consumer must not be routable")
+	}
+}
+
+func mcpRegistry(gatewayID ids.GatewayID) *registrydomain.Registry {
+	return &registrydomain.Registry{
+		ID:        ids.New[ids.RegistryKind](),
+		GatewayID: gatewayID,
+		Type:      registrydomain.TypeMCP,
+		Enabled:   true,
+	}
+}
+
+func TestData_EffectiveRegistries_InlineReturnsDirectRegistries(t *testing.T) {
+	t.Parallel()
+	gatewayID := ids.New[ids.GatewayKind]()
+	reg := mcpRegistry(gatewayID)
+	rc := routable("inline1x", true)
+	rc.Consumer.RoutingMode = domain.RoutingModeInline
+	rc.Registries = []*registrydomain.Registry{reg}
+	d := NewData(gatewayID, []RoutableConsumer{rc})
+
+	got := d.EffectiveRegistries(&d.Consumers[0])
+	if len(got) != 1 || got[0].ID != reg.ID {
+		t.Fatalf("inline EffectiveRegistries = %v, want [%s]", got, reg.ID)
+	}
+}
+
+func TestData_EffectiveRegistries_RoleBasedUnionsRoleRegistries(t *testing.T) {
+	t.Parallel()
+	gatewayID := ids.New[ids.GatewayKind]()
+	regA := mcpRegistry(gatewayID)
+	regB := mcpRegistry(gatewayID)
+	roleID := ids.New[ids.RoleKind]()
+	otherRoleID := ids.New[ids.RoleKind]()
+
+	rc := routable("rolebsd1", true)
+	rc.Consumer.RoutingMode = domain.RoutingModeRoleBased
+	rc.Consumer.RoleIDs = []ids.RoleID{roleID}
+
+	roles := []*roledomain.Role{
+		{ID: roleID, RegistryIDs: []ids.RegistryID{regA.ID, regB.ID}},
+		{ID: otherRoleID, RegistryIDs: []ids.RegistryID{mcpRegistry(gatewayID).ID}},
+	}
+	d := NewData(gatewayID, []RoutableConsumer{rc}, roles)
+	d.SetRegistryIndex(map[ids.RegistryID]*registrydomain.Registry{
+		regA.ID: regA,
+		regB.ID: regB,
+	})
+
+	got := d.EffectiveRegistries(&d.Consumers[0])
+	if len(got) != 2 {
+		t.Fatalf("role_based EffectiveRegistries len = %d, want 2 (got %v)", len(got), got)
+	}
+	seen := map[ids.RegistryID]bool{}
+	for _, reg := range got {
+		seen[reg.ID] = true
+	}
+	if !seen[regA.ID] || !seen[regB.ID] {
+		t.Fatalf("role_based EffectiveRegistries missing role registries: %v", got)
+	}
+}
+
+func TestData_EffectiveRegistries_RoleBasedSkipsUnassignedRoles(t *testing.T) {
+	t.Parallel()
+	gatewayID := ids.New[ids.GatewayKind]()
+	reg := mcpRegistry(gatewayID)
+	assignedRole := ids.New[ids.RoleKind]()
+	unassignedRole := ids.New[ids.RoleKind]()
+
+	rc := routable("rolebsd2", true)
+	rc.Consumer.RoutingMode = domain.RoutingModeRoleBased
+	rc.Consumer.RoleIDs = []ids.RoleID{assignedRole}
+
+	roles := []*roledomain.Role{
+		{ID: unassignedRole, RegistryIDs: []ids.RegistryID{reg.ID}},
+	}
+	d := NewData(gatewayID, []RoutableConsumer{rc}, roles)
+	d.SetRegistryIndex(map[ids.RegistryID]*registrydomain.Registry{reg.ID: reg})
+
+	if got := d.EffectiveRegistries(&d.Consumers[0]); len(got) != 0 {
+		t.Fatalf("EffectiveRegistries from unassigned role = %v, want empty", got)
 	}
 }

--- a/pkg/app/oauth/connect.go
+++ b/pkg/app/oauth/connect.go
@@ -65,12 +65,12 @@ func (s *connectService) mintTicket(ctx context.Context, t ConnectTicket) (strin
 }
 
 func (s *connectService) Page(ctx context.Context, ticketID string) (*ConnectPage, error) {
-	ticket, gatewayID, rc, err := s.resolve(ctx, ticketID)
+	ticket, gatewayID, data, rc, err := s.resolve(ctx, ticketID)
 	if err != nil {
 		return nil, err
 	}
 	page := &ConnectPage{ConsumerPath: ticket.ConsumerPath, ResumeURL: ticket.ResumeURL}
-	for _, reg := range rc.Registries {
+	for _, reg := range data.EffectiveRegistries(rc) {
 		cfg := forwardedAuth(reg)
 		if cfg == nil {
 			continue
@@ -91,11 +91,11 @@ func (s *connectService) Page(ctx context.Context, ticketID string) (*ConnectPag
 }
 
 func (s *connectService) Start(ctx context.Context, baseURL, ticketID, provider string) (string, error) {
-	ticket, gatewayID, rc, err := s.resolve(ctx, ticketID)
+	ticket, gatewayID, data, rc, err := s.resolve(ctx, ticketID)
 	if err != nil {
 		return "", err
 	}
-	reg := providerRegistry(rc, provider)
+	reg := providerRegistry(data.EffectiveRegistries(rc), provider)
 	if reg == nil {
 		return "", ErrProviderNotFound
 	}
@@ -133,11 +133,11 @@ func (s *connectService) Callback(ctx context.Context, baseURL, provider, state,
 	if errCode != "" {
 		return st.TicketID, oauthErr(errCode, errDesc)
 	}
-	gatewayID, rc, err := s.routable(ctx, &st.Ticket)
+	gatewayID, data, rc, err := s.routable(ctx, &st.Ticket)
 	if err != nil {
 		return st.TicketID, err
 	}
-	reg := providerRegistry(rc, provider)
+	reg := providerRegistry(data.EffectiveRegistries(rc), provider)
 	if reg == nil {
 		return st.TicketID, ErrProviderNotFound
 	}
@@ -163,42 +163,42 @@ func (s *connectService) Callback(ctx context.Context, baseURL, provider, state,
 }
 
 func (s *connectService) Disconnect(ctx context.Context, ticketID, provider string) error {
-	ticket, gatewayID, _, err := s.resolve(ctx, ticketID)
+	ticket, gatewayID, _, _, err := s.resolve(ctx, ticketID)
 	if err != nil {
 		return err
 	}
 	return s.vault.Delete(ctx, gatewayID, ticket.PrincipalSub, provider)
 }
 
-func (s *connectService) resolve(ctx context.Context, ticketID string) (*ConnectTicket, ids.GatewayID, *appconsumer.RoutableConsumer, error) {
+func (s *connectService) resolve(ctx context.Context, ticketID string) (*ConnectTicket, ids.GatewayID, *appconsumer.Data, *appconsumer.RoutableConsumer, error) {
 	ticket, err := s.store.GetTicket(ctx, ticketID)
 	if err != nil {
-		return nil, ids.GatewayID{}, nil, err
+		return nil, ids.GatewayID{}, nil, nil, err
 	}
 	if ticket == nil {
-		return nil, ids.GatewayID{}, nil, ErrTicketNotFound
+		return nil, ids.GatewayID{}, nil, nil, ErrTicketNotFound
 	}
-	gatewayID, rc, err := s.routable(ctx, ticket)
+	gatewayID, data, rc, err := s.routable(ctx, ticket)
 	if err != nil {
-		return nil, ids.GatewayID{}, nil, err
+		return nil, ids.GatewayID{}, nil, nil, err
 	}
-	return ticket, gatewayID, rc, nil
+	return ticket, gatewayID, data, rc, nil
 }
 
-func (s *connectService) routable(ctx context.Context, ticket *ConnectTicket) (ids.GatewayID, *appconsumer.RoutableConsumer, error) {
+func (s *connectService) routable(ctx context.Context, ticket *ConnectTicket) (ids.GatewayID, *appconsumer.Data, *appconsumer.RoutableConsumer, error) {
 	gatewayID, err := ids.Parse[ids.GatewayKind](ticket.GatewayID)
 	if err != nil {
-		return ids.GatewayID{}, nil, fmt.Errorf("oauth connect: bad gateway id in ticket: %w", err)
+		return ids.GatewayID{}, nil, nil, fmt.Errorf("oauth connect: bad gateway id in ticket: %w", err)
 	}
 	data, err := s.consumers.FindByGateway(ctx, gatewayID)
 	if err != nil {
-		return ids.GatewayID{}, nil, err
+		return ids.GatewayID{}, nil, nil, err
 	}
 	rc, ok := data.MatchPath(ticket.ConsumerPath)
 	if !ok {
-		return ids.GatewayID{}, nil, fmt.Errorf("oauth connect: consumer path %s no longer exists", ticket.ConsumerPath)
+		return ids.GatewayID{}, nil, nil, fmt.Errorf("oauth connect: consumer path %s no longer exists", ticket.ConsumerPath)
 	}
-	return gatewayID, rc, nil
+	return gatewayID, data, rc, nil
 }
 
 func forwardedAuth(reg *registrydomain.Registry) *registrydomain.MCPAuth {
@@ -211,8 +211,8 @@ func forwardedAuth(reg *registrydomain.Registry) *registrydomain.MCPAuth {
 	return reg.MCPTarget.Auth
 }
 
-func providerRegistry(rc *appconsumer.RoutableConsumer, provider string) *registrydomain.Registry {
-	for _, reg := range rc.Registries {
+func providerRegistry(regs []*registrydomain.Registry, provider string) *registrydomain.Registry {
+	for _, reg := range regs {
 		if cfg := forwardedAuth(reg); cfg != nil && cfg.Provider == provider {
 			return reg
 		}

--- a/pkg/app/oauth/connect_chain.go
+++ b/pkg/app/oauth/connect_chain.go
@@ -50,7 +50,7 @@ func (s *connectService) chainTarget(ctx context.Context, data *appconsumer.Data
 	if resource != "" {
 		if res, err := url.Parse(resource); err == nil && res.Path != "" {
 			if rc, ok := data.MatchPath(res.Path); ok {
-				if s.hasUnlinked(ctx, gatewayID, rc, principalSub) {
+				if s.hasUnlinked(ctx, gatewayID, data, rc, principalSub) {
 					return rc
 				}
 				return nil
@@ -62,15 +62,15 @@ func (s *connectService) chainTarget(ctx context.Context, data *appconsumer.Data
 		if rc.Consumer == nil || !rc.Consumer.Active {
 			continue
 		}
-		if s.hasUnlinked(ctx, gatewayID, rc, principalSub) {
+		if s.hasUnlinked(ctx, gatewayID, data, rc, principalSub) {
 			return rc
 		}
 	}
 	return nil
 }
 
-func (s *connectService) hasUnlinked(ctx context.Context, gatewayID ids.GatewayID, rc *appconsumer.RoutableConsumer, principalSub string) bool {
-	for _, reg := range rc.Registries {
+func (s *connectService) hasUnlinked(ctx context.Context, gatewayID ids.GatewayID, data *appconsumer.Data, rc *appconsumer.RoutableConsumer, principalSub string) bool {
+	for _, reg := range data.EffectiveRegistries(rc) {
 		cfg := forwardedAuth(reg)
 		if cfg == nil {
 			continue


### PR DESCRIPTION
## Summary

Forwarded-auth MCP registries attached to a **role** were invisible to the OAuth connect plane. `Page`, `Start`, `Callback` and the post-auth consent chaining all iterated the consumer's *directly attached* registries, which are empty for `role_based` consumers — their registries live on roles and are only merged by the MCP plane's `RoleScoper`.

As a result, a `role_based` consumer with a forwarded registry (e.g. Linear) attached to its role:
- never got the consent **detour** after the inbound OAuth login,
- saw an empty connect page ("No third-party providers configured"),
- and failed with `ErrProviderNotFound` when trying to connect a provider.

This was the root cause of "0 tools" + "no connect screen" for a Linear (forwarded) registry bound to a role.

## Changes

- **`Data.EffectiveRegistries`** (`pkg/app/consumer/consumer_data.go`): returns the consumer's registries for inline consumers, and the union of the assigned roles' MCP registries for `role_based` consumers, mirroring `RoleScoper` resolution.
- **`connect.go`** (`Page`/`Start`/`Callback`) and **`connect_chain.go`** (`hasUnlinked`) now use `EffectiveRegistries`, so the connect plane sees role-bound registries.
- **Wildcard routes** for connect/callback/disconnect so provider keys containing slashes (e.g. `app.linear/mcp`) resolve instead of returning `405 Method Not Allowed`.
- **Connect page** now shows the registry name as the row title and the provider key as the subtitle.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/app/consumer/... ./pkg/app/oauth/... ./pkg/api/handler/http/oauth/...`
- [x] New unit tests: `EffectiveRegistries` (inline, role_based union, unassigned roles ignored) and connect route with a slashed provider.
- [x] Manual: with a `role_based` consumer + Linear forwarded registry on the role, the post-auth detour now fires (`oauth: detouring to downstream consent page`), the connect page lists Linear, and `/oauth/connect/app.linear/mcp` resolves (302 → Linear authorize).

> Note: Linear's DCR rejects plaintext-HTTP redirect URIs on non-loopback hosts, so the connect button only completes over HTTPS (works on develop) or via `localhost` locally. This is a provider-side policy, not part of this change.

Made with [Cursor](https://cursor.com)