### PR TITLE
fix(oauth): scope IdP fallback to the addressed gateway

### DIFF
--- a/pkg/api/handler/http/oauth/authorize_handler.go
+++ b/pkg/api/handler/http/oauth/authorize_handler.go
@@ -15,6 +15,7 @@
 package oauth
 
 import (
+	"github.com/NeuralTrust/TrustGate/pkg/api/resolver"
 	appoauth "github.com/NeuralTrust/TrustGate/pkg/app/oauth"
 	"github.com/gofiber/fiber/v2"
 )
@@ -22,11 +23,12 @@ import (
 const AuthorizePath = "/oauth/authorize"
 
 type AuthorizeHandler struct {
-	proxy appoauth.AuthProxy
+	proxy    appoauth.AuthProxy
+	gateways resolver.GatewayResolver
 }
 
-func NewAuthorizeHandler(proxy appoauth.AuthProxy) *AuthorizeHandler {
-	return &AuthorizeHandler{proxy: proxy}
+func NewAuthorizeHandler(proxy appoauth.AuthProxy, gateways resolver.GatewayResolver) *AuthorizeHandler {
+	return &AuthorizeHandler{proxy: proxy, gateways: gateways}
 }
 
 func (h *AuthorizeHandler) Handle(c *fiber.Ctx) error {
@@ -40,7 +42,8 @@ func (h *AuthorizeHandler) Handle(c *fiber.Ctx) error {
 		CodeChallengeMethod: c.Query("code_challenge_method"),
 		Resource:            c.Query("resource"),
 	}
-	location, err := h.proxy.Authorize(c.UserContext(), c.BaseURL(), req)
+	ctx := resolver.WithResolvedGateway(c, h.gateways)
+	location, err := h.proxy.Authorize(ctx, c.BaseURL(), req)
 	if err != nil {
 		return writeOAuthError(c, err)
 	}

--- a/pkg/api/handler/http/oauth/token_handler.go
+++ b/pkg/api/handler/http/oauth/token_handler.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 
 	"github.com/NeuralTrust/TrustGate/pkg/api/handler/http/helpers"
+	"github.com/NeuralTrust/TrustGate/pkg/api/resolver"
 	appoauth "github.com/NeuralTrust/TrustGate/pkg/app/oauth"
 	"github.com/gofiber/fiber/v2"
 )
@@ -25,11 +26,12 @@ import (
 const TokenPath = "/oauth/token" // #nosec G101 -- route path, not a credential
 
 type TokenHandler struct {
-	proxy appoauth.AuthProxy
+	proxy    appoauth.AuthProxy
+	gateways resolver.GatewayResolver
 }
 
-func NewTokenHandler(proxy appoauth.AuthProxy) *TokenHandler {
-	return &TokenHandler{proxy: proxy}
+func NewTokenHandler(proxy appoauth.AuthProxy, gateways resolver.GatewayResolver) *TokenHandler {
+	return &TokenHandler{proxy: proxy, gateways: gateways}
 }
 
 func (h *TokenHandler) Handle(c *fiber.Ctx) error {
@@ -42,7 +44,8 @@ func (h *TokenHandler) Handle(c *fiber.Ctx) error {
 		RefreshToken: c.FormValue("refresh_token"),
 		Resource:     c.FormValue("resource"),
 	}
-	token, err := h.proxy.Exchange(c.UserContext(), c.BaseURL(), req)
+	ctx := resolver.WithResolvedGateway(c, h.gateways)
+	token, err := h.proxy.Exchange(ctx, c.BaseURL(), req)
 	if err != nil {
 		return writeOAuthError(c, err)
 	}

--- a/pkg/api/resolver/gateway_resolver.go
+++ b/pkg/api/resolver/gateway_resolver.go
@@ -15,6 +15,7 @@
 package resolver
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -34,6 +35,23 @@ const gatewayDiscoveryModeSubdomain = "subdomain"
 
 type GatewayResolver interface {
 	Resolve(c *fiber.Ctx) (*gatewaydomain.Gateway, error)
+}
+
+// WithResolvedGateway best-effort resolves the gateway addressed by the request
+// (gateway-slug header or subdomain, per the configured discovery mode) and
+// returns a context carrying it. On any resolution miss it returns the request
+// context unchanged, so callers that can still operate without a pinned gateway
+// keep working.
+func WithResolvedGateway(c *fiber.Ctx, r GatewayResolver) context.Context {
+	ctx := c.UserContext()
+	if r == nil {
+		return ctx
+	}
+	gw, err := r.Resolve(c)
+	if err != nil {
+		return ctx
+	}
+	return appgateway.WithGateway(ctx, gw)
 }
 
 func NewGatewayResolver(finder appgateway.Finder, mode, baseDomain string) GatewayResolver {

--- a/pkg/app/oauth/proxy_auth_selection.go
+++ b/pkg/app/oauth/proxy_auth_selection.go
@@ -21,6 +21,7 @@ import (
 	"log/slog"
 	"net/url"
 
+	appgateway "github.com/NeuralTrust/TrustGate/pkg/app/gateway"
 	authdomain "github.com/NeuralTrust/TrustGate/pkg/domain/auth"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
 )
@@ -34,21 +35,32 @@ func (p *authProxy) authForResource(ctx context.Context, resource string) (*auth
 	// its own: fall back to the single IdP configured on that consumer's
 	// gateway instead of scanning every tenant on the platform.
 	if matched {
-		a, err := p.singleOAuth2AuthForGateway(ctx, gatewayID)
-		switch {
-		case errors.Is(err, ErrAmbiguousAuthorizationServer):
-			return nil, oauthErr("invalid_target",
-				"multiple identity providers configured for this gateway; attach a single oauth2 identity provider to the MCP consumer")
-		case errors.Is(err, ErrNoAuthorizationServer):
-			return nil, oauthErr("invalid_request",
-				"this MCP server has no oauth2 identity provider; interactive login requires an oauth2 auth with a pre-registered client at your identity provider")
-		}
-		return a, err
+		return p.gatewayScopedAuth(ctx, gatewayID)
+	}
+	// No usable resource indicator, but the request was still routed to a
+	// specific gateway (by subdomain or by the gateway-slug header). Scope the
+	// fallback to that gateway instead of treating every issuer on the platform
+	// as a candidate.
+	if gw, ok := appgateway.FromContext(ctx); ok {
+		return p.gatewayScopedAuth(ctx, gw.ID)
 	}
 	a, err := p.singleOAuth2Auth(ctx)
 	if errors.Is(err, ErrAmbiguousAuthorizationServer) {
 		return nil, oauthErr("invalid_target",
 			"multiple identity providers configured; send an RFC 8707 resource parameter identifying the MCP server")
+	}
+	return a, err
+}
+
+func (p *authProxy) gatewayScopedAuth(ctx context.Context, gatewayID ids.GatewayID) (*authdomain.Auth, error) {
+	a, err := p.singleOAuth2AuthForGateway(ctx, gatewayID)
+	switch {
+	case errors.Is(err, ErrAmbiguousAuthorizationServer):
+		return nil, oauthErr("invalid_target",
+			"multiple identity providers configured for this gateway; attach a single oauth2 identity provider to the MCP consumer")
+	case errors.Is(err, ErrNoAuthorizationServer):
+		return nil, oauthErr("invalid_request",
+			"this MCP server has no oauth2 identity provider; interactive login requires an oauth2 auth with a pre-registered client at your identity provider")
 	}
 	return a, err
 }

--- a/pkg/app/oauth/proxy_test.go
+++ b/pkg/app/oauth/proxy_test.go
@@ -27,7 +27,9 @@ import (
 	"testing"
 
 	appconsumer "github.com/NeuralTrust/TrustGate/pkg/app/consumer"
+	appgateway "github.com/NeuralTrust/TrustGate/pkg/app/gateway"
 	authdomain "github.com/NeuralTrust/TrustGate/pkg/domain/auth"
+	gatewaydomain "github.com/NeuralTrust/TrustGate/pkg/domain/gateway"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
 )
 
@@ -594,6 +596,46 @@ func TestAuthorizeMultiIssuerRequiresResource(t *testing.T) {
 	var oe *OAuthError
 	if !errors.As(err, &oe) || oe.Code != "invalid_target" {
 		t.Fatalf("expected invalid_target, got %v", err)
+	}
+}
+
+// Without a resource indicator, the gateway addressed by the request (resolved
+// upstream from the subdomain or the gateway-slug header and carried on the
+// context) scopes IdP selection, so a single-issuer gateway resolves even when
+// other tenants run different IdPs across the platform.
+func TestAuthorizeFallsBackToContextGatewayWithoutResource(t *testing.T) {
+	t.Parallel()
+	idpGateway, _ := fakeIdP(t)
+	idpOther, capturedOther := fakeIdP(t)
+
+	gatewayID := ids.New[ids.GatewayKind]()
+	gatewayAuth := enabledOAuth2Auth(t, authdomain.OAuth2Config{Issuer: idpGateway.URL, ClientID: "client-gw"})
+	gatewayAuth.GatewayID = gatewayID
+	otherAuth := enabledOAuth2Auth(t, authdomain.OAuth2Config{Issuer: idpOther.URL, ClientID: "client-other"})
+
+	finder := &fakeCredentialFinder{oauth2: []*authdomain.Auth{gatewayAuth, otherAuth}}
+	proxy := NewAuthProxy(finder, &fakePathResolver{}, http.DefaultClient, newMemFlowStore(), nil)
+
+	ctx := appgateway.WithGateway(context.Background(), &gatewaydomain.Gateway{ID: gatewayID, Slug: "acme"})
+	location, err := proxy.Authorize(ctx, "https://acme.mcp.example.com", AuthorizeRequest{
+		ResponseType:        "code",
+		ClientID:            "client-gw",
+		RedirectURI:         "cursor://anysphere.cursor-mcp/oauth/callback",
+		CodeChallenge:       s256("v"),
+		CodeChallengeMethod: "S256",
+	})
+	if err != nil {
+		t.Fatalf("authorize must resolve the context gateway's single IdP, got %v", err)
+	}
+	loc, err := url.Parse(location)
+	if err != nil {
+		t.Fatalf("parse redirect: %v", err)
+	}
+	if got := loc.Scheme + "://" + loc.Host; got != idpGateway.URL {
+		t.Fatalf("authorize must redirect to the context gateway IdP, got %s (want %s)", got, idpGateway.URL)
+	}
+	if len(*capturedOther) != 0 {
+		t.Fatalf("another tenant's IdP must never be contacted, got %v", *capturedOther)
 	}
 }
 

--- a/pkg/container/modules/api.go
+++ b/pkg/container/modules/api.go
@@ -160,13 +160,19 @@ func API(c *container.Container) error {
 	if err := c.Provide(oauthhttp.NewRegisterHandler); err != nil {
 		return err
 	}
-	if err := c.Provide(oauthhttp.NewAuthorizeHandler); err != nil {
+	if err := c.Provide(func(proxy appoauth.AuthProxy, finder appgateway.Finder, cfg *config.Config) *oauthhttp.AuthorizeHandler {
+		gateways := resolver.NewGatewayResolver(finder, cfg.Server.GatewayDiscoveryMode, cfg.Server.MCPBaseDomain)
+		return oauthhttp.NewAuthorizeHandler(proxy, gateways)
+	}); err != nil {
 		return err
 	}
 	if err := c.Provide(oauthhttp.NewCallbackHandler); err != nil {
 		return err
 	}
-	if err := c.Provide(oauthhttp.NewTokenHandler); err != nil {
+	if err := c.Provide(func(proxy appoauth.AuthProxy, finder appgateway.Finder, cfg *config.Config) *oauthhttp.TokenHandler {
+		gateways := resolver.NewGatewayResolver(finder, cfg.Server.GatewayDiscoveryMode, cfg.Server.MCPBaseDomain)
+		return oauthhttp.NewTokenHandler(proxy, gateways)
+	}); err != nil {
 		return err
 	}
 	if err := c.Provide(oauthhttp.NewConnectHandler); err != nil {


### PR DESCRIPTION
## Summary
- An MCP client connecting through the OAuth AS facade (`pkg/app/oauth`) hit `multiple identity providers configured; send an RFC 8707 resource parameter identifying the MCP server` whenever it omitted the `resource` parameter and the platform had several OAuth2 issuers.
- The fix resolves the addressed gateway upstream — by subdomain **or** the `X-AG-Gateway-Slug` header, per the configured discovery mode — in the `authorize`/`token` handlers, carries it on the request context, and scopes `authForResource`'s fallback to that gateway's single IdP before falling back to a platform-wide selection.
- A single-issuer gateway now resolves without depending on the `resource` indicator, mirroring the single-issuer era.

## Changes
- `pkg/app/oauth/proxy_auth_selection.go`: `authForResource` reads the gateway from context (`appgateway.FromContext`) and scopes IdP selection to it; removed the proxy-side subdomain parsing.
- `pkg/api/handler/http/oauth/{authorize,token}_handler.go`: resolve the gateway (best-effort) via `GatewayResolver` and attach it to the context before calling the broker.
- `pkg/api/resolver/gateway_resolver.go`: new `WithResolvedGateway` helper (honors header + subdomain, no-op on miss).
- `pkg/container/modules/api.go`: wire the authorize/token handlers with an MCP-plane `GatewayResolver` built from `cfg.Server.MCPBaseDomain`.
- `pkg/app/oauth/proxy_test.go`: context-based fallback test (`TestAuthorizeFallsBackToContextGatewayWithoutResource`).

### IdP resolution order
1. RFC 8707 `resource` → concrete consumer.
2. `resource` pins a consumer without its own IdP → that consumer's gateway's single IdP.
3. No usable `resource` → **gateway from context** (subdomain or `X-AG-Gateway-Slug`) → that gateway's single IdP.
4. Last resort → platform-wide selection (structured `invalid_target` if ambiguous).

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/app/oauth/... ./pkg/api/handler/http/oauth/... ./pkg/api/resolver/... ./pkg/container/...`
- [ ] Connect an MCP client (e.g. Cursor) to a single-issuer gateway without sending `resource` and confirm the brokered login succeeds.

Made with [Cursor](https://cursor.com)