### PR TITLE
feat(catalog): enum options with display labels (RUN-751)

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2925,7 +2925,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Deletes a gateway. Fails if it still has dependent resources.",
+                "description": "Deletes a gateway and cascades the deletion to every resource that belongs to it (consumers, roles, policies, auths, registries and vault credentials).",
                 "produces": [
                     "application/json"
                 ],
@@ -2961,12 +2961,6 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
-                        }
-                    },
-                    "409": {
-                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
                         }
@@ -3097,58 +3091,6 @@ const docTemplate = `{
                         "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/playground/traces/{trace_id}": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Returns the metrics Event captured for a playground request, keyed by the X-AG-Trace-Id returned in the proxy response. Traces expire after a short TTL.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "playground"
-                ],
-                "summary": "Get a playground trace",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Trace id (X-AG-Trace-Id from the proxy response)",
-                        "name": "trace_id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Event"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_helpers.ErrorBody"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_helpers.ErrorBody"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_helpers.ErrorBody"
                         }
                     }
                 }
@@ -3406,6 +3348,15 @@ const docTemplate = `{
                     "items": {
                         "type": "string"
                     }
+                },
+                "session_mode": {
+                    "type": "boolean"
+                },
+                "subject_claim": {
+                    "type": "string"
+                },
+                "userinfo_url": {
+                    "type": "string"
                 }
             }
         },
@@ -3592,6 +3543,15 @@ const docTemplate = `{
                     "items": {
                         "type": "string"
                     }
+                },
+                "session_mode": {
+                    "type": "boolean"
+                },
+                "subject_claim": {
+                    "type": "string"
+                },
+                "userinfo_url": {
+                    "type": "string"
                 }
             }
         },
@@ -5489,7 +5449,7 @@ const docTemplate = `{
                 "enum": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_app_plugins.EnumOption"
                     }
                 },
                 "key": {
@@ -5569,6 +5529,17 @@ const docTemplate = `{
                 }
             }
         },
+        "github_com_NeuralTrust_TrustGate_pkg_app_plugins.EnumOption": {
+            "type": "object",
+            "properties": {
+                "label": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
         "github_com_NeuralTrust_TrustGate_pkg_app_plugins.Field": {
             "type": "object",
             "properties": {
@@ -5579,7 +5550,7 @@ const docTemplate = `{
                 "enum": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_app_plugins.EnumOption"
                     }
                 },
                 "fields": {
@@ -6059,8 +6030,14 @@ const docTemplate = `{
                 "is_flagged": {
                     "type": "boolean"
                 },
+                "kind": {
+                    "type": "string"
+                },
                 "latency": {
                     "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_infra_metrics_events.Latency"
+                },
+                "mcp": {
+                    "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_infra_metrics_events.MCP"
                 },
                 "occurred_on": {
                     "type": "integer"
@@ -6126,6 +6103,56 @@ const docTemplate = `{
                 },
                 "total_ms": {
                     "type": "integer"
+                }
+            }
+        },
+        "github_com_NeuralTrust_TrustGate_pkg_infra_metrics_events.MCP": {
+            "type": "object",
+            "properties": {
+                "catalog_code": {
+                    "type": "string"
+                },
+                "host": {
+                    "type": "string"
+                },
+                "method": {
+                    "type": "string"
+                },
+                "operation": {
+                    "type": "string"
+                },
+                "prompt": {
+                    "type": "string"
+                },
+                "registry_id": {
+                    "type": "string"
+                },
+                "resource_uri": {
+                    "type": "string"
+                },
+                "rpc_error_code": {
+                    "type": "integer"
+                },
+                "server_name": {
+                    "type": "string"
+                },
+                "targets": {
+                    "type": "integer"
+                },
+                "tool": {
+                    "type": "string"
+                },
+                "transport": {
+                    "type": "string"
+                },
+                "upstream_latency_ms": {
+                    "type": "integer"
+                },
+                "upstream_status": {
+                    "type": "string"
+                },
+                "upstream_tool": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3653,7 +3653,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Deletes a gateway. Fails if it still has dependent resources.",
+                "description": "Deletes a gateway and cascades the deletion to every resource that belongs to it (consumers, roles, policies, auths, registries and vault credentials).",
                 "tags": [
                     "gateways"
                 ],
@@ -3696,16 +3696,6 @@
                     },
                     "404": {
                         "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
-                                }
-                            }
-                        }
-                    },
-                    "409": {
-                        "description": "Conflict",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -3865,73 +3855,6 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/playground/traces/{trace_id}": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Returns the metrics Event captured for a playground request, keyed by the X-AG-Trace-Id returned in the proxy response. Traces expire after a short TTL.",
-                "tags": [
-                    "playground"
-                ],
-                "summary": "Get a playground trace",
-                "parameters": [
-                    {
-                        "description": "Trace id (X-AG-Trace-Id from the proxy response)",
-                        "name": "trace_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Event"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_helpers.ErrorBody"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_helpers.ErrorBody"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_helpers.ErrorBody"
                                 }
                             }
                         }
@@ -4242,6 +4165,15 @@
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "session_mode": {
+                        "type": "boolean"
+                    },
+                    "subject_claim": {
+                        "type": "string"
+                    },
+                    "userinfo_url": {
+                        "type": "string"
                     }
                 }
             },
@@ -4428,6 +4360,15 @@
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "session_mode": {
+                        "type": "boolean"
+                    },
+                    "subject_claim": {
+                        "type": "string"
+                    },
+                    "userinfo_url": {
+                        "type": "string"
                     }
                 }
             },
@@ -6325,7 +6266,7 @@
                     "enum": {
                         "type": "array",
                         "items": {
-                            "type": "string"
+                            "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_app_plugins.EnumOption"
                         }
                     },
                     "key": {
@@ -6405,6 +6346,17 @@
                     }
                 }
             },
+            "github_com_NeuralTrust_TrustGate_pkg_app_plugins.EnumOption": {
+                "type": "object",
+                "properties": {
+                    "label": {
+                        "type": "string"
+                    },
+                    "value": {
+                        "type": "string"
+                    }
+                }
+            },
             "github_com_NeuralTrust_TrustGate_pkg_app_plugins.Field": {
                 "type": "object",
                 "properties": {
@@ -6415,7 +6367,7 @@
                     "enum": {
                         "type": "array",
                         "items": {
-                            "type": "string"
+                            "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_app_plugins.EnumOption"
                         }
                     },
                     "fields": {
@@ -6895,8 +6847,14 @@
                     "is_flagged": {
                         "type": "boolean"
                     },
+                    "kind": {
+                        "type": "string"
+                    },
                     "latency": {
                         "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_infra_metrics_events.Latency"
+                    },
+                    "mcp": {
+                        "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_infra_metrics_events.MCP"
                     },
                     "occurred_on": {
                         "type": "integer"
@@ -6962,6 +6920,56 @@
                     },
                     "total_ms": {
                         "type": "integer"
+                    }
+                }
+            },
+            "github_com_NeuralTrust_TrustGate_pkg_infra_metrics_events.MCP": {
+                "type": "object",
+                "properties": {
+                    "catalog_code": {
+                        "type": "string"
+                    },
+                    "host": {
+                        "type": "string"
+                    },
+                    "method": {
+                        "type": "string"
+                    },
+                    "operation": {
+                        "type": "string"
+                    },
+                    "prompt": {
+                        "type": "string"
+                    },
+                    "registry_id": {
+                        "type": "string"
+                    },
+                    "resource_uri": {
+                        "type": "string"
+                    },
+                    "rpc_error_code": {
+                        "type": "integer"
+                    },
+                    "server_name": {
+                        "type": "string"
+                    },
+                    "targets": {
+                        "type": "integer"
+                    },
+                    "tool": {
+                        "type": "string"
+                    },
+                    "transport": {
+                        "type": "string"
+                    },
+                    "upstream_latency_ms": {
+                        "type": "integer"
+                    },
+                    "upstream_status": {
+                        "type": "string"
+                    },
+                    "upstream_tool": {
+                        "type": "string"
                     }
                 }
             },

--- a/docs/policies.json
+++ b/docs/policies.json
@@ -37,13 +37,34 @@
                   "label": "Method",
                   "type": "enum",
                   "enum": [
-                    "GET",
-                    "POST",
-                    "PUT",
-                    "PATCH",
-                    "DELETE",
-                    "OPTIONS",
-                    "HEAD"
+                    {
+                      "value": "GET",
+                      "label": "GET"
+                    },
+                    {
+                      "value": "POST",
+                      "label": "POST"
+                    },
+                    {
+                      "value": "PUT",
+                      "label": "PUT"
+                    },
+                    {
+                      "value": "PATCH",
+                      "label": "PATCH"
+                    },
+                    {
+                      "value": "DELETE",
+                      "label": "DELETE"
+                    },
+                    {
+                      "value": "OPTIONS",
+                      "label": "OPTIONS"
+                    },
+                    {
+                      "value": "HEAD",
+                      "label": "HEAD"
+                    }
                   ]
                 }
               },
@@ -150,9 +171,18 @@
                 "description": "Unit used to interpret the allowed payload size.",
                 "default": "megabytes",
                 "enum": [
-                  "bytes",
-                  "kilobytes",
-                  "megabytes"
+                  {
+                    "value": "bytes",
+                    "label": "Bytes"
+                  },
+                  {
+                    "value": "kilobytes",
+                    "label": "Kilobytes"
+                  },
+                  {
+                    "value": "megabytes",
+                    "label": "Megabytes"
+                  }
                 ]
               },
               {
@@ -198,8 +228,14 @@
                 "description": "Whether budgets count provider tokens or USD cost.",
                 "default": "tokens",
                 "enum": [
-                  "tokens",
-                  "dollars"
+                  {
+                    "value": "tokens",
+                    "label": "Tokens"
+                  },
+                  {
+                    "value": "dollars",
+                    "label": "Dollars"
+                  }
                 ]
               },
               {
@@ -209,9 +245,18 @@
                 "description": "Which usage figure accrues against the budget.",
                 "default": "total",
                 "enum": [
-                  "total",
-                  "input",
-                  "output"
+                  {
+                    "value": "total",
+                    "label": "Total"
+                  },
+                  {
+                    "value": "input",
+                    "label": "Input"
+                  },
+                  {
+                    "value": "output",
+                    "label": "Output"
+                  }
                 ]
               },
               {
@@ -275,10 +320,22 @@
                 "description": "Action taken when a budget is exceeded under enforce mode.",
                 "default": "reject",
                 "enum": [
-                  "reject",
-                  "throttle",
-                  "downgrade_model",
-                  "alert_only"
+                  {
+                    "value": "reject",
+                    "label": "Reject"
+                  },
+                  {
+                    "value": "throttle",
+                    "label": "Throttle"
+                  },
+                  {
+                    "value": "downgrade_model",
+                    "label": "Downgrade Model"
+                  },
+                  {
+                    "value": "alert_only",
+                    "label": "Alert Only"
+                  }
                 ]
               },
               {
@@ -391,8 +448,14 @@
                 "description": "Action taken when a model exceeds its cost ceiling under enforce mode.",
                 "default": "reject",
                 "enum": [
-                  "reject",
-                  "downgrade"
+                  {
+                    "value": "reject",
+                    "label": "Reject"
+                  },
+                  {
+                    "value": "downgrade",
+                    "label": "Downgrade"
+                  }
                 ]
               },
               {
@@ -408,9 +471,18 @@
                 "description": "How to treat a model with no resolvable price.",
                 "default": "reject",
                 "enum": [
-                  "reject",
-                  "pass_through",
-                  "assume_max"
+                  {
+                    "value": "reject",
+                    "label": "Reject"
+                  },
+                  {
+                    "value": "pass_through",
+                    "label": "Pass Through"
+                  },
+                  {
+                    "value": "assume_max",
+                    "label": "Assume Max"
+                  }
                 ]
               },
               {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2918,7 +2918,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Deletes a gateway. Fails if it still has dependent resources.",
+                "description": "Deletes a gateway and cascades the deletion to every resource that belongs to it (consumers, roles, policies, auths, registries and vault credentials).",
                 "produces": [
                     "application/json"
                 ],
@@ -2954,12 +2954,6 @@
                     },
                     "404": {
                         "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
-                        }
-                    },
-                    "409": {
-                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
                         }
@@ -3090,58 +3084,6 @@
                         "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/playground/traces/{trace_id}": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Returns the metrics Event captured for a playground request, keyed by the X-AG-Trace-Id returned in the proxy response. Traces expire after a short TTL.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "playground"
-                ],
-                "summary": "Get a playground trace",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Trace id (X-AG-Trace-Id from the proxy response)",
-                        "name": "trace_id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_infra_metrics_events.Event"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_helpers.ErrorBody"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_helpers.ErrorBody"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/github_com_NeuralTrust_AgentGateway_pkg_api_handler_http_helpers.ErrorBody"
                         }
                     }
                 }
@@ -3399,6 +3341,15 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "session_mode": {
+                    "type": "boolean"
+                },
+                "subject_claim": {
+                    "type": "string"
+                },
+                "userinfo_url": {
+                    "type": "string"
                 }
             }
         },
@@ -3585,6 +3536,15 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "session_mode": {
+                    "type": "boolean"
+                },
+                "subject_claim": {
+                    "type": "string"
+                },
+                "userinfo_url": {
+                    "type": "string"
                 }
             }
         },
@@ -5482,7 +5442,7 @@
                 "enum": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_app_plugins.EnumOption"
                     }
                 },
                 "key": {
@@ -5562,6 +5522,17 @@
                 }
             }
         },
+        "github_com_NeuralTrust_TrustGate_pkg_app_plugins.EnumOption": {
+            "type": "object",
+            "properties": {
+                "label": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
         "github_com_NeuralTrust_TrustGate_pkg_app_plugins.Field": {
             "type": "object",
             "properties": {
@@ -5572,7 +5543,7 @@
                 "enum": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_app_plugins.EnumOption"
                     }
                 },
                 "fields": {
@@ -6052,8 +6023,14 @@
                 "is_flagged": {
                     "type": "boolean"
                 },
+                "kind": {
+                    "type": "string"
+                },
                 "latency": {
                     "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_infra_metrics_events.Latency"
+                },
+                "mcp": {
+                    "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_infra_metrics_events.MCP"
                 },
                 "occurred_on": {
                     "type": "integer"
@@ -6119,6 +6096,56 @@
                 },
                 "total_ms": {
                     "type": "integer"
+                }
+            }
+        },
+        "github_com_NeuralTrust_TrustGate_pkg_infra_metrics_events.MCP": {
+            "type": "object",
+            "properties": {
+                "catalog_code": {
+                    "type": "string"
+                },
+                "host": {
+                    "type": "string"
+                },
+                "method": {
+                    "type": "string"
+                },
+                "operation": {
+                    "type": "string"
+                },
+                "prompt": {
+                    "type": "string"
+                },
+                "registry_id": {
+                    "type": "string"
+                },
+                "resource_uri": {
+                    "type": "string"
+                },
+                "rpc_error_code": {
+                    "type": "integer"
+                },
+                "server_name": {
+                    "type": "string"
+                },
+                "targets": {
+                    "type": "integer"
+                },
+                "tool": {
+                    "type": "string"
+                },
+                "transport": {
+                    "type": "string"
+                },
+                "upstream_latency_ms": {
+                    "type": "integer"
+                },
+                "upstream_status": {
+                    "type": "string"
+                },
+                "upstream_tool": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -61,6 +61,12 @@ definitions:
         items:
           type: string
         type: array
+      session_mode:
+        type: boolean
+      subject_claim:
+        type: string
+      userinfo_url:
+        type: string
     type: object
   github_com_NeuralTrust_TrustGate_pkg_api_handler_http_auth_request.OIDCConfigRequest:
     properties:
@@ -183,6 +189,12 @@ definitions:
         items:
           type: string
         type: array
+      session_mode:
+        type: boolean
+      subject_claim:
+        type: string
+      userinfo_url:
+        type: string
     type: object
   github_com_NeuralTrust_TrustGate_pkg_api_handler_http_auth_response.OIDCConfigResponse:
     properties:
@@ -1441,7 +1453,7 @@ definitions:
         type: string
       enum:
         items:
-          type: string
+          $ref: '#/definitions/github_com_NeuralTrust_TrustGate_pkg_app_plugins.EnumOption'
         type: array
       key:
         type: string
@@ -1493,6 +1505,13 @@ definitions:
       type:
         type: string
     type: object
+  github_com_NeuralTrust_TrustGate_pkg_app_plugins.EnumOption:
+    properties:
+      label:
+        type: string
+      value:
+        type: string
+    type: object
   github_com_NeuralTrust_TrustGate_pkg_app_plugins.Field:
     properties:
       default: {}
@@ -1500,7 +1519,7 @@ definitions:
         type: string
       enum:
         items:
-          type: string
+          $ref: '#/definitions/github_com_NeuralTrust_TrustGate_pkg_app_plugins.EnumOption'
         type: array
       fields:
         description: Fields lists the child fields of an object.
@@ -1862,8 +1881,12 @@ definitions:
         type: string
       is_flagged:
         type: boolean
+      kind:
+        type: string
       latency:
         $ref: '#/definitions/github_com_NeuralTrust_TrustGate_pkg_infra_metrics_events.Latency'
+      mcp:
+        $ref: '#/definitions/github_com_NeuralTrust_TrustGate_pkg_infra_metrics_events.MCP'
       occurred_on:
         type: integer
       policy_chain:
@@ -1907,6 +1930,39 @@ definitions:
         type: integer
       total_ms:
         type: integer
+    type: object
+  github_com_NeuralTrust_TrustGate_pkg_infra_metrics_events.MCP:
+    properties:
+      catalog_code:
+        type: string
+      host:
+        type: string
+      method:
+        type: string
+      operation:
+        type: string
+      prompt:
+        type: string
+      registry_id:
+        type: string
+      resource_uri:
+        type: string
+      rpc_error_code:
+        type: integer
+      server_name:
+        type: string
+      targets:
+        type: integer
+      tool:
+        type: string
+      transport:
+        type: string
+      upstream_latency_ms:
+        type: integer
+      upstream_status:
+        type: string
+      upstream_tool:
+        type: string
     type: object
   github_com_NeuralTrust_TrustGate_pkg_infra_metrics_events.PolicyEntry:
     properties:
@@ -3945,7 +4001,8 @@ paths:
       - roles
   /v1/gateways/{id}:
     delete:
-      description: Deletes a gateway. Fails if it still has dependent resources.
+      description: Deletes a gateway and cascades the deletion to every resource that
+        belongs to it (consumers, roles, policies, auths, registries and vault credentials).
       parameters:
       - description: Gateway id
         format: uuid
@@ -3968,10 +4025,6 @@ paths:
             $ref: '#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody'
-        "409":
-          description: Conflict
           schema:
             $ref: '#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody'
       security:

--- a/pkg/app/catalog/provider_options.go
+++ b/pkg/app/catalog/provider_options.go
@@ -14,7 +14,10 @@
 
 package catalog
 
-import "github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+import (
+	appplugins "github.com/NeuralTrust/TrustGate/pkg/app/plugins"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+)
 
 type OptionFieldType string
 
@@ -25,13 +28,13 @@ const (
 )
 
 type ProviderOptionField struct {
-	Key         string          `json:"key"`
-	Label       string          `json:"label"`
-	Type        OptionFieldType `json:"type"`
-	Description string          `json:"description,omitempty"`
-	Required    bool            `json:"required,omitempty"`
-	Default     any             `json:"default,omitempty"`
-	Enum        []string        `json:"enum,omitempty"`
+	Key         string                  `json:"key"`
+	Label       string                  `json:"label"`
+	Type        OptionFieldType         `json:"type"`
+	Description string                  `json:"description,omitempty"`
+	Required    bool                    `json:"required,omitempty"`
+	Default     any                     `json:"default,omitempty"`
+	Enum        []appplugins.EnumOption `json:"enum,omitempty"`
 }
 
 var providerOptionsCatalog = map[string][]ProviderOptionField{
@@ -41,7 +44,10 @@ var providerOptionsCatalog = map[string][]ProviderOptionField{
 			Label:       "API",
 			Type:        OptionFieldTypeEnum,
 			Description: "OpenAI API surface to target.",
-			Enum:        []string{providers.OpenAIAPICompletions, providers.OpenAIAPIResponses},
+			Enum: []appplugins.EnumOption{
+				{Value: providers.OpenAIAPICompletions, Label: "Completions"},
+				{Value: providers.OpenAIAPIResponses, Label: "Responses"},
+			},
 		},
 		{
 			Key:         "base_url",

--- a/pkg/app/plugins/catalog.go
+++ b/pkg/app/plugins/catalog.go
@@ -37,17 +37,25 @@ const (
 	FieldTypeMap      FieldType = "map"
 )
 
+// EnumOption is a single selectable value of an enum field. Value is the value
+// the admin UI must send back to the API; Label is the human-readable text the
+// UI shows for it.
+type EnumOption struct {
+	Value string `json:"value"`
+	Label string `json:"label"`
+}
+
 // Field describes a single settings entry. Containers use ordered child slices
 // (Fields, Item, Value) instead of maps so the frontend can render a stable
 // form layout.
 type Field struct {
-	Key         string    `json:"key"`
-	Label       string    `json:"label"`
-	Type        FieldType `json:"type"`
-	Description string    `json:"description,omitempty"`
-	Required    bool      `json:"required,omitempty"`
-	Default     any       `json:"default,omitempty"`
-	Enum        []string  `json:"enum,omitempty"`
+	Key         string       `json:"key"`
+	Label       string       `json:"label"`
+	Type        FieldType    `json:"type"`
+	Description string       `json:"description,omitempty"`
+	Required    bool         `json:"required,omitempty"`
+	Default     any          `json:"default,omitempty"`
+	Enum        []EnumOption `json:"enum,omitempty"`
 	// Fields lists the child fields of an object.
 	Fields []Field `json:"fields,omitempty"`
 	// Item describes the element schema of an array.

--- a/pkg/app/plugins/catalog_metadata.go
+++ b/pkg/app/plugins/catalog_metadata.go
@@ -108,7 +108,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 					Label:       "Size Unit",
 					Type:        FieldTypeEnum,
 					Description: "Unit used to interpret the allowed payload size.",
-					Enum:        []string{"bytes", "kilobytes", "megabytes"},
+					Enum:        enumOptions("bytes", "kilobytes", "megabytes"),
 					Default:     "megabytes",
 				},
 				{
@@ -151,7 +151,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 						Key:   "method",
 						Label: "Method",
 						Type:  FieldTypeEnum,
-						Enum:  []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"},
+						Enum:  enumOptions("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"),
 					},
 				},
 				{
@@ -195,7 +195,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 					Label:       "Unit",
 					Type:        FieldTypeEnum,
 					Description: "Whether budgets count provider tokens or USD cost.",
-					Enum:        []string{"tokens", "dollars"},
+					Enum:        enumOptions("tokens", "dollars"),
 					Default:     "tokens",
 				},
 				{
@@ -203,7 +203,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 					Label:       "Counting",
 					Type:        FieldTypeEnum,
 					Description: "Which usage figure accrues against the budget.",
-					Enum:        []string{"total", "input", "output"},
+					Enum:        enumOptions("total", "input", "output"),
 					Default:     "total",
 				},
 				{
@@ -265,7 +265,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 					Label:       "Behavior On Exceeded",
 					Type:        FieldTypeEnum,
 					Description: "Action taken when a budget is exceeded under enforce mode.",
-					Enum:        []string{"reject", "throttle", "downgrade_model", "alert_only"},
+					Enum:        enumOptions("reject", "throttle", "downgrade_model", "alert_only"),
 					Default:     "reject",
 				},
 				{
@@ -370,7 +370,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 					Label:       "Behavior On Violation",
 					Type:        FieldTypeEnum,
 					Description: "Action taken when a model exceeds its cost ceiling under enforce mode.",
-					Enum:        []string{"reject", "downgrade"},
+					Enum:        enumOptions("reject", "downgrade"),
 					Default:     "reject",
 				},
 				{
@@ -384,7 +384,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 					Label:       "Unknown Model",
 					Type:        FieldTypeEnum,
 					Description: "How to treat a model with no resolvable price.",
-					Enum:        []string{"reject", "pass_through", "assume_max"},
+					Enum:        enumOptions("reject", "pass_through", "assume_max"),
 					Default:     "reject",
 				},
 				{
@@ -472,7 +472,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 								Label:       "Behavior",
 								Type:        FieldTypeEnum,
 								Description: "Action when a window is exceeded. reject_response and strip_tool_from_request act on the next request (PreRequest); inject_error_result rewrites the response (PreResponse). Defaults to the policy-level default behavior.",
-								Enum:        []string{"reject_response", "inject_error_result", "strip_tool_from_request"},
+								Enum:        enumOptions("reject_response", "inject_error_result", "strip_tool_from_request"),
 							},
 						},
 					},
@@ -482,7 +482,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 					Label:       "Default Behavior",
 					Type:        FieldTypeEnum,
 					Description: "Behavior applied to rules without an explicit behavior and to tools matched by a catch-all rule.",
-					Enum:        []string{"reject_response", "inject_error_result", "strip_tool_from_request"},
+					Enum:        enumOptions("reject_response", "inject_error_result", "strip_tool_from_request"),
 					Default:     "reject_response",
 				},
 				{
@@ -490,7 +490,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 					Label:       "Scope",
 					Type:        FieldTypeEnum,
 					Description: "Informational; effective scope derives from the policy global flag.",
-					Enum:        []string{"consumer", "global"},
+					Enum:        enumOptions("consumer", "global"),
 				},
 			},
 		},
@@ -506,7 +506,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 					Label:       "Mode",
 					Type:        FieldTypeEnum,
 					Description: "Match strategy: exact (normalized text equality), semantic (embedding similarity), or both.",
-					Enum:        []string{"exact", "semantic", "both"},
+					Enum:        enumOptions("exact", "semantic", "both"),
 					Default:     "semantic",
 				},
 				{
@@ -514,7 +514,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 					Label:       "Scope",
 					Type:        FieldTypeEnum,
 					Description: "Cache partition scope: consumer isolates entries per consumer, global shares them gateway-wide.",
-					Enum:        []string{"consumer", "global"},
+					Enum:        enumOptions("consumer", "global"),
 					Default:     "consumer",
 				},
 				{
@@ -522,7 +522,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 					Label:       "Vector Store",
 					Type:        FieldTypeEnum,
 					Description: "Backing store for cached embeddings and responses.",
-					Enum:        []string{"redis", "pgvector", "in_memory"},
+					Enum:        enumOptions("redis", "pgvector", "in_memory"),
 					Default:     "redis",
 				},
 				{
@@ -635,7 +635,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 					Label:       "Behavior On Disallowed",
 					Type:        FieldTypeEnum,
 					Description: "Action taken when a requested model is not in the allowlist.",
-					Enum:        []string{"reject", "substitute"},
+					Enum:        enumOptions("reject", "substitute"),
 					Default:     "reject",
 				},
 				{
@@ -678,7 +678,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 					Label:       "On Empty After Filter",
 					Type:        FieldTypeEnum,
 					Description: "Behavior when filtering removes every tool from the request.",
-					Enum:        []string{"reject", "pass_through_empty", "strip_tools_field"},
+					Enum:        enumOptions("reject", "pass_through_empty", "strip_tools_field"),
 					Default:     "reject",
 				},
 				{
@@ -686,7 +686,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 					Label:       "Scope",
 					Type:        FieldTypeEnum,
 					Description: "Informational; effective scope derives from the policy global flag.",
-					Enum:        []string{"consumer", "global"},
+					Enum:        enumOptions("consumer", "global"),
 				},
 			},
 		},
@@ -714,7 +714,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 							Label:       "Provider",
 							Type:        FieldTypeEnum,
 							Description: "LLM provider backing semantic validation.",
-							Enum:        []string{"openai"},
+							Enum:        enumOptions("openai"),
 							Default:     "openai",
 						},
 						{
@@ -755,7 +755,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 								Type:        FieldTypeEnum,
 								Description: "Validation strategy applied to the tool call.",
 								Required:    true,
-								Enum:        []string{"not_in_allowed_list", "json_schema", "semantic", "regex", "denylist"},
+								Enum:        enumOptions("not_in_allowed_list", "json_schema", "semantic", "regex", "denylist"),
 							},
 							{
 								Key:         "argument_path",
@@ -781,7 +781,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 								Label:       "Behavior",
 								Type:        FieldTypeEnum,
 								Description: "Action taken when the rule matches. Redact, mask, and replace_with apply only to the regex and denylist validators.",
-								Enum:        []string{"reject_response", "redact", "mask", "replace_with"},
+								Enum:        enumOptions("reject_response", "redact", "mask", "replace_with"),
 								Default:     "reject_response",
 							},
 							{
@@ -807,7 +807,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 					Label:       "Template Engine",
 					Type:        FieldTypeEnum,
 					Description: "Placeholder rendering engine. Only mustache is supported in v1.",
-					Enum:        []string{"mustache", "jinja2_subset"},
+					Enum:        enumOptions("mustache", "jinja2_subset"),
 					Default:     "mustache",
 				},
 				{
@@ -825,7 +825,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 								Label:       "Source",
 								Type:        FieldTypeEnum,
 								Description: "Where the variable value is read from.",
-								Enum:        []string{"header", "jwt_claim"},
+								Enum:        enumOptions("header", "jwt_claim"),
 								Required:    true,
 							},
 							{
@@ -860,7 +860,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 								Label:       "Position",
 								Type:        FieldTypeEnum,
 								Description: "Where the rendered content is injected. Only system is supported in v1.",
-								Enum:        []string{"system"},
+								Enum:        enumOptions("system"),
 								Default:     "system",
 							},
 							{
@@ -882,7 +882,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 								Label:       "On Existing System",
 								Type:        FieldTypeEnum,
 								Description: "How to combine with an existing system prompt.",
-								Enum:        []string{"merge", "replace"},
+								Enum:        enumOptions("merge", "replace"),
 								Default:     "merge",
 							},
 						},
@@ -951,7 +951,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 														Label:       "Type",
 														Type:        FieldTypeEnum,
 														Description: "Expected scalar type of the client value.",
-														Enum:        []string{"string", "number", "boolean"},
+														Enum:        enumOptions("string", "number", "boolean"),
 													},
 													{
 														Key:         "enum",
@@ -987,7 +987,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 					Label:       "On Missing Context Variable",
 					Type:        FieldTypeEnum,
 					Description: "Behavior when a context variable cannot be resolved.",
-					Enum:        []string{"error", "empty_string", "skip_injection"},
+					Enum:        enumOptions("error", "empty_string", "skip_injection"),
 					Default:     "error",
 				},
 				{
@@ -995,7 +995,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 					Label:       "On Missing Client Variable",
 					Type:        FieldTypeEnum,
 					Description: "Behavior when a non-required client variable is absent.",
-					Enum:        []string{"error", "empty_string"},
+					Enum:        enumOptions("error", "empty_string"),
 					Default:     "error",
 				},
 				{
@@ -1067,7 +1067,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 								Label:       "Type",
 								Type:        FieldTypeEnum,
 								Description: "Tool kind. Only function tools are supported.",
-								Enum:        []string{"function"},
+								Enum:        enumOptions("function"),
 								Default:     "function",
 							},
 							{
@@ -1105,7 +1105,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 					Label:       "On Conflict",
 					Type:        FieldTypeEnum,
 					Description: "Resolution when an injected tool name collides with a surviving or already-injected tool.",
-					Enum:        []string{"gateway_wins", "client_wins", "reject"},
+					Enum:        enumOptions("gateway_wins", "client_wins", "reject"),
 					Default:     "gateway_wins",
 				},
 				{
@@ -1113,7 +1113,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 					Label:       "Scope",
 					Type:        FieldTypeEnum,
 					Description: "Informational; effective scope derives from the policy global flag.",
-					Enum:        []string{"consumer", "global"},
+					Enum:        enumOptions("consumer", "global"),
 				},
 			},
 		},
@@ -1129,7 +1129,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 					Label:       "Inspect",
 					Type:        FieldTypeEnum,
 					Description: "Which legs to inspect: the request, the response, or both.",
-					Enum:        []string{"request", "response", "request_response"},
+					Enum:        enumOptions("request", "response", "request_response"),
 					Default:     "request_response",
 				},
 				{
@@ -1170,7 +1170,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 						Key:   "stage",
 						Label: "Stage",
 						Type:  FieldTypeEnum,
-						Enum:  []string{"pre_request", "pre_response"},
+						Enum:  enumOptions("pre_request", "pre_response"),
 					},
 				},
 				{
@@ -1243,7 +1243,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 					Label:       "Output Type",
 					Type:        FieldTypeEnum,
 					Description: "Severity scale returned by Azure: four levels (0/2/4/6) or eight levels (0-7).",
-					Enum:        []string{"FourSeverityLevels", "EightSeverityLevels"},
+					Enum:        enumOptions("FourSeverityLevels", "EightSeverityLevels"),
 					Default:     "FourSeverityLevels",
 				},
 				{
@@ -1255,7 +1255,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 						Key:   "category",
 						Label: "Category",
 						Type:  FieldTypeEnum,
-						Enum:  []string{"Hate", "Violence", "SelfHarm", "Sexual"},
+						Enum:  enumOptions("Hate", "Violence", "SelfHarm", "Sexual"),
 					},
 				},
 				{
@@ -1301,7 +1301,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 					Label:       "PII Action",
 					Type:        FieldTypeEnum,
 					Description: "How TrustGate reacts when the sensitive-information policy fires: block the call or anonymize the matched spans in place.",
-					Enum:        []string{"block", "anonymize"},
+					Enum:        enumOptions("block", "anonymize"),
 					Default:     "block",
 				},
 				{

--- a/pkg/app/plugins/catalog_test.go
+++ b/pkg/app/plugins/catalog_test.go
@@ -154,6 +154,22 @@ func fieldByKey(fields []Field, key string) (Field, bool) {
 	return Field{}, false
 }
 
+func enumValues(options []EnumOption) []string {
+	values := make([]string, len(options))
+	for i, o := range options {
+		values[i] = o.Value
+	}
+	return values
+}
+
+func enumLabels(options []EnumOption) []string {
+	labels := make([]string, len(options))
+	for i, o := range options {
+		labels[i] = o.Label
+	}
+	return labels
+}
+
 func TestTokenRateLimiterSchema_BudgetTree(t *testing.T) {
 	meta, ok := pluginCatalogMeta["token_rate_limiter"]
 	require.True(t, ok)
@@ -165,17 +181,19 @@ func TestTokenRateLimiterSchema_BudgetTree(t *testing.T) {
 	unit, ok := fieldByKey(fields, "unit")
 	require.True(t, ok)
 	assert.Equal(t, FieldTypeEnum, unit.Type)
-	assert.Equal(t, []string{"tokens", "dollars"}, unit.Enum)
+	assert.Equal(t, []string{"tokens", "dollars"}, enumValues(unit.Enum))
+	assert.Equal(t, []string{"Tokens", "Dollars"}, enumLabels(unit.Enum))
 
 	counting, ok := fieldByKey(fields, "counting")
 	require.True(t, ok)
-	assert.Equal(t, []string{"total", "input", "output"}, counting.Enum)
+	assert.Equal(t, []string{"total", "input", "output"}, enumValues(counting.Enum))
 
 	behavior, ok := fieldByKey(fields, "behavior_on_exceeded")
 	require.True(t, ok)
 	assert.Equal(t, FieldTypeEnum, behavior.Type)
-	assert.Equal(t, []string{"reject", "throttle", "downgrade_model", "alert_only"}, behavior.Enum)
-	assert.Contains(t, behavior.Enum, "alert_only")
+	assert.Equal(t, []string{"reject", "throttle", "downgrade_model", "alert_only"}, enumValues(behavior.Enum))
+	assert.Equal(t, []string{"Reject", "Throttle", "Downgrade Model", "Alert Only"}, enumLabels(behavior.Enum))
+	assert.Contains(t, enumValues(behavior.Enum), "alert_only")
 
 	for _, k := range []string{"downgrade_to", "stream_usage_injection", "count_cache_reads", "custom_pricing", "group_by_header"} {
 		_, ok := fieldByKey(fields, k)
@@ -245,11 +263,11 @@ func TestCostCapSchema(t *testing.T) {
 
 	behaviorOnViolation, ok := fieldByKey(fields, "behavior_on_violation")
 	require.True(t, ok)
-	assert.Equal(t, []string{"reject", "downgrade"}, behaviorOnViolation.Enum)
+	assert.Equal(t, []string{"reject", "downgrade"}, enumValues(behaviorOnViolation.Enum))
 
 	unknownModel, ok := fieldByKey(fields, "unknown_model")
 	require.True(t, ok)
-	assert.Equal(t, []string{"reject", "pass_through", "assume_max"}, unknownModel.Enum)
+	assert.Equal(t, []string{"reject", "pass_through", "assume_max"}, enumValues(unknownModel.Enum))
 
 	overrides, ok := fieldByKey(fields, "per_model_overrides")
 	require.True(t, ok)
@@ -321,7 +339,7 @@ func TestToolDefinitionTransformationSchema_Fields(t *testing.T) {
 	injectType, ok := fieldByKey(injectTools.Item.Fields, "type")
 	require.True(t, ok)
 	assert.Equal(t, FieldTypeEnum, injectType.Type)
-	assert.Equal(t, []string{"function"}, injectType.Enum)
+	assert.Equal(t, []string{"function"}, enumValues(injectType.Enum))
 	assert.Equal(t, "function", injectType.Default)
 
 	function, ok := fieldByKey(injectTools.Item.Fields, "function")
@@ -341,13 +359,13 @@ func TestToolDefinitionTransformationSchema_Fields(t *testing.T) {
 	onConflict, ok := fieldByKey(fields, "on_conflict")
 	require.True(t, ok)
 	assert.Equal(t, FieldTypeEnum, onConflict.Type)
-	assert.Equal(t, []string{"gateway_wins", "client_wins", "reject"}, onConflict.Enum)
+	assert.Equal(t, []string{"gateway_wins", "client_wins", "reject"}, enumValues(onConflict.Enum))
 	assert.Equal(t, "gateway_wins", onConflict.Default)
 
 	scope, ok := fieldByKey(fields, "scope")
 	require.True(t, ok)
 	assert.Equal(t, FieldTypeEnum, scope.Type)
-	assert.Equal(t, []string{"consumer", "global"}, scope.Enum)
+	assert.Equal(t, []string{"consumer", "global"}, enumValues(scope.Enum))
 }
 
 func TestToolAllowlistSchema(t *testing.T) {
@@ -373,13 +391,13 @@ func TestToolAllowlistSchema(t *testing.T) {
 	onEmpty, ok := fieldByKey(fields, "on_empty_after_filter")
 	require.True(t, ok)
 	assert.Equal(t, FieldTypeEnum, onEmpty.Type)
-	assert.Equal(t, []string{"reject", "pass_through_empty", "strip_tools_field"}, onEmpty.Enum)
+	assert.Equal(t, []string{"reject", "pass_through_empty", "strip_tools_field"}, enumValues(onEmpty.Enum))
 	assert.Equal(t, "reject", onEmpty.Default)
 
 	scope, ok := fieldByKey(fields, "scope")
 	require.True(t, ok)
 	assert.Equal(t, FieldTypeEnum, scope.Type)
-	assert.Equal(t, []string{"consumer", "global"}, scope.Enum)
+	assert.Equal(t, []string{"consumer", "global"}, enumValues(scope.Enum))
 }
 
 func TestTrustGuardSchema(t *testing.T) {
@@ -397,7 +415,8 @@ func TestTrustGuardSchema(t *testing.T) {
 	inspect, ok := fieldByKey(fields, "inspect")
 	require.True(t, ok)
 	assert.Equal(t, FieldTypeEnum, inspect.Type)
-	assert.Equal(t, []string{"request", "response", "request_response"}, inspect.Enum)
+	assert.Equal(t, []string{"request", "response", "request_response"}, enumValues(inspect.Enum))
+	assert.Equal(t, []string{"Request", "Response", "Request & Response"}, enumLabels(inspect.Enum))
 	assert.Equal(t, "request_response", inspect.Default)
 
 	baseURL, ok := fieldByKey(fields, "base_url")
@@ -427,7 +446,8 @@ func TestAzureContentSafetySchema(t *testing.T) {
 	outputType, ok := fieldByKey(fields, "output_type")
 	require.True(t, ok)
 	assert.Equal(t, FieldTypeEnum, outputType.Type)
-	assert.Equal(t, []string{"FourSeverityLevels", "EightSeverityLevels"}, outputType.Enum)
+	assert.Equal(t, []string{"FourSeverityLevels", "EightSeverityLevels"}, enumValues(outputType.Enum))
+	assert.Equal(t, []string{"Four Severity Levels", "Eight Severity Levels"}, enumLabels(outputType.Enum))
 	assert.Equal(t, "FourSeverityLevels", outputType.Default)
 	assert.False(t, outputType.Required)
 
@@ -437,7 +457,8 @@ func TestAzureContentSafetySchema(t *testing.T) {
 	assert.False(t, categories.Required)
 	require.NotNil(t, categories.Item)
 	assert.Equal(t, FieldTypeEnum, categories.Item.Type)
-	assert.Equal(t, []string{"Hate", "Violence", "SelfHarm", "Sexual"}, categories.Item.Enum)
+	assert.Equal(t, []string{"Hate", "Violence", "SelfHarm", "Sexual"}, enumValues(categories.Item.Enum))
+	assert.Equal(t, []string{"Hate", "Violence", "Self-Harm", "Sexual"}, enumLabels(categories.Item.Enum))
 
 	categorySeverity, ok := fieldByKey(fields, "category_severity")
 	require.True(t, ok)
@@ -463,19 +484,20 @@ func TestSemanticCacheSchema(t *testing.T) {
 	mode, ok := fieldByKey(fields, "mode")
 	require.True(t, ok)
 	assert.Equal(t, FieldTypeEnum, mode.Type)
-	assert.Equal(t, []string{"exact", "semantic", "both"}, mode.Enum)
+	assert.Equal(t, []string{"exact", "semantic", "both"}, enumValues(mode.Enum))
 	assert.Equal(t, "semantic", mode.Default)
 
 	scope, ok := fieldByKey(fields, "scope")
 	require.True(t, ok)
 	assert.Equal(t, FieldTypeEnum, scope.Type)
-	assert.Equal(t, []string{"consumer", "global"}, scope.Enum)
+	assert.Equal(t, []string{"consumer", "global"}, enumValues(scope.Enum))
 	assert.Equal(t, "consumer", scope.Default)
 
 	vectorStore, ok := fieldByKey(fields, "vector_store")
 	require.True(t, ok)
 	assert.Equal(t, FieldTypeEnum, vectorStore.Type)
-	assert.Equal(t, []string{"redis", "pgvector", "in_memory"}, vectorStore.Enum)
+	assert.Equal(t, []string{"redis", "pgvector", "in_memory"}, enumValues(vectorStore.Enum))
+	assert.Equal(t, []string{"Redis", "pgvector", "In-Memory"}, enumLabels(vectorStore.Enum))
 	assert.Equal(t, "redis", vectorStore.Default)
 
 	ttlSeconds, ok := fieldByKey(fields, "ttl_seconds")
@@ -588,7 +610,7 @@ func TestPromptTemplateSchema_Tree(t *testing.T) {
 	engineField, ok := fieldByKey(fields, "template_engine")
 	require.True(t, ok)
 	assert.Equal(t, FieldTypeEnum, engineField.Type)
-	assert.Equal(t, []string{"mustache", "jinja2_subset"}, engineField.Enum)
+	assert.Equal(t, []string{"mustache", "jinja2_subset"}, enumValues(engineField.Enum))
 	assert.Equal(t, "mustache", engineField.Default)
 
 	contextVars, ok := fieldByKey(fields, "context_variables")
@@ -598,7 +620,8 @@ func TestPromptTemplateSchema_Tree(t *testing.T) {
 	assert.Equal(t, FieldTypeObject, contextVars.Value.Type)
 	source, ok := fieldByKey(contextVars.Value.Fields, "source")
 	require.True(t, ok)
-	assert.Equal(t, []string{"header", "jwt_claim"}, source.Enum)
+	assert.Equal(t, []string{"header", "jwt_claim"}, enumValues(source.Enum))
+	assert.Equal(t, []string{"Header", "JWT Claim"}, enumLabels(source.Enum))
 	ctxName, ok := fieldByKey(contextVars.Value.Fields, "name")
 	require.True(t, ok)
 	assert.Equal(t, FieldTypeString, ctxName.Type)
@@ -613,7 +636,7 @@ func TestPromptTemplateSchema_Tree(t *testing.T) {
 	}
 	onExisting, ok := fieldByKey(inject.Item.Fields, "on_existing_system")
 	require.True(t, ok)
-	assert.Equal(t, []string{"merge", "replace"}, onExisting.Enum)
+	assert.Equal(t, []string{"merge", "replace"}, enumValues(onExisting.Enum))
 
 	named, ok := fieldByKey(fields, "named_templates")
 	require.True(t, ok)
@@ -646,7 +669,7 @@ func TestPromptTemplateSchema_Tree(t *testing.T) {
 	assert.Equal(t, FieldTypeObject, requiredVars.Value.Type)
 	rvType, ok := fieldByKey(requiredVars.Value.Fields, "type")
 	require.True(t, ok)
-	assert.Equal(t, []string{"string", "number", "boolean"}, rvType.Enum)
+	assert.Equal(t, []string{"string", "number", "boolean"}, enumValues(rvType.Enum))
 
 	rvEnum, ok := fieldByKey(requiredVars.Value.Fields, "enum")
 	require.True(t, ok)
@@ -660,11 +683,11 @@ func TestPromptTemplateSchema_Tree(t *testing.T) {
 
 	onMissingContext, ok := fieldByKey(fields, "on_missing_context_variable")
 	require.True(t, ok)
-	assert.Equal(t, []string{"error", "empty_string", "skip_injection"}, onMissingContext.Enum)
+	assert.Equal(t, []string{"error", "empty_string", "skip_injection"}, enumValues(onMissingContext.Enum))
 
 	onMissingClient, ok := fieldByKey(fields, "on_missing_client_variable")
 	require.True(t, ok)
-	assert.Equal(t, []string{"error", "empty_string"}, onMissingClient.Enum)
+	assert.Equal(t, []string{"error", "empty_string"}, enumValues(onMissingClient.Enum))
 
 	for _, k := range []string{"allow_untemplated_requests", "default_label", "escape_json_control_chars"} {
 		_, ok := fieldByKey(fields, k)

--- a/pkg/app/plugins/enum_options.go
+++ b/pkg/app/plugins/enum_options.go
@@ -1,0 +1,119 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugins
+
+import (
+	"strings"
+	"unicode"
+)
+
+// enumLabelOverrides maps raw enum values whose pretty label cannot be derived
+// mechanically to the exact label shown in the admin UI.
+var enumLabelOverrides = map[string]string{
+	"request_response": "Request & Response",
+	"in_memory":        "In-Memory",
+	"pre_request":      "Pre-Request",
+	"pre_response":     "Pre-Response",
+	"pgvector":         "pgvector",
+	"SelfHarm":         "Self-Harm",
+}
+
+// enumLabelAcronyms maps lowercased word tokens to their canonical casing so
+// labels read naturally (e.g. "json" -> "JSON").
+var enumLabelAcronyms = map[string]string{
+	"openai": "OpenAI",
+	"json":   "JSON",
+	"jwt":    "JWT",
+	"http":   "HTTP",
+	"url":    "URL",
+	"api":    "API",
+	"id":     "ID",
+	"pii":    "PII",
+	"ttl":    "TTL",
+}
+
+// enumOptions pairs each raw enum value with a human-readable label for the
+// admin UI. The value sent back to the API stays the raw enum string.
+func enumOptions(values ...string) []EnumOption {
+	options := make([]EnumOption, len(values))
+	for i, value := range values {
+		options[i] = EnumOption{Value: value, Label: humanizeEnumLabel(value)}
+	}
+	return options
+}
+
+func humanizeEnumLabel(value string) string {
+	if label, ok := enumLabelOverrides[value]; ok {
+		return label
+	}
+	words := splitEnumWords(value)
+	for i, word := range words {
+		if isAllUpper(word) {
+			continue
+		}
+		lower := strings.ToLower(word)
+		if acronym, ok := enumLabelAcronyms[lower]; ok {
+			words[i] = acronym
+			continue
+		}
+		words[i] = strings.ToUpper(word[:1]) + word[1:]
+	}
+	return strings.Join(words, " ")
+}
+
+// splitEnumWords breaks an enum value into words on underscores and camelCase
+// boundaries, keeping all-uppercase tokens (e.g. HTTP methods) intact.
+func splitEnumWords(value string) []string {
+	words := make([]string, 0, 4)
+	for _, part := range strings.Split(value, "_") {
+		if part == "" {
+			continue
+		}
+		words = append(words, splitCamelCase(part)...)
+	}
+	return words
+}
+
+func splitCamelCase(part string) []string {
+	if isAllUpper(part) {
+		return []string{part}
+	}
+	var words []string
+	var current strings.Builder
+	for i, r := range part {
+		if i > 0 && unicode.IsUpper(r) && !unicode.IsUpper(rune(part[i-1])) {
+			words = append(words, current.String())
+			current.Reset()
+		}
+		current.WriteRune(r)
+	}
+	if current.Len() > 0 {
+		words = append(words, current.String())
+	}
+	return words
+}
+
+func isAllUpper(s string) bool {
+	hasLetter := false
+	for _, r := range s {
+		if unicode.IsLetter(r) {
+			hasLetter = true
+			if !unicode.IsUpper(r) {
+				return false
+			}
+		}
+	}
+	return hasLetter
+}


### PR DESCRIPTION
## Summary
- Enum fields in the policy catalog (`GET /v1/policies-catalog`) and provider options now expose `{ value, label }` pairs instead of plain strings, so the admin UI can show a human-readable label while sending the raw enum value to the API.
- Adds an `EnumOption` type, an `enumOptions(...)` builder and a `humanizeEnumLabel` helper (snake_case/camelCase → readable, with overrides for non-obvious cases and acronyms; HTTP methods kept uppercase).
- Migrates every enum in the catalog metadata and provider options; updates tests and regenerates the API docs (swagger/openapi/docs.go/policies.json).

## Linear
RUN-751 — https://linear.app/neuraltrust/issue/RUN-751/featpolicies-enum-options-with-display-labels-in-policy-catalog

## Note
This is a coordinated wire-format change; the frontend consumer is updated in the `app` repo PR (same Linear issue).

## Test plan
- [x] `go build ./...`, `go vet`, package tests green
- [x] `make docs` regenerated and committed
- [ ] Frontend renders friendly labels and persists correct enum values

Made with [Cursor](https://cursor.com)