### PR TITLE
fix(oauth): accept form-encoded IdP token responses (GitHub)

### DIFF
--- a/pkg/app/oauth/proxy.go
+++ b/pkg/app/oauth/proxy.go
@@ -17,11 +17,13 @@ package oauth
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -300,6 +302,7 @@ func (p *authProxy) idpTokenCall(ctx context.Context, endpoint string, form url.
 		return nil, err
 	}
 	httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	httpReq.Header.Set("Accept", "application/json")
 	res, err := p.client.Do(httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("oauth: IdP token call: %w", err)
@@ -309,9 +312,9 @@ func (p *authProxy) idpTokenCall(ctx context.Context, endpoint string, form url.
 	if err != nil {
 		return nil, fmt.Errorf("oauth: read IdP token response: %w", err)
 	}
-	var doc map[string]any
-	if err := json.Unmarshal(body, &doc); err != nil {
-		return nil, fmt.Errorf("oauth: IdP token response is not JSON (status %d)", res.StatusCode)
+	doc, err := decodeTokenResponse(body)
+	if err != nil {
+		return nil, fmt.Errorf("oauth: unparseable IdP token response (status %d)", res.StatusCode)
 	}
 	if res.StatusCode != http.StatusOK {
 		code, _ := doc["error"].(string)
@@ -320,6 +323,31 @@ func (p *authProxy) idpTokenCall(ctx context.Context, endpoint string, form url.
 			code = "server_error"
 		}
 		return nil, oauthErr(code, desc)
+	}
+	return doc, nil
+}
+
+// decodeTokenResponse parses an OAuth token endpoint response. RFC 6749 mandates
+// a JSON body, but some identity providers (notably GitHub) answer with
+// application/x-www-form-urlencoded unless asked otherwise, so fall back to form
+// decoding when the body is not JSON.
+func decodeTokenResponse(body []byte) (map[string]any, error) {
+	var doc map[string]any
+	if json.Unmarshal(body, &doc) == nil && doc != nil {
+		return doc, nil
+	}
+	values, err := url.ParseQuery(string(body))
+	if err != nil || values.Get("access_token") == "" && values.Get("error") == "" {
+		return nil, errors.New("oauth: token response is neither JSON nor form-encoded")
+	}
+	doc = make(map[string]any, len(values))
+	for key := range values {
+		doc[key] = values.Get(key)
+	}
+	if raw, ok := doc["expires_in"].(string); ok {
+		if seconds, convErr := strconv.Atoi(raw); convErr == nil {
+			doc["expires_in"] = seconds
+		}
 	}
 	return doc, nil
 }

--- a/pkg/app/oauth/proxy_test.go
+++ b/pkg/app/oauth/proxy_test.go
@@ -668,6 +668,62 @@ func TestRefreshUsesResourceIndicator(t *testing.T) {
 	}
 }
 
+func TestDecodeTokenResponseFormEncoded(t *testing.T) {
+	t.Parallel()
+	doc, err := decodeTokenResponse([]byte("access_token=gho_abc&token_type=bearer&scope=&expires_in=3600"))
+	if err != nil {
+		t.Fatalf("decode form-encoded token: %v", err)
+	}
+	if doc["access_token"] != "gho_abc" || doc["token_type"] != "bearer" {
+		t.Fatalf("unexpected decoded token: %v", doc)
+	}
+	if doc["expires_in"] != 3600 {
+		t.Fatalf("expires_in must be numeric, got %T %v", doc["expires_in"], doc["expires_in"])
+	}
+}
+
+func TestDecodeTokenResponseRejectsGarbage(t *testing.T) {
+	t.Parallel()
+	if _, err := decodeTokenResponse([]byte("<html>nope</html>")); err == nil {
+		t.Fatal("expected error for a non-token body")
+	}
+}
+
+// GitHub's token endpoint replies with application/x-www-form-urlencoded unless
+// Accept: application/json is sent; the broker must still parse the token.
+func TestRefreshAcceptsFormEncodedIdP(t *testing.T) {
+	t.Parallel()
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"issuer":                 srv.URL,
+				"authorization_endpoint": srv.URL + "/authorize",
+				"token_endpoint":         srv.URL + "/token",
+			})
+		case "/token":
+			w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
+			_, _ = w.Write([]byte("access_token=gho_live&token_type=bearer&scope=mcp.access"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	proxy := newProxyUnderTest(t, srv.URL, newMemFlowStore())
+	token, err := proxy.Exchange(context.Background(), "http://gw.example.com", TokenRequest{
+		GrantType:    "refresh_token",
+		RefreshToken: "rt-1",
+	})
+	if err != nil {
+		t.Fatalf("refresh against form-encoded IdP: %v", err)
+	}
+	if token["access_token"] != "gho_live" {
+		t.Fatalf("expected form-decoded access token, got %v", token)
+	}
+}
+
 type fakeChainer struct {
 	url      string
 	calls    int


### PR DESCRIPTION
## Summary
- After a successful GitHub login, the brokered code exchange failed on `/oauth/callback` with `oauth: IdP token response is not JSON (status 200)` and returned HTTP 500.
- GitHub's OAuth token endpoint replies with `application/x-www-form-urlencoded` (e.g. `access_token=...&token_type=bearer`) unless the request sends `Accept: application/json`. The broker sent neither and only parsed JSON.

## Changes
- `pkg/app/oauth/proxy.go`:
  - Send `Accept: application/json` on the IdP token call so spec-compliant providers (and GitHub) return JSON.
  - Add `decodeTokenResponse`: fall back to form-urlencoded decoding when the body is not JSON, normalizing `expires_in` to a number; reject bodies that are neither a token nor an error.
- `pkg/app/oauth/proxy_test.go`: cover form-encoded decoding, garbage rejection, and a refresh against a form-encoded IdP.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/app/oauth/...`
- [ ] Complete an MCP GitHub login end-to-end and confirm `/oauth/callback` mints a token (no 500).

Made with [Cursor](https://cursor.com)