### PR TITLE
feat(plugins): group catalog policies into meaningful categories

### DIFF
--- a/pkg/app/plugins/catalog_metadata.go
+++ b/pkg/app/plugins/catalog_metadata.go
@@ -18,10 +18,13 @@ package plugins
 // here so it stays isolated from plugin execution code and can evolve without
 // touching the plugin implementations.
 const (
-	groupTrafficControl = "Traffic Control"
-	groupQuota          = "Quota"
-	groupRouting        = "Routing"
-	groupOther          = "Other"
+	groupTrafficControl   = "Traffic Control"
+	groupQuota            = "Quota"
+	groupRouting          = "Routing"
+	groupPromptManagement = "Prompt Management"
+	groupToolGovernance   = "Tool Governance"
+	groupGuardrails       = "Guardrails"
+	groupOther            = "Other"
 )
 
 // groupOrder fixes the order groups appear in the catalog response.
@@ -29,6 +32,9 @@ var groupOrder = []string{
 	groupTrafficControl,
 	groupQuota,
 	groupRouting,
+	groupPromptManagement,
+	groupToolGovernance,
+	groupGuardrails,
 	groupOther,
 }
 
@@ -687,7 +693,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 	},
 	"tool_call_validation": {
 		name:        "Tool Call Validation",
-		group:       groupOther,
+		group:       groupToolGovernance,
 		description: "Validate the tool calls an LLM returns against per-tool rules, rejecting or redacting responses that violate them.",
 		schema: SettingsSchema{
 			Fields: []Field{
@@ -792,7 +798,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 	},
 	"prompt_template": {
 		name:        "Prompt Template",
-		group:       groupOther,
+		group:       groupPromptManagement,
 		description: "Inject context-bound system prompts (Mode A) and/or render client-referenced named, versioned templates (Mode B) into the request before it reaches the model.",
 		schema: SettingsSchema{
 			Fields: []Field{
@@ -1010,7 +1016,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 	},
 	"tool_definition_transformation": {
 		name:        "Tool Definition Transformation",
-		group:       groupOther,
+		group:       groupToolGovernance,
 		description: "Reshape tool definitions on the request leg before they reach the model: patch a matched tool's JSON schema, override its description, and inject operator-authored tools. This is a governance and steering layer, not an access gate.",
 		schema: SettingsSchema{
 			Fields: []Field{
@@ -1114,7 +1120,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 	},
 	"trustguard": {
 		name:        "TrustGuard",
-		group:       groupOther,
+		group:       groupGuardrails,
 		description: "Inspect request and/or response content with the external TrustGuard guardrail service and block content it flags. Fails open on any transport error, timeout, non-2xx response, or missing base URL. Streaming responses cannot be blocked in realtime.",
 		schema: SettingsSchema{
 			Fields: []Field{

--- a/pkg/app/plugins/catalog_test.go
+++ b/pkg/app/plugins/catalog_test.go
@@ -69,7 +69,7 @@ func TestCatalogService_GroupsAndOrder(t *testing.T) {
 	for _, g := range catalog.Groups {
 		types = append(types, g.Type)
 	}
-	assert.Equal(t, []string{groupTrafficControl, groupQuota, groupRouting, groupOther}, types)
+	assert.Equal(t, []string{groupTrafficControl, groupQuota, groupRouting, groupPromptManagement}, types)
 
 	byType := make(map[string][]string)
 	for _, g := range catalog.Groups {
@@ -80,7 +80,7 @@ func TestCatalogService_GroupsAndOrder(t *testing.T) {
 	assert.ElementsMatch(t, []string{"rate_limiter", "request_size_limiter", "cors"}, byType[groupTrafficControl])
 	assert.ElementsMatch(t, []string{"token_rate_limiter", "cost_cap"}, byType[groupQuota])
 	assert.ElementsMatch(t, []string{"semantic_cache", "model_allowlist", "tool_allowlist"}, byType[groupRouting])
-	assert.Equal(t, []string{"prompt_template"}, byType[groupOther])
+	assert.Equal(t, []string{"prompt_template"}, byType[groupPromptManagement])
 }
 
 func TestCatalogService_EntriesHaveStagesAndSchema(t *testing.T) {
@@ -273,7 +273,7 @@ func TestToolDefinitionTransformation_CatalogEntry(t *testing.T) {
 	catalog := NewCatalogService(reg).Catalog()
 	require.Len(t, catalog.Groups, 1)
 	group := catalog.Groups[0]
-	assert.Equal(t, groupOther, group.Type)
+	assert.Equal(t, groupToolGovernance, group.Type)
 	require.Len(t, group.Items, 1)
 
 	entry := group.Items[0]
@@ -288,7 +288,7 @@ func TestToolDefinitionTransformationSchema_Fields(t *testing.T) {
 	meta, ok := pluginCatalogMeta["tool_definition_transformation"]
 	require.True(t, ok)
 	assert.Equal(t, "Tool Definition Transformation", meta.name)
-	assert.Equal(t, groupOther, meta.group)
+	assert.Equal(t, groupToolGovernance, meta.group)
 
 	fields := meta.schema.Fields
 
@@ -386,7 +386,7 @@ func TestTrustGuardSchema(t *testing.T) {
 	meta, ok := pluginCatalogMeta["trustguard"]
 	require.True(t, ok)
 	assert.Equal(t, "TrustGuard", meta.name)
-	assert.Equal(t, groupOther, meta.group)
+	assert.Equal(t, groupGuardrails, meta.group)
 
 	fields := meta.schema.Fields
 
@@ -518,7 +518,7 @@ func TestPromptTemplate_CatalogEntry(t *testing.T) {
 	var entry CatalogEntry
 	found := false
 	for _, g := range catalog.Groups {
-		if g.Type != groupOther {
+		if g.Type != groupPromptManagement {
 			continue
 		}
 		for _, item := range g.Items {
@@ -529,7 +529,7 @@ func TestPromptTemplate_CatalogEntry(t *testing.T) {
 		}
 	}
 
-	require.True(t, found, "prompt_template missing from the Other group")
+	require.True(t, found, "prompt_template missing from the Prompt Management group")
 	assert.Equal(t, "Prompt Template", entry.Name)
 	assert.Contains(t, entry.SupportedModes, policy.ModeEnforce)
 	assert.Equal(t, policy.DefaultMode, entry.DefaultMode)
@@ -541,7 +541,7 @@ func TestPromptTemplateSchema_Tree(t *testing.T) {
 	meta, ok := pluginCatalogMeta["prompt_template"]
 	require.True(t, ok)
 	assert.Equal(t, "Prompt Template", meta.name)
-	assert.Equal(t, groupOther, meta.group)
+	assert.Equal(t, groupPromptManagement, meta.group)
 
 	fields := meta.schema.Fields
 


### PR DESCRIPTION
## Summary
- Add `Prompt Management`, `Tool Governance`, and `Guardrails` catalog groups so policies no longer fall under `Other`.
- Assign `prompt_template`, `tool_call_validation`, `tool_definition_transformation`, and `trustguard` to the matching group.
- Update catalog tests to assert the new taxonomy and group order.

## Test plan
- [x] `go test ./pkg/app/plugins/...`
- [x] Pre-commit hook (golangci-lint, gosec, tests)


Made with [Cursor](https://cursor.com)