### PR TITLE
fix(telemetry): honor SASL/TLS env vars in Kafka producer

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -177,6 +177,14 @@ type SessionStoreConfig struct {
 
 type KafkaConfig struct {
 	Brokers []string
+	// SASL/TLS client settings consumed by the Kafka telemetry exporter. All are
+	// optional: when SecurityProtocol is empty the producer stays on PLAINTEXT, so
+	// existing deployments against an unauthenticated broker are unchanged.
+	SecurityProtocol string
+	SASLMechanism    string
+	SASLUsername     string
+	SASLPassword     string
+	SSLCALocation    string
 }
 
 type TelemetryConfig struct {
@@ -352,7 +360,14 @@ func getSessionStoreConfig() SessionStoreConfig {
 }
 
 func getKafkaConfig() KafkaConfig {
-	return KafkaConfig{Brokers: splitCSV(getEnv("KAFKA_BROKERS", defaultKafkaBrokers))}
+	return KafkaConfig{
+		Brokers:          splitCSV(getEnv("KAFKA_BROKERS", defaultKafkaBrokers)),
+		SecurityProtocol: getEnv("KAFKA_SECURITY_PROTOCOL", ""),
+		SASLMechanism:    getEnv("KAFKA_SASL_MECHANISM", ""),
+		SASLUsername:     getEnv("KAFKA_SASL_USERNAME", ""),
+		SASLPassword:     getEnv("KAFKA_SASL_PASSWORD", ""),
+		SSLCALocation:    getEnv("KAFKA_SSL_CA_LOCATION", ""),
+	}
 }
 
 func getTelemetryConfig() TelemetryConfig {

--- a/pkg/infra/telemetry/kafka_base.go
+++ b/pkg/infra/telemetry/kafka_base.go
@@ -53,6 +53,33 @@ func NewKafkaBase(logger *slog.Logger, envCfg config.KafkaConfig) KafkaBase {
 	}
 }
 
+// applyKafkaSecurity sets SASL/TLS client properties from the environment-derived
+// config. Every key is optional: when SecurityProtocol is empty the producer
+// stays on PLAINTEXT, so deployments against an unauthenticated broker are
+// unchanged. This mirrors the env vars the platform Helm chart injects
+// (KAFKA_SECURITY_PROTOCOL, KAFKA_SASL_*, KAFKA_SSL_CA_LOCATION).
+func applyKafkaSecurity(cm *kafka.ConfigMap, env config.KafkaConfig) error {
+	set := func(key, value string) error {
+		if strings.TrimSpace(value) == "" {
+			return nil
+		}
+		return cm.SetKey(key, value)
+	}
+	if err := set("security.protocol", env.SecurityProtocol); err != nil {
+		return err
+	}
+	if err := set("sasl.mechanism", env.SASLMechanism); err != nil {
+		return err
+	}
+	if err := set("sasl.username", env.SASLUsername); err != nil {
+		return err
+	}
+	if err := set("sasl.password", env.SASLPassword); err != nil {
+		return err
+	}
+	return set("ssl.ca.location", env.SSLCALocation)
+}
+
 func (b *KafkaBase) ResolveBaseConfig(settings map[string]interface{}) (KafkaBaseConfig, error) {
 	var cfg KafkaBaseConfig
 	if err := mapstructure.Decode(settings, &cfg); err != nil {
@@ -79,9 +106,13 @@ func (b *KafkaBase) ValidateBaseConfig(settings map[string]interface{}) error {
 // handler. Topic creation runs in the background so an unreachable broker never
 // blocks startup.
 func (b *KafkaBase) InitProducer(cfg KafkaBaseConfig) error {
-	producer, err := kafka.NewProducer(&kafka.ConfigMap{
+	producerCfg := &kafka.ConfigMap{
 		"bootstrap.servers": strings.Join(cfg.Brokers, ","),
-	})
+	}
+	if err := applyKafkaSecurity(producerCfg, b.EnvCfg); err != nil {
+		return fmt.Errorf("failed to configure kafka security: %w", err)
+	}
+	producer, err := kafka.NewProducer(producerCfg)
 	if err != nil {
 		return fmt.Errorf("failed to create kafka producer: %w", err)
 	}

--- a/pkg/infra/telemetry/kafka_base_test.go
+++ b/pkg/infra/telemetry/kafka_base_test.go
@@ -1,0 +1,53 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/NeuralTrust/TrustGate/pkg/config"
+	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyKafkaSecurity(t *testing.T) {
+	t.Parallel()
+
+	t.Run("plaintext leaves security keys unset", func(t *testing.T) {
+		cm := &kafka.ConfigMap{}
+		require.NoError(t, applyKafkaSecurity(cm, config.KafkaConfig{}))
+		for _, key := range []string{"security.protocol", "sasl.mechanism", "sasl.username", "sasl.password", "ssl.ca.location"} {
+			_, ok := (*cm)[key]
+			assert.Falsef(t, ok, "expected %q to be unset for a plaintext broker", key)
+		}
+	})
+
+	t.Run("sasl settings are applied", func(t *testing.T) {
+		cm := &kafka.ConfigMap{}
+		require.NoError(t, applyKafkaSecurity(cm, config.KafkaConfig{
+			SecurityProtocol: "SASL_PLAINTEXT",
+			SASLMechanism:    "SCRAM-SHA-512",
+			SASLUsername:     "user",
+			SASLPassword:     "pass",
+			SSLCALocation:    "/etc/kafka/ssl/ca.crt",
+		}))
+		assert.Equal(t, "SASL_PLAINTEXT", (*cm)["security.protocol"])
+		assert.Equal(t, "SCRAM-SHA-512", (*cm)["sasl.mechanism"])
+		assert.Equal(t, "user", (*cm)["sasl.username"])
+		assert.Equal(t, "pass", (*cm)["sasl.password"])
+		assert.Equal(t, "/etc/kafka/ssl/ca.crt", (*cm)["ssl.ca.location"])
+	})
+}


### PR DESCRIPTION
## Summary
Reapertura del cambio del PR #139, que se mergeó a `main` por error y se está revirtiendo en #140.

- Carga `KAFKA_SECURITY_PROTOCOL`, `KAFKA_SASL_*` y `KAFKA_SSL_CA_LOCATION` en `KafkaConfig` desde el entorno.
- Aplica esos ajustes al crear el producer de telemetría (`KafkaBase.InitProducer`).
- Sin variables de seguridad definidas, el comportamiento es el mismo (PLAINTEXT).

## Nota
El diff real aparecerá en cuanto se mergee el revert #140 (mientras tanto `main` aún contiene el cambio). Reemplaza al #139 para revisarlo/mergearlo correctamente.

## Test plan
- `go test ./pkg/config/... ./pkg/infra/telemetry/...`

Made with [Cursor](https://cursor.com)