### PR TITLE
fix(auth): auto-detach auth from consumers on delete

### DIFF
--- a/pkg/app/auth/deleter.go
+++ b/pkg/app/auth/deleter.go
@@ -65,7 +65,7 @@ func (d *deleter) Delete(ctx context.Context, gatewayID ids.GatewayID, id ids.Au
 	if existing.GatewayID != gatewayID {
 		return domain.ErrNotFound
 	}
-	if err := guardAuthDelete(ctx, d.consumerRepo, id); err != nil {
+	if err := detachAuthFromConsumers(ctx, d.consumerRepo, id); err != nil {
 		return err
 	}
 	if err := d.repo.Delete(ctx, gatewayID, id); err != nil {

--- a/pkg/app/auth/deleter_test.go
+++ b/pkg/app/auth/deleter_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	appauth "github.com/NeuralTrust/TrustGate/pkg/app/auth"
-	commonerrors "github.com/NeuralTrust/TrustGate/pkg/common/errors"
 	domain "github.com/NeuralTrust/TrustGate/pkg/domain/auth"
 	repomocks "github.com/NeuralTrust/TrustGate/pkg/domain/auth/mocks"
 	consumerdomain "github.com/NeuralTrust/TrustGate/pkg/domain/consumer"
@@ -78,21 +77,26 @@ func TestDeleter_Delete_WrongGateway(t *testing.T) {
 	}
 }
 
-func TestDeleter_Delete_RejectsWhenReferencedByConsumer(t *testing.T) {
+func TestDeleter_Delete_DetachesReferencingConsumers(t *testing.T) {
 	t.Parallel()
 	repo := repomocks.NewRepository(t)
 	id := ids.New[ids.AuthKind]()
 	gwID := ids.New[ids.GatewayKind]()
 	repo.EXPECT().FindByID(mock.Anything, id).Return(&domain.Auth{ID: id, GatewayID: gwID}, nil).Once()
+	repo.EXPECT().Delete(mock.Anything, gwID, id).Return(nil).Once()
 
+	firstConsumer := ids.New[ids.ConsumerKind]()
+	secondConsumer := ids.New[ids.ConsumerKind]()
 	consumerRepo := consumermocks.NewRepository(t)
-	consumerRepo.EXPECT().ListByAuthID(mock.Anything, id).Return([]*consumerdomain.Consumer{{
-		ID:   ids.New[ids.ConsumerKind](),
-		Slug: "cons",
-	}}, nil).Once()
+	consumerRepo.EXPECT().ListByAuthID(mock.Anything, id).Return([]*consumerdomain.Consumer{
+		{ID: firstConsumer, Slug: "cons-a"},
+		{ID: secondConsumer, Slug: "cons-b"},
+	}, nil).Once()
+	consumerRepo.EXPECT().DetachAuth(mock.Anything, firstConsumer, id).Return(nil).Once()
+	consumerRepo.EXPECT().DetachAuth(mock.Anything, secondConsumer, id).Return(nil).Once()
 
 	deleter := appauth.NewDeleter(repo, consumerRepo, newCacheManager(), cachetest.NoopPublisher(), newTestLogger())
-	if err := deleter.Delete(context.Background(), gwID, id); !errors.Is(err, commonerrors.ErrConflict) {
-		t.Fatalf("err = %v, want ErrConflict (auth still referenced by a consumer)", err)
+	if err := deleter.Delete(context.Background(), gwID, id); err != nil {
+		t.Fatalf("Delete error: %v", err)
 	}
 }

--- a/pkg/app/auth/guard.go
+++ b/pkg/app/auth/guard.go
@@ -92,16 +92,15 @@ func consumerHasOtherUsableAuth(ctx context.Context, auths domain.Repository, c 
 	return false, nil
 }
 
-func guardAuthDelete(ctx context.Context, consumers consumerdomain.Repository, authID ids.AuthID) error {
+func detachAuthFromConsumers(ctx context.Context, consumers consumerdomain.Repository, authID ids.AuthID) error {
 	refs, err := referencingConsumers(ctx, consumers, authID)
 	if err != nil {
 		return err
 	}
-	if len(refs) > 0 {
-		return fmt.Errorf(
-			"%w: auth is referenced by %d consumer(s); detach it from them before deleting",
-			commonerrors.ErrConflict, len(refs),
-		)
+	for _, c := range refs {
+		if err := consumers.DetachAuth(ctx, c.ID, authID); err != nil {
+			return fmt.Errorf("auth: detach from consumer %q: %w", c.Slug, err)
+		}
 	}
 	return nil
 }

--- a/tests/functional/delete_auth_test.go
+++ b/tests/functional/delete_auth_test.go
@@ -29,7 +29,7 @@ func TestDeleteAuth_Success(t *testing.T) {
 	assert.Equal(t, "not_found", body["error"])
 }
 
-func TestDeleteAuth_RejectedWhileAttachedThenAllowedAfterDetach(t *testing.T) {
+func TestDeleteAuth_WhileAttachedAutoDetachesFromConsumer(t *testing.T) {
 	defer Track(t, "DeleteAuth")()
 	gwID := CreateGateway(t, map[string]any{"slug": uniqueName("auth-del-ref")})
 	authID := CreateAuth(t, gwID, validAuthPayload(uniqueName("api-key-ref")))
@@ -39,17 +39,13 @@ func TestDeleteAuth_RejectedWhileAttachedThenAllowedAfterDetach(t *testing.T) {
 	status, body := sendRequest(t, http.MethodDelete,
 		fmt.Sprintf("%s/v1/gateways/%s/auths/%s", AdminURL, gwID, authID), nil, nil,
 	)
-	require.Equal(t, http.StatusConflict, status, "an auth referenced by a consumer must not be deletable, body=%v", body)
+	require.Equal(t, http.StatusNoContent, status, "an attached auth must be deletable and auto-detached, body=%v", body)
 
-	status, body = sendRequest(t, http.MethodDelete,
-		fmt.Sprintf("%s/v1/gateways/%s/consumers/%s/auths/%s", AdminURL, gwID, coID, authID), nil, nil,
-	)
-	require.Equal(t, http.StatusNoContent, status, "detach auth failed, body=%v", body)
-
-	status, body = sendRequest(t, http.MethodDelete,
+	status, body = sendRequest(t, http.MethodGet,
 		fmt.Sprintf("%s/v1/gateways/%s/auths/%s", AdminURL, gwID, authID), nil, nil,
 	)
-	require.Equal(t, http.StatusNoContent, status, "a detached auth must be deletable, body=%v", body)
+	require.Equal(t, http.StatusNotFound, status, "the deleted auth must be gone, body=%v", body)
+	assert.Equal(t, "not_found", body["error"])
 
 	status, body = sendRequest(t, http.MethodGet,
 		fmt.Sprintf("%s/v1/gateways/%s/consumers/%s", AdminURL, gwID, coID), nil, nil,


### PR DESCRIPTION
## Summary
- Deleting an auth referenced by one or more consumers returned `409 resource conflict`, forcing the caller to manually detach every consumer before deleting.
- The auth deleter now detaches the auth from each referencing consumer before removing it, so the delete succeeds and the consumers survive without the stale auth binding.
- Cache stays consistent: the deleter already publishes `InvalidateGatewayDataEvent`, whose subscriber clears the consumer/auth caches for the gateway.

## Changes
- `pkg/app/auth/guard.go`: replaced `guardAuthDelete` (blocked with `ErrConflict`) with `detachAuthFromConsumers`, which detaches the auth from every referencing consumer.
- `pkg/app/auth/deleter.go`: `Delete` now auto-detaches before removing the auth.
- `pkg/app/auth/deleter_test.go`: unit test asserts `DetachAuth` is called per referencing consumer and the delete succeeds.
- `tests/functional/delete_auth_test.go`: functional test asserts delete-while-attached auto-detaches from the consumer (consumer survives with empty `auth_ids`, auth is gone).

## Test plan
- [x] `go test -race ./pkg/app/auth/...`
- [x] `go test -tags functional ./tests/functional/ -run TestDeleteAuth`
- [x] `golangci-lint run`
- [x] `make license-check`

## Behavior note
`guardAuthDisable` still protects *disabling* an auth that is the sole identity provider of a `role_based`/`MCP` consumer. Deleting such an auth now auto-detaches it (the consumer is left without that binding), matching the requested behavior.

Made with [Cursor](https://cursor.com)