### PR TITLE
feat(plugins): model_allowlist plugin (RUN-700)

### DIFF
--- a/pkg/app/plugins/catalog_metadata.go
+++ b/pkg/app/plugins/catalog_metadata.go
@@ -268,4 +268,41 @@ var pluginCatalogMeta = map[string]catalogMeta{
 			},
 		},
 	},
+	"model_allowlist": {
+		name:        "Model Allowlist",
+		group:       groupRouting,
+		description: "Restrict which models a consumer or gateway may call, matching by name with glob patterns. Reject disallowed models with a 403 or transparently substitute them.",
+		schema: SettingsSchema{
+			Fields: []Field{
+				{
+					Key:         "allowed_models",
+					Label:       "Allowed Models",
+					Type:        FieldTypeArray,
+					Description: "Model name patterns permitted. Use * as a wildcard (e.g. gpt-5*).",
+					Required:    true,
+					Item:        &Field{Key: "model", Label: "Model", Type: FieldTypeString},
+				},
+				{
+					Key:         "behavior_on_disallowed",
+					Label:       "Behavior On Disallowed",
+					Type:        FieldTypeEnum,
+					Description: "Action taken when a requested model is not in the allowlist.",
+					Enum:        []string{"reject", "substitute"},
+					Default:     "reject",
+				},
+				{
+					Key:         "substitute_with",
+					Label:       "Substitute With",
+					Type:        FieldTypeString,
+					Description: "Model written back when behavior is substitute. Must match the allowlist.",
+				},
+				{
+					Key:         "default_model",
+					Label:       "Default Model",
+					Type:        FieldTypeString,
+					Description: "Model injected when the request omits one. Must match the allowlist.",
+				},
+			},
+		},
+	},
 }

--- a/pkg/app/plugins/catalog_test.go
+++ b/pkg/app/plugins/catalog_test.go
@@ -31,6 +31,7 @@ var builtinSlugs = []string{
 	"cors",
 	"token_rate_limiter",
 	"semantic_cache",
+	"model_allowlist",
 }
 
 func registerBuiltins(t *testing.T) Registry {
@@ -46,6 +47,7 @@ func registerBuiltins(t *testing.T) Registry {
 		{"cors", []policy.Stage{policy.StagePreRequest}, []policy.Stage{policy.StagePreRequest}},
 		{"token_rate_limiter", []policy.Stage{policy.StagePreRequest, policy.StagePostResponse}, []policy.Stage{policy.StagePreRequest, policy.StagePostResponse}},
 		{"semantic_cache", []policy.Stage{policy.StagePreRequest, policy.StagePostResponse}, []policy.Stage{policy.StagePreRequest, policy.StagePostResponse}},
+		{"model_allowlist", []policy.Stage{policy.StagePreRequest}, []policy.Stage{policy.StagePreRequest}},
 	}
 	for _, s := range specs {
 		require.NoError(t, reg.Register(&stagePlugin{name: s.name, mandatory: s.mandatory, supported: s.supported}))
@@ -71,7 +73,7 @@ func TestCatalogService_GroupsAndOrder(t *testing.T) {
 	}
 	assert.ElementsMatch(t, []string{"rate_limiter", "request_size_limiter", "cors"}, byType[groupTrafficControl])
 	assert.Equal(t, []string{"token_rate_limiter"}, byType[groupQuota])
-	assert.Equal(t, []string{"semantic_cache"}, byType[groupRouting])
+	assert.ElementsMatch(t, []string{"semantic_cache", "model_allowlist"}, byType[groupRouting])
 }
 
 func TestCatalogService_EntriesHaveStagesAndSchema(t *testing.T) {

--- a/pkg/container/modules/plugins.go
+++ b/pkg/container/modules/plugins.go
@@ -24,6 +24,7 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/infra/cache/semantic"
 	embeddingfactory "github.com/NeuralTrust/TrustGate/pkg/infra/embedding/factory"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/plugins/cors"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/plugins/modelallowlist"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/plugins/ratelimit"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/plugins/requestsize"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/plugins/semanticcache"
@@ -68,6 +69,7 @@ func newPluginRegistry(p pluginParams) (appplugins.Registry, error) {
 		requestsize.New(),
 		cors.New(),
 		semanticcache.New(store, p.Locator, p.Adapters),
+		modelallowlist.New(),
 	}
 	for _, plugin := range catalog {
 		if err := reg.Register(plugin); err != nil {

--- a/pkg/infra/plugins/modelallowlist/config.go
+++ b/pkg/infra/plugins/modelallowlist/config.go
@@ -1,0 +1,119 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modelallowlist
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/plugins/pluginutil"
+)
+
+type behavior string
+
+const (
+	behaviorReject     behavior = "reject"
+	behaviorSubstitute behavior = "substitute"
+)
+
+type config struct {
+	AllowedModels  []string `mapstructure:"allowed_models"`
+	DefaultModel   string   `mapstructure:"default_model"`
+	Behavior       behavior `mapstructure:"behavior_on_disallowed"`
+	SubstituteWith string   `mapstructure:"substitute_with"`
+}
+
+func parseConfig(settings map[string]any) (*config, error) {
+	cfg, err := pluginutil.Parse[config](settings)
+	if err != nil {
+		return nil, err
+	}
+	cfg.applyDefaults()
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+func (c *config) applyDefaults() {
+	if c.Behavior == "" {
+		c.Behavior = behaviorReject
+	}
+}
+
+func (c *config) validate() error {
+	if len(c.AllowedModels) == 0 {
+		return fmt.Errorf("model_allowlist: allowed_models must not be empty")
+	}
+	for _, p := range c.AllowedModels {
+		if strings.TrimSpace(p) == "" {
+			return fmt.Errorf("model_allowlist: allowed_models entries must not be blank")
+		}
+	}
+	switch c.Behavior {
+	case behaviorReject, behaviorSubstitute:
+	default:
+		return fmt.Errorf("model_allowlist: behavior_on_disallowed must be reject or substitute")
+	}
+	if c.Behavior == behaviorSubstitute {
+		if c.SubstituteWith == "" {
+			return fmt.Errorf("model_allowlist: substitute_with is required when behavior_on_disallowed is substitute")
+		}
+		if _, ok := matchAny(c.SubstituteWith, c.AllowedModels); !ok {
+			return fmt.Errorf("model_allowlist: substitute_with %q does not match allowed_models", c.SubstituteWith)
+		}
+	} else if c.SubstituteWith != "" {
+		return fmt.Errorf("model_allowlist: substitute_with must not be set when behavior_on_disallowed is %q", c.Behavior)
+	}
+	if c.DefaultModel != "" {
+		if _, ok := matchAny(c.DefaultModel, c.AllowedModels); !ok {
+			return fmt.Errorf("model_allowlist: default_model %q does not match allowed_models", c.DefaultModel)
+		}
+	}
+	return nil
+}
+
+func matchAny(model string, patterns []string) (string, bool) {
+	for _, p := range patterns {
+		if matchGlob(p, model) {
+			return p, true
+		}
+	}
+	return "", false
+}
+
+func matchGlob(pattern, s string) bool {
+	if !strings.Contains(pattern, "*") {
+		return pattern == s
+	}
+	parts := strings.Split(pattern, "*")
+	if !strings.HasPrefix(s, parts[0]) {
+		return false
+	}
+	s = s[len(parts[0]):]
+	for i := 1; i < len(parts)-1; i++ {
+		part := parts[i]
+		if part == "" {
+			continue
+		}
+		idx := strings.Index(s, part)
+		if idx < 0 {
+			return false
+		}
+		s = s[idx+len(part):]
+	}
+	last := parts[len(parts)-1]
+	return strings.HasSuffix(s, last)
+}

--- a/pkg/infra/plugins/modelallowlist/config_test.go
+++ b/pkg/infra/plugins/modelallowlist/config_test.go
@@ -1,0 +1,187 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modelallowlist
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMatchGlob(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		input   string
+		want    bool
+	}{
+		{name: "exact match", pattern: "gpt-4o", input: "gpt-4o", want: true},
+		{name: "exact mismatch", pattern: "gpt-5", input: "gpt-5-turbo", want: false},
+		{name: "suffix wildcard matches base", pattern: "gpt-5*", input: "gpt-5", want: true},
+		{name: "suffix wildcard matches family", pattern: "gpt-5*", input: "gpt-5-mini", want: true},
+		{name: "prefix wildcard", pattern: "*turbo", input: "gpt-4-turbo", want: true},
+		{name: "prefix wildcard no match", pattern: "*turbo", input: "gpt-4-mini", want: false},
+		{name: "wildcard matches empty run", pattern: "claude-sonnet-*", input: "claude-sonnet-", want: true},
+		{name: "wildcard matches any run", pattern: "claude-sonnet-*", input: "claude-sonnet-4.6", want: true},
+		{name: "interior scan a*b*c", pattern: "a*b*c", input: "axxbyyc", want: true},
+		{name: "interior scan a*b*c no tail", pattern: "a*b*c", input: "axxbyyd", want: false},
+		{name: "interior scan a*b*c missing middle", pattern: "a*b*c", input: "axxc", want: false},
+		{name: "double star matches everything", pattern: "**", input: "anything-at-all", want: true},
+		{name: "double star matches empty", pattern: "**", input: "", want: true},
+		{name: "case sensitive mismatch", pattern: "gpt-5*", input: "GPT-5", want: false},
+		{name: "bedrock arn literal match", pattern: "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude", input: "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude", want: true},
+		{name: "bedrock arn glob match", pattern: "arn:aws:bedrock:*", input: "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude", want: true},
+		{name: "bedrock arn glob no match", pattern: "arn:aws:bedrock:*", input: "arn:aws:sagemaker:us-east-1", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, matchGlob(tt.pattern, tt.input))
+		})
+	}
+}
+
+func TestMatchAny(t *testing.T) {
+	patterns := []string{"gpt-5*", "claude-sonnet-*"}
+	tests := []struct {
+		name        string
+		input       string
+		wantMatched string
+		wantOK      bool
+	}{
+		{name: "first pattern", input: "gpt-5-turbo", wantMatched: "gpt-5*", wantOK: true},
+		{name: "second pattern", input: "claude-sonnet-4.6", wantMatched: "claude-sonnet-*", wantOK: true},
+		{name: "no match", input: "mistral-large", wantMatched: "", wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matched, ok := matchAny(tt.input, patterns)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantMatched, matched)
+		})
+	}
+}
+
+func TestConfigValidate(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings map[string]any
+		wantErr  bool
+	}{
+		{
+			name:     "valid reject defaults behavior",
+			settings: map[string]any{"allowed_models": []string{"gpt-5*"}},
+		},
+		{
+			name:     "valid explicit reject",
+			settings: map[string]any{"allowed_models": []string{"gpt-5*"}, "behavior_on_disallowed": "reject"},
+		},
+		{
+			name: "valid substitute in allowlist",
+			settings: map[string]any{
+				"allowed_models":         []string{"gpt-5*"},
+				"behavior_on_disallowed": "substitute",
+				"substitute_with":        "gpt-5",
+			},
+		},
+		{
+			name:     "valid default model in allowlist",
+			settings: map[string]any{"allowed_models": []string{"gpt-5*"}, "default_model": "gpt-5"},
+		},
+		{
+			name:     "empty allowlist",
+			settings: map[string]any{"allowed_models": []string{}},
+			wantErr:  true,
+		},
+		{
+			name:     "missing allowlist",
+			settings: map[string]any{"behavior_on_disallowed": "reject"},
+			wantErr:  true,
+		},
+		{
+			name:     "blank entry",
+			settings: map[string]any{"allowed_models": []string{"gpt-5*", "  "}},
+			wantErr:  true,
+		},
+		{
+			name:     "bad behavior enum",
+			settings: map[string]any{"allowed_models": []string{"gpt-5*"}, "behavior_on_disallowed": "drop"},
+			wantErr:  true,
+		},
+		{
+			name:     "substitute missing substitute_with",
+			settings: map[string]any{"allowed_models": []string{"gpt-5*"}, "behavior_on_disallowed": "substitute"},
+			wantErr:  true,
+		},
+		{
+			name: "substitute_with not in allowlist",
+			settings: map[string]any{
+				"allowed_models":         []string{"gpt-5*"},
+				"behavior_on_disallowed": "substitute",
+				"substitute_with":        "claude-3",
+			},
+			wantErr: true,
+		},
+		{
+			name:     "default_model not in allowlist",
+			settings: map[string]any{"allowed_models": []string{"gpt-5*"}, "default_model": "claude-3"},
+			wantErr:  true,
+		},
+		{
+			name: "substitute_with set under reject",
+			settings: map[string]any{
+				"allowed_models":         []string{"gpt-5*"},
+				"behavior_on_disallowed": "reject",
+				"substitute_with":        "gpt-5",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseConfig(tt.settings)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestConfigApplyDefaults(t *testing.T) {
+	cfg, err := parseConfig(map[string]any{"allowed_models": []string{"gpt-5*"}})
+	require.NoError(t, err)
+	assert.Equal(t, behaviorReject, cfg.Behavior)
+}
+
+func TestObserveDecision(t *testing.T) {
+	assert.Equal(t, decisionWouldReject, observeDecision(behaviorReject))
+	assert.Equal(t, decisionWouldSubstitute, observeDecision(behaviorSubstitute))
+}
+
+func TestModelAllowlistDataDecisions(t *testing.T) {
+	data := ModelAllowlistData{
+		RequestedModel:  "gpt-3.5",
+		Decision:        decisionSubstituted,
+		MatchedPattern:  "gpt-5*",
+		SubstitutedWith: "gpt-5",
+		Behavior:        string(behaviorSubstitute),
+	}
+	assert.Equal(t, decisionSubstituted, data.Decision)
+	assert.NotEqual(t, decisionAllowed, data.Decision)
+	assert.NotEqual(t, decisionRejected, data.Decision)
+	assert.NotEqual(t, decisionDefaulted, data.Decision)
+}

--- a/pkg/infra/plugins/modelallowlist/data.go
+++ b/pkg/infra/plugins/modelallowlist/data.go
@@ -1,0 +1,39 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modelallowlist
+
+const (
+	decisionAllowed         = "allowed"
+	decisionRejected        = "rejected"
+	decisionSubstituted     = "substituted"
+	decisionDefaulted       = "defaulted"
+	decisionWouldReject     = "would_reject"
+	decisionWouldSubstitute = "would_substitute"
+)
+
+type ModelAllowlistData struct {
+	RequestedModel  string `json:"requested_model"`
+	Decision        string `json:"decision"`
+	MatchedPattern  string `json:"matched_pattern,omitempty"`
+	SubstitutedWith string `json:"substituted_with,omitempty"`
+	Behavior        string `json:"behavior"`
+}
+
+func observeDecision(b behavior) string {
+	if b == behaviorSubstitute {
+		return decisionWouldSubstitute
+	}
+	return decisionWouldReject
+}

--- a/pkg/infra/plugins/modelallowlist/plugin.go
+++ b/pkg/infra/plugins/modelallowlist/plugin.go
@@ -1,0 +1,164 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modelallowlist
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	appplugins "github.com/NeuralTrust/TrustGate/pkg/app/plugins"
+	"github.com/NeuralTrust/TrustGate/pkg/domain/policy"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/adapter"
+)
+
+const PluginName = "model_allowlist"
+
+var _ appplugins.Plugin = (*Plugin)(nil)
+
+type Plugin struct{}
+
+func New() *Plugin { return &Plugin{} }
+
+func (p *Plugin) Name() string { return PluginName }
+
+func (p *Plugin) MandatoryStages() []policy.Stage {
+	return []policy.Stage{policy.StagePreRequest}
+}
+
+func (p *Plugin) SupportedStages() []policy.Stage {
+	return []policy.Stage{policy.StagePreRequest}
+}
+
+func (p *Plugin) SupportedModes() []policy.Mode {
+	return []policy.Mode{policy.ModeEnforce, policy.ModeObserve}
+}
+
+func (p *Plugin) ValidateConfig(settings map[string]any) error {
+	_, err := parseConfig(settings)
+	return err
+}
+
+func (p *Plugin) Execute(_ context.Context, in appplugins.ExecInput) (*appplugins.Result, error) {
+	cfg, err := parseConfig(in.Config.Settings)
+	if err != nil {
+		return nil, fmt.Errorf("model_allowlist: %w", err)
+	}
+
+	blocks := appplugins.Blocks(in.Mode)
+
+	if in.Request == nil {
+		return okResult(), nil
+	}
+
+	model, err := adapter.ExtractModel(in.Request.Body)
+	if err != nil {
+		setExtras(in.Event, ModelAllowlistData{Decision: decisionAllowed, Behavior: string(cfg.Behavior)})
+		return okResult(), nil
+	}
+
+	if model == "" {
+		if cfg.DefaultModel != "" && blocks {
+			in.Request.Body = adapter.OverrideModel(in.Request.Body, cfg.DefaultModel)
+			setExtras(in.Event, ModelAllowlistData{
+				Decision:        decisionDefaulted,
+				SubstitutedWith: cfg.DefaultModel,
+				Behavior:        string(cfg.Behavior),
+			})
+			return okResult(), nil
+		}
+		setExtras(in.Event, ModelAllowlistData{Decision: decisionAllowed, Behavior: string(cfg.Behavior)})
+		return okResult(), nil
+	}
+
+	if pattern, ok := matchAny(model, cfg.AllowedModels); ok {
+		setExtras(in.Event, ModelAllowlistData{
+			RequestedModel: model,
+			Decision:       decisionAllowed,
+			MatchedPattern: pattern,
+			Behavior:       string(cfg.Behavior),
+		})
+		return okResult(), nil
+	}
+
+	if !blocks {
+		setExtras(in.Event, ModelAllowlistData{
+			RequestedModel: model,
+			Decision:       observeDecision(cfg.Behavior),
+			Behavior:       string(cfg.Behavior),
+		})
+		appplugins.SetDecision(in.Event, in.Mode)
+		return okResult(), nil
+	}
+
+	if cfg.Behavior == behaviorSubstitute {
+		in.Request.Body = adapter.OverrideModel(in.Request.Body, cfg.SubstituteWith)
+		setExtras(in.Event, ModelAllowlistData{
+			RequestedModel:  model,
+			Decision:        decisionSubstituted,
+			SubstitutedWith: cfg.SubstituteWith,
+			Behavior:        string(cfg.Behavior),
+		})
+		return okResult(), nil
+	}
+
+	setExtras(in.Event, ModelAllowlistData{
+		RequestedModel: model,
+		Decision:       decisionRejected,
+		Behavior:       string(cfg.Behavior),
+	})
+	return newRejectResult(model, cfg.AllowedModels)
+}
+
+type errorBody struct {
+	Error errorDetail `json:"error"`
+}
+
+type errorDetail struct {
+	Type    string   `json:"type"`
+	Model   string   `json:"model"`
+	Allowed []string `json:"allowed"`
+}
+
+func newErrorBody(model string, allowed []string) errorBody {
+	return errorBody{Error: errorDetail{Type: "model_not_allowed", Model: model, Allowed: allowed}}
+}
+
+func newRejectResult(model string, allowed []string) (*appplugins.Result, error) {
+	body, err := json.Marshal(newErrorBody(model, allowed))
+	if err != nil {
+		return nil, &appplugins.PluginError{
+			StatusCode: http.StatusForbidden,
+			Message:    "model not allowed",
+		}
+	}
+	return &appplugins.Result{
+		StopUpstream: true,
+		StatusCode:   http.StatusForbidden,
+		Headers:      map[string][]string{"Content-Type": {"application/json"}},
+		Body:         body,
+	}, nil
+}
+
+func okResult() *appplugins.Result { return &appplugins.Result{StatusCode: http.StatusOK} }
+
+func setExtras(event *metrics.EventContext, data ModelAllowlistData) {
+	if event == nil {
+		return
+	}
+	event.SetExtras(data)
+}

--- a/pkg/infra/plugins/modelallowlist/plugin_test.go
+++ b/pkg/infra/plugins/modelallowlist/plugin_test.go
@@ -1,0 +1,282 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modelallowlist
+
+import (
+	"context"
+	"testing"
+
+	appplugins "github.com/NeuralTrust/TrustGate/pkg/app/plugins"
+	"github.com/NeuralTrust/TrustGate/pkg/domain/policy"
+	infracontext "github.com/NeuralTrust/TrustGate/pkg/infra/context"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/adapter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func input(mode policy.Mode, settings map[string]any, req *infracontext.RequestContext) appplugins.ExecInput {
+	return appplugins.ExecInput{
+		Stage:    policy.StagePreRequest,
+		Mode:     mode,
+		Config:   policy.PluginConfig{ID: "ma-1", Slug: PluginName, Name: PluginName, Settings: settings},
+		Request:  req,
+		Response: &infracontext.ResponseContext{},
+	}
+}
+
+func TestPlugin_StagesModesName(t *testing.T) {
+	p := New()
+	assert.Equal(t, PluginName, p.Name())
+	assert.Equal(t, []policy.Stage{policy.StagePreRequest}, p.MandatoryStages())
+	assert.Equal(t, []policy.Stage{policy.StagePreRequest}, p.SupportedStages())
+	assert.Equal(t, []policy.Mode{policy.ModeEnforce, policy.ModeObserve}, p.SupportedModes())
+}
+
+func TestPlugin_ValidateConfig(t *testing.T) {
+	p := New()
+	require.NoError(t, p.ValidateConfig(map[string]any{"allowed_models": []string{"gpt-5*"}}))
+	require.Error(t, p.ValidateConfig(map[string]any{"allowed_models": []string{}}))
+}
+
+func TestPlugin_Execute(t *testing.T) {
+	rejectGPT5 := map[string]any{"allowed_models": []string{"gpt-5*"}, "behavior_on_disallowed": "reject"}
+	substituteGPT5 := map[string]any{
+		"allowed_models":         []string{"gpt-5*"},
+		"behavior_on_disallowed": "substitute",
+		"substitute_with":        "gpt-5",
+	}
+	defaultGPT5 := map[string]any{"allowed_models": []string{"gpt-5*"}, "default_model": "gpt-5"}
+
+	tests := []struct {
+		name       string
+		mode       policy.Mode
+		settings   map[string]any
+		nilRequest bool
+		body       string
+		check      func(t *testing.T, res *appplugins.Result, err error, req *infracontext.RequestContext)
+	}{
+		{
+			name:     "exact allow",
+			mode:     policy.ModeEnforce,
+			settings: map[string]any{"allowed_models": []string{"gpt-4o"}},
+			body:     `{"model":"gpt-4o"}`,
+			check: func(t *testing.T, res *appplugins.Result, err error, req *infracontext.RequestContext) {
+				require.NoError(t, err)
+				assert.Equal(t, 200, res.StatusCode)
+				assert.False(t, res.StopUpstream)
+				assert.JSONEq(t, `{"model":"gpt-4o"}`, string(req.Body))
+			},
+		},
+		{
+			name:     "glob allow prefix",
+			mode:     policy.ModeEnforce,
+			settings: rejectGPT5,
+			body:     `{"model":"gpt-5-mini"}`,
+			check: func(t *testing.T, res *appplugins.Result, err error, req *infracontext.RequestContext) {
+				require.NoError(t, err)
+				assert.Equal(t, 200, res.StatusCode)
+				assert.JSONEq(t, `{"model":"gpt-5-mini"}`, string(req.Body))
+			},
+		},
+		{
+			name:     "glob allow suffix",
+			mode:     policy.ModeEnforce,
+			settings: map[string]any{"allowed_models": []string{"*sonnet*"}},
+			body:     `{"model":"claude-sonnet-4"}`,
+			check: func(t *testing.T, res *appplugins.Result, err error, req *infracontext.RequestContext) {
+				require.NoError(t, err)
+				assert.Equal(t, 200, res.StatusCode)
+				assert.JSONEq(t, `{"model":"claude-sonnet-4"}`, string(req.Body))
+			},
+		},
+		{
+			name:     "disallowed reject body",
+			mode:     policy.ModeEnforce,
+			settings: rejectGPT5,
+			body:     `{"model":"gpt-3.5"}`,
+			check: func(t *testing.T, res *appplugins.Result, err error, req *infracontext.RequestContext) {
+				require.NoError(t, err)
+				require.NotNil(t, res)
+				assert.Equal(t, 403, res.StatusCode)
+				assert.True(t, res.StopUpstream)
+				assert.Equal(t, []string{"application/json"}, res.Headers["Content-Type"])
+				assert.Equal(t, `{"error":{"type":"model_not_allowed","model":"gpt-3.5","allowed":["gpt-5*"]}}`, string(res.Body))
+			},
+		},
+		{
+			name:     "disallowed substitute rewrites body",
+			mode:     policy.ModeEnforce,
+			settings: substituteGPT5,
+			body:     `{"model":"gpt-3.5"}`,
+			check: func(t *testing.T, res *appplugins.Result, err error, req *infracontext.RequestContext) {
+				require.NoError(t, err)
+				assert.Equal(t, 200, res.StatusCode)
+				assert.False(t, res.StopUpstream)
+				model, mErr := adapter.ExtractModel(req.Body)
+				require.NoError(t, mErr)
+				assert.Equal(t, "gpt-5", model)
+			},
+		},
+		{
+			name:     "default injection on absent model",
+			mode:     policy.ModeEnforce,
+			settings: defaultGPT5,
+			body:     `{"messages":[]}`,
+			check: func(t *testing.T, res *appplugins.Result, err error, req *infracontext.RequestContext) {
+				require.NoError(t, err)
+				assert.Equal(t, 200, res.StatusCode)
+				model, mErr := adapter.ExtractModel(req.Body)
+				require.NoError(t, mErr)
+				assert.Equal(t, "gpt-5", model)
+			},
+		},
+		{
+			name:     "absent model no default is no-op",
+			mode:     policy.ModeEnforce,
+			settings: rejectGPT5,
+			body:     `{"messages":[]}`,
+			check: func(t *testing.T, res *appplugins.Result, err error, req *infracontext.RequestContext) {
+				require.NoError(t, err)
+				assert.Equal(t, 200, res.StatusCode)
+				assert.JSONEq(t, `{"messages":[]}`, string(req.Body))
+			},
+		},
+		{
+			name:     "observe disallowed reject never blocks",
+			mode:     policy.ModeObserve,
+			settings: rejectGPT5,
+			body:     `{"model":"gpt-3.5"}`,
+			check: func(t *testing.T, res *appplugins.Result, err error, req *infracontext.RequestContext) {
+				require.NoError(t, err)
+				assert.Equal(t, 200, res.StatusCode)
+				assert.False(t, res.StopUpstream)
+				assert.JSONEq(t, `{"model":"gpt-3.5"}`, string(req.Body))
+			},
+		},
+		{
+			name:     "observe disallowed substitute never mutates",
+			mode:     policy.ModeObserve,
+			settings: substituteGPT5,
+			body:     `{"model":"gpt-3.5"}`,
+			check: func(t *testing.T, res *appplugins.Result, err error, req *infracontext.RequestContext) {
+				require.NoError(t, err)
+				assert.Equal(t, 200, res.StatusCode)
+				assert.JSONEq(t, `{"model":"gpt-3.5"}`, string(req.Body))
+			},
+		},
+		{
+			name:     "observe absent default never mutates",
+			mode:     policy.ModeObserve,
+			settings: defaultGPT5,
+			body:     `{"messages":[]}`,
+			check: func(t *testing.T, res *appplugins.Result, err error, req *infracontext.RequestContext) {
+				require.NoError(t, err)
+				assert.Equal(t, 200, res.StatusCode)
+				assert.JSONEq(t, `{"messages":[]}`, string(req.Body))
+			},
+		},
+		{
+			name:     "malformed body is no-op allow",
+			mode:     policy.ModeEnforce,
+			settings: rejectGPT5,
+			body:     `not json`,
+			check: func(t *testing.T, res *appplugins.Result, err error, req *infracontext.RequestContext) {
+				require.NoError(t, err)
+				assert.Equal(t, 200, res.StatusCode)
+				assert.False(t, res.StopUpstream)
+				assert.Equal(t, "not json", string(req.Body))
+			},
+		},
+		{
+			name:     "malformed body with default is no-op allow",
+			mode:     policy.ModeEnforce,
+			settings: map[string]any{"allowed_models": []string{"gpt-5*"}, "default_model": "gpt-5"},
+			body:     `not json`,
+			check: func(t *testing.T, res *appplugins.Result, err error, req *infracontext.RequestContext) {
+				require.NoError(t, err)
+				assert.Equal(t, 200, res.StatusCode)
+				assert.False(t, res.StopUpstream)
+				assert.Equal(t, "not json", string(req.Body))
+			},
+		},
+		{
+			name:     "bedrock modelId substitute rewrites",
+			mode:     policy.ModeEnforce,
+			settings: substituteGPT5,
+			body:     `{"modelId":"anthropic.claude"}`,
+			check: func(t *testing.T, res *appplugins.Result, err error, req *infracontext.RequestContext) {
+				require.NoError(t, err)
+				assert.Equal(t, 200, res.StatusCode)
+				model, mErr := adapter.ExtractModel(req.Body)
+				require.NoError(t, mErr)
+				assert.Equal(t, "gpt-5", model)
+			},
+		},
+		{
+			name:     "bedrock modelId allowed pass through",
+			mode:     policy.ModeEnforce,
+			settings: map[string]any{"allowed_models": []string{"arn:aws:bedrock:*"}},
+			body:     `{"modelId":"arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude"}`,
+			check: func(t *testing.T, res *appplugins.Result, err error, req *infracontext.RequestContext) {
+				require.NoError(t, err)
+				assert.Equal(t, 200, res.StatusCode)
+				assert.JSONEq(t, `{"modelId":"arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude"}`, string(req.Body))
+			},
+		},
+		{
+			name:       "nil request is no-op",
+			mode:       policy.ModeEnforce,
+			settings:   rejectGPT5,
+			nilRequest: true,
+			check: func(t *testing.T, res *appplugins.Result, err error, req *infracontext.RequestContext) {
+				require.NoError(t, err)
+				require.NotNil(t, res)
+				assert.Equal(t, 200, res.StatusCode)
+			},
+		},
+		{
+			name:     "bad config returns error",
+			mode:     policy.ModeEnforce,
+			settings: map[string]any{"allowed_models": []string{}},
+			body:     `{"model":"gpt-4o"}`,
+			check: func(t *testing.T, res *appplugins.Result, err error, req *infracontext.RequestContext) {
+				require.Error(t, err)
+				assert.Nil(t, res)
+			},
+		},
+		{
+			name:     "arn literal exact allow",
+			mode:     policy.ModeEnforce,
+			settings: map[string]any{"allowed_models": []string{"arn:aws:bedrock:us-east-1::foundation-model/claude"}},
+			body:     `{"model":"arn:aws:bedrock:us-east-1::foundation-model/claude"}`,
+			check: func(t *testing.T, res *appplugins.Result, err error, req *infracontext.RequestContext) {
+				require.NoError(t, err)
+				assert.Equal(t, 200, res.StatusCode)
+			},
+		},
+	}
+
+	p := New()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var req *infracontext.RequestContext
+			if !tt.nilRequest {
+				req = &infracontext.RequestContext{Body: []byte(tt.body)}
+			}
+			res, err := p.Execute(context.Background(), input(tt.mode, tt.settings, req))
+			tt.check(t, res, err, req)
+		})
+	}
+}

--- a/tests/functional/plugin_model_allowlist_test.go
+++ b/tests/functional/plugin_model_allowlist_test.go
@@ -1,0 +1,67 @@
+//go:build functional
+
+package functional_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPluginE2E_ModelAllowlist_Reject(t *testing.T) {
+	defer Track(t, "PluginModelAllowlist")()
+
+	up := newJSONUpstream(t, "allowlist-upstream")
+	apiKey, path := setupPolicyRoute(t, up,
+		policyPlugin("model_allowlist", map[string]any{
+			"allowed_models":         []string{"gpt-5*"},
+			"behavior_on_disallowed": "reject",
+		}),
+	)
+
+	t.Run("allowed model passes through", func(t *testing.T) {
+		status, _, raw := proxyRequest(t, http.MethodPost, apiKey, path, nil,
+			mustJSON(t, chatRequestModel("gpt-5-turbo")),
+		)
+		assert.Equal(t, http.StatusOK, status, "body: %s", raw)
+		assert.Contains(t, string(raw), "allowlist-upstream")
+	})
+
+	t.Run("disallowed model returns exact 403 body", func(t *testing.T) {
+		hitsBefore := up.Hits()
+		status, header, raw := proxyRequest(t, http.MethodPost, apiKey, path, nil,
+			mustJSON(t, chatRequestModel("claude-opus-4-5")),
+		)
+		assert.Equal(t, http.StatusForbidden, status)
+		assert.Equal(t, "application/json", header.Get("Content-Type"))
+		assert.JSONEq(t,
+			`{"error":{"type":"model_not_allowed","model":"claude-opus-4-5","allowed":["gpt-5*"]}}`,
+			string(raw),
+		)
+		assert.Equal(t, hitsBefore, up.Hits(), "a rejected request must not reach the upstream")
+	})
+}
+
+func TestPluginE2E_ModelAllowlist_Substitute(t *testing.T) {
+	defer Track(t, "PluginModelAllowlist")()
+
+	up := newJSONUpstream(t, "substitute-upstream")
+	apiKey, path := setupPolicyRoute(t, up,
+		policyPlugin("model_allowlist", map[string]any{
+			"allowed_models":         []string{"gpt-5*"},
+			"behavior_on_disallowed": "substitute",
+			"substitute_with":        "gpt-5",
+		}),
+	)
+
+	status, _, raw := proxyRequest(t, http.MethodPost, apiKey, path, nil,
+		mustJSON(t, chatRequestModel("claude-opus-4-5")),
+	)
+	assert.Equal(t, http.StatusOK, status, "body: %s", raw)
+	assert.Equal(t, 1, up.Hits(), "a substituted request must still reach the upstream")
+	assert.Contains(t, string(up.LastBody()), `"model":"gpt-5"`,
+		"the disallowed model must be rewritten to substitute_with before reaching the upstream")
+	assert.NotContains(t, string(up.LastBody()), "claude-opus-4-5",
+		"the original disallowed model must not reach the upstream")
+}


### PR DESCRIPTION
## Summary

Adds a new built-in **`model_allowlist`** plugin that restricts which models a request may call, by name, at the `pre_request` stage. It composes with the rest of the policy chain (name-based gating here; price-based gating lives in Budget's `cost_cap`, RUN-696).

- **Glob allowlist**: `allowed_models` supports `*` wildcards (e.g. `gpt-5*`, `claude-sonnet-*`); patterns without `*` match exactly; matching is case-sensitive on the literal request `model`/`modelId`.
- **Behaviors** (`behavior_on_disallowed`):
  - `reject` (default) → short-circuits with `403` and the exact body `{"error":{"type":"model_not_allowed","model":"...","allowed":[...]}}` (`Content-Type: application/json`), upstream not contacted.
  - `substitute` → rewrites the body's model to `substitute_with` in place (via `adapter.OverrideModel`) and proceeds.
- **`default_model`**: injected when the client omits the model.
- **`observe` mode**: log-only — never rejects or rewrites; records the decision on the trace.
- **Registration**: wired into the plugin registry (`pkg/container/modules/plugins.go`) and the UI catalog under **Routing** (`pkg/app/plugins/catalog_metadata.go`).

## Deliberate scope decisions (resolved against the codebase)

- **No `scope` config field** — scope is the policy's `global` flag (surfaced as `RuntimeScope`), consistent with every existing plugin. The plugin is stateless.
- **Exact 403 body via `Result{StopUpstream}`** — not the shared `pluginErrorResult` (which hardcodes `plugin_rejected`), so no other plugin's error shape changes.
- **v1 gates body-based providers** (OpenAI/Anthropic/Bedrock/Mistral). Gemini/Vertex carry the model in the URL path → out of scope (follow-up); when no model is in the body and no default is set, the plugin is a no-op allow so those providers are not broken. Malformed/non-JSON bodies are also a safe no-op.
- **Provider-name normalization** is out of scope — globs match the literal request value.

### Known limitation

`substitute`/`default` mutate `req.Body` in place. If the owning policy is configured `Parallel` with other plugins at the same priority, the executor clones the request and merges back only Headers/Metadata, so the rewrite is dropped. Single-plugin / sequential batches (the default) preserve it.

## Phases (per-commit)

1. config + `*`-glob matcher + trace DTO + unit tests
2. `Execute` behavior (reject/substitute/default/observe) + 403 error body + 16-case table test
3. registration (registry + Routing catalog metadata)
4. functional test (`//go:build functional`)

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test -race ./pkg/infra/plugins/modelallowlist/... ./pkg/app/plugins/... ./pkg/container/...` green
- [x] `golangci-lint run` + gosec clean (pre-commit hook on every commit)
- [ ] CI runs the `//go:build functional` end-to-end test (requires Postgres/Redis; not runnable locally — parity with existing functional tests)

Refs RUN-700

Made with [Cursor](https://cursor.com)