### PR TITLE
feat(auth): expose oauth2 session_mode fields in the auth API (RUN-712)

### DIFF
--- a/pkg/api/handler/http/auth/request/create_auth_request.go
+++ b/pkg/api/handler/http/auth/request/create_auth_request.go
@@ -44,6 +44,9 @@ type OAuth2ConfigRequest struct {
 	ClientSecret     string   `json:"client_secret,omitempty"`
 	RequiredScopes   []string `json:"required_scopes,omitempty"`
 	Algorithms       []string `json:"allowed_algorithms,omitempty"`
+	SessionMode      bool     `json:"session_mode,omitempty"`
+	UserInfoURL      string   `json:"userinfo_url,omitempty"`
+	SubjectClaim     string   `json:"subject_claim,omitempty"`
 }
 
 type OIDCConfigRequest struct {
@@ -95,6 +98,9 @@ func (c ConfigRequest) ToDomain() domain.Config {
 			ClientSecret:     c.OAuth2.ClientSecret,
 			RequiredScopes:   c.OAuth2.RequiredScopes,
 			Algorithms:       c.OAuth2.Algorithms,
+			SessionMode:      c.OAuth2.SessionMode,
+			UserInfoURL:      c.OAuth2.UserInfoURL,
+			SubjectClaim:     c.OAuth2.SubjectClaim,
 		}
 	}
 	if c.OIDC != nil {

--- a/pkg/api/handler/http/auth/request/create_auth_request_test.go
+++ b/pkg/api/handler/http/auth/request/create_auth_request_test.go
@@ -1,0 +1,45 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package request
+
+import "testing"
+
+func TestConfigRequestToDomainMapsOAuth2SessionFields(t *testing.T) {
+	req := ConfigRequest{
+		OAuth2: &OAuth2ConfigRequest{
+			Issuer:       "https://github.com",
+			Audiences:    []string{"mcp"},
+			ClientID:     "client",
+			SessionMode:  true,
+			UserInfoURL:  "https://api.github.com/user",
+			SubjectClaim: "id",
+		},
+	}
+
+	got := req.ToDomain()
+
+	if got.OAuth2 == nil {
+		t.Fatal("expected oauth2 config to be mapped")
+	}
+	if !got.OAuth2.SessionMode {
+		t.Error("session_mode not mapped to domain")
+	}
+	if got.OAuth2.UserInfoURL != "https://api.github.com/user" {
+		t.Errorf("userinfo_url not mapped: got %q", got.OAuth2.UserInfoURL)
+	}
+	if got.OAuth2.SubjectClaim != "id" {
+		t.Errorf("subject_claim not mapped: got %q", got.OAuth2.SubjectClaim)
+	}
+}

--- a/pkg/api/handler/http/auth/response/auth_response.go
+++ b/pkg/api/handler/http/auth/response/auth_response.go
@@ -49,6 +49,9 @@ type OAuth2ConfigResponse struct {
 	ClientSecret     string   `json:"client_secret,omitempty"`
 	RequiredScopes   []string `json:"required_scopes,omitempty"`
 	Algorithms       []string `json:"allowed_algorithms,omitempty"`
+	SessionMode      bool     `json:"session_mode,omitempty"`
+	UserInfoURL      string   `json:"userinfo_url,omitempty"`
+	SubjectClaim     string   `json:"subject_claim,omitempty"`
 }
 
 type OIDCConfigResponse struct {
@@ -99,6 +102,9 @@ func fromConfig(c domain.Config) ConfigResponse {
 			ClientSecret:     secret.Mask(c.OAuth2.ClientSecret),
 			RequiredScopes:   c.OAuth2.RequiredScopes,
 			Algorithms:       c.OAuth2.Algorithms,
+			SessionMode:      c.OAuth2.SessionMode,
+			UserInfoURL:      c.OAuth2.UserInfoURL,
+			SubjectClaim:     c.OAuth2.SubjectClaim,
 		}
 	}
 	if c.OIDC != nil {


### PR DESCRIPTION
## Summary

Follow-up to #112 (RUN-712). The gateway-minted session token feature added `session_mode`, `userinfo_url` and `subject_claim` to the OAuth2 **domain** config, but the auth API request/response DTOs dropped them — so the opt-in could only be enabled by editing the database directly. This wires the three fields through the API end to end.

- `OAuth2ConfigRequest` gains the three fields and `ConfigRequest.ToDomain()` maps them (covers both create and update, which share `ConfigRequest`).
- `OAuth2ConfigResponse` exposes them so the dashboard can round-trip the config.

Companion dashboard PR (NeuralTrust/app): adds the optional fields to the OAuth2 auth modal.

RUN-712 — https://linear.app/neuraltrust/issue/RUN-712

## Test plan
- [x] `go build`, `go vet`, `golangci-lint` (0 issues), gosec, full `go test` suite — green via pre-commit hook.
- [x] Added `TestConfigRequestToDomainMapsOAuth2SessionFields` covering the new mapping.

Made with [Cursor](https://cursor.com)