### PR TITLE
fix(oauth): preserve numeric subject claims instead of scientific notation

### DIFF
--- a/pkg/app/oauth/proxy.go
+++ b/pkg/app/oauth/proxy.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -280,13 +281,33 @@ func subjectFromClaims(claims jwt.MapClaims, claim string) string {
 }
 
 func coerceClaim(v any) string {
-	if v == nil {
+	switch t := v.(type) {
+	case nil:
 		return ""
+	case string:
+		return t
+	case json.Number:
+		return t.String()
+	case float64:
+		return formatNumericClaim(t)
+	case float32:
+		return formatNumericClaim(float64(t))
+	case int:
+		return strconv.FormatInt(int64(t), 10)
+	case int64:
+		return strconv.FormatInt(t, 10)
+	case bool:
+		return strconv.FormatBool(t)
+	default:
+		return fmt.Sprintf("%v", v)
 	}
-	if s, ok := v.(string); ok {
-		return s
+}
+
+func formatNumericClaim(f float64) string {
+	if !math.IsInf(f, 0) && !math.IsNaN(f) && f == math.Trunc(f) {
+		return strconv.FormatInt(int64(f), 10)
 	}
-	return fmt.Sprintf("%v", v)
+	return strconv.FormatFloat(f, 'f', -1, 64)
 }
 
 func grantedScopes(token map[string]any, requested string) []string {

--- a/pkg/app/oauth/proxy_session_test.go
+++ b/pkg/app/oauth/proxy_session_test.go
@@ -137,6 +137,48 @@ func TestCaptureSubjectUserInfoCoercesNumericID(t *testing.T) {
 	}
 }
 
+func TestCaptureSubjectUserInfoLargeNumericIDIsNotScientific(t *testing.T) {
+	t.Parallel()
+	userinfo := &fakeUserInfo{info: map[string]any{"id": float64(97445496)}}
+	p := &authProxy{userinfo: userinfo}
+	cfg := &authdomain.OAuth2Config{UserInfoURL: "https://api.github.com/user", SubjectClaim: "id"}
+
+	sub, err := p.captureSubject(context.Background(), cfg, map[string]any{"access_token": "gho_token"})
+	if err != nil {
+		t.Fatalf("captureSubject: %v", err)
+	}
+	if sub != "97445496" {
+		t.Fatalf("expected plain integer subject, got %q", sub)
+	}
+}
+
+func TestCoerceClaim(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   any
+		want string
+	}{
+		{"nil", nil, ""},
+		{"string", "abc", "abc"},
+		{"json number integer", json.Number("97445496"), "97445496"},
+		{"json number large", json.Number("1234567890123456789"), "1234567890123456789"},
+		{"float64 integral", float64(97445496), "97445496"},
+		{"float64 small integral", float64(583231), "583231"},
+		{"float64 fractional", float64(1.5), "1.5"},
+		{"bool", true, "true"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := coerceClaim(tc.in); got != tc.want {
+				t.Fatalf("coerceClaim(%v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
 func sessionAuth(t *testing.T, idpURL string) *authdomain.Auth {
 	t.Helper()
 	return oauth2Auth(t, authdomain.OAuth2Config{

--- a/pkg/infra/oauth/userinfo_client.go
+++ b/pkg/infra/oauth/userinfo_client.go
@@ -15,6 +15,7 @@
 package oauth
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -57,8 +58,10 @@ func (c *UserInfoClient) Fetch(ctx context.Context, userInfoURL, accessToken str
 	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusMultipleChoices {
 		return nil, fmt.Errorf("oauth userinfo: unexpected status %d", res.StatusCode)
 	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
 	var claims map[string]any
-	if err := json.Unmarshal(body, &claims); err != nil {
+	if err := decoder.Decode(&claims); err != nil {
 		return nil, fmt.Errorf("oauth userinfo: decode response: %w", err)
 	}
 	return claims, nil

--- a/pkg/infra/oauth/userinfo_client_test.go
+++ b/pkg/infra/oauth/userinfo_client_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oauth_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	infraoauth "github.com/NeuralTrust/TrustGate/pkg/infra/oauth"
+)
+
+func TestUserInfoClientPreservesIntegerIDsAsJSONNumber(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer gho_token" {
+			t.Errorf("unexpected auth header: %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":97445496,"login":"octocat"}`))
+	}))
+	defer srv.Close()
+
+	client := infraoauth.NewUserInfoClient(srv.Client())
+	info, err := client.Fetch(context.Background(), srv.URL, "gho_token")
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	num, ok := info["id"].(json.Number)
+	if !ok {
+		t.Fatalf("expected id to decode as json.Number, got %T (%v)", info["id"], info["id"])
+	}
+	if num.String() != "97445496" {
+		t.Fatalf("expected exact integer id, got %q", num.String())
+	}
+}


### PR DESCRIPTION
## Summary
- In OAuth2 **session mode** for opaque-token IdPs (e.g. GitHub), the gateway derives the subject from a userinfo claim such as the numeric `id`. JSON numbers decode to `float64`, and `coerceClaim` formatted them with `fmt.Sprintf("%v", ...)`, which renders large integers in **scientific notation** (`97445496` → `"9.7445496e+07"`).
- That malformed subject becomes the key for downstream consent linking in the vault (`vault_credentials.principal_sub`). It "works" only because the bad formatting is deterministic; it's fragile and wrong, and makes the stored subject unreadable / non-portable.
- Fix `coerceClaim` to format integral `float64`/`float32` and `json.Number` values as plain integers, and decode userinfo responses with `json.Decoder.UseNumber()` so large IDs keep full precision (no float rounding for IDs beyond 2^53 either).

## Changes
- `pkg/app/oauth/proxy.go`: rewrite `coerceClaim` with a type switch (`nil`, `string`, `json.Number`, `float64`/`float32` via `formatNumericClaim`, integer types, `bool`, fallback). Integral floats format via `strconv.FormatInt`.
- `pkg/infra/oauth/userinfo_client.go`: decode the userinfo body with `json.Decoder` + `UseNumber()`.
- Tests: large-id regression (`97445496` → `"97445496"`), `coerceClaim` table test (incl. `json.Number`, fractional, bool), and a userinfo-client test asserting integer IDs decode as `json.Number` with full precision.

## Test plan
- [x] `go build ./pkg/app/oauth/... ./pkg/infra/oauth/...`
- [x] `go test ./pkg/app/oauth/... ./pkg/infra/oauth/...`
- [x] `go vet ./pkg/app/oauth/... ./pkg/infra/oauth/...`
- [ ] Manual: GitHub login in session mode → subject stored as plain integer (e.g. `97445496`), downstream consent linking stable across re-logins.

## Notes
- Pre-existing rows with scientific-notation subjects (e.g. `9.7445496e+07`) won't auto-migrate. After deploy, those users re-link the downstream provider once under the corrected subject (their old orphaned `vault_credentials` row can be deleted).

Made with [Cursor](https://cursor.com)