### PR TITLE
feat(registry): encrypt provider credentials at rest

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,13 @@ SERVER_READ_TIMEOUT=60s
 SERVER_WRITE_TIMEOUT=60s
 SERVER_IDLE_TIMEOUT=120s
 
+# Server Secret (REQUIRED, at least 32 bytes of random data)
+# Signs and verifies admin-plane and playground JWTs, and derives the AES-256-GCM
+# key used to encrypt provider credentials in registries (registries.auth) and
+# vault credentials at rest. The process fails to boot if this is shorter than 32
+# bytes. Generate one with: openssl rand -base64 32
+SERVER_SECRET_KEY=
+
 # Gateway Discovery
 # GATEWAY_DISCOVERY_MODE: header (X-AG-Gateway-Slug with host fallback, self-hosted default) | subdomain (host only, cloud)
 # GATEWAY_BASE_DOMAIN: suffix to resolve {slug}.<base-domain> proxy hosts (gw.neuraltrust.sandbox for local dev, see make local-dns)

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -6,9 +6,12 @@ ADMIN_API_URL=http://localhost:8080
 # Local dev: http://localhost:8081  ·  docker-compose: http://proxy:8081
 PROXY_API_URL=http://localhost:8081
 
-# Shared HS256 secret used to sign admin JWTs. MUST match the admin server's
+# Shared secret used to sign admin JWTs. MUST match the admin server's
 # SERVER_SECRET_KEY, otherwise the admin API rejects the dashboard's tokens.
-SERVER_SECRET_KEY=change-me
+# Must be at least 32 bytes: the gateway derives its registry/vault encryption
+# key from it and refuses to boot with a shorter value. Generate one with:
+# openssl rand -base64 32
+SERVER_SECRET_KEY=change-me-to-a-32-byte-random-secret-value
 
 # Optional JWT claims forwarded to the admin API.
 # ADMIN_TEAM_ID=

--- a/pkg/container/modules/core.go
+++ b/pkg/container/modules/core.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/NeuralTrust/TrustGate/pkg/config"
 	"github.com/NeuralTrust/TrustGate/pkg/container"
+	vaultdomain "github.com/NeuralTrust/TrustGate/pkg/domain/vault"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/crypto"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/database"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/logger"
 )
@@ -49,6 +51,11 @@ func Core(c *container.Container) error {
 		return err
 	}
 	if err := c.Provide(database.NewMigrationsManagerProvider); err != nil {
+		return err
+	}
+	if err := c.Provide(func(cfg *config.Config) (vaultdomain.Encrypter, error) {
+		return crypto.NewCipher(cfg.Server.SecretKey)
+	}); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/container/modules/mcp.go
+++ b/pkg/container/modules/mcp.go
@@ -30,7 +30,6 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/container"
 	vaultdomain "github.com/NeuralTrust/TrustGate/pkg/domain/vault"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/cache"
-	"github.com/NeuralTrust/TrustGate/pkg/infra/crypto"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/database"
 	infrasts "github.com/NeuralTrust/TrustGate/pkg/infra/identity/sts"
 	mcpclient "github.com/NeuralTrust/TrustGate/pkg/infra/mcp/client"
@@ -44,11 +43,6 @@ func MCP(c *container.Container) error {
 	}
 	if err := c.Provide(func(client *mcpclient.Client, logger *slog.Logger) appmcp.Dialer {
 		return mcpclient.NewCachedDialer(client, logger)
-	}); err != nil {
-		return err
-	}
-	if err := c.Provide(func(cfg *config.Config) (vaultdomain.Encrypter, error) {
-		return crypto.NewCipher(cfg.Server.SecretKey)
 	}); err != nil {
 		return err
 	}

--- a/pkg/container/modules/registry.go
+++ b/pkg/container/modules/registry.go
@@ -19,13 +19,14 @@ import (
 	appregistry "github.com/NeuralTrust/TrustGate/pkg/app/registry"
 	"github.com/NeuralTrust/TrustGate/pkg/container"
 	domain "github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	vaultdomain "github.com/NeuralTrust/TrustGate/pkg/domain/vault"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/database"
 	registryrepo "github.com/NeuralTrust/TrustGate/pkg/infra/repository/registry"
 )
 
 func Registry(c *container.Container) error {
-	if err := c.Provide(func(conn *database.Connection) domain.Repository {
-		return registryrepo.NewRepository(conn)
+	if err := c.Provide(func(conn *database.Connection, enc vaultdomain.Encrypter) domain.Repository {
+		return registryrepo.NewRepository(conn, enc)
 	}); err != nil {
 		return err
 	}

--- a/pkg/infra/database/migrations/20260626000000_registry_auth_to_text.go
+++ b/pkg/infra/database/migrations/20260626000000_registry_auth_to_text.go
@@ -1,0 +1,39 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrations
+
+import (
+	"context"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/database"
+	"github.com/jackc/pgx/v5"
+)
+
+func init() {
+	database.RegisterMigration(database.Migration{
+		ID:   "20260626000000_registry_auth_to_text",
+		Name: "store registries.auth as encrypted text instead of jsonb",
+		Up: func(ctx context.Context, tx pgx.Tx) error {
+			const ddl = `ALTER TABLE registries ALTER COLUMN auth TYPE TEXT USING auth::text;`
+			_, err := tx.Exec(ctx, ddl)
+			return err
+		},
+		Down: func(ctx context.Context, tx pgx.Tx) error {
+			const ddl = `ALTER TABLE registries ALTER COLUMN auth TYPE JSONB USING auth::jsonb;`
+			_, err := tx.Exec(ctx, ddl)
+			return err
+		},
+	})
+}

--- a/pkg/infra/repository/registry/repository.go
+++ b/pkg/infra/repository/registry/repository.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
 	domain "github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	vaultdomain "github.com/NeuralTrust/TrustGate/pkg/domain/vault"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/database"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -36,11 +37,12 @@ const (
 var _ domain.Repository = (*Repository)(nil)
 
 type Repository struct {
-	conn *database.Connection
+	conn   *database.Connection
+	cipher vaultdomain.Encrypter
 }
 
-func NewRepository(conn *database.Connection) *Repository {
-	return &Repository{conn: conn}
+func NewRepository(conn *database.Connection, cipher vaultdomain.Encrypter) *Repository {
+	return &Repository{conn: conn, cipher: cipher}
 }
 
 func (r *Repository) Save(ctx context.Context, b *domain.Registry) error {
@@ -51,9 +53,9 @@ func (r *Repository) Save(ctx context.Context, b *domain.Registry) error {
 	if err != nil {
 		return fmt.Errorf("registry repository: marshal provider_options: %w", err)
 	}
-	authBytes, err := marshalAuth(b.Auth())
+	authStored, err := r.encryptAuth(b.Auth())
 	if err != nil {
-		return fmt.Errorf("registry repository: marshal auth: %w", err)
+		return fmt.Errorf("registry repository: encrypt auth: %w", err)
 	}
 	healthChecksBytes, err := marshalHealthChecks(b.HealthChecks())
 	if err != nil {
@@ -68,7 +70,7 @@ func (r *Repository) Save(ctx context.Context, b *domain.Registry) error {
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`
 	return database.WithTx(ctx, r.conn, func(tx pgx.Tx) error {
 		if _, err := tx.Exec(ctx, query,
-			b.ID, b.GatewayID, b.Name, registryType(b), b.Enabled, b.Provider(), providerOptionsBytes, authBytes, b.Description, healthChecksBytes, mcpTargetBytes, b.CreatedAt, b.UpdatedAt,
+			b.ID, b.GatewayID, b.Name, registryType(b), b.Enabled, b.Provider(), providerOptionsBytes, authStored, b.Description, healthChecksBytes, mcpTargetBytes, b.CreatedAt, b.UpdatedAt,
 		); err != nil {
 			return mapPgError(err)
 		}
@@ -84,9 +86,9 @@ func (r *Repository) Update(ctx context.Context, b *domain.Registry) error {
 	if err != nil {
 		return fmt.Errorf("registry repository: marshal provider_options: %w", err)
 	}
-	authBytes, err := marshalAuth(b.Auth())
+	authStored, err := r.encryptAuth(b.Auth())
 	if err != nil {
-		return fmt.Errorf("registry repository: marshal auth: %w", err)
+		return fmt.Errorf("registry repository: encrypt auth: %w", err)
 	}
 	healthChecksBytes, err := marshalHealthChecks(b.HealthChecks())
 	if err != nil {
@@ -111,7 +113,7 @@ func (r *Repository) Update(ctx context.Context, b *domain.Registry) error {
 		 WHERE id = $1 AND gateway_id = $12`
 	return database.WithTx(ctx, r.conn, func(tx pgx.Tx) error {
 		cmd, err := tx.Exec(ctx, query,
-			b.ID, b.Name, registryType(b), b.Enabled, b.Provider(), providerOptionsBytes, authBytes, b.Description, healthChecksBytes, mcpTargetBytes, b.UpdatedAt, b.GatewayID,
+			b.ID, b.Name, registryType(b), b.Enabled, b.Provider(), providerOptionsBytes, authStored, b.Description, healthChecksBytes, mcpTargetBytes, b.UpdatedAt, b.GatewayID,
 		)
 		if err != nil {
 			return mapPgError(err)
@@ -166,7 +168,7 @@ func (r *Repository) FindByID(ctx context.Context, id ids.RegistryID) (*domain.R
 		  FROM registries
 		 WHERE id = $1`
 	row := r.conn.Pool.QueryRow(ctx, query, id)
-	b, err := scanRegistry(row)
+	b, err := r.scanRegistry(row)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, domain.ErrNotFound
@@ -193,7 +195,7 @@ func (r *Repository) FindByIDs(ctx context.Context, gatewayID ids.GatewayID, reg
 
 	out := make([]*domain.Registry, 0, len(registryIDs))
 	for rows.Next() {
-		b, err := scanRegistry(rows)
+		b, err := r.scanRegistry(rows)
 		if err != nil {
 			return nil, fmt.Errorf("registry repository: scan: %w", err)
 		}
@@ -242,7 +244,7 @@ func (r *Repository) List(ctx context.Context, filter domain.ListFilter) ([]*dom
 
 	items := make([]*domain.Registry, 0, filter.Size)
 	for rows.Next() {
-		b, err := scanRegistry(rows)
+		b, err := r.scanRegistry(rows)
 		if err != nil {
 			return nil, 0, fmt.Errorf("registry repository: scan: %w", err)
 		}
@@ -258,7 +260,7 @@ type rowScanner interface {
 	Scan(dest ...any) error
 }
 
-func scanRegistry(s rowScanner) (*domain.Registry, error) {
+func (r *Repository) scanRegistry(s rowScanner) (*domain.Registry, error) {
 	b := &domain.Registry{}
 	var providerOptionsRaw, authRaw, healthChecksRaw, mcpTargetRaw []byte
 	var providerRaw *string
@@ -286,8 +288,12 @@ func scanRegistry(s rowScanner) (*domain.Registry, error) {
 			}
 		}
 		if len(authRaw) > 0 {
+			plain, err := r.cipher.Decrypt(string(authRaw))
+			if err != nil {
+				return nil, fmt.Errorf("decrypt auth: %w", err)
+			}
 			var auth domain.TargetAuth
-			if err := json.Unmarshal(authRaw, &auth); err != nil {
+			if err := json.Unmarshal([]byte(plain), &auth); err != nil {
 				return nil, fmt.Errorf("scan auth: %w", err)
 			}
 			target.Auth = &auth
@@ -339,6 +345,17 @@ func marshalAuth(a *domain.TargetAuth) ([]byte, error) {
 		return nil, nil
 	}
 	return json.Marshal(a)
+}
+
+func (r *Repository) encryptAuth(a *domain.TargetAuth) (any, error) {
+	authBytes, err := marshalAuth(a)
+	if err != nil {
+		return nil, err
+	}
+	if authBytes == nil {
+		return nil, nil
+	}
+	return r.cipher.Encrypt(string(authBytes))
 }
 
 func marshalHealthChecks(h *domain.HealthChecks) ([]byte, error) {

--- a/pkg/infra/repository/registry/repository_test.go
+++ b/pkg/infra/repository/registry/repository_test.go
@@ -16,9 +16,14 @@ package registry
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
 	domain "github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/crypto"
 )
 
 func TestMarshalAuth_PreservesAzureFieldsByMode(t *testing.T) {
@@ -105,4 +110,102 @@ func TestMarshalAuth_PreservesAzureFieldsByMode(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRepository_AuthEncryptionRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cipher, err := crypto.NewCipher("functional-test-secret-0123456789abcdef")
+	if err != nil {
+		t.Fatalf("new cipher: %v", err)
+	}
+	r := &Repository{cipher: cipher}
+
+	const apiKey = "sk-super-secret-value"
+	stored, err := r.encryptAuth(domain.NewAPIKeyAuth(apiKey))
+	if err != nil {
+		t.Fatalf("encryptAuth: %v", err)
+	}
+	ciphertext, ok := stored.(string)
+	if !ok || ciphertext == "" {
+		t.Fatalf("encryptAuth returned %T (%v), want non-empty string", stored, stored)
+	}
+	if strings.Contains(ciphertext, apiKey) {
+		t.Fatalf("stored auth leaks the plaintext secret: %q", ciphertext)
+	}
+
+	provider := "openai"
+	reg, err := r.scanRegistry(fakeRow{values: []any{
+		ids.New[ids.RegistryKind](),
+		ids.New[ids.GatewayKind](),
+		"openai-pool",
+		string(domain.TypeLLM),
+		true,
+		&provider,
+		[]byte(nil),
+		[]byte(ciphertext),
+		"",
+		[]byte(nil),
+		[]byte(nil),
+		time.Now().UTC(),
+		time.Now().UTC(),
+	}})
+	if err != nil {
+		t.Fatalf("scanRegistry: %v", err)
+	}
+	if reg.Auth() == nil || reg.Auth().APIKey == nil {
+		t.Fatalf("decrypted auth lost data: %+v", reg.Auth())
+	}
+	if reg.Auth().APIKey.APIKey != apiKey {
+		t.Fatalf("decrypted api key = %q, want %q", reg.Auth().APIKey.APIKey, apiKey)
+	}
+}
+
+func TestRepository_AuthEncryption_NilAuthStoresNull(t *testing.T) {
+	t.Parallel()
+
+	cipher, err := crypto.NewCipher("functional-test-secret-0123456789abcdef")
+	if err != nil {
+		t.Fatalf("new cipher: %v", err)
+	}
+	r := &Repository{cipher: cipher}
+
+	stored, err := r.encryptAuth(nil)
+	if err != nil {
+		t.Fatalf("encryptAuth(nil): %v", err)
+	}
+	if stored != nil {
+		t.Fatalf("encryptAuth(nil) = %v, want nil", stored)
+	}
+}
+
+type fakeRow struct {
+	values []any
+}
+
+func (f fakeRow) Scan(dest ...any) error {
+	if len(dest) != len(f.values) {
+		return fmt.Errorf("fakeRow: got %d dest, have %d values", len(dest), len(f.values))
+	}
+	for i, d := range dest {
+		switch dst := d.(type) {
+		case *ids.RegistryID:
+			*dst = f.values[i].(ids.RegistryID)
+		case *ids.GatewayID:
+			*dst = f.values[i].(ids.GatewayID)
+		case *string:
+			*dst = f.values[i].(string)
+		case **string:
+			*dst = f.values[i].(*string)
+		case *bool:
+			*dst = f.values[i].(bool)
+		case *[]byte:
+			*dst = f.values[i].([]byte)
+		case *time.Time:
+			*dst = f.values[i].(time.Time)
+		default:
+			return fmt.Errorf("fakeRow: unsupported dest type %T", d)
+		}
+	}
+	return nil
 }

--- a/tests/functional/repositories/consumer/repository_test.go
+++ b/tests/functional/repositories/consumer/repository_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
 	registrydomain "github.com/NeuralTrust/TrustGate/pkg/domain/registry"
 	roledomain "github.com/NeuralTrust/TrustGate/pkg/domain/role"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/crypto"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/database"
 	_ "github.com/NeuralTrust/TrustGate/pkg/infra/database/migrations"
 	repo "github.com/NeuralTrust/TrustGate/pkg/infra/repository/consumer"
@@ -23,6 +24,14 @@ import (
 	rolerepo "github.com/NeuralTrust/TrustGate/pkg/infra/repository/role"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+func newRegistryRepo(conn *database.Connection) *registryrepo.Repository {
+	cipher, err := crypto.NewCipher("functional-test-secret-0123456789abcdef")
+	if err != nil {
+		panic(err)
+	}
+	return registryrepo.NewRepository(conn, cipher)
+}
 
 type fixture struct {
 	repo  *repo.Repository
@@ -71,7 +80,7 @@ func setupRepo(t *testing.T) fixture {
 	return fixture{
 		repo:  repo.NewRepository(conn),
 		gw:    gatewayrepo.NewRepository(conn),
-		be:    registryrepo.NewRepository(conn),
+		be:    newRegistryRepo(conn),
 		roles: rolerepo.NewRepository(conn),
 		conn:  conn,
 	}

--- a/tests/functional/repositories/policy/repository_test.go
+++ b/tests/functional/repositories/policy/repository_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
 	domain "github.com/NeuralTrust/TrustGate/pkg/domain/policy"
 	registrydomain "github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/crypto"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/database"
 	_ "github.com/NeuralTrust/TrustGate/pkg/infra/database/migrations"
 	consumerrepo "github.com/NeuralTrust/TrustGate/pkg/infra/repository/consumer"
@@ -23,6 +24,14 @@ import (
 	registryrepo "github.com/NeuralTrust/TrustGate/pkg/infra/repository/registry"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+func newRegistryRepo(conn *database.Connection) *registryrepo.Repository {
+	cipher, err := crypto.NewCipher("functional-test-secret-0123456789abcdef")
+	if err != nil {
+		panic(err)
+	}
+	return registryrepo.NewRepository(conn, cipher)
+}
 
 func setupRepo(t *testing.T) (*repo.Repository, *gatewayrepo.Repository, *database.Connection) {
 	t.Helper()
@@ -72,7 +81,7 @@ func seedConsumer(t *testing.T, conn *database.Connection, gwID ids.GatewayID, n
 	if err != nil {
 		t.Fatalf("registry domain.NewLLMRegistry: %v", err)
 	}
-	if err := registryrepo.NewRepository(conn).Save(ctx, reg); err != nil {
+	if err := newRegistryRepo(conn).Save(ctx, reg); err != nil {
 		t.Fatalf("registry Save: %v", err)
 	}
 	cons, err := consumerdomain.New(consumerdomain.CreateParams{

--- a/tests/functional/repositories/registry/repository_test.go
+++ b/tests/functional/repositories/registry/repository_test.go
@@ -13,12 +13,15 @@ import (
 	gatewaydomain "github.com/NeuralTrust/TrustGate/pkg/domain/gateway"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
 	domain "github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/crypto"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/database"
 	_ "github.com/NeuralTrust/TrustGate/pkg/infra/database/migrations"
 	gatewayrepo "github.com/NeuralTrust/TrustGate/pkg/infra/repository/gateway"
 	repo "github.com/NeuralTrust/TrustGate/pkg/infra/repository/registry"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+const testSecretKey = "functional-test-secret-0123456789abcdef"
 
 func setupRepo(t *testing.T) (*repo.Repository, *gatewayrepo.Repository, *database.Connection) {
 	t.Helper()
@@ -55,7 +58,13 @@ func setupRepo(t *testing.T) (*repo.Repository, *gatewayrepo.Repository, *databa
 		pool.Close()
 	})
 
-	return repo.NewRepository(conn), gatewayrepo.NewRepository(conn), conn
+	cipher, err := crypto.NewCipher(testSecretKey)
+	if err != nil {
+		pool.Close()
+		t.Fatalf("new cipher: %v", err)
+	}
+
+	return repo.NewRepository(conn, cipher), gatewayrepo.NewRepository(conn), conn
 }
 
 func seedGateway(t *testing.T, gw *gatewayrepo.Repository, name string) ids.GatewayID {

--- a/tests/functional/repositories/role/repository_test.go
+++ b/tests/functional/repositories/role/repository_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
 	registrydomain "github.com/NeuralTrust/TrustGate/pkg/domain/registry"
 	domain "github.com/NeuralTrust/TrustGate/pkg/domain/role"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/crypto"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/database"
 	_ "github.com/NeuralTrust/TrustGate/pkg/infra/database/migrations"
 	gatewayrepo "github.com/NeuralTrust/TrustGate/pkg/infra/repository/gateway"
@@ -21,6 +22,14 @@ import (
 	repo "github.com/NeuralTrust/TrustGate/pkg/infra/repository/role"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+func newRegistryRepo(conn *database.Connection) *registryrepo.Repository {
+	cipher, err := crypto.NewCipher("functional-test-secret-0123456789abcdef")
+	if err != nil {
+		panic(err)
+	}
+	return registryrepo.NewRepository(conn, cipher)
+}
 
 type fixture struct {
 	repo     *repo.Repository
@@ -66,7 +75,7 @@ func setupRepo(t *testing.T) fixture {
 	return fixture{
 		repo:     repo.NewRepository(conn),
 		gateway:  gatewayrepo.NewRepository(conn),
-		registry: registryrepo.NewRepository(conn),
+		registry: newRegistryRepo(conn),
 	}
 }
 


### PR DESCRIPTION
## Summary
- Encrypt LLM registry provider credentials (OpenAI/Azure/AWS/OAuth/GCP keys) at rest. The whole `TargetAuth` blob is encrypted with the existing AES-256-GCM cipher (derived from `SERVER_SECRET_KEY`) at the registry repository boundary and decrypted on read.
- The domain object stays plaintext in memory, so API response masking (`FromAuth`) and update secret-resolution (`ResolveSecretsFrom`) are unchanged; the connection tester does not touch the DB and is unaffected.
- `registries.auth` column changed from `JSONB` to `TEXT` to hold the ciphertext (new migration).
- The `Encrypter` provider moved from the MCP DI module to the core module, since the registry repository (core) now depends on it.

## Changes
- `pkg/infra/database/migrations/20260626000000_registry_auth_to_text.go` — alter `registries.auth` JSONB -> TEXT (Up/Down).
- `pkg/infra/repository/registry/repository.go` — inject `Encrypter`; `encryptAuth` on Save/Update; `scanRegistry` becomes a method and decrypts before unmarshal.
- `pkg/container/modules/{core,mcp,registry}.go` — move the `Encrypter` provider to core; wire it into the registry repository.
- Tests: encrypted round-trip + nil-auth unit tests; functional repo test builds the repo with a real cipher.
- Docs/env: document `SERVER_SECRET_KEY` (>= 32 bytes, required) in `.env.example`; bump the `frontend/.env.example` dev value to a valid length.

## Impact
- **Breaking for ops:** every run mode (admin/proxy/mcp/run) now requires `SERVER_SECRET_KEY` of at least 32 bytes to boot, because the core registry repository depends on the cipher.
- No legacy data handling: this assumes a fresh/recreated DB (no existing plaintext rows to migrate).
- Nothing queries the `auth` JSON via SQL, so the column type change does not affect queries or triggers.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/infra/repository/registry/...` (encryption round-trip, nil-auth)
- [x] `go vet` on touched packages; functional tests compile (`-tags functional`)
- [ ] Recreate DB, create a registry, confirm `registries.auth` stores ciphertext while the API returns the masked value and the proxy uses the decrypted key

Made with [Cursor](https://cursor.com)