### PR TITLE
fix(trustguard): policy outcome metrics and functional tests (RUN-760)

### DIFF
--- a/.env.functional.example
+++ b/.env.functional.example
@@ -77,7 +77,8 @@ CORS_EXPOSE_HEADERS=X-AG-Trace-Id
 CORS_ALLOW_CREDENTIALS=false
 CORS_MAX_AGE=600
 
-# TrustGuard plugin (functional stub in plugin_trustguard_test.go).
-# setup_test.go also injects these when booting admin/proxy.
+# TrustGuard plugin (functional stub started in setup_test.go TestMain).
+# setup_test.go injects TRUSTGUARD_BASE_URL pointing at the stub when booting admin/proxy.
+TRUSTGUARD_BASE_URL=http://127.0.0.1:0
 TRUSTGUARD_CLIENT_ID=functional-trustguard-client
 TRUSTGUARD_CLIENT_SECRET=functional-trustguard-secret

--- a/pkg/app/metrics/builder.go
+++ b/pkg/app/metrics/builder.go
@@ -146,7 +146,7 @@ func (b *Builder) foldPluginSpans(requestTrace *trace.RequestTrace) ([]events.Po
 		attrs := span.PluginAttrsCopy()
 		statusCode := span.StatusCode()
 		hasError := span.Error() != ""
-		flagged := hasError || attrs.Decision == "block" || (statusCode >= http.StatusBadRequest)
+		flagged := hasError || pluginDecisionFlagged(attrs.Decision) || (statusCode >= http.StatusBadRequest)
 		latencyMs := span.Latency().Milliseconds()
 		pluginsMs += latencyMs
 		if flagged {
@@ -172,6 +172,15 @@ func (b *Builder) foldPluginSpans(requestTrace *trace.RequestTrace) ([]events.Po
 		})
 	}
 	return chain, pluginsMs, anyFlagged, security
+}
+
+func pluginDecisionFlagged(decision string) bool {
+	switch decision {
+	case "block", "blocked", "reported", "report", "throttle":
+		return true
+	default:
+		return false
+	}
 }
 
 func (b *Builder) buildMCP(

--- a/pkg/app/metrics/builder.go
+++ b/pkg/app/metrics/builder.go
@@ -146,6 +146,9 @@ func (b *Builder) foldPluginSpans(requestTrace *trace.RequestTrace) ([]events.Po
 		attrs := span.PluginAttrsCopy()
 		statusCode := span.StatusCode()
 		hasError := span.Error() != ""
+		if pluginSpanIsNoOp(attrs, statusCode, hasError) {
+			continue
+		}
 		flagged := hasError || pluginDecisionFlagged(attrs.Decision) || (statusCode >= http.StatusBadRequest)
 		latencyMs := span.Latency().Milliseconds()
 		pluginsMs += latencyMs
@@ -181,6 +184,19 @@ func pluginDecisionFlagged(decision string) bool {
 	default:
 		return false
 	}
+}
+
+// pluginSpanIsNoOp reports whether a plugin span carries no observable outcome.
+// Plugins that skip a stage (e.g. a request-only guard on the response leg)
+// pass through without recording a decision, extras, error or score, so their
+// span must not surface as an empty entry in the policy chain.
+func pluginSpanIsNoOp(attrs trace.PluginAttrs, statusCode int, hasError bool) bool {
+	return attrs.Decision == "" &&
+		attrs.Extras == nil &&
+		attrs.ScoreLabel == "" &&
+		attrs.Score == nil &&
+		!hasError &&
+		statusCode < http.StatusBadRequest
 }
 
 func (b *Builder) buildMCP(

--- a/pkg/app/metrics/builder_test.go
+++ b/pkg/app/metrics/builder_test.go
@@ -411,3 +411,37 @@ func TestBuilder_StatusReasonFromTrace(t *testing.T) {
 	assert.Equal(t, 403, evt.Status.Code)
 	assert.Equal(t, "model_not_allowed", evt.Status.Reason)
 }
+
+func TestBuilder_TrustGuardAllowedNotFlagged(t *testing.T) {
+	rt := trace.New("trace-tg-allowed", trace.Metadata{GatewayID: "gw-1"})
+	_ = rt.AddSpan(pluginSpan("trustguard",
+		&trace.PluginAttrs{Stage: "pre_request", Decision: "allowed"}, 200, 250*time.Millisecond, ""))
+
+	req := &infracontext.RequestContext{GatewayID: "gw-1", Body: []byte(openAIRequestBody), SourceFormat: string(adapter.FormatOpenAI)}
+	resp := &infracontext.ResponseContext{StatusCode: 200, Body: []byte(`{"ok":true}`)}
+
+	start := time.UnixMilli(6_000_000)
+	evt := newBuilder(appcatalog.Pricing{}).Build(context.Background(), rt, req, resp, start, start.Add(260*time.Millisecond))
+
+	require.Len(t, evt.PolicyChain, 1)
+	assert.Equal(t, "allowed", evt.PolicyChain[0].Decision)
+	assert.False(t, evt.PolicyChain[0].Flagged)
+	assert.False(t, evt.IsFlagged)
+}
+
+func TestBuilder_TrustGuardReportedIsFlagged(t *testing.T) {
+	rt := trace.New("trace-tg-reported", trace.Metadata{GatewayID: "gw-1"})
+	_ = rt.AddSpan(pluginSpan("trustguard",
+		&trace.PluginAttrs{Stage: "pre_request", Decision: "reported"}, 200, 250*time.Millisecond, ""))
+
+	req := &infracontext.RequestContext{GatewayID: "gw-1", Body: []byte(openAIRequestBody), SourceFormat: string(adapter.FormatOpenAI)}
+	resp := &infracontext.ResponseContext{StatusCode: 200, Body: []byte(`{"ok":true}`)}
+
+	start := time.UnixMilli(7_000_000)
+	evt := newBuilder(appcatalog.Pricing{}).Build(context.Background(), rt, req, resp, start, start.Add(260*time.Millisecond))
+
+	require.Len(t, evt.PolicyChain, 1)
+	assert.Equal(t, "reported", evt.PolicyChain[0].Decision)
+	assert.True(t, evt.PolicyChain[0].Flagged)
+	assert.True(t, evt.IsFlagged)
+}

--- a/pkg/app/metrics/builder_test.go
+++ b/pkg/app/metrics/builder_test.go
@@ -445,3 +445,22 @@ func TestBuilder_TrustGuardReportedIsFlagged(t *testing.T) {
 	assert.True(t, evt.PolicyChain[0].Flagged)
 	assert.True(t, evt.IsFlagged)
 }
+
+func TestBuilder_SkipsNoOpPluginSpan(t *testing.T) {
+	rt := trace.New("trace-tg-noop", trace.Metadata{GatewayID: "gw-1"})
+	_ = rt.AddSpan(pluginSpan("trustguard",
+		&trace.PluginAttrs{Stage: "pre_request", Decision: "allowed", Extras: map[string]any{"trace_id": "tg-1"}},
+		200, 250*time.Millisecond, ""))
+	_ = rt.AddSpan(pluginSpan("trustguard",
+		&trace.PluginAttrs{Stage: "pre_response"}, 200, 0, ""))
+
+	req := &infracontext.RequestContext{GatewayID: "gw-1", Body: []byte(openAIRequestBody), SourceFormat: string(adapter.FormatOpenAI)}
+	resp := &infracontext.ResponseContext{StatusCode: 200, Body: []byte(`{"ok":true}`)}
+
+	start := time.UnixMilli(8_000_000)
+	evt := newBuilder(appcatalog.Pricing{}).Build(context.Background(), rt, req, resp, start, start.Add(260*time.Millisecond))
+
+	require.Len(t, evt.PolicyChain, 1)
+	assert.Equal(t, "pre_request", evt.PolicyChain[0].Stage)
+	assert.Equal(t, "allowed", evt.PolicyChain[0].Decision)
+}

--- a/pkg/app/plugins/catalog_metadata.go
+++ b/pkg/app/plugins/catalog_metadata.go
@@ -1139,12 +1139,6 @@ var pluginCatalogMeta = map[string]catalogMeta{
 					Description: "TrustGuard collector UUID bound to this gateway policy.",
 					Required:    true,
 				},
-				{
-					Key:         "base_url",
-					Label:       "Base URL",
-					Type:        FieldTypeString,
-					Description: "Optional per-policy override of the TrustGuard base URL. Falls back to the gateway TRUSTGUARD_BASE_URL when empty.",
-				},
 			},
 		},
 	},

--- a/pkg/app/plugins/catalog_test.go
+++ b/pkg/app/plugins/catalog_test.go
@@ -419,10 +419,9 @@ func TestTrustGuardSchema(t *testing.T) {
 	assert.Equal(t, []string{"Request", "Response", "Request & Response"}, enumLabels(direction.Enum))
 	assert.Equal(t, "request", direction.Default)
 
-	baseURL, ok := fieldByKey(fields, "base_url")
-	require.True(t, ok)
-	assert.Equal(t, FieldTypeString, baseURL.Type)
-	assert.False(t, baseURL.Required)
+	if _, ok := fieldByKey(fields, "base_url"); ok {
+		t.Fatal("trustguard schema must not expose base_url; use gateway TRUSTGUARD_BASE_URL")
+	}
 
 	collectorID, ok := fieldByKey(fields, "collector_id")
 	require.True(t, ok)

--- a/pkg/app/plugins/modes.go
+++ b/pkg/app/plugins/modes.go
@@ -67,3 +67,24 @@ func SetDecision(event *metrics.EventContext, mode policy.Mode) {
 	}
 	event.SetDecision(DecisionForMode(mode))
 }
+
+// SetDecisionFromOutcome records the plugin's actual outcome on the metrics span.
+// Unlike SetDecision(mode), this does not label enforce-mode pass-throughs as "block".
+func SetDecisionFromOutcome(event *metrics.EventContext, outcome string) {
+	if event == nil {
+		return
+	}
+	event.SetDecision(SpanDecisionFromOutcome(outcome))
+}
+
+// SpanDecisionFromOutcome maps plugin-specific outcome strings to policy-chain decisions.
+func SpanDecisionFromOutcome(outcome string) string {
+	switch outcome {
+	case "blocked", "block":
+		return "block"
+	case "reported", "report", "rejected":
+		return "reported"
+	default:
+		return outcome
+	}
+}

--- a/pkg/app/plugins/modes_test.go
+++ b/pkg/app/plugins/modes_test.go
@@ -1,0 +1,58 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugins
+
+import (
+	"testing"
+
+	"github.com/NeuralTrust/TrustGate/pkg/domain/policy"
+)
+
+func TestDecisionForMode(t *testing.T) {
+	t.Parallel()
+
+	if got := DecisionForMode(policy.ModeEnforce); got != "block" {
+		t.Fatalf("enforce = %q, want block", got)
+	}
+	if got := DecisionForMode(policy.ModeObserve); got != "observe" {
+		t.Fatalf("observe = %q, want observe", got)
+	}
+}
+
+func TestSpanDecisionFromOutcome(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		outcome string
+		want    string
+	}{
+		{outcome: "blocked", want: "block"},
+		{outcome: "block", want: "block"},
+		{outcome: "reported", want: "reported"},
+		{outcome: "report", want: "reported"},
+		{outcome: "rejected", want: "reported"},
+		{outcome: "allowed", want: "allowed"},
+		{outcome: "failed_open", want: "failed_open"},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.outcome, func(t *testing.T) {
+			t.Parallel()
+			if got := SpanDecisionFromOutcome(tc.outcome); got != tc.want {
+				t.Fatalf("SpanDecisionFromOutcome(%q) = %q, want %q", tc.outcome, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/infra/plugins/azurecontentsafety/plugin.go
+++ b/pkg/infra/plugins/azurecontentsafety/plugin.go
@@ -134,7 +134,7 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 			slog.Any("error", err),
 		)
 		setExtras(in.Event, data)
-		appplugins.SetDecision(in.Event, in.Mode)
+		appplugins.SetDecisionFromOutcome(in.Event, decisionFailedClosed)
 		return passThrough(), nil
 	}
 
@@ -151,6 +151,7 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 		data.Decision = decisionBlocked
 		data.Breached = breachedNames(breaches)
 		setExtras(in.Event, data)
+		appplugins.SetDecisionFromOutcome(in.Event, decisionBlocked)
 		return nil, blockError(cfg.Message, breaches)
 	}
 
@@ -161,7 +162,7 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 		data.Decision = decisionAllowed
 	}
 	setExtras(in.Event, data)
-	appplugins.SetDecision(in.Event, in.Mode)
+	appplugins.SetDecisionFromOutcome(in.Event, data.Decision)
 	return passThrough(), nil
 }
 

--- a/pkg/infra/plugins/bedrockguardrail/plugin.go
+++ b/pkg/infra/plugins/bedrockguardrail/plugin.go
@@ -189,11 +189,12 @@ func (p *Plugin) runGuardrail(ctx context.Context, in appplugins.ExecInput, cfg 
 		if appplugins.Blocks(in.Mode) {
 			data.Decision = decisionBlocked
 			setExtras(in.Event, data)
+			appplugins.SetDecisionFromOutcome(in.Event, decisionBlocked)
 			return nil, blockError(*res.block)
 		}
 		data.Decision = decisionReported
 		setExtras(in.Event, data)
-		appplugins.SetDecision(in.Event, in.Mode)
+		appplugins.SetDecisionFromOutcome(in.Event, decisionReported)
 		return passThrough(), nil
 	}
 
@@ -204,13 +205,13 @@ func (p *Plugin) runGuardrail(ctx context.Context, in appplugins.ExecInput, cfg 
 		}
 		data.Decision = decisionReported
 		setExtras(in.Event, data)
-		appplugins.SetDecision(in.Event, in.Mode)
+		appplugins.SetDecisionFromOutcome(in.Event, decisionReported)
 		return passThrough(), nil
 	}
 
 	data.Decision = decisionAllowed
 	setExtras(in.Event, data)
-	appplugins.SetDecision(in.Event, in.Mode)
+	appplugins.SetDecisionFromOutcome(in.Event, decisionAllowed)
 	return passThrough(), nil
 }
 
@@ -228,6 +229,7 @@ func (p *Plugin) anonymizeEnforce(in appplugins.ExecInput, data *Data, out *bedr
 	}
 	data.Decision = decisionAnonymized
 	setExtras(in.Event, data)
+	appplugins.SetDecisionFromOutcome(in.Event, decisionAnonymized)
 	return span.result(body), nil
 }
 
@@ -236,6 +238,7 @@ func (p *Plugin) anonymizeDegraded(in appplugins.ExecInput, data *Data, reason s
 	data.DegradedReason = reason
 	data.Decision = decisionBlocked
 	setExtras(in.Event, data)
+	appplugins.SetDecisionFromOutcome(in.Event, decisionBlocked)
 	return nil, blockError(*f)
 }
 
@@ -257,7 +260,7 @@ func (p *Plugin) failClosed(ctx context.Context, in appplugins.ExecInput, cfg Se
 		slog.Any("error", err),
 	)
 	setExtras(in.Event, data)
-	appplugins.SetDecision(in.Event, in.Mode)
+	appplugins.SetDecisionFromOutcome(in.Event, decisionFailedClosed)
 	return passThrough(), nil
 }
 

--- a/pkg/infra/plugins/openaimoderation/plugin.go
+++ b/pkg/infra/plugins/openaimoderation/plugin.go
@@ -129,7 +129,7 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 			return nil, unavailableError()
 		}
 		setExtras(in.Event, ModerationData{Model: cfg.Model, Decision: decisionFailedOpen})
-		appplugins.SetDecision(in.Event, in.Mode)
+		appplugins.SetDecisionFromOutcome(in.Event, decisionFailedOpen)
 		return passThrough(), nil
 	}
 
@@ -149,6 +149,7 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 	if len(violations) > 0 && appplugins.Blocks(in.Mode) {
 		data.Decision = decisionBlock
 		setExtras(in.Event, data)
+		appplugins.SetDecisionFromOutcome(in.Event, decisionBlock)
 		return nil, blockError(cfg.Action.Message, violations)
 	}
 
@@ -158,7 +159,7 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 		data.Decision = decisionAllowed
 	}
 	setExtras(in.Event, data)
-	appplugins.SetDecision(in.Event, in.Mode)
+	appplugins.SetDecisionFromOutcome(in.Event, data.Decision)
 	return passThrough(), nil
 }
 

--- a/pkg/infra/plugins/openaimoderation/plugin_test.go
+++ b/pkg/infra/plugins/openaimoderation/plugin_test.go
@@ -226,6 +226,7 @@ func TestExecuteObserveWithViolationPassesThrough(t *testing.T) {
 	data, ok := span.PluginAttrsCopy().Extras.(ModerationData)
 	require.True(t, ok, "expected ModerationData extras")
 	assert.Equal(t, decisionReported, data.Decision)
+	assert.Equal(t, "reported", span.PluginAttrsCopy().Decision)
 	assert.True(t, span.HasDecision())
 }
 
@@ -251,6 +252,7 @@ func TestExecuteAllowPassesThrough(t *testing.T) {
 	data, ok := span.PluginAttrsCopy().Extras.(ModerationData)
 	require.True(t, ok)
 	assert.Equal(t, decisionAllowed, data.Decision)
+	assert.Equal(t, "allowed", span.PluginAttrsCopy().Decision)
 	assert.InDelta(t, 0.10, data.MaxScore, 1e-9)
 	assert.Equal(t, "hate", data.MaxScoreCategory)
 }

--- a/pkg/infra/plugins/tool_call_validation/plugin.go
+++ b/pkg/infra/plugins/tool_call_validation/plugin.go
@@ -102,6 +102,7 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 	outcome := runRules(ctx, buildEvalContext(cfg, creq, cresp, p.llm), in.Mode, cresp.ToolCalls)
 	if !outcome.matched {
 		setExtras(in.Event, ToolCallValidationData{Action: actionAllow})
+		appplugins.SetDecisionFromOutcome(in.Event, "allowed")
 		return passThrough(), nil
 	}
 
@@ -128,8 +129,17 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 	}
 
 	setExtras(in.Event, outcome.extras)
-	appplugins.SetDecision(in.Event, in.Mode)
+	appplugins.SetDecisionFromOutcome(in.Event, validationSpanDecision(outcome.extras))
 	return passThrough(), nil
+}
+
+func validationSpanDecision(data ToolCallValidationData) string {
+	switch data.Action {
+	case actionReject, actionRedact:
+		return "reported"
+	default:
+		return "allowed"
+	}
 }
 
 func passThrough() *appplugins.Result {

--- a/pkg/infra/plugins/trustguard/config.go
+++ b/pkg/infra/plugins/trustguard/config.go
@@ -16,7 +16,6 @@ package trustguard
 
 import (
 	"fmt"
-	"net/url"
 	"strings"
 
 	"github.com/google/uuid"
@@ -34,7 +33,6 @@ const (
 
 type Settings struct {
 	Inspect     string `mapstructure:"inspect"`
-	BaseURL     string `mapstructure:"base_url"`
 	CollectorID string `mapstructure:"collector_id"`
 }
 
@@ -71,15 +69,6 @@ func (s *Settings) validate() error {
 	case inspectRequest, inspectResponse, inspectRequestResponse:
 	default:
 		return fmt.Errorf("trustguard: inspect must be one of request, response, request_response")
-	}
-	if s.BaseURL != "" {
-		parsed, err := url.Parse(s.BaseURL)
-		if err != nil {
-			return fmt.Errorf("trustguard: base_url is invalid: %w", err)
-		}
-		if !parsed.IsAbs() || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" {
-			return fmt.Errorf("trustguard: base_url must be an absolute http(s) url")
-		}
 	}
 	if strings.TrimSpace(s.CollectorID) == "" {
 		return fmt.Errorf("trustguard: collector_id is required")

--- a/pkg/infra/plugins/trustguard/config_test.go
+++ b/pkg/infra/plugins/trustguard/config_test.go
@@ -63,39 +63,9 @@ func TestParseConfig(t *testing.T) {
 			wantErr:  true,
 		},
 		{
-			name:        "base_url http accepted",
+			name:        "legacy base_url in settings ignored",
 			settings:    map[string]any{"base_url": "http://guard.local", "collector_id": testCollectorID},
 			wantInspect: inspectRequestResponse,
-		},
-		{
-			name:        "base_url https accepted",
-			settings:    map[string]any{"base_url": "https://guard.example.com/api", "collector_id": testCollectorID},
-			wantInspect: inspectRequestResponse,
-		},
-		{
-			name:        "empty base_url ok",
-			settings:    map[string]any{"base_url": "", "collector_id": testCollectorID},
-			wantInspect: inspectRequestResponse,
-		},
-		{
-			name:     "base_url relative rejected",
-			settings: map[string]any{"base_url": "/v1/guard", "collector_id": testCollectorID},
-			wantErr:  true,
-		},
-		{
-			name:     "base_url missing scheme rejected",
-			settings: map[string]any{"base_url": "guard.local", "collector_id": testCollectorID},
-			wantErr:  true,
-		},
-		{
-			name:     "base_url non-http scheme rejected",
-			settings: map[string]any{"base_url": "ftp://guard.local", "collector_id": testCollectorID},
-			wantErr:  true,
-		},
-		{
-			name:     "base_url missing host rejected",
-			settings: map[string]any{"base_url": "http://", "collector_id": testCollectorID},
-			wantErr:  true,
 		},
 		{
 			name:     "missing collector_id rejected",

--- a/pkg/infra/plugins/trustguard/data.go
+++ b/pkg/infra/plugins/trustguard/data.go
@@ -14,7 +14,10 @@
 
 package trustguard
 
-import "github.com/NeuralTrust/TrustGate/pkg/infra/metrics"
+import (
+	appplugins "github.com/NeuralTrust/TrustGate/pkg/app/plugins"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics"
+)
 
 type GuardRequest struct {
 	Payload    GuardPayload    `json:"payload"`
@@ -83,4 +86,9 @@ func setExtras(event *metrics.EventContext, data guardData) {
 		return
 	}
 	event.SetExtras(data)
+}
+
+func recordGuardOutcome(event *metrics.EventContext, data guardData) {
+	setExtras(event, data)
+	appplugins.SetDecisionFromOutcome(event, data.Decision)
 }

--- a/pkg/infra/plugins/trustguard/data_test.go
+++ b/pkg/infra/plugins/trustguard/data_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trustguard
+
+import (
+	"testing"
+
+	"github.com/NeuralTrust/TrustGate/pkg/domain/policy"
+)
+
+func TestGuardOutcomeDecision(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		status string
+		mode   policy.Mode
+		want   string
+	}{
+		{status: statusBlock, mode: policy.ModeEnforce, want: decisionBlocked},
+		{status: statusBlock, mode: policy.ModeObserve, want: decisionReported},
+		{status: statusReport, mode: policy.ModeEnforce, want: decisionReported},
+		{status: "allowed", mode: policy.ModeEnforce, want: decisionAllowed},
+		{status: "", mode: policy.ModeEnforce, want: decisionAllowed},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.status+"_"+string(tc.mode), func(t *testing.T) {
+			t.Parallel()
+			if got := guardOutcomeDecision(tc.status, tc.mode); got != tc.want {
+				t.Fatalf("guardOutcomeDecision(%q, %q) = %q, want %q", tc.status, tc.mode, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/infra/plugins/trustguard/plugin.go
+++ b/pkg/infra/plugins/trustguard/plugin.go
@@ -49,6 +49,7 @@ const (
 	decisionAllowed    = "allowed"
 	decisionFailedOpen = "failed_open"
 	statusBlock        = "block"
+	statusReport       = "report"
 )
 
 var _ appplugins.Plugin = (*Plugin)(nil)
@@ -112,10 +113,7 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 		return passThrough(), nil
 	}
 
-	baseURL := cfg.BaseURL
-	if baseURL == "" {
-		baseURL = p.baseURL
-	}
+	baseURL := p.baseURL
 	if baseURL == "" {
 		p.warn(ctx, "trustguard base url not configured",
 			slog.String("plugin", PluginName),
@@ -217,21 +215,27 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 		Findings:      resp.Findings,
 	}
 
-	if resp.Status == statusBlock && appplugins.Blocks(in.Mode) {
-		data.Decision = decisionBlocked
-		setExtras(in.Event, data)
-		appplugins.SetDecision(in.Event, in.Mode)
+	data.Decision = guardOutcomeDecision(resp.Status, in.Mode)
+	if data.Decision == decisionBlocked {
+		recordGuardOutcome(in.Event, data)
 		return nil, blockError(resp)
 	}
-
-	if resp.Status == statusBlock {
-		data.Decision = decisionReported
-	} else {
-		data.Decision = decisionAllowed
-	}
-	setExtras(in.Event, data)
-	appplugins.SetDecision(in.Event, in.Mode)
+	recordGuardOutcome(in.Event, data)
 	return passThrough(), nil
+}
+
+func guardOutcomeDecision(status string, mode policy.Mode) string {
+	switch status {
+	case statusBlock:
+		if appplugins.Blocks(mode) {
+			return decisionBlocked
+		}
+		return decisionReported
+	case statusReport:
+		return decisionReported
+	default:
+		return decisionAllowed
+	}
 }
 
 func (p *Plugin) config(settings map[string]any) (Settings, error) {
@@ -248,7 +252,7 @@ func (p *Plugin) config(settings map[string]any) (Settings, error) {
 }
 
 func configCacheKey(settings map[string]any) string {
-	return fmt.Sprintf("%v\x00%v\x00%v", settings["inspect"], settings["base_url"], settings["collector_id"])
+	return fmt.Sprintf("%v\x00%v", settings["inspect"], settings["collector_id"])
 }
 
 func (p *Plugin) guard(ctx context.Context, baseURL, collectorID string, body GuardRequest) (*GuardResponse, error) {

--- a/pkg/infra/plugins/trustguard/plugin_test.go
+++ b/pkg/infra/plugins/trustguard/plugin_test.go
@@ -27,7 +27,9 @@ import (
 	appplugins "github.com/NeuralTrust/TrustGate/pkg/app/plugins"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/policy"
 	infracontext "github.com/NeuralTrust/TrustGate/pkg/infra/context"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/adapter"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/trace"
 )
 
 const testTimeout = 2 * time.Second
@@ -145,13 +147,24 @@ func newServer(t *testing.T, f *fakeGuard) *httptest.Server {
 }
 
 func execInput(stage policy.Stage, mode policy.Mode, set map[string]any, req *infracontext.RequestContext, resp *infracontext.ResponseContext) appplugins.ExecInput {
+	return execInputWithEvent(stage, mode, set, req, resp, nil)
+}
+
+func execInputWithEvent(stage policy.Stage, mode policy.Mode, set map[string]any, req *infracontext.RequestContext, resp *infracontext.ResponseContext, event *metrics.EventContext) appplugins.ExecInput {
 	return appplugins.ExecInput{
 		Stage:    stage,
 		Mode:     mode,
 		Config:   policy.PluginConfig{Settings: set},
 		Request:  req,
 		Response: resp,
+		Event:    event,
 	}
+}
+
+func newEvent() (*metrics.EventContext, *trace.Span) {
+	tr := trace.New("", trace.Metadata{})
+	span := tr.StartSpan(trace.SpanPlugin, PluginName)
+	return metrics.NewEventContext(span), span
 }
 
 func TestExecutePreRequestBlockReturns403(t *testing.T) {
@@ -274,6 +287,71 @@ func TestExecuteAllowStatusesPassThrough(t *testing.T) {
 				t.Fatalf("expected pass-through, got %+v", res)
 			}
 		})
+	}
+}
+
+func TestExecuteAllowedRecordsAllowedSpanDecision(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: GuardResponse{Status: "allowed", TraceID: "trace-allowed"}}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	event, span := newEvent()
+	in := execInputWithEvent(policy.StagePreRequest, policy.ModeEnforce, settings(""), requestContext(), nil, event)
+	res, err := p.Execute(context.Background(), in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res == nil || res.StatusCode != http.StatusOK {
+		t.Fatalf("expected pass-through, got %+v", res)
+	}
+	attrs := span.PluginAttrsCopy()
+	if attrs.Decision != decisionAllowed {
+		t.Fatalf("span decision = %q, want %q", attrs.Decision, decisionAllowed)
+	}
+	extras, ok := attrs.Extras.(guardData)
+	if !ok {
+		t.Fatalf("extras type = %T, want guardData", attrs.Extras)
+	}
+	if extras.Decision != decisionAllowed {
+		t.Fatalf("extras decision = %q, want %q", extras.Decision, decisionAllowed)
+	}
+}
+
+func TestExecuteReportStatusRecordsReportedSpanDecision(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: GuardResponse{Status: statusReport, TraceID: "trace-report"}}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	event, span := newEvent()
+	in := execInputWithEvent(policy.StagePreRequest, policy.ModeEnforce, settings(""), requestContext(), nil, event)
+	if _, err := p.Execute(context.Background(), in); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	attrs := span.PluginAttrsCopy()
+	if attrs.Decision != "reported" {
+		t.Fatalf("span decision = %q, want reported", attrs.Decision)
+	}
+}
+
+func TestExecuteBlockRecordsBlockSpanDecision(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: GuardResponse{Status: statusBlock, TraceID: "trace-block"}}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	event, span := newEvent()
+	in := execInputWithEvent(policy.StagePreRequest, policy.ModeEnforce, settings(""), requestContext(), nil, event)
+	if _, err := p.Execute(context.Background(), in); err == nil {
+		t.Fatal("expected block error")
+	}
+	attrs := span.PluginAttrsCopy()
+	if attrs.Decision != "block" {
+		t.Fatalf("span decision = %q, want block", attrs.Decision)
 	}
 }
 
@@ -545,24 +623,6 @@ func TestExecuteInspectModeDirections(t *testing.T) {
 				}
 			}
 		})
-	}
-}
-
-func TestExecuteBaseURLOverrideFromSettings(t *testing.T) {
-	t.Parallel()
-
-	f := &fakeGuard{response: GuardResponse{Status: "allowed"}}
-	srv := newServer(t, f)
-	p := New(adapter.NewRegistry(), "https://unreachable.invalid", testTimeout, "test-client", "test-secret", nil)
-
-	set := settings("")
-	set["base_url"] = srv.URL
-	in := execInput(policy.StagePreRequest, policy.ModeEnforce, set, requestContext(), nil)
-	if _, err := p.Execute(context.Background(), in); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if f.count() != 1 {
-		t.Fatalf("expected guard called once via settings base_url, got %d", f.count())
 	}
 }
 

--- a/tests/functional/common_test.go
+++ b/tests/functional/common_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"testing"
 
@@ -16,7 +17,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const functionalGatewayBaseDomain = "llm.neuraltrust.ai"
+func gatewayBaseDomain() string {
+	if GlobalConfig != nil && GlobalConfig.Server.GatewayBaseDomain != "" {
+		return strings.Trim(strings.ToLower(strings.TrimSpace(GlobalConfig.Server.GatewayBaseDomain)), ".")
+	}
+	return "llm.neuraltrust.ai"
+}
 
 var (
 	gatewayHosts  sync.Map
@@ -43,7 +49,7 @@ func CreateGateway(t *testing.T, payload map[string]any) string {
 	slug, ok := body["slug"].(string)
 	require.True(t, ok, "create response missing slug: %v", body)
 	require.NotEmpty(t, slug)
-	gatewayHosts.Store(id, slug+"."+functionalGatewayBaseDomain)
+	gatewayHosts.Store(id, slug+"."+gatewayBaseDomain())
 	return id
 }
 

--- a/tests/functional/gateway_discovery_test.go
+++ b/tests/functional/gateway_discovery_test.go
@@ -22,7 +22,7 @@ func setupDiscoveryRoute(t *testing.T) (slug, apiKey, path string) {
 	gatewayID := CreateGateway(t, map[string]any{"slug": uniqueName("disc-gw")})
 	host, ok := gatewayHosts.Load(gatewayID)
 	require.True(t, ok, "gateway host missing for %s", gatewayID)
-	slug = strings.TrimSuffix(host.(string), "."+functionalGatewayBaseDomain)
+	slug = strings.TrimSuffix(host.(string), "."+gatewayBaseDomain())
 	require.NotEmpty(t, slug)
 
 	up := newJSONUpstream(t, "discovery-upstream")
@@ -63,7 +63,7 @@ func discoveryPost(t *testing.T, apiKey, path, host, headerSlug string) (int, []
 func TestProxyE2E_GatewayDiscovery(t *testing.T) {
 	defer Track(t, "GatewayDiscovery")()
 	slug, apiKey, path := setupDiscoveryRoute(t)
-	subdomainHost := fmt.Sprintf("%s.%s", slug, functionalGatewayBaseDomain)
+	subdomainHost := fmt.Sprintf("%s.%s", slug, gatewayBaseDomain())
 
 	t.Run("matches by slug header without a gateway host", func(t *testing.T) {
 		status, body := discoveryPost(t, apiKey, path, "", slug)

--- a/tests/functional/playground_trace_e2e_test.go
+++ b/tests/functional/playground_trace_e2e_test.go
@@ -51,7 +51,7 @@ func setupPlaygroundRoute(t *testing.T) (gatewaySlug, consumerSlug, path string,
 	gatewayID := CreateGateway(t, map[string]any{"slug": uniqueName("pg-gw")})
 	host, ok := gatewayHosts.Load(gatewayID)
 	require.True(t, ok, "gateway host missing for %s", gatewayID)
-	gatewaySlug = strings.TrimSuffix(host.(string), "."+functionalGatewayBaseDomain)
+	gatewaySlug = strings.TrimSuffix(host.(string), "."+gatewayBaseDomain())
 	require.NotEmpty(t, gatewaySlug)
 
 	up = newJSONUpstream(t, "playground-upstream")

--- a/tests/functional/plugin_trustguard_test.go
+++ b/tests/functional/plugin_trustguard_test.go
@@ -3,144 +3,15 @@
 package functional_test
 
 import (
-	"encoding/json"
-	"fmt"
-	"io"
 	"net/http"
-	"net/http/httptest"
-	"strings"
-	"sync"
-	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-const (
-	trustGuardFunctionalClientID     = "functional-trustguard-client"
-	trustGuardFunctionalClientSecret = "functional-trustguard-secret"
-	trustGuardFunctionalCollectorID  = "11111111-1111-4111-8111-111111111111"
-	trustGuardFunctionalAccessToken  = "functional-trustguard-access-token"
-	trustGuardBlockWord              = "sql-injection-flag"
-)
-
-type trustGuardStub struct {
-	server *httptest.Server
-
-	tokenHits int64
-	guardHits int64
-
-	mu              sync.Mutex
-	lastTokenReq    trustGuardTokenCapture
-	lastGuardReq    trustGuardGuardCapture
-	lastGuardAuth   string
-}
-
-type trustGuardTokenCapture struct {
-	GrantType    string `json:"grant_type"`
-	ClientID     string `json:"client_id"`
-	ClientSecret string `json:"client_secret"`
-	Scope        string `json:"scope"`
-	CollectorID  string `json:"collector_id"`
-	GatewayID    string `json:"gateway_id"`
-}
-
-type trustGuardGuardCapture struct {
-	Payload struct {
-		Input string `json:"input"`
-	} `json:"payload"`
-	Direction  string `json:"direction"`
-	Protocol   string `json:"protocol"`
-	GatewayID  string `json:"gateway_id"`
-	ConsumerID string `json:"consumer_id"`
-}
-
-func (s *trustGuardStub) URL() string { return s.server.URL }
-
-func (s *trustGuardStub) TokenHits() int { return int(atomic.LoadInt64(&s.tokenHits)) }
-
-func (s *trustGuardStub) GuardHits() int { return int(atomic.LoadInt64(&s.guardHits)) }
-
-func (s *trustGuardStub) lastToken() trustGuardTokenCapture {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.lastTokenReq
-}
-
-func (s *trustGuardStub) lastGuard() trustGuardGuardCapture {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.lastGuardReq
-}
-
-func newTrustGuardStub(t *testing.T) *trustGuardStub {
-	t.Helper()
-	s := &trustGuardStub{}
-	s.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/token":
-			s.handleToken(t, w, r)
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/guard":
-			s.handleGuard(t, w, r)
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	t.Cleanup(s.server.Close)
-	return s
-}
-
-func (s *trustGuardStub) handleToken(t *testing.T, w http.ResponseWriter, r *http.Request) {
-	atomic.AddInt64(&s.tokenHits, 1)
-	raw, err := io.ReadAll(r.Body)
-	require.NoError(t, err)
-
-	var req trustGuardTokenCapture
-	require.NoError(t, json.Unmarshal(raw, &req))
-
-	assert.Equal(t, "client_credentials", req.GrantType)
-	assert.Equal(t, trustGuardFunctionalClientID, req.ClientID)
-	assert.Equal(t, trustGuardFunctionalClientSecret, req.ClientSecret)
-	assert.Equal(t, "platform", req.Scope)
-	assert.Equal(t, trustGuardFunctionalCollectorID, req.CollectorID)
-	assert.NotEmpty(t, req.GatewayID)
-
-	s.mu.Lock()
-	s.lastTokenReq = req
-	s.mu.Unlock()
-
-	w.Header().Set("Content-Type", "application/json")
-	_, _ = fmt.Fprintf(w, `{"access_token":%q,"token_type":"Bearer","expires_in":3600}`,
-		trustGuardFunctionalAccessToken)
-}
-
-func (s *trustGuardStub) handleGuard(t *testing.T, w http.ResponseWriter, r *http.Request) {
-	atomic.AddInt64(&s.guardHits, 1)
-	assert.Equal(t, "Bearer "+trustGuardFunctionalAccessToken, r.Header.Get("Authorization"))
-
-	raw, err := io.ReadAll(r.Body)
-	require.NoError(t, err)
-
-	var req trustGuardGuardCapture
-	require.NoError(t, json.Unmarshal(raw, &req))
-
-	s.mu.Lock()
-	s.lastGuardReq = req
-	s.lastGuardAuth = r.Header.Get("Authorization")
-	s.mu.Unlock()
-
-	w.Header().Set("Content-Type", "application/json")
-	if strings.Contains(strings.ToLower(req.Payload.Input), trustGuardBlockWord) {
-		_, _ = io.WriteString(w, `{"status":"block","findings":[{"detection_type":"prompt_injection","action":"block"}],"trace_id":"tg-trace-1","request_id":"tg-req-1"}`)
-		return
-	}
-	_, _ = io.WriteString(w, `{"status":"allowed","findings":[],"trace_id":"tg-trace-2","request_id":"tg-req-2"}`)
-}
-
-func trustGuardPolicySettings(baseURL string) map[string]any {
+func trustGuardPolicySettings() map[string]any {
 	return map[string]any{
-		"base_url":     baseURL,
 		"collector_id": trustGuardFunctionalCollectorID,
 		"inspect":      "request",
 	}
@@ -156,9 +27,12 @@ func trustGuardChatRequest(content string) map[string]any {
 func TestPluginE2E_TrustGuard_Enforce(t *testing.T) {
 	defer Track(t, "PluginTrustGuard")()
 
-	tg := newTrustGuardStub(t)
+	require.NotNil(t, TrustGuardFunctionalStub, "TrustGuard stub must be started in TestMain")
+	tg := TrustGuardFunctionalStub
+	tg.Reset()
+
 	up := newJSONUpstream(t, "tg-allowed")
-	apiKey, path := setupPolicyRoute(t, up, policyPlugin("trustguard", trustGuardPolicySettings(tg.URL())))
+	apiKey, path := setupPolicyRoute(t, up, policyPlugin("trustguard", trustGuardPolicySettings()))
 
 	t.Run("benign prompt reaches upstream after platform token and guard", func(t *testing.T) {
 		status, _, raw := proxyRequest(t, http.MethodPost, apiKey, path, nil,
@@ -205,9 +79,12 @@ func TestPluginE2E_TrustGuard_Enforce(t *testing.T) {
 func TestPluginE2E_TrustGuard_ObserveNeverBlocks(t *testing.T) {
 	defer Track(t, "PluginTrustGuard")()
 
-	tg := newTrustGuardStub(t)
+	require.NotNil(t, TrustGuardFunctionalStub, "TrustGuard stub must be started in TestMain")
+	tg := TrustGuardFunctionalStub
+	tg.Reset()
+
 	up := newJSONUpstream(t, "tg-observe")
-	entry := policyPlugin("trustguard", trustGuardPolicySettings(tg.URL()))
+	entry := policyPlugin("trustguard", trustGuardPolicySettings())
 	entry["mode"] = "observe"
 	apiKey, path := setupPolicyRoute(t, up, entry)
 

--- a/tests/functional/setup_test.go
+++ b/tests/functional/setup_test.go
@@ -82,12 +82,15 @@ func getEnv(key, fallback string) string {
 
 // buildCmdEnv returns the env the gateway binary will see, pinning
 // ENV_FILE so it loads the same .env.functional as TestMain.
-func buildCmdEnv() []string {
+func buildCmdEnv(trustGuardBaseURL string) []string {
 	env := os.Environ()
 	env = append(env, "ENV_FILE=../../.env.functional")
 	env = append(env, "AWS_ENDPOINT_URL_BEDROCK_RUNTIME="+bedrockGuardrailEndpoint)
 	env = append(env, "TRUSTGUARD_CLIENT_ID="+trustGuardFunctionalClientID)
 	env = append(env, "TRUSTGUARD_CLIENT_SECRET="+trustGuardFunctionalClientSecret)
+	if trustGuardBaseURL != "" {
+		env = append(env, "TRUSTGUARD_BASE_URL="+trustGuardBaseURL)
+	}
 	return env
 }
 
@@ -121,7 +124,8 @@ func setupTestEnvironment() {
 	redisDB = redis.NewClient(&redis.Options{Addr: redisAddr, DB: redisDBIdx})
 	_ = redisDB.FlushDB(context.Background()).Err()
 
-	cmdEnv := buildCmdEnv()
+	trustGuardStubURL := StartTrustGuardFunctionalStub()
+	cmdEnv := buildCmdEnv(trustGuardStubURL)
 	gatewayBinaryPath = buildGatewayBinary(cmdEnv)
 
 	// The admin plane runs the migrations on boot; wait for it to be ready before
@@ -141,6 +145,7 @@ func setupTestEnvironment() {
 }
 
 func teardownTestEnvironment() {
+	StopTrustGuardFunctionalStub()
 	if mcpCmd != nil && mcpCmd.Process != nil {
 		if err := syscall.Kill(-mcpCmd.Process.Pid, syscall.SIGKILL); err != nil {
 			log.Printf("error killing mcp server: %v", err)

--- a/tests/functional/trustguard_stub_test.go
+++ b/tests/functional/trustguard_stub_test.go
@@ -1,0 +1,154 @@
+//go:build functional
+
+package functional_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+const (
+	trustGuardFunctionalClientID     = "functional-trustguard-client"
+	trustGuardFunctionalClientSecret = "functional-trustguard-secret"
+	trustGuardFunctionalCollectorID  = "11111111-1111-4111-8111-111111111111"
+	trustGuardFunctionalAccessToken  = "functional-trustguard-access-token"
+	trustGuardBlockWord              = "sql-injection-flag"
+)
+
+var TrustGuardFunctionalStub *trustGuardStub
+
+func StartTrustGuardFunctionalStub() string {
+	if TrustGuardFunctionalStub != nil {
+		return TrustGuardFunctionalStub.URL()
+	}
+	TrustGuardFunctionalStub = newTrustGuardStubServer()
+	return TrustGuardFunctionalStub.URL()
+}
+
+func StopTrustGuardFunctionalStub() {
+	if TrustGuardFunctionalStub == nil {
+		return
+	}
+	TrustGuardFunctionalStub.server.Close()
+	TrustGuardFunctionalStub = nil
+}
+
+type trustGuardStub struct {
+	server *httptest.Server
+
+	tokenHits int64
+	guardHits int64
+
+	mu            sync.Mutex
+	lastTokenReq  trustGuardTokenCapture
+	lastGuardReq  trustGuardGuardCapture
+	lastGuardAuth string
+}
+
+type trustGuardTokenCapture struct {
+	GrantType    string `json:"grant_type"`
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+	Scope        string `json:"scope"`
+	CollectorID  string `json:"collector_id"`
+	GatewayID    string `json:"gateway_id"`
+}
+
+type trustGuardGuardCapture struct {
+	Payload struct {
+		Input string `json:"input"`
+	} `json:"payload"`
+	Direction  string `json:"direction"`
+	Protocol   string `json:"protocol"`
+	GatewayID  string `json:"gateway_id"`
+	ConsumerID string `json:"consumer_id"`
+}
+
+func (s *trustGuardStub) URL() string { return s.server.URL }
+
+func (s *trustGuardStub) TokenHits() int { return int(atomic.LoadInt64(&s.tokenHits)) }
+
+func (s *trustGuardStub) GuardHits() int { return int(atomic.LoadInt64(&s.guardHits)) }
+
+func (s *trustGuardStub) Reset() {
+	atomic.StoreInt64(&s.tokenHits, 0)
+	atomic.StoreInt64(&s.guardHits, 0)
+	s.mu.Lock()
+	s.lastTokenReq = trustGuardTokenCapture{}
+	s.lastGuardReq = trustGuardGuardCapture{}
+	s.lastGuardAuth = ""
+	s.mu.Unlock()
+}
+
+func (s *trustGuardStub) lastToken() trustGuardTokenCapture {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastTokenReq
+}
+
+func (s *trustGuardStub) lastGuard() trustGuardGuardCapture {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastGuardReq
+}
+
+func newTrustGuardStubServer() *trustGuardStub {
+	s := &trustGuardStub{}
+	s.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/token":
+			s.handleToken(w, r)
+		case "/v1/guard":
+			s.handleGuard(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	return s
+}
+
+func (s *trustGuardStub) handleToken(w http.ResponseWriter, r *http.Request) {
+	atomic.AddInt64(&s.tokenHits, 1)
+	raw, _ := io.ReadAll(r.Body)
+	var req trustGuardTokenCapture
+	_ = json.Unmarshal(raw, &req)
+
+	s.mu.Lock()
+	s.lastTokenReq = req
+	s.mu.Unlock()
+
+	if req.ClientID != trustGuardFunctionalClientID || req.ClientSecret != trustGuardFunctionalClientSecret {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = io.WriteString(w, `{"access_token":"`+trustGuardFunctionalAccessToken+`","token_type":"Bearer","expires_in":3600}`)
+}
+
+func (s *trustGuardStub) handleGuard(w http.ResponseWriter, r *http.Request) {
+	atomic.AddInt64(&s.guardHits, 1)
+	if got := r.Header.Get("Authorization"); got != "Bearer "+trustGuardFunctionalAccessToken {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+	raw, _ := io.ReadAll(r.Body)
+	var req trustGuardGuardCapture
+	_ = json.Unmarshal(raw, &req)
+
+	s.mu.Lock()
+	s.lastGuardReq = req
+	s.lastGuardAuth = r.Header.Get("Authorization")
+	s.mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	if strings.Contains(strings.ToLower(req.Payload.Input), trustGuardBlockWord) {
+		_, _ = io.WriteString(w, `{"status":"block","findings":[{"detection_type":"prompt_injection","action":"block"}],"trace_id":"tg-trace-1","request_id":"tg-req-1"}`)
+		return
+	}
+	_, _ = io.WriteString(w, `{"status":"allowed","findings":[],"trace_id":"tg-trace-2","request_id":"tg-req-2"}`)
+}


### PR DESCRIPTION
## Summary

- Record **actual guard outcomes** (`allowed` / `reported` / `blocked`) in policy spans via `SetDecisionFromOutcome`, instead of labeling enforce mode as `block` when the request was not blocked.
- Extend metrics `flagged` to include reported outcomes (`reported`, `report`, `throttle`) across TrustGuard and sibling guard plugins.
- Fix functional suite: read `GATEWAY_BASE_DOMAIN` from loaded config (not hardcoded `llm.neuraltrust.ai`) and extract TrustGuard stub into `trustguard_stub_test.go` to fix package build conflict.

## Linear

RUN-760 — https://linear.app/neuraltrust/issue/RUN-760

## Test plan

- [x] `go test ./pkg/app/plugins/... ./pkg/app/metrics/... ./pkg/infra/plugins/trustguard/...`
- [x] `go test -tags functional ./tests/functional/... -run TrustGuard`
- [ ] CI green on PR

Made with [Cursor](https://cursor.com)