### PR TITLE
docs(postman): use agentgateway_proxy_url for model_allowlist proxy host

### DIFF
--- a/docs/TrustGate.postman_collection.json
+++ b/docs/TrustGate.postman_collection.json
@@ -27,6 +27,11 @@
       "type": "string"
     },
     {
+      "key": "agentgateway_proxy_url",
+      "value": "http://localhost:8081",
+      "type": "string"
+    },
+    {
       "key": "trace_id",
       "value": "",
       "type": "string"
@@ -7889,9 +7894,9 @@
                   "raw": "{\n  \"model\": \"gpt-4o-mini\",\n  \"messages\": [\n    { \"role\": \"user\", \"content\": \"Hello from TrustGate\" }\n  ]\n}"
                 },
                 "url": {
-                  "raw": "{{proxy_url}}/{{consumer_slug}}/v1/chat/completions",
+                  "raw": "{{agentgateway_proxy_url}}/{{consumer_slug}}/v1/chat/completions",
                   "host": [
-                    "{{proxy_url}}"
+                    "{{agentgateway_proxy_url}}"
                   ],
                   "path": [
                     "{{consumer_slug}}",
@@ -7944,9 +7949,9 @@
                   "raw": "{\n  \"model\": \"gpt-3.5-turbo\",\n  \"messages\": [\n    { \"role\": \"user\", \"content\": \"Hello from TrustGate\" }\n  ]\n}"
                 },
                 "url": {
-                  "raw": "{{proxy_url}}/{{consumer_slug}}/v1/chat/completions",
+                  "raw": "{{agentgateway_proxy_url}}/{{consumer_slug}}/v1/chat/completions",
                   "host": [
-                    "{{proxy_url}}"
+                    "{{agentgateway_proxy_url}}"
                   ],
                   "path": [
                     "{{consumer_slug}}",
@@ -8037,9 +8042,9 @@
                   "raw": "{\n  \"model\": \"gpt-3.5-turbo\",\n  \"messages\": [\n    { \"role\": \"user\", \"content\": \"Hello from TrustGate\" }\n  ]\n}"
                 },
                 "url": {
-                  "raw": "{{proxy_url}}/{{consumer_slug}}/v1/chat/completions",
+                  "raw": "{{agentgateway_proxy_url}}/{{consumer_slug}}/v1/chat/completions",
                   "host": [
-                    "{{proxy_url}}"
+                    "{{agentgateway_proxy_url}}"
                   ],
                   "path": [
                     "{{consumer_slug}}",


### PR DESCRIPTION
## Summary

Follow-up to #105. Points the **Model allowlist** E2E proxy requests at a dedicated `{{agentgateway_proxy_url}}` collection variable instead of `{{proxy_url}}`, and defines that variable (default `http://localhost:8081`) so it resolves out of the box. An environment-level value still takes precedence.

Only the three proxy calls in the `E2E Plugin Flows/Model allowlist` folder are affected; the pre-existing flows keep using `{{proxy_url}}`.

## Test plan

- [x] Collection parses as valid JSON
- [ ] Run the `Model allowlist` folder in Postman/Newman with a real `openai_api_key`

Refs RUN-700

Made with [Cursor](https://cursor.com)