### PR TITLE
feat(trustguard): use real consumer id, drop consumer_id setting + functional tests (RUN-669)

### DIFF
--- a/openspec/changes/trustguard-connector/design.md
+++ b/openspec/changes/trustguard-connector/design.md
@@ -11,7 +11,8 @@ external-guardrail decode-and-block flow of `tool_call_validation` (adapter
 `net/http` client of `oauth/provider_client.go` (`*http.Client{Timeout}`,
 `NewRequestWithContext`, Bearer auth, `io.LimitReader`, JSON decode). Base URL +
 timeout come from env via `pkg/config`, injected through DI; per-policy
-`Settings` carry `api_key`, `consumer_id`, `inspect`, optional `base_url`.
+`Settings` carry `api_key`, `inspect`, optional `base_url`. The `consumer_id`
+sent to TrustGuard is the real TrustGate consumer id (`Request.ConsumerID`).
 
 ## Architecture Decisions
 
@@ -92,10 +93,9 @@ const (
 )
 
 type Settings struct {
-    APIKey     string `mapstructure:"api_key"` // #nosec G101 -- config field name
-    ConsumerID string `mapstructure:"consumer_id"`
-    Inspect    string `mapstructure:"inspect"`
-    BaseURL    string `mapstructure:"base_url"`
+    APIKey  string `mapstructure:"api_key"` // #nosec G101 -- config field name
+    Inspect string `mapstructure:"inspect"`
+    BaseURL string `mapstructure:"base_url"`
 }
 
 func parseConfig(settings map[string]any) (*Settings, error) // Parse -> applyDefaults(Inspect="request_response") -> validate

--- a/openspec/changes/trustguard-connector/proposal.md
+++ b/openspec/changes/trustguard-connector/proposal.md
@@ -102,7 +102,6 @@ framework, modeled on the established external-guardrail pattern
 ```json
 {
   "api_key": "tg_live_...",
-  "consumer_id": "acme-prod",
   "inspect": "request_response",
   "base_url": "https://trustguard.internal/"
 }
@@ -110,8 +109,6 @@ framework, modeled on the established external-guardrail pattern
 
 - `api_key` — **string, required**. Bearer token for TrustGuard
   (`Authorization: Bearer <api_key>`).
-- `consumer_id` — **string, required**. Sent as TrustGuard `consumer_id` (the
-  product/tenant identifier; distinct from the proxy request's `ConsumerID`).
 - `inspect` — **enum `request | response | request_response`, default
   `request_response`**. Selects which legs are inspected (see matrix).
 - `base_url` — **string, optional**. Overrides `TRUSTGUARD_BASE_URL` for this
@@ -177,7 +174,7 @@ Request-leg (`pre_request`) inspection is unaffected by streaming.
   "direction": "input",
   "protocol": "llm",
   "session_id": "<in.Request.SessionID>",
-  "consumer_id": "<config.consumer_id>",
+  "consumer_id": "<in.Request.ConsumerID>",
   "input": { "input": "<decoded request/response text>" },
   "attributes": {
     "content_type": "application/json",
@@ -190,9 +187,10 @@ Request-leg (`pre_request`) inspection is unaffected by streaming.
 ```
 
 - `direction` — from stage (`input` for pre_request, `output` for pre_response).
-- `protocol` — constant `"llm"` in v1.
+- `protocol` — derived from the resolved consumer `Type` (`LLM → "llm"`,
+  `MCP → "mcp"`, `A2A → "a2a"`; defaults to `"llm"`).
 - `session_id` — `in.Request.SessionID`.
-- `consumer_id` — from config (not the proxy request's `ConsumerID`).
+- `consumer_id` — the real TrustGate consumer id (`in.Request.ConsumerID`).
 - `input.input` — text decoded via the adapter `Registry`
   (`DecodeRequestFor` messages/system content on input; `DecodeResponseFor`
   content on output).
@@ -228,7 +226,7 @@ Request-leg (`pre_request`) inspection is unaffected by streaming.
 | `pkg/infra/plugins/trustguard/data.go` | New | `/v1/guard` request/response DTOs + event-extras struct. |
 | `pkg/infra/plugins/trustguard/*_test.go` | New | Table-driven config tests + `Execute` tests against `httptest.NewServer`. |
 | `pkg/container/modules/plugins.go` | Modified | Import `trustguard` and add `trustguard.New(...)` to the `newPluginRegistry` catalog slice with DI params (config, adapters, logger). |
-| `pkg/app/plugins/catalog_metadata.go` (+ `catalog_test.go`) | Modified | Catalog metadata entry (name, group, hand-authored `SettingsSchema`: `api_key`, `consumer_id`, `inspect` enum, optional `base_url`). |
+| `pkg/app/plugins/catalog_metadata.go` (+ `catalog_test.go`) | Modified | Catalog metadata entry (name, group, hand-authored `SettingsSchema`: `api_key`, `inspect` enum, optional `base_url`). |
 | `pkg/config/*` | Modified | Add `TRUSTGUARD_BASE_URL` (no default) and `TRUSTGUARD_TIMEOUT` (default `15s`) env-only config, wired into DI. |
 | Plugin docs | New/Modified | Document slug, config, stages, blocking/fail-open, streaming limitation (RUN-669 "connector documented"). |
 
@@ -242,14 +240,14 @@ Request-leg (`pre_request`) inspection is unaffected by streaming.
 | **Missing attributes** | `attachments`, consumer `tag`/`type`, `collector.type` omitted (not on the proxy request context). Future: enrich via consumer lookup / attachment extraction. |
 | **Empty session splits legs** | When `Request.SessionID` is empty (e.g. gateway session config disabled), TrustGuard mints a fresh session per `/v1/guard` call, so the request and response legs are not correlated in TrustGuard. The proxy data plane exposes no stable per-transaction id (the request-id middleware is admin-only). Blocking is unaffected (it decides per leg). Future: stamp a stable per-transaction session id in the proxy request context. |
 | **Added latency** | Each guarded leg adds a synchronous TrustGuard round-trip. Mitigation: bounded per-call timeout (`TRUSTGUARD_TIMEOUT`); operators scope the policy. |
-| **`consumer_id` semantics** | Config `consumer_id` (TrustGuard tenant) is intentionally distinct from the proxy `Request.ConsumerID`; documented to avoid confusion. |
+| **`consumer_id` semantics** | The `consumer_id` sent to TrustGuard is the real TrustGate consumer id (`Request.ConsumerID`), stamped in `stampConsumerScope`; it is not a plugin setting. |
 | **Empty base URL** | No env default; an unconfigured base URL passes through with a warning rather than failing requests. |
 
 ## Acceptance criteria (mapped to RUN-669)
 
 - [ ] **TrustGate configurable with a TrustGuard connector** — new `trustguard`
       plugin registered in `newPluginRegistry` + catalog metadata; per-policy
-      Settings `api_key`, `consumer_id`, `inspect`, optional `base_url`; env
+      Settings `api_key`, `inspect`, optional `base_url`; env
       `TRUSTGUARD_BASE_URL` / `TRUSTGUARD_TIMEOUT` via `pkg/config`.
 - [ ] **Requests forwarded correctly** — `Execute` builds the `/v1/guard` body
       (direction, protocol, session_id, consumer_id, decoded `input`, model

--- a/openspec/changes/trustguard-connector/tasks.md
+++ b/openspec/changes/trustguard-connector/tasks.md
@@ -41,7 +41,7 @@ Apache header on every new file. No other comments. `go test -race` per phase.
 
 ## Phase 3: Plugin config
 
-- [x] 3.1 Create `pkg/infra/plugins/trustguard/config.go`: `inspect*` consts, `Settings` (mapstructure tags, `#nosec G101`), `parseConfig` (Parse→applyDefaults `request_response`→validate: `api_key`/`consumer_id` required, enum, `base_url` URL), `selectsStage`.
+- [x] 3.1 Create `pkg/infra/plugins/trustguard/config.go`: `inspect*` consts, `Settings` (mapstructure tags, `#nosec G101`), `parseConfig` (Parse→applyDefaults `request_response`→validate: `api_key` required, enum, `base_url` URL), `selectsStage`.
 - [x] 3.2 Add `config_test.go`: required-field rejection, inspect enum+default, `base_url` validation, `selectsStage` matrix.
 
 ## Phase 4: Plugin core
@@ -53,6 +53,6 @@ Apache header on every new file. No other comments. `go test -race` per phase.
 ## Phase 5: Wiring & catalog
 
 - [x] 5.1 `pkg/container/modules/plugins.go`: import `trustguard`, add `Cfg *config.Config` to `pluginParams`, append `trustguard.New(p.Adapters, p.Cfg.TrustGuard.BaseURL, p.Cfg.TrustGuard.Timeout, p.Logger)` to `newPluginRegistry`.
-- [x] 5.2 `pkg/app/plugins/catalog_metadata.go`: add `"trustguard"` entry (`groupOther`, hand-authored `SettingsSchema`: `api_key`, `consumer_id`, `inspect` enum, optional `base_url`).
+- [x] 5.2 `pkg/app/plugins/catalog_metadata.go`: add `"trustguard"` entry (`groupOther`, hand-authored `SettingsSchema`: `api_key`, `inspect` enum, optional `base_url`).
 - [x] 5.3 `pkg/app/plugins/catalog_test.go`: add `TestTrustGuardSchema` mirroring the token-schema test.
 - [x] 5.4 Add `TRUSTGUARD_BASE_URL` + `TRUSTGUARD_TIMEOUT` to `.env.example`. Plugin docs skipped: repo has no per-plugin docs convention (no markdown exists for `tool_call_validation`/`prompt_template`/`tool_definition_transformation`); slug/config/stage-direction matrix/fail-open/streaming limitation are documented under `openspec/changes/trustguard-connector/`.

--- a/pkg/app/plugins/catalog_metadata.go
+++ b/pkg/app/plugins/catalog_metadata.go
@@ -1132,13 +1132,6 @@ var pluginCatalogMeta = map[string]catalogMeta{
 					Required:    true,
 				},
 				{
-					Key:         "consumer_id",
-					Label:       "Consumer ID",
-					Type:        FieldTypeString,
-					Description: "Identifier forwarded to TrustGuard to attribute the guarded call.",
-					Required:    true,
-				},
-				{
 					Key:         "inspect",
 					Label:       "Inspect",
 					Type:        FieldTypeEnum,

--- a/pkg/app/plugins/catalog_test.go
+++ b/pkg/app/plugins/catalog_test.go
@@ -395,11 +395,6 @@ func TestTrustGuardSchema(t *testing.T) {
 	assert.Equal(t, FieldTypeString, apiKey.Type)
 	assert.True(t, apiKey.Required)
 
-	consumerID, ok := fieldByKey(fields, "consumer_id")
-	require.True(t, ok)
-	assert.Equal(t, FieldTypeString, consumerID.Type)
-	assert.True(t, consumerID.Required)
-
 	inspect, ok := fieldByKey(fields, "inspect")
 	require.True(t, ok)
 	assert.Equal(t, FieldTypeEnum, inspect.Type)

--- a/pkg/infra/plugins/trustguard/config.go
+++ b/pkg/infra/plugins/trustguard/config.go
@@ -31,10 +31,9 @@ const (
 )
 
 type Settings struct {
-	APIKey     string `mapstructure:"api_key"` // #nosec G101 -- config field name, not a credential
-	ConsumerID string `mapstructure:"consumer_id"`
-	Inspect    string `mapstructure:"inspect"`
-	BaseURL    string `mapstructure:"base_url"`
+	APIKey  string `mapstructure:"api_key"` // #nosec G101 -- config field name, not a credential
+	Inspect string `mapstructure:"inspect"`
+	BaseURL string `mapstructure:"base_url"`
 }
 
 func parseConfig(settings map[string]any) (Settings, error) {
@@ -58,9 +57,6 @@ func (s *Settings) applyDefaults() {
 func (s *Settings) validate() error {
 	if strings.TrimSpace(s.APIKey) == "" {
 		return fmt.Errorf("trustguard: api_key is required")
-	}
-	if strings.TrimSpace(s.ConsumerID) == "" {
-		return fmt.Errorf("trustguard: consumer_id is required")
 	}
 	switch s.Inspect {
 	case inspectRequest, inspectResponse, inspectRequestResponse:

--- a/pkg/infra/plugins/trustguard/config_test.go
+++ b/pkg/infra/plugins/trustguard/config_test.go
@@ -32,82 +32,72 @@ func TestParseConfig(t *testing.T) {
 	}{
 		{
 			name:        "valid minimal config defaults inspect",
-			settings:    map[string]any{"api_key": "key", "consumer_id": "consumer"},
+			settings:    map[string]any{"api_key": "key"},
 			wantInspect: inspectRequestResponse,
 		},
 		{
 			name:     "missing api_key",
-			settings: map[string]any{"consumer_id": "consumer"},
+			settings: map[string]any{},
 			wantErr:  true,
 		},
 		{
 			name:     "blank api_key",
-			settings: map[string]any{"api_key": "  ", "consumer_id": "consumer"},
-			wantErr:  true,
-		},
-		{
-			name:     "missing consumer_id",
-			settings: map[string]any{"api_key": "key"},
-			wantErr:  true,
-		},
-		{
-			name:     "blank consumer_id",
-			settings: map[string]any{"api_key": "key", "consumer_id": "  "},
+			settings: map[string]any{"api_key": "  "},
 			wantErr:  true,
 		},
 		{
 			name:        "inspect request accepted",
-			settings:    map[string]any{"api_key": "key", "consumer_id": "consumer", "inspect": inspectRequest},
+			settings:    map[string]any{"api_key": "key", "inspect": inspectRequest},
 			wantInspect: inspectRequest,
 		},
 		{
 			name:        "inspect response accepted",
-			settings:    map[string]any{"api_key": "key", "consumer_id": "consumer", "inspect": inspectResponse},
+			settings:    map[string]any{"api_key": "key", "inspect": inspectResponse},
 			wantInspect: inspectResponse,
 		},
 		{
 			name:        "inspect request_response accepted",
-			settings:    map[string]any{"api_key": "key", "consumer_id": "consumer", "inspect": inspectRequestResponse},
+			settings:    map[string]any{"api_key": "key", "inspect": inspectRequestResponse},
 			wantInspect: inspectRequestResponse,
 		},
 		{
 			name:     "invalid inspect",
-			settings: map[string]any{"api_key": "key", "consumer_id": "consumer", "inspect": "both"},
+			settings: map[string]any{"api_key": "key", "inspect": "both"},
 			wantErr:  true,
 		},
 		{
 			name:        "base_url http accepted",
-			settings:    map[string]any{"api_key": "key", "consumer_id": "consumer", "base_url": "http://guard.local"},
+			settings:    map[string]any{"api_key": "key", "base_url": "http://guard.local"},
 			wantInspect: inspectRequestResponse,
 		},
 		{
 			name:        "base_url https accepted",
-			settings:    map[string]any{"api_key": "key", "consumer_id": "consumer", "base_url": "https://guard.example.com/api"},
+			settings:    map[string]any{"api_key": "key", "base_url": "https://guard.example.com/api"},
 			wantInspect: inspectRequestResponse,
 		},
 		{
 			name:        "empty base_url ok",
-			settings:    map[string]any{"api_key": "key", "consumer_id": "consumer", "base_url": ""},
+			settings:    map[string]any{"api_key": "key", "base_url": ""},
 			wantInspect: inspectRequestResponse,
 		},
 		{
 			name:     "base_url relative rejected",
-			settings: map[string]any{"api_key": "key", "consumer_id": "consumer", "base_url": "/v1/guard"},
+			settings: map[string]any{"api_key": "key", "base_url": "/v1/guard"},
 			wantErr:  true,
 		},
 		{
 			name:     "base_url missing scheme rejected",
-			settings: map[string]any{"api_key": "key", "consumer_id": "consumer", "base_url": "guard.local"},
+			settings: map[string]any{"api_key": "key", "base_url": "guard.local"},
 			wantErr:  true,
 		},
 		{
 			name:     "base_url non-http scheme rejected",
-			settings: map[string]any{"api_key": "key", "consumer_id": "consumer", "base_url": "ftp://guard.local"},
+			settings: map[string]any{"api_key": "key", "base_url": "ftp://guard.local"},
 			wantErr:  true,
 		},
 		{
 			name:     "base_url missing host rejected",
-			settings: map[string]any{"api_key": "key", "consumer_id": "consumer", "base_url": "http://"},
+			settings: map[string]any{"api_key": "key", "base_url": "http://"},
 			wantErr:  true,
 		},
 	}

--- a/pkg/infra/plugins/trustguard/plugin.go
+++ b/pkg/infra/plugins/trustguard/plugin.go
@@ -157,7 +157,7 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 		Direction:  direction,
 		Protocol:   protocolFor(in.Request.ConsumerType),
 		SessionID:  in.Request.SessionID,
-		ConsumerID: cfg.ConsumerID,
+		ConsumerID: in.Request.ConsumerID,
 		Attributes: GuardAttributes{
 			ContentType: contentTypeJSON,
 			Model: GuardModel{

--- a/pkg/infra/plugins/trustguard/plugin_test.go
+++ b/pkg/infra/plugins/trustguard/plugin_test.go
@@ -61,11 +61,17 @@ func settings(inspect string) map[string]any {
 }
 
 type fakeGuard struct {
-	mu       sync.Mutex
-	hits     int
-	lastBody GuardRequest
-	status   int
-	response GuardResponse
+	mu          sync.Mutex
+	hits        int
+	lastBody    GuardRequest
+	lastMethod  string
+	lastPath    string
+	lastAuth    string
+	lastCT      string
+	directions  []string
+	status      int
+	response    GuardResponse
+	responseFor map[string]GuardResponse
 }
 
 func (f *fakeGuard) handler() http.HandlerFunc {
@@ -73,6 +79,10 @@ func (f *fakeGuard) handler() http.HandlerFunc {
 		f.mu.Lock()
 		defer f.mu.Unlock()
 		f.hits++
+		f.lastMethod = r.Method
+		f.lastPath = r.URL.Path
+		f.lastAuth = r.Header.Get("Authorization")
+		f.lastCT = r.Header.Get("Content-Type")
 		if r.URL.Path != guardPath {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -80,14 +90,33 @@ func (f *fakeGuard) handler() http.HandlerFunc {
 		var body GuardRequest
 		_ = json.NewDecoder(r.Body).Decode(&body)
 		f.lastBody = body
+		f.directions = append(f.directions, body.Direction)
 		status := f.status
 		if status == 0 {
 			status = http.StatusOK
 		}
+		resp := f.response
+		if r, ok := f.responseFor[body.Direction]; ok {
+			resp = r
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(status)
-		_ = json.NewEncoder(w).Encode(f.response)
+		_ = json.NewEncoder(w).Encode(resp)
 	}
+}
+
+func (f *fakeGuard) http() (method, path, auth, contentType string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.lastMethod, f.lastPath, f.lastAuth, f.lastCT
+}
+
+func (f *fakeGuard) seenDirections() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.directions))
+	copy(out, f.directions)
+	return out
 }
 
 func (f *fakeGuard) count() int {
@@ -371,5 +400,163 @@ func TestProtocolFor(t *testing.T) {
 		if got := protocolFor(raw); got != want {
 			t.Fatalf("protocolFor(%q) = %q, want %q", raw, got, want)
 		}
+	}
+}
+
+func TestExecuteForwardsFullGuardRequest(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: GuardResponse{Status: "allowed"}}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, nil)
+
+	req := requestContext()
+	req.ConsumerType = "MCP"
+	req.ConsumerID = "consumer-real-42"
+	in := execInput(policy.StagePreRequest, policy.ModeEnforce, settings(""), req, nil)
+	if _, err := p.Execute(context.Background(), in); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	method, path, auth, ct := f.http()
+	if method != http.MethodPost {
+		t.Fatalf("method = %q, want POST", method)
+	}
+	if path != guardPath {
+		t.Fatalf("path = %q, want %q", path, guardPath)
+	}
+	if auth != "Bearer secret-key" {
+		t.Fatalf("authorization = %q, want %q", auth, "Bearer secret-key")
+	}
+	if ct != contentTypeJSON {
+		t.Fatalf("content-type = %q, want %q", ct, contentTypeJSON)
+	}
+
+	got := f.captured()
+	if got.Direction != directionInput {
+		t.Fatalf("direction = %q, want %q", got.Direction, directionInput)
+	}
+	if got.Protocol != protocolMCP {
+		t.Fatalf("protocol = %q, want %q", got.Protocol, protocolMCP)
+	}
+	if got.SessionID != "sess-123" {
+		t.Fatalf("session_id = %q, want sess-123", got.SessionID)
+	}
+	if got.ConsumerID != "consumer-real-42" {
+		t.Fatalf("consumer_id = %q, want consumer-real-42", got.ConsumerID)
+	}
+	if got.Input.Input != "be safe\nhello world" {
+		t.Fatalf("input = %q, want %q", got.Input.Input, "be safe\nhello world")
+	}
+	if got.Attributes.ContentType != contentTypeJSON {
+		t.Fatalf("attributes.content_type = %q, want %q", got.Attributes.ContentType, contentTypeJSON)
+	}
+	if got.Attributes.Model.Name != "gpt-4o-mini" || got.Attributes.Model.Provider != "openai" {
+		t.Fatalf("model = %+v, want gpt-4o-mini/openai", got.Attributes.Model)
+	}
+}
+
+func TestExecuteConsumerIDComesFromRequestNotSettings(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: GuardResponse{Status: "allowed"}}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, nil)
+
+	req := requestContext()
+	req.ConsumerID = "from-request"
+	set := settings("")
+	set["consumer_id"] = "from-settings-should-be-ignored"
+	in := execInput(policy.StagePreRequest, policy.ModeEnforce, set, req, nil)
+	if _, err := p.Execute(context.Background(), in); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := f.captured().ConsumerID; got != "from-request" {
+		t.Fatalf("consumer_id = %q, want from-request", got)
+	}
+}
+
+func TestExecuteInspectModeDirections(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		inspect    string
+		directions []string
+	}{
+		{name: "request only", inspect: inspectRequest, directions: []string{directionInput}},
+		{name: "response only", inspect: inspectResponse, directions: []string{directionOutput}},
+		{name: "request_response", inspect: inspectRequestResponse, directions: []string{directionInput, directionOutput}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			f := &fakeGuard{response: GuardResponse{Status: "allowed"}}
+			srv := newServer(t, f)
+			p := New(adapter.NewRegistry(), srv.URL, testTimeout, nil)
+
+			resp := &infracontext.ResponseContext{StatusCode: 200, Body: openAIResponseBody()}
+			for _, stage := range []policy.Stage{policy.StagePreRequest, policy.StagePreResponse} {
+				in := execInput(stage, policy.ModeEnforce, settings(tc.inspect), requestContext(), resp)
+				if _, err := p.Execute(context.Background(), in); err != nil {
+					t.Fatalf("stage %s: unexpected error: %v", stage, err)
+				}
+			}
+
+			got := f.seenDirections()
+			if len(got) != len(tc.directions) {
+				t.Fatalf("directions = %v, want %v", got, tc.directions)
+			}
+			for i, d := range tc.directions {
+				if got[i] != d {
+					t.Fatalf("direction[%d] = %q, want %q", i, got[i], d)
+				}
+			}
+		})
+	}
+}
+
+func TestExecuteBaseURLOverrideFromSettings(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: GuardResponse{Status: "allowed"}}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), "https://unreachable.invalid", testTimeout, nil)
+
+	set := settings("")
+	set["base_url"] = srv.URL
+	in := execInput(policy.StagePreRequest, policy.ModeEnforce, set, requestContext(), nil)
+	if _, err := p.Execute(context.Background(), in); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.count() != 1 {
+		t.Fatalf("expected guard called once via settings base_url, got %d", f.count())
+	}
+}
+
+func TestExecuteBlocksOnlyOnFlaggedLeg(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{responseFor: map[string]GuardResponse{
+		directionInput:  {Status: "allowed"},
+		directionOutput: {Status: statusBlock, TraceID: "trace-out"},
+	}}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, nil)
+
+	reqIn := execInput(policy.StagePreRequest, policy.ModeEnforce, settings(""), requestContext(), nil)
+	if _, err := p.Execute(context.Background(), reqIn); err != nil {
+		t.Fatalf("pre_request leg must pass (allowed), got %v", err)
+	}
+
+	resp := &infracontext.ResponseContext{StatusCode: 200, Body: openAIResponseBody()}
+	respIn := execInput(policy.StagePreResponse, policy.ModeEnforce, settings(""), requestContext(), resp)
+	res, err := p.Execute(context.Background(), respIn)
+	if res != nil {
+		t.Fatalf("expected nil result on response block, got %+v", res)
+	}
+	if _, ok := appplugins.AsPluginError(err); !ok {
+		t.Fatalf("expected *PluginError on response block, got %v", err)
 	}
 }

--- a/pkg/infra/plugins/trustguard/plugin_test.go
+++ b/pkg/infra/plugins/trustguard/plugin_test.go
@@ -44,6 +44,7 @@ func requestContext() *infracontext.RequestContext {
 		Provider:       "openai",
 		SourceFormat:   "openai",
 		SessionID:      "sess-123",
+		ConsumerID:     "consumer-9",
 		RequestedModel: "gpt-4o-mini",
 		Body:           openAIRequestBody(),
 	}
@@ -51,8 +52,7 @@ func requestContext() *infracontext.RequestContext {
 
 func settings(inspect string) map[string]any {
 	s := map[string]any{
-		"api_key":     "secret-key",
-		"consumer_id": "consumer-9",
+		"api_key": "secret-key",
 	}
 	if inspect != "" {
 		s["inspect"] = inspect


### PR DESCRIPTION
## Summary

Follow-up to #123 (already merged). Two changes that landed on the branch after #123 was merged and were therefore not part of it:

- **Drop the `consumer_id` plugin setting.** The `consumer_id` sent to TrustGuard is now the real TrustGate consumer id stamped on the request context (`Request.ConsumerID`) in `stampConsumerScope`, instead of a per-policy config value. Removed from `Settings`, validation, catalog schema and tests; SDD docs updated.
- **Harden functional test coverage against a faked TrustGuard.** The faked guard server now also captures HTTP method, path, `Authorization`/`Content-Type` headers and per-direction responses, with new functional tests asserting the full outgoing `/v1/guard` contract.

## Details

- `consumer_id` is no longer required in the plugin config; only `api_key` is required (`inspect` and `base_url` optional).
- New functional tests: full `GuardRequest` contract (bearer auth, JSON content type, body, model attributes), `consumer_id` sourced from the request (not settings), inspect-mode direction sequencing, per-policy `base_url` override, and per-leg blocking.

## Test plan

- `go build ./...`
- `go test -race ./pkg/infra/plugins/trustguard/... ./pkg/app/plugins/...`
- Rebased onto latest `develop` (includes #125 catalog grouping); cherry-pick applied cleanly.

RUN-669

Made with [Cursor](https://cursor.com)