### PR TITLE
feat(gateway): cascade delete gateway-owned resources + role_based MCP consent fix

### DIFF
--- a/pkg/api/handler/http/gateway/delete_gateway_handler.go
+++ b/pkg/api/handler/http/gateway/delete_gateway_handler.go
@@ -31,7 +31,7 @@ func NewDeleteGatewayHandler(deleter appgateway.Deleter) *DeleteGatewayHandler {
 
 // Handle godoc
 // @Summary      Delete a gateway
-// @Description  Deletes a gateway. Fails if it still has dependent resources.
+// @Description  Deletes a gateway and cascades the deletion to every resource that belongs to it (consumers, roles, policies, auths, registries and vault credentials).
 // @Tags         gateways
 // @Produce      json
 // @Security     BearerAuth
@@ -40,7 +40,6 @@ func NewDeleteGatewayHandler(deleter appgateway.Deleter) *DeleteGatewayHandler {
 // @Failure      400  {object}  helpers.ErrorBody
 // @Failure      401  {object}  helpers.ErrorBody
 // @Failure      404  {object}  helpers.ErrorBody
-// @Failure      409  {object}  helpers.ErrorBody
 // @Router       /v1/gateways/{id} [delete]
 func (h *DeleteGatewayHandler) Handle(c *fiber.Ctx) error {
 	id, err := helpers.ParseUUIDParam[ids.GatewayKind](c, "id")

--- a/pkg/api/handler/http/oauth/connect_handler.go
+++ b/pkg/api/handler/http/oauth/connect_handler.go
@@ -16,15 +16,18 @@ package oauth
 
 import (
 	"errors"
+	"strings"
 
 	appoauth "github.com/NeuralTrust/AgentGateway/pkg/app/oauth"
 	"github.com/gofiber/fiber/v2"
 )
 
+// Provider keys can contain slashes (e.g. "app.linear/mcp"), so these routes
+// use a greedy wildcard segment instead of a single-segment :provider param.
 const (
-	ConnectStartPath    = "/oauth/connect/:provider"
-	ConnectCallbackPath = "/oauth/callback/:provider"
-	DisconnectPath      = "/oauth/disconnect/:provider"
+	ConnectStartPath    = "/oauth/connect/*"
+	ConnectCallbackPath = "/oauth/callback/*"
+	DisconnectPath      = "/oauth/disconnect/*"
 )
 
 type ConnectHandler struct {
@@ -44,7 +47,7 @@ func (h *ConnectHandler) Page(c *fiber.Ctx) error {
 }
 
 func (h *ConnectHandler) Start(c *fiber.Ctx) error {
-	location, err := h.connect.Start(c.UserContext(), c.BaseURL(), c.Query("ticket"), c.Params("provider"))
+	location, err := h.connect.Start(c.UserContext(), c.BaseURL(), c.Query("ticket"), providerParam(c))
 	if err != nil {
 		return h.pageError(c, err)
 	}
@@ -53,7 +56,7 @@ func (h *ConnectHandler) Start(c *fiber.Ctx) error {
 
 func (h *ConnectHandler) Callback(c *fiber.Ctx) error {
 	ticketID, err := h.connect.Callback(
-		c.UserContext(), c.BaseURL(), c.Params("provider"),
+		c.UserContext(), c.BaseURL(), providerParam(c),
 		c.Query("state"), c.Query("code"), c.Query("error"), c.Query("error_description"),
 	)
 	if err != nil {
@@ -67,10 +70,14 @@ func (h *ConnectHandler) Callback(c *fiber.Ctx) error {
 
 func (h *ConnectHandler) Disconnect(c *fiber.Ctx) error {
 	ticket := c.Query("ticket")
-	if err := h.connect.Disconnect(c.UserContext(), ticket, c.Params("provider")); err != nil {
+	if err := h.connect.Disconnect(c.UserContext(), ticket, providerParam(c)); err != nil {
 		return h.pageError(c, err)
 	}
 	return h.showPage(c, ticket, "")
+}
+
+func providerParam(c *fiber.Ctx) string {
+	return strings.TrimPrefix(c.Params("*"), "/")
 }
 
 func (h *ConnectHandler) showPage(c *fiber.Ctx, ticket, flash string) error {

--- a/pkg/api/handler/http/oauth/connect_handler_test.go
+++ b/pkg/api/handler/http/oauth/connect_handler_test.go
@@ -28,8 +28,9 @@ import (
 )
 
 type stubConnectService struct {
-	page *appoauth.ConnectPage
-	err  error
+	page        *appoauth.ConnectPage
+	err         error
+	gotProvider string
 }
 
 func (s *stubConnectService) CreateTicket(context.Context, ids.GatewayID, string, string) (string, error) {
@@ -40,7 +41,8 @@ func (s *stubConnectService) Page(context.Context, string) (*appoauth.ConnectPag
 	return s.page, s.err
 }
 
-func (s *stubConnectService) Start(context.Context, string, string, string) (string, error) {
+func (s *stubConnectService) Start(_ context.Context, _, _, provider string) (string, error) {
+	s.gotProvider = provider
 	return "https://github.com/login/oauth/authorize?x=1", nil
 }
 
@@ -122,5 +124,23 @@ func TestConnectStart_RedirectsToProvider(t *testing.T) {
 	}
 	if loc := res.Header.Get("Location"); !strings.HasPrefix(loc, "https://github.com/") {
 		t.Fatalf("Location = %q", loc)
+	}
+}
+
+func TestConnectStart_ProviderWithSlash(t *testing.T) {
+	t.Parallel()
+	stub := &stubConnectService{}
+	h := NewConnectHandler(stub)
+	app := fiber.New()
+	app.Get(ConnectStartPath, h.Start)
+	res, err := app.Test(httptest.NewRequest("GET", "/oauth/connect/app.linear/mcp?ticket=abc", nil))
+	if err != nil {
+		t.Fatalf("route test: %v", err)
+	}
+	if res.StatusCode != fiber.StatusFound {
+		t.Fatalf("status = %d, want 302", res.StatusCode)
+	}
+	if stub.gotProvider != "app.linear/mcp" {
+		t.Fatalf("provider = %q, want app.linear/mcp", stub.gotProvider)
 	}
 }

--- a/pkg/api/handler/http/oauth/pages.go
+++ b/pkg/api/handler/http/oauth/pages.go
@@ -48,11 +48,10 @@ body{
 }
 .brand{display:flex;align-items:center;gap:10px;margin-bottom:24px}
 .brand .mark{
-  width:28px;height:28px;border-radius:8px;flex:none;
-  background:linear-gradient(135deg,var(--accent),#4f4fd9);
+  width:28px;height:28px;border-radius:8px;flex:none;overflow:hidden;
   display:flex;align-items:center;justify-content:center;
-  color:#fff;font-weight:700;font-size:14px;
 }
+.brand .mark svg{width:100%;height:100%;display:block}
 .brand .name{font-weight:600;font-size:14px;letter-spacing:.01em}
 .brand .product{color:var(--faint);font-size:14px}
 h1{font-size:19px;font-weight:600;margin:0 0 6px}
@@ -100,7 +99,9 @@ a.btn.continue:hover{background:#6ee7a0}
 .hint a:hover{color:var(--fg)}
 `
 
-const brandHeader = `<div class="brand"><div class="mark">N</div><div class="name">NeuralTrust</div><div class="product">/ TrustGate</div></div>`
+const brandMark = `<svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><g clip-path="url(#ntClip)"><path fill="url(#ntGrad)" d="M32 0H0v32h32z"/><path fill="#fff" d="M18.092 20.06a.67.67 0 0 1-.55.3.7.7 0 0 1-.565-.286l-2.704-3.814-1.45 2.103 2.197 3.098a3.08 3.08 0 0 0 2.51 1.297h.038a3.06 3.06 0 0 0 2.502-1.342l8.02-11.477h-2.926z"/><path fill="#fff" d="M14.292 11.518a.63.63 0 0 1 .552.286l2.652 3.74 1.449-2.103-2.145-3.024a3.08 3.08 0 0 0-2.509-1.297h-.039a3.06 3.06 0 0 0-2.506 1.35L3.925 21.85l-.085.123h2.91l6.98-10.155a.68.68 0 0 1 .562-.3"/></g><defs><linearGradient id="ntGrad" x1="30.667" x2="6.667" y1="0" y2="32" gradientUnits="userSpaceOnUse"><stop stop-color="#03AFFF"/><stop offset="1" stop-color="#9B29FF"/></linearGradient><clipPath id="ntClip"><path fill="#fff" d="M0 0h32v32H0z"/></clipPath></defs></svg>`
+
+const brandHeader = `<div class="brand"><div class="mark">` + brandMark + `</div><div class="name">NeuralTrust</div><div class="product">/ TrustGate</div></div>`
 
 var connectPageTmpl = template.Must(template.New("connect").Parse(`<!doctype html>
 <html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">

--- a/pkg/api/handler/http/oauth/pages.go
+++ b/pkg/api/handler/http/oauth/pages.go
@@ -111,7 +111,7 @@ var connectPageTmpl = template.Must(template.New("connect").Parse(`<!doctype htm
 {{if .Flash}}<div class="flash">{{.Flash}}</div>{{end}}
 {{if not .Providers}}<p class="empty">No third-party providers are configured for this virtual MCP.</p>{{end}}
 {{range .Providers}}<div class="row">
-  <div><div class="name">{{.Provider}}</div><div class="reg">{{.Registry}}</div></div>
+  <div><div class="name">{{.Registry}}</div><div class="reg">{{.Provider}}</div></div>
   <div class="actions">{{if .Linked}}
     <span class="status"><span class="dot"></span>Connected</span>
     <form method="post" action="/oauth/disconnect/{{.Provider}}?ticket={{$.Ticket}}"><button class="btn revoke">Revoke</button></form>

--- a/pkg/app/consumer/consumer_data.go
+++ b/pkg/app/consumer/consumer_data.go
@@ -78,6 +78,41 @@ func (d *Data) indexRegistries() {
 	}
 }
 
+func (d *Data) EffectiveRegistries(rc *RoutableConsumer) []*registrydomain.Registry {
+	if rc == nil || rc.Consumer == nil {
+		return nil
+	}
+	if rc.Consumer.RoutingMode != domain.RoutingModeRoleBased {
+		return rc.Registries
+	}
+	assigned := make(map[ids.RoleID]struct{}, len(rc.Consumer.RoleIDs))
+	for _, id := range rc.Consumer.RoleIDs {
+		assigned[id] = struct{}{}
+	}
+	seen := make(map[ids.RegistryID]struct{})
+	out := make([]*registrydomain.Registry, 0)
+	for _, role := range d.Roles {
+		if role == nil {
+			continue
+		}
+		if _, ok := assigned[role.ID]; !ok {
+			continue
+		}
+		for _, id := range role.RegistryIDs {
+			reg, ok := d.RegistryByID(id)
+			if !ok || !reg.IsMCP() {
+				continue
+			}
+			if _, dup := seen[reg.ID]; dup {
+				continue
+			}
+			seen[reg.ID] = struct{}{}
+			out = append(out, reg)
+		}
+	}
+	return out
+}
+
 func (d *Data) MatchSlug(slug string) (*RoutableConsumer, bool) {
 	if d == nil || d.bySlug == nil {
 		return nil, false

--- a/pkg/app/consumer/consumer_data_test.go
+++ b/pkg/app/consumer/consumer_data_test.go
@@ -19,6 +19,8 @@ import (
 
 	domain "github.com/NeuralTrust/AgentGateway/pkg/domain/consumer"
 	"github.com/NeuralTrust/AgentGateway/pkg/domain/ids"
+	registrydomain "github.com/NeuralTrust/AgentGateway/pkg/domain/registry"
+	roledomain "github.com/NeuralTrust/AgentGateway/pkg/domain/role"
 )
 
 func routable(slug string, active bool) RoutableConsumer {
@@ -50,5 +52,86 @@ func TestData_MatchSlug_SkipsInactiveConsumers(t *testing.T) {
 
 	if _, ok := d.MatchSlug("X84Yhsy8"); ok {
 		t.Fatal("inactive consumer must not be routable")
+	}
+}
+
+func mcpRegistry(gatewayID ids.GatewayID) *registrydomain.Registry {
+	return &registrydomain.Registry{
+		ID:        ids.New[ids.RegistryKind](),
+		GatewayID: gatewayID,
+		Type:      registrydomain.TypeMCP,
+		Enabled:   true,
+	}
+}
+
+func TestData_EffectiveRegistries_InlineReturnsDirectRegistries(t *testing.T) {
+	t.Parallel()
+	gatewayID := ids.New[ids.GatewayKind]()
+	reg := mcpRegistry(gatewayID)
+	rc := routable("inline1x", true)
+	rc.Consumer.RoutingMode = domain.RoutingModeInline
+	rc.Registries = []*registrydomain.Registry{reg}
+	d := NewData(gatewayID, []RoutableConsumer{rc})
+
+	got := d.EffectiveRegistries(&d.Consumers[0])
+	if len(got) != 1 || got[0].ID != reg.ID {
+		t.Fatalf("inline EffectiveRegistries = %v, want [%s]", got, reg.ID)
+	}
+}
+
+func TestData_EffectiveRegistries_RoleBasedUnionsRoleRegistries(t *testing.T) {
+	t.Parallel()
+	gatewayID := ids.New[ids.GatewayKind]()
+	regA := mcpRegistry(gatewayID)
+	regB := mcpRegistry(gatewayID)
+	roleID := ids.New[ids.RoleKind]()
+	otherRoleID := ids.New[ids.RoleKind]()
+
+	rc := routable("rolebsd1", true)
+	rc.Consumer.RoutingMode = domain.RoutingModeRoleBased
+	rc.Consumer.RoleIDs = []ids.RoleID{roleID}
+
+	roles := []*roledomain.Role{
+		{ID: roleID, RegistryIDs: []ids.RegistryID{regA.ID, regB.ID}},
+		{ID: otherRoleID, RegistryIDs: []ids.RegistryID{mcpRegistry(gatewayID).ID}},
+	}
+	d := NewData(gatewayID, []RoutableConsumer{rc}, roles)
+	d.SetRegistryIndex(map[ids.RegistryID]*registrydomain.Registry{
+		regA.ID: regA,
+		regB.ID: regB,
+	})
+
+	got := d.EffectiveRegistries(&d.Consumers[0])
+	if len(got) != 2 {
+		t.Fatalf("role_based EffectiveRegistries len = %d, want 2 (got %v)", len(got), got)
+	}
+	seen := map[ids.RegistryID]bool{}
+	for _, reg := range got {
+		seen[reg.ID] = true
+	}
+	if !seen[regA.ID] || !seen[regB.ID] {
+		t.Fatalf("role_based EffectiveRegistries missing role registries: %v", got)
+	}
+}
+
+func TestData_EffectiveRegistries_RoleBasedSkipsUnassignedRoles(t *testing.T) {
+	t.Parallel()
+	gatewayID := ids.New[ids.GatewayKind]()
+	reg := mcpRegistry(gatewayID)
+	assignedRole := ids.New[ids.RoleKind]()
+	unassignedRole := ids.New[ids.RoleKind]()
+
+	rc := routable("rolebsd2", true)
+	rc.Consumer.RoutingMode = domain.RoutingModeRoleBased
+	rc.Consumer.RoleIDs = []ids.RoleID{assignedRole}
+
+	roles := []*roledomain.Role{
+		{ID: unassignedRole, RegistryIDs: []ids.RegistryID{reg.ID}},
+	}
+	d := NewData(gatewayID, []RoutableConsumer{rc}, roles)
+	d.SetRegistryIndex(map[ids.RegistryID]*registrydomain.Registry{reg.ID: reg})
+
+	if got := d.EffectiveRegistries(&d.Consumers[0]); len(got) != 0 {
+		t.Fatalf("EffectiveRegistries from unassigned role = %v, want empty", got)
 	}
 }

--- a/pkg/app/oauth/connect.go
+++ b/pkg/app/oauth/connect.go
@@ -65,12 +65,12 @@ func (s *connectService) mintTicket(ctx context.Context, t ConnectTicket) (strin
 }
 
 func (s *connectService) Page(ctx context.Context, ticketID string) (*ConnectPage, error) {
-	ticket, gatewayID, rc, err := s.resolve(ctx, ticketID)
+	ticket, gatewayID, data, rc, err := s.resolve(ctx, ticketID)
 	if err != nil {
 		return nil, err
 	}
 	page := &ConnectPage{ConsumerPath: ticket.ConsumerPath, ResumeURL: ticket.ResumeURL}
-	for _, reg := range rc.Registries {
+	for _, reg := range data.EffectiveRegistries(rc) {
 		cfg := forwardedAuth(reg)
 		if cfg == nil {
 			continue
@@ -91,11 +91,11 @@ func (s *connectService) Page(ctx context.Context, ticketID string) (*ConnectPag
 }
 
 func (s *connectService) Start(ctx context.Context, baseURL, ticketID, provider string) (string, error) {
-	ticket, gatewayID, rc, err := s.resolve(ctx, ticketID)
+	ticket, gatewayID, data, rc, err := s.resolve(ctx, ticketID)
 	if err != nil {
 		return "", err
 	}
-	reg := providerRegistry(rc, provider)
+	reg := providerRegistry(data.EffectiveRegistries(rc), provider)
 	if reg == nil {
 		return "", ErrProviderNotFound
 	}
@@ -133,11 +133,11 @@ func (s *connectService) Callback(ctx context.Context, baseURL, provider, state,
 	if errCode != "" {
 		return st.TicketID, oauthErr(errCode, errDesc)
 	}
-	gatewayID, rc, err := s.routable(ctx, &st.Ticket)
+	gatewayID, data, rc, err := s.routable(ctx, &st.Ticket)
 	if err != nil {
 		return st.TicketID, err
 	}
-	reg := providerRegistry(rc, provider)
+	reg := providerRegistry(data.EffectiveRegistries(rc), provider)
 	if reg == nil {
 		return st.TicketID, ErrProviderNotFound
 	}
@@ -163,42 +163,42 @@ func (s *connectService) Callback(ctx context.Context, baseURL, provider, state,
 }
 
 func (s *connectService) Disconnect(ctx context.Context, ticketID, provider string) error {
-	ticket, gatewayID, _, err := s.resolve(ctx, ticketID)
+	ticket, gatewayID, _, _, err := s.resolve(ctx, ticketID)
 	if err != nil {
 		return err
 	}
 	return s.vault.Delete(ctx, gatewayID, ticket.PrincipalSub, provider)
 }
 
-func (s *connectService) resolve(ctx context.Context, ticketID string) (*ConnectTicket, ids.GatewayID, *appconsumer.RoutableConsumer, error) {
+func (s *connectService) resolve(ctx context.Context, ticketID string) (*ConnectTicket, ids.GatewayID, *appconsumer.Data, *appconsumer.RoutableConsumer, error) {
 	ticket, err := s.store.GetTicket(ctx, ticketID)
 	if err != nil {
-		return nil, ids.GatewayID{}, nil, err
+		return nil, ids.GatewayID{}, nil, nil, err
 	}
 	if ticket == nil {
-		return nil, ids.GatewayID{}, nil, ErrTicketNotFound
+		return nil, ids.GatewayID{}, nil, nil, ErrTicketNotFound
 	}
-	gatewayID, rc, err := s.routable(ctx, ticket)
+	gatewayID, data, rc, err := s.routable(ctx, ticket)
 	if err != nil {
-		return nil, ids.GatewayID{}, nil, err
+		return nil, ids.GatewayID{}, nil, nil, err
 	}
-	return ticket, gatewayID, rc, nil
+	return ticket, gatewayID, data, rc, nil
 }
 
-func (s *connectService) routable(ctx context.Context, ticket *ConnectTicket) (ids.GatewayID, *appconsumer.RoutableConsumer, error) {
+func (s *connectService) routable(ctx context.Context, ticket *ConnectTicket) (ids.GatewayID, *appconsumer.Data, *appconsumer.RoutableConsumer, error) {
 	gatewayID, err := ids.Parse[ids.GatewayKind](ticket.GatewayID)
 	if err != nil {
-		return ids.GatewayID{}, nil, fmt.Errorf("oauth connect: bad gateway id in ticket: %w", err)
+		return ids.GatewayID{}, nil, nil, fmt.Errorf("oauth connect: bad gateway id in ticket: %w", err)
 	}
 	data, err := s.consumers.FindByGateway(ctx, gatewayID)
 	if err != nil {
-		return ids.GatewayID{}, nil, err
+		return ids.GatewayID{}, nil, nil, err
 	}
 	rc, ok := data.MatchPath(ticket.ConsumerPath)
 	if !ok {
-		return ids.GatewayID{}, nil, fmt.Errorf("oauth connect: consumer path %s no longer exists", ticket.ConsumerPath)
+		return ids.GatewayID{}, nil, nil, fmt.Errorf("oauth connect: consumer path %s no longer exists", ticket.ConsumerPath)
 	}
-	return gatewayID, rc, nil
+	return gatewayID, data, rc, nil
 }
 
 func forwardedAuth(reg *registrydomain.Registry) *registrydomain.MCPAuth {
@@ -211,8 +211,8 @@ func forwardedAuth(reg *registrydomain.Registry) *registrydomain.MCPAuth {
 	return reg.MCPTarget.Auth
 }
 
-func providerRegistry(rc *appconsumer.RoutableConsumer, provider string) *registrydomain.Registry {
-	for _, reg := range rc.Registries {
+func providerRegistry(regs []*registrydomain.Registry, provider string) *registrydomain.Registry {
+	for _, reg := range regs {
 		if cfg := forwardedAuth(reg); cfg != nil && cfg.Provider == provider {
 			return reg
 		}

--- a/pkg/app/oauth/connect_chain.go
+++ b/pkg/app/oauth/connect_chain.go
@@ -50,7 +50,7 @@ func (s *connectService) chainTarget(ctx context.Context, data *appconsumer.Data
 	if resource != "" {
 		if res, err := url.Parse(resource); err == nil && res.Path != "" {
 			if rc, ok := data.MatchPath(res.Path); ok {
-				if s.hasUnlinked(ctx, gatewayID, rc, principalSub) {
+				if s.hasUnlinked(ctx, gatewayID, data, rc, principalSub) {
 					return rc
 				}
 				return nil
@@ -62,15 +62,15 @@ func (s *connectService) chainTarget(ctx context.Context, data *appconsumer.Data
 		if rc.Consumer == nil || !rc.Consumer.Active {
 			continue
 		}
-		if s.hasUnlinked(ctx, gatewayID, rc, principalSub) {
+		if s.hasUnlinked(ctx, gatewayID, data, rc, principalSub) {
 			return rc
 		}
 	}
 	return nil
 }
 
-func (s *connectService) hasUnlinked(ctx context.Context, gatewayID ids.GatewayID, rc *appconsumer.RoutableConsumer, principalSub string) bool {
-	for _, reg := range rc.Registries {
+func (s *connectService) hasUnlinked(ctx context.Context, gatewayID ids.GatewayID, data *appconsumer.Data, rc *appconsumer.RoutableConsumer, principalSub string) bool {
+	for _, reg := range data.EffectiveRegistries(rc) {
 		cfg := forwardedAuth(reg)
 		if cfg == nil {
 			continue

--- a/pkg/infra/cache/subscriber/invalidate_gateway_data_event_subscriber.go
+++ b/pkg/infra/cache/subscriber/invalidate_gateway_data_event_subscriber.go
@@ -35,6 +35,8 @@ type InvalidateGatewayDataEventSubscriber struct {
 	authCache         *cache.TTLMap
 	consumerPathCache *cache.TTLMap
 	roleCache         *cache.TTLMap
+	registryCache     *cache.TTLMap
+	policyCache       *cache.TTLMap
 }
 
 func NewInvalidateGatewayDataEventSubscriber(
@@ -51,6 +53,8 @@ func NewInvalidateGatewayDataEventSubscriber(
 		authCache:         c.GetTTLMap(cache.AuthTTLName),
 		consumerPathCache: c.GetTTLMap(cache.ConsumerPathTTLName),
 		roleCache:         c.GetTTLMap(cache.RoleTTLName),
+		registryCache:     c.GetTTLMap(cache.RegistryTTLName),
+		policyCache:       c.GetTTLMap(cache.PolicyTTLName),
 	}
 }
 
@@ -77,6 +81,12 @@ func (s *InvalidateGatewayDataEventSubscriber) OnEvent(ctx context.Context, evt 
 	}
 	if s.roleCache != nil {
 		s.roleCache.Clear()
+	}
+	if s.registryCache != nil {
+		s.registryCache.Clear()
+	}
+	if s.policyCache != nil {
+		s.policyCache.Clear()
 	}
 
 	if err := s.cache.DeleteAllByGatewayID(ctx, evt.GatewayID); err != nil {

--- a/pkg/infra/cache/subscriber/invalidate_gateway_data_event_subscriber_test.go
+++ b/pkg/infra/cache/subscriber/invalidate_gateway_data_event_subscriber_test.go
@@ -49,6 +49,8 @@ func TestInvalidateGatewayDataEventSubscriber_OnEvent_EvictsGatewayScopedEntries
 	authMap := cache.NewTTLMap(cache.AuthCacheTTL)
 	consumerPathMap := cache.NewTTLMap(cache.ConsumerDataCacheTTL)
 	roleMap := cache.NewTTLMap(cache.RoleCacheTTL)
+	registryMap := cache.NewTTLMap(cache.RegistryCacheTTL)
+	policyMap := cache.NewTTLMap(cache.PolicyCacheTTL)
 	gatewayMap.Set("id:"+gatewayID, gw)
 	gatewayMap.Set("slug:acme", gw)
 	gatewayMap.Set("id:"+otherID, "keep")
@@ -61,6 +63,10 @@ func TestInvalidateGatewayDataEventSubscriber_OnEvent_EvictsGatewayScopedEntries
 	consumerPathMap.Set("|/v1/mcp/linear", "path-match")
 	roleID := ids.New[ids.RoleKind]().String()
 	roleMap.Set(roleID, "role")
+	registryID := ids.New[ids.RegistryKind]().String()
+	registryMap.Set(registryID, "registry")
+	policyID := ids.New[ids.PolicyKind]().String()
+	policyMap.Set(policyID, "policy")
 
 	client := cachemocks.NewClient(t)
 	client.EXPECT().GetTTLMap(cache.GatewayTTLName).Return(gatewayMap).Once()
@@ -70,6 +76,8 @@ func TestInvalidateGatewayDataEventSubscriber_OnEvent_EvictsGatewayScopedEntries
 	client.EXPECT().GetTTLMap(cache.AuthTTLName).Return(authMap).Once()
 	client.EXPECT().GetTTLMap(cache.ConsumerPathTTLName).Return(consumerPathMap).Once()
 	client.EXPECT().GetTTLMap(cache.RoleTTLName).Return(roleMap).Once()
+	client.EXPECT().GetTTLMap(cache.RegistryTTLName).Return(registryMap).Once()
+	client.EXPECT().GetTTLMap(cache.PolicyTTLName).Return(policyMap).Once()
 	client.EXPECT().DeleteAllByGatewayID(mock.Anything, gatewayID).Return(nil).Once()
 
 	sub := subscriber.NewInvalidateGatewayDataEventSubscriber(discardLogger(), client)
@@ -94,6 +102,12 @@ func TestInvalidateGatewayDataEventSubscriber_OnEvent_EvictsGatewayScopedEntries
 	}
 	if _, ok := roleMap.Get(roleID); ok {
 		t.Fatal("role entry was not evicted")
+	}
+	if _, ok := registryMap.Get(registryID); ok {
+		t.Fatal("registry entry was not evicted; gateway delete leaves stale registry reads")
+	}
+	if _, ok := policyMap.Get(policyID); ok {
+		t.Fatal("policy entry was not evicted; gateway delete leaves stale policy reads")
 	}
 	if _, ok := gatewayMap.Get("id:" + otherID); !ok {
 		t.Fatal("unrelated gateway entry must be preserved")

--- a/pkg/infra/repository/gateway/repository.go
+++ b/pkg/infra/repository/gateway/repository.go
@@ -125,10 +125,29 @@ func (r *Repository) Update(ctx context.Context, g *domain.Gateway) error {
 	})
 }
 
+// cascadeDeleteStatements removes every resource that belongs to the gateway
+// before the gateway row itself. The order respects the ON DELETE RESTRICT
+// foreign keys on the junction tables (consumer_auth.auth_id,
+// consumer_policy.policy_id, role_registry.registry_id, consumer_registry.registry_id):
+// consumers and roles are deleted first so their junction rows cascade away,
+// leaving auths, policies and registries free to be removed.
+var cascadeDeleteStatements = []string{
+	`DELETE FROM consumers  WHERE gateway_id = $1`,
+	`DELETE FROM roles      WHERE gateway_id = $1`,
+	`DELETE FROM policies   WHERE gateway_id = $1`,
+	`DELETE FROM auths      WHERE gateway_id = $1`,
+	`DELETE FROM registries WHERE gateway_id = $1`,
+}
+
 func (r *Repository) Delete(ctx context.Context, id ids.GatewayID) error {
-	const query = `DELETE FROM gateways WHERE id = $1`
+	const deleteGateway = `DELETE FROM gateways WHERE id = $1`
 	return database.WithTx(ctx, r.conn, func(tx pgx.Tx) error {
-		cmd, err := tx.Exec(ctx, query, id)
+		for _, stmt := range cascadeDeleteStatements {
+			if _, err := tx.Exec(ctx, stmt, id); err != nil {
+				return mapPgError(err)
+			}
+		}
+		cmd, err := tx.Exec(ctx, deleteGateway, id)
 		if err != nil {
 			return mapPgError(err)
 		}

--- a/tests/functional/delete_consumer_test.go
+++ b/tests/functional/delete_consumer_test.go
@@ -66,17 +66,22 @@ func TestDeleteConsumer_InvalidConsumerUUID(t *testing.T) {
 	assert.Equal(t, "invalid_uuid", body["error"])
 }
 
-func TestDeleteGateway_FailsWhenItHasConsumers(t *testing.T) {
+func TestDeleteGateway_CascadesConsumers(t *testing.T) {
 	defer Track(t, "DeleteConsumer")()
 	gwID := CreateGateway(t, map[string]any{"name": uniqueName("co-del-gw-cascade")})
-	_ = CreateConsumer(t, gwID, validConsumerPayload(uniqueName("co-del-gw-cascade-co")))
+	coID := CreateConsumer(t, gwID, validConsumerPayload(uniqueName("co-del-gw-cascade-co")))
 
 	status, body := sendRequest(t, http.MethodDelete,
 		fmt.Sprintf("%s/v1/gateways/%s", AdminURL, gwID),
 		nil, nil,
 	)
-	require.Equal(t, http.StatusConflict, status, "body=%v", body)
-	assert.Equal(t, "has_dependents", body["error"])
+	require.Equal(t, http.StatusNoContent, status, "deleting a gateway must cascade to its consumers, body=%v", body)
+
+	status, body = sendRequest(t, http.MethodGet,
+		fmt.Sprintf("%s/v1/gateways/%s/consumers/%s", AdminURL, gwID, coID),
+		nil, nil,
+	)
+	require.Equal(t, http.StatusNotFound, status, "the consumer must be gone after the gateway deletion, body=%v", body)
 }
 
 func TestDeleteRegistry_CascadesInlineConsumerBinding(t *testing.T) {

--- a/tests/functional/delete_registry_test.go
+++ b/tests/functional/delete_registry_test.go
@@ -87,14 +87,18 @@ func TestDeleteRegistry_InvalidRegistryUUID(t *testing.T) {
 	assert.Equal(t, "invalid_uuid", body["error"])
 }
 
-func TestDeleteGateway_FailsWhenItHasBackends(t *testing.T) {
+func TestDeleteGateway_CascadesRegistries(t *testing.T) {
 	defer Track(t, "DeleteRegistry")()
 	gwID := CreateGateway(t, map[string]any{"name": uniqueName("be-del-cascade-gw")})
-	_ = CreateRegistry(t, gwID, validRegistryPayload(uniqueName("be-del-cascade-be")))
+	beID := CreateRegistry(t, gwID, validRegistryPayload(uniqueName("be-del-cascade-be")))
 
 	status, body := sendRequest(t, http.MethodDelete,
 		fmt.Sprintf("%s/v1/gateways/%s", AdminURL, gwID), nil, nil,
 	)
-	require.Equal(t, http.StatusConflict, status, "body=%v", body)
-	assert.Equal(t, "has_dependents", body["error"])
+	require.Equal(t, http.StatusNoContent, status, "deleting a gateway must cascade to its registries, body=%v", body)
+
+	status, body = sendRequest(t, http.MethodGet,
+		fmt.Sprintf("%s/v1/gateways/%s/registries/%s", AdminURL, gwID, beID), nil, nil,
+	)
+	require.Equal(t, http.StatusNotFound, status, "the registry must be gone after the gateway deletion, body=%v", body)
 }


### PR DESCRIPTION
## Summary
- **Cascade delete on gateways**: `DELETE /v1/gateways/:id` now removes every resource owned by the gateway (consumers, roles, policies, auths, registries and vault credentials) inside a single transaction, instead of returning `409 has_dependents`. The delete order respects the `ON DELETE RESTRICT` FKs on the junction tables (`consumer_*`, `role_registry`): consumers and roles go first so their junction rows cascade away, then auths/policies/registries, then the gateway (which cascades `vault_credentials`).
- **OAuth connect/consent pages**: swap the placeholder "N" brand mark for the NeuralTrust SVG logo.
- **MCP role_based consent**: resolve `role_based` registries in the connect plane (carried from the previous commit on this branch).

## Changes
- `pkg/infra/repository/gateway/repository.go`: cascade deletes in `Repository.Delete`.
- `pkg/api/handler/http/gateway/delete_gateway_handler.go`: updated Swagger description, removed the `409` response.
- `pkg/api/handler/http/oauth/pages.go`: SVG brand logo.
- `tests/functional/delete_consumer_test.go`, `tests/functional/delete_registry_test.go`: replaced the `409 has_dependents` expectations with cascade-deletion assertions.

## Test plan
- [x] `go build ./...`
- [x] `go vet -tags functional ./tests/functional/...`
- [x] Gateway unit tests pass; pre-commit hook (build + tests) green.
- [ ] Run functional suite against Postgres/Redis to validate the new cascade behavior end-to-end.

Made with [Cursor](https://cursor.com)