### PR TITLE
feat(oauth): explicit authorize_url/token_url for inbound oauth2

### DIFF
--- a/pkg/api/handler/http/auth/request/create_auth_request.go
+++ b/pkg/api/handler/http/auth/request/create_auth_request.go
@@ -47,6 +47,8 @@ type OAuth2ConfigRequest struct {
 	SessionMode      bool     `json:"session_mode,omitempty"`
 	UserInfoURL      string   `json:"userinfo_url,omitempty"`
 	SubjectClaim     string   `json:"subject_claim,omitempty"`
+	AuthorizeURL     string   `json:"authorize_url,omitempty"`
+	TokenURL         string   `json:"token_url,omitempty"`
 }
 
 type OIDCConfigRequest struct {
@@ -101,6 +103,8 @@ func (c ConfigRequest) ToDomain() domain.Config {
 			SessionMode:      c.OAuth2.SessionMode,
 			UserInfoURL:      c.OAuth2.UserInfoURL,
 			SubjectClaim:     c.OAuth2.SubjectClaim,
+			AuthorizeURL:     c.OAuth2.AuthorizeURL,
+			TokenURL:         c.OAuth2.TokenURL,
 		}
 	}
 	if c.OIDC != nil {

--- a/pkg/api/handler/http/auth/response/auth_response.go
+++ b/pkg/api/handler/http/auth/response/auth_response.go
@@ -52,6 +52,8 @@ type OAuth2ConfigResponse struct {
 	SessionMode      bool     `json:"session_mode,omitempty"`
 	UserInfoURL      string   `json:"userinfo_url,omitempty"`
 	SubjectClaim     string   `json:"subject_claim,omitempty"`
+	AuthorizeURL     string   `json:"authorize_url,omitempty"`
+	TokenURL         string   `json:"token_url,omitempty"`
 }
 
 type OIDCConfigResponse struct {
@@ -105,6 +107,8 @@ func fromConfig(c domain.Config) ConfigResponse {
 			SessionMode:      c.OAuth2.SessionMode,
 			UserInfoURL:      c.OAuth2.UserInfoURL,
 			SubjectClaim:     c.OAuth2.SubjectClaim,
+			AuthorizeURL:     c.OAuth2.AuthorizeURL,
+			TokenURL:         c.OAuth2.TokenURL,
 		}
 	}
 	if c.OIDC != nil {

--- a/pkg/app/oauth/proxy.go
+++ b/pkg/app/oauth/proxy.go
@@ -91,7 +91,7 @@ func (p *authProxy) Authorize(ctx context.Context, baseURL string, req Authorize
 	if err := p.validateClientRedirect(ctx, req.ClientID, req.RedirectURI); err != nil {
 		return "", err
 	}
-	endpoints, err := p.idpEndpoints(ctx, cfg.Issuer)
+	endpoints, err := p.idpEndpoints(ctx, cfg)
 	if err != nil {
 		return "", err
 	}
@@ -152,7 +152,7 @@ func (p *authProxy) Callback(ctx context.Context, baseURL, state, code, idpErr, 
 		return "", err
 	}
 	cfg := auth.Config.OAuth2
-	endpoints, err := p.idpEndpoints(ctx, cfg.Issuer)
+	endpoints, err := p.idpEndpoints(ctx, cfg)
 	if err != nil {
 		return "", err
 	}
@@ -415,7 +415,7 @@ func (p *authProxy) refresh(ctx context.Context, req TokenRequest) (map[string]a
 		return nil, err
 	}
 	cfg := auth.Config.OAuth2
-	endpoints, err := p.idpEndpoints(ctx, cfg.Issuer)
+	endpoints, err := p.idpEndpoints(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -460,15 +460,18 @@ type idpEndpoints struct {
 	token     string
 }
 
-func (p *authProxy) idpEndpoints(ctx context.Context, issuer string) (*idpEndpoints, error) {
-	doc, err := p.idp.fetchASMetadata(ctx, issuer)
+func (p *authProxy) idpEndpoints(ctx context.Context, cfg *authdomain.OAuth2Config) (*idpEndpoints, error) {
+	if cfg.AuthorizeURL != "" && cfg.TokenURL != "" {
+		return &idpEndpoints{authorize: cfg.AuthorizeURL, token: cfg.TokenURL}, nil
+	}
+	doc, err := p.idp.fetchASMetadata(ctx, cfg.Issuer)
 	if err != nil {
 		return nil, fmt.Errorf("oauth: resolve IdP endpoints: %w", err)
 	}
 	authorize, _ := doc["authorization_endpoint"].(string)
 	token, _ := doc["token_endpoint"].(string)
 	if authorize == "" || token == "" {
-		return nil, fmt.Errorf("oauth: IdP metadata for %s lacks authorization/token endpoints", issuer)
+		return nil, fmt.Errorf("oauth: IdP metadata for %s lacks authorization/token endpoints", cfg.Issuer)
 	}
 	return &idpEndpoints{authorize: authorize, token: token}, nil
 }

--- a/pkg/app/oauth/proxy_functional_test.go
+++ b/pkg/app/oauth/proxy_functional_test.go
@@ -251,3 +251,98 @@ func TestOktaFlowNoRegressionEndToEnd(t *testing.T) {
 		t.Fatalf("subject must derive from the IdP token, got issuer %q", iss)
 	}
 }
+
+// githubNoDiscoveryIdP models real GitHub: the authorization-server metadata
+// paths 404, only the fixed login/token endpoints and a GitHub-shaped userinfo
+// endpoint respond.
+func githubNoDiscoveryIdP(t *testing.T, userID int) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login/oauth/access_token":
+			w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
+			_, _ = w.Write([]byte("access_token=gho_opaque&token_type=bearer&scope=read:user"))
+		case "/user":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": userID, "login": "octocat"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// GitHub publishes no authorization-server discovery, so the inbound oauth2
+// auth pins authorize_url/token_url explicitly. Authorize must redirect to the
+// pinned endpoint without any discovery call, and the opaque login must still
+// mint a verifiable gateway session token.
+func TestSessionFlowGitHubExplicitEndpointsNoDiscovery(t *testing.T) {
+	t.Parallel()
+	idp := githubNoDiscoveryIdP(t, 4242)
+	signer := newTestSigner(t)
+	finder := &fakeCredentialFinder{oauth2: []*authdomain.Auth{
+		oauth2Auth(t, authdomain.OAuth2Config{
+			Issuer:         "https://github.com",
+			ClientID:       "gw-client-id",
+			ClientSecret:   "gw-secret",
+			SessionMode:    true,
+			UserInfoURL:    idp.URL + "/user",
+			SubjectClaim:   "id",
+			Audiences:      []string{"api://gw"},
+			RequiredScopes: []string{"read:user"},
+			AuthorizeURL:   idp.URL + "/login/oauth/authorize",
+			TokenURL:       idp.URL + "/login/oauth/access_token",
+		}),
+	}}
+	proxy := NewAuthProxy(finder, nil, http.DefaultClient, newMemFlowStore(), &fakeChainer{url: ""}, signer, httpUserInfo{http.DefaultClient})
+	ctx := context.Background()
+
+	location, err := proxy.Authorize(ctx, "http://gw.example.com", AuthorizeRequest{
+		ResponseType:        "code",
+		ClientID:            "gw-client-id",
+		RedirectURI:         "cursor://anysphere.cursor-mcp/oauth/callback",
+		State:               "client-state",
+		CodeChallenge:       s256("client-verifier"),
+		CodeChallengeMethod: "S256",
+	})
+	if err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	loc, err := url.Parse(location)
+	if err != nil {
+		t.Fatalf("parse redirect: %v", err)
+	}
+	if base := loc.Scheme + "://" + loc.Host + loc.Path; base != idp.URL+"/login/oauth/authorize" {
+		t.Fatalf("authorize must redirect to the pinned endpoint, got %s", base)
+	}
+
+	clientLoc, err := proxy.Callback(ctx, "http://gw.example.com", loc.Query().Get("state"), "idp-code", "", "")
+	if err != nil {
+		t.Fatalf("callback: %v", err)
+	}
+	resp, err := proxy.Exchange(ctx, "http://gw.example.com", TokenRequest{
+		GrantType:    "authorization_code",
+		Code:         exchangeCodeFrom(t, clientLoc),
+		RedirectURI:  "cursor://anysphere.cursor-mcp/oauth/callback",
+		CodeVerifier: "client-verifier",
+	})
+	if err != nil {
+		t.Fatalf("exchange: %v", err)
+	}
+	access, _ := resp["access_token"].(string)
+	if access == "" {
+		t.Fatal("expected a minted session access_token")
+	}
+	verifier, err := authsession.NewVerifier(signer)
+	if err != nil {
+		t.Fatalf("new verifier: %v", err)
+	}
+	principal, err := verifier.Verify(ctx, access)
+	if err != nil {
+		t.Fatalf("minted token must verify against the gateway JWKS: %v", err)
+	}
+	if principal.Subject != "4242" {
+		t.Fatalf("subject must follow the GitHub id, got %q", principal.Subject)
+	}
+}

--- a/pkg/domain/auth/config.go
+++ b/pkg/domain/auth/config.go
@@ -43,6 +43,8 @@ type OAuth2Config struct {
 	SessionMode      bool     `json:"session_mode,omitempty"`
 	UserInfoURL      string   `json:"userinfo_url,omitempty"`
 	SubjectClaim     string   `json:"subject_claim,omitempty"`
+	AuthorizeURL     string   `json:"authorize_url,omitempty"`
+	TokenURL         string   `json:"token_url,omitempty"`
 }
 
 type OIDCConfig struct {
@@ -139,6 +141,9 @@ func (c *OAuth2Config) validate() error {
 			return fmt.Errorf("%w: oauth2.userinfo_url must be an http(s) URL", ErrInvalidConfig)
 		}
 	}
+	if err := c.validateAuthorizationEndpoints(); err != nil {
+		return err
+	}
 	if !c.SessionMode && strings.TrimSpace(c.JWKSURL) == "" && strings.TrimSpace(c.IntrospectionURL) == "" {
 		// Without an explicit endpoint the JWKS is resolved via OIDC
 		// discovery, which needs the issuer to be a resolvable http(s) URL.
@@ -147,6 +152,33 @@ func (c *OAuth2Config) validate() error {
 			return fmt.Errorf("%w: oauth2 requires jwks_url or introspection_url, or an http(s) issuer for OIDC discovery", ErrInvalidConfig)
 		}
 	}
+	return nil
+}
+
+// validateAuthorizationEndpoints enforces the manual brokering endpoints used
+// for identity providers that publish no authorization-server metadata (e.g.
+// GitHub): authorize_url and token_url must be provided together, be http(s)
+// URLs, and require a pre-registered client_id.
+func (c *OAuth2Config) validateAuthorizationEndpoints() error {
+	authorizeURL := strings.TrimSpace(c.AuthorizeURL)
+	tokenURL := strings.TrimSpace(c.TokenURL)
+	if authorizeURL == "" && tokenURL == "" {
+		return nil
+	}
+	if authorizeURL == "" || tokenURL == "" {
+		return fmt.Errorf("%w: oauth2.authorize_url and oauth2.token_url must be set together", ErrInvalidConfig)
+	}
+	if strings.TrimSpace(c.ClientID) == "" {
+		return fmt.Errorf("%w: oauth2.authorize_url/token_url require oauth2.client_id (interactive brokering needs a pre-registered client)", ErrInvalidConfig)
+	}
+	for _, ep := range []struct{ name, value string }{{"authorize_url", authorizeURL}, {"token_url", tokenURL}} {
+		u, err := url.Parse(ep.value)
+		if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+			return fmt.Errorf("%w: oauth2.%s must be an http(s) URL", ErrInvalidConfig, ep.name)
+		}
+	}
+	c.AuthorizeURL = authorizeURL
+	c.TokenURL = tokenURL
 	return nil
 }
 

--- a/pkg/domain/auth/config_test.go
+++ b/pkg/domain/auth/config_test.go
@@ -102,3 +102,78 @@ func TestOAuth2Config_Validate_SessionMode(t *testing.T) {
 		})
 	}
 }
+
+func TestOAuth2Config_Validate_ManualAuthorizationEndpoints(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		config  OAuth2Config
+		wantErr bool
+	}{
+		{
+			name: "github session mode with explicit endpoints and client id",
+			config: OAuth2Config{
+				Issuer:       "https://github.com",
+				Audiences:    []string{"gateway"},
+				ClientID:     "gh-client",
+				ClientSecret: "gh-secret",
+				SessionMode:  true,
+				UserInfoURL:  "https://api.github.com/user",
+				AuthorizeURL: "https://github.com/login/oauth/authorize",
+				TokenURL:     "https://github.com/login/oauth/access_token",
+			},
+			wantErr: false,
+		},
+		{
+			name: "authorize url without token url",
+			config: OAuth2Config{
+				Issuer:       "https://github.com",
+				Audiences:    []string{"gateway"},
+				ClientID:     "gh-client",
+				SessionMode:  true,
+				AuthorizeURL: "https://github.com/login/oauth/authorize",
+			},
+			wantErr: true,
+		},
+		{
+			name: "explicit endpoints without client id",
+			config: OAuth2Config{
+				Issuer:       "https://github.com",
+				Audiences:    []string{"gateway"},
+				SessionMode:  true,
+				AuthorizeURL: "https://github.com/login/oauth/authorize",
+				TokenURL:     "https://github.com/login/oauth/access_token",
+			},
+			wantErr: true,
+		},
+		{
+			name: "malformed authorize url",
+			config: OAuth2Config{
+				Issuer:       "https://github.com",
+				Audiences:    []string{"gateway"},
+				ClientID:     "gh-client",
+				SessionMode:  true,
+				AuthorizeURL: "://github.com/login/oauth/authorize",
+				TokenURL:     "https://github.com/login/oauth/access_token",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := tt.config
+			err := cfg.validate()
+			if tt.wantErr {
+				if !errors.Is(err, ErrInvalidConfig) {
+					t.Fatalf("validate() error = %v, want ErrInvalidConfig", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("validate() error = %v, want nil", err)
+			}
+		})
+	}
+}

--- a/postman/TrustGate.postman_collection.json
+++ b/postman/TrustGate.postman_collection.json
@@ -7497,8 +7497,8 @@
           ]
         },
         {
-          "name": "9. Flow I - GitHub end-to-end (inbound OAuth + upstream forwarded GitHub)",
-          "description": "Self-contained. The full GitHub story on real services: INBOUND OAuth brokered through a discovery-capable IdP (Entra here) plus UPSTREAM GitHub Copilot MCP in forwarded mode with manual registration (a pre-registered GitHub OAuth app). Both legs are OAuth 2.x; the GitHub OAuth is the UPSTREAM leg.\n\nIMPORTANT - why the INBOUND IdP is NOT GitHub: the AS facade resolves the IdP's authorize/token endpoints purely via issuer discovery ({issuer}/.well-known/oauth-authorization-server then /openid-configuration). GitHub OAuth apps publish no such metadata, and https://token.actions.githubusercontent.com only exposes JWKS (no authorization/token endpoints). Pointing the INBOUND oauth2 auth at a GitHub issuer makes GET /oauth/authorize fail with 'oauth: IdP metadata for ... lacks authorization/token endpoints' (HTTP 500). GitHub OAuth therefore belongs to the UPSTREAM (forwarded) leg, where authorize_url/token_url are set explicitly. For the inbound IdP use Entra/Okta/Auth0/Cognito/Google (anything with AS discovery).\n\nRun the admin requests top to bottom, then 'Get Entra token', then the MCP plane requests. The first tools/list returns -32003 with data.connect_url: open it in a browser, click Connect GitHub, approve, re-run. Finish with the Cleanup requests.\n\nPrereqs:\n1. entra_tenant_id / entra_client_id / entra_client_secret (see Flow C for the Entra app setup) for the INBOUND leg.\n2. A GitHub OAuth app for the UPSTREAM leg: set github_client_id / github_client_secret and the app's Authorization callback URL to {{mcp_url}}/oauth/callback/github.\n\nMCP endpoint: {{mcp_url}}/{{consumer_slug}}/mcp - the consumer slug is generated on creation and captured by the create request.\n\nNOTE: only one ENABLED oauth2 auth may cover the same (issuer, audience) pair - run another Entra folder's Cleanup first or 'Create oauth2 auth' answers 409.",
+          "name": "9. Flow I - GitHub MCP (oauth2 inbound + forwarded upstream, NO role)",
+          "description": "Minimal provisioning, no roles. Four admin steps as requested:\n1. Create registry -> GitHub (MCP, forwarded upstream GitHub OAuth).\n2. Create auth type oauth2 -> GitHub (inbound, session_mode for GitHub's opaque tokens).\n3. Create consumer (type MCP).\n4. Associate auth + registry to the consumer.\n(A gateway is created first as the parent container, and Cleanup deletes everything at the end.)\n\nPrereqs: a GitHub OAuth app. Set github_client_id / github_client_secret. Authorization callback URL = {{mcp_url}}/oauth/callback (inbound) and {{mcp_url}}/oauth/callback/github (upstream) - register both.\n\nHEADS-UP about the inbound oauth2 -> GitHub: creation of all four resources succeeds (the admin API accepts a session_mode GitHub auth). But the runtime interactive login at GET /oauth/authorize resolves the IdP's authorize/token endpoints via issuer discovery ({issuer}/.well-known/oauth-authorization-server then /openid-configuration). github.com returns 404 on both (verified), so the browser login leg fails with 'lacks authorization/token endpoints' (HTTP 500) until the gateway gains a way to set authorize_url/token_url for inbound (today only the upstream/forwarded leg has those). M2M (Bearer-token) inbound is unaffected. The four resources below are still created exactly as asked.",
           "item": [
             {
               "name": "Create gateway",
@@ -7529,36 +7529,7 @@
               }
             },
             {
-              "name": "Create oauth2 auth (Entra) [INBOUND IdP]",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.environment.set('oauth2_auth_id', pm.response.json().id);"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"name\": \"entra\",\n  \"type\": \"oauth2\",\n  \"config\": {\n    \"oauth2\": {\n      \"issuer\": \"https://login.microsoftonline.com/{{entra_tenant_id}}/v2.0\",\n      \"audiences\": [\"api://{{entra_client_id}}\"],\n      \"client_id\": \"{{entra_client_id}}\",\n      \"client_secret\": \"{{entra_client_secret}}\",\n      \"required_scopes\": [\"api://{{entra_client_id}}/mcp.access\", \"offline_access\"]\n    }\n  }\n}"
-                },
-                "description": "INBOUND identity provider. This is the IdP the gateway delegates the MCP client login to (the AS facade brokers an authorization-code flow against this issuer). It is NOT GitHub on purpose: GitHub publishes no AS discovery, so a GitHub issuer here would make /oauth/authorize fail with 'lacks authorization/token endpoints' (HTTP 500). Swap Entra for Okta/Auth0/Cognito/Google freely. See Flow C's 'Create oauth2 auth' for the field-by-field Entra explanation. 409 means another ENABLED oauth2 auth already covers this (issuer, audience): run that folder's Cleanup or disable it."
-              }
-            },
-            {
-              "name": "Create GitHub MCP registry (forwarded + manual) [UPSTREAM GitHub OAuth]",
+              "name": "1. Create registry -> GitHub (MCP, forwarded upstream)",
               "event": [
                 {
                   "listen": "test",
@@ -7583,11 +7554,40 @@
                   "mode": "raw",
                   "raw": "{\n  \"name\": \"github-mcp\",\n  \"type\": \"MCP\",\n  \"mcp_target\": {\n    \"url\": \"https://api.githubcopilot.com/mcp/\",\n    \"transport\": \"streamable-http\",\n    \"auth\": {\n      \"mode\": \"forwarded\",\n      \"provider\": \"github\",\n      \"registration\": \"manual\",\n      \"client_id\": \"{{github_client_id}}\",\n      \"client_secret\": \"{{github_client_secret}}\",\n      \"authorize_url\": \"https://github.com/login/oauth/authorize\",\n      \"token_url\": \"https://github.com/login/oauth/access_token\",\n      \"scopes\": [\"repo\", \"read:org\", \"read:user\", \"user:email\"],\n      \"resource\": \"https://api.githubcopilot.com/mcp/\"\n    }\n  }\n}"
                 },
-                "description": "UPSTREAM GitHub OAuth (the second OAuth leg). forwarded + manual registration: the gateway drives a per-user authorization-code flow against the GitHub OAuth app you pre-registered (github.com is NOT discovery-capable, hence the explicit authorize_url/token_url). Set the GitHub app's Authorization callback URL to {{mcp_url}}/oauth/callback/github. At tools time a user without a linked GitHub account gets JSON-RPC error -32003 with data.connect_url; after consent the gateway vaults that user's GitHub token and injects it upstream. client_secret is write-only (reads return it masked)."
+                "description": "UPSTREAM GitHub OAuth. forwarded + manual: the gateway drives a per-user authorization-code flow against your GitHub OAuth app (github.com publishes no discovery, hence explicit authorize_url/token_url). GitHub app Authorization callback URL must be {{mcp_url}}/oauth/callback/github. client_secret is write-only (reads return it masked)."
               }
             },
             {
-              "name": "Create MCP consumer",
+              "name": "2. Create auth type oauth2 -> GitHub (inbound, session_mode)",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.environment.set('oauth2_auth_id', pm.response.json().id);"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"name\": \"github\",\n  \"type\": \"oauth2\",\n  \"config\": {\n    \"oauth2\": {\n      \"issuer\": \"https://github.com\",\n      \"audiences\": [\"{{mcp_url}}\"],\n      \"client_id\": \"{{github_client_id}}\",\n      \"client_secret\": \"{{github_client_secret}}\",\n      \"session_mode\": true,\n      \"userinfo_url\": \"https://api.github.com/user\",\n      \"subject_claim\": \"id\",\n      \"authorize_url\": \"https://github.com/login/oauth/authorize\",\n      \"token_url\": \"https://github.com/login/oauth/access_token\",\n      \"required_scopes\": [\"read:user\"]\n    }\n  }\n}"
+                },
+                "description": "INBOUND oauth2 -> GitHub. GitHub publishes no authorization-server discovery, so authorize_url/token_url are pinned explicitly (the gateway skips the {issuer}/.well-known lookup when both are set). session_mode mints gateway session tokens from GitHub's opaque access tokens; subject_claim=id reads the stable user id from userinfo_url. GitHub OAuth app Authorization callback URL must be {{mcp_url}}/oauth/callback. client_id is required (pre-registered client). 409 means another ENABLED oauth2 auth already covers this (issuer, audience). For a discovery-capable IdP (Okta/Entra/Auth0/Google) omit authorize_url/token_url/session_mode and just set issuer + jwks_url."
+              }
+            },
+            {
+              "name": "3. Create consumer (type MCP)",
               "event": [
                 {
                   "listen": "test",
@@ -7616,215 +7616,17 @@
               }
             },
             {
-              "name": "Attach oauth2 auth to consumer",
+              "name": "4. Associate auth to consumer",
               "request": {
                 "method": "POST",
                 "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/auths/{{oauth2_auth_id}}"
               }
             },
             {
-              "name": "Attach GitHub registry to consumer",
+              "name": "4. Associate registry to consumer",
               "request": {
                 "method": "POST",
                 "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/registries/{{registry_id}}"
-              }
-            },
-            {
-              "name": "Set toolkit (all GitHub tools)",
-              "request": {
-                "method": "PUT",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"toolkit\": [\n    {\n      \"registry_id\": \"{{registry_id}}\",\n      \"tool\": \"*\"\n    }\n  ],\n  \"fail_mode\": \"closed\"\n}"
-                },
-                "description": "Wildcard exposes every GitHub MCP tool. Replace with explicit {tool, expose_as} entries to curate or rename."
-              }
-            },
-            {
-              "name": "Get Entra token (client credentials)",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "const res = pm.response.json();",
-                      "pm.test('access token issued', () => pm.expect(res.access_token).to.be.a('string'));",
-                      "pm.environment.set('entra_token', res.access_token);",
-                      "let b64 = res.access_token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');",
-                      "while (b64.length % 4) b64 += '=';",
-                      "const claims = JSON.parse(atob(b64));",
-                      "console.log('token claims', { iss: claims.iss, aud: claims.aud, oid: claims.oid, roles: claims.roles });",
-                      "pm.test('v2.0 issuer (else set requestedAccessTokenVersion=2 in the manifest)', () => {",
-                      "  pm.expect(claims.iss).to.include('/v2.0');",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "url": "https://login.microsoftonline.com/{{entra_tenant_id}}/oauth2/v2.0/token",
-                "body": {
-                  "mode": "urlencoded",
-                  "urlencoded": [
-                    {
-                      "key": "grant_type",
-                      "value": "client_credentials"
-                    },
-                    {
-                      "key": "client_id",
-                      "value": "{{entra_client_id}}"
-                    },
-                    {
-                      "key": "client_secret",
-                      "value": "{{entra_client_secret}}"
-                    },
-                    {
-                      "key": "scope",
-                      "value": "api://{{entra_client_id}}/.default"
-                    }
-                  ]
-                },
-                "description": "INBOUND M2M token for Postman testing (the inbound leg). The scope must be your own app's .default. This token links the GitHub account to the service principal; real users in Cursor each link their own GitHub account. See Flow C's note about the mcp.access app role for client-credentials tokens."
-              }
-            },
-            {
-              "name": "initialize (Entra JWT)",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "const sid = pm.response.headers.get('Mcp-Session-Id');",
-                      "if (sid) pm.environment.set('mcp_session_id', sid);"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "Authorization",
-                    "value": "Bearer {{entra_token}}"
-                  }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"initialize\",\n  \"params\": {\n    \"protocolVersion\": \"2025-06-18\",\n    \"capabilities\": {},\n    \"clientInfo\": { \"name\": \"postman\", \"version\": \"1.0\" }\n  }\n}"
-                },
-                "description": "Authenticates the INBOUND leg with the Entra JWT. Get {{entra_token}} first via this folder's 'Get Entra token (client credentials)'."
-              }
-            },
-            {
-              "name": "tools/list -> GitHub consent error on first run",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "const body = pm.response.json();",
-                      "if (body.error && body.error.code === -32003) {",
-                      "  const url = body.error.data.connect_url;",
-                      "  const ticket = (url.split('ticket=')[1] || '').split('&')[0];",
-                      "  pm.environment.set('connect_ticket', ticket);",
-                      "  console.log('Open in a browser to link GitHub:', url);",
-                      "} else if (body.result) {",
-                      "  console.log('Linked: ' + body.result.tools.length + ' GitHub tools exposed');",
-                      "}"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "Authorization",
-                    "value": "Bearer {{entra_token}}"
-                  }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 2,\n  \"method\": \"tools/list\"\n}"
-                },
-                "description": "First run: no vaulted GitHub token for this principal, so the gateway answers JSON-RPC error -32003 with data.connect_url (the script saves the ticket and logs the URL). Open it in a browser, click Connect GitHub, approve at GitHub, then re-run: the result lists GitHub's tools. This is the UPSTREAM GitHub OAuth leg in action."
-              }
-            },
-            {
-              "name": "Connect page (browser UI)",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "GET",
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp/connect?ticket={{connect_ticket}}",
-                "description": "The ticket-authenticated consent page: one button per forwarded provider behind this virtual MCP (GitHub here), with linked/unlinked status. Normally opened in a browser via the connect_url from the -32003 error. Tickets expire after 15 minutes."
-              }
-            },
-            {
-              "name": "tools/call get_me (after linking)",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "Authorization",
-                    "value": "Bearer {{entra_token}}"
-                  }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 3,\n  \"method\": \"tools/call\",\n  \"params\": {\n    \"name\": \"get_me\",\n    \"arguments\": {}\n  }\n}"
-                },
-                "description": "Check the exact tool names in the tools/list result (the composer prefixes with the registry name only on collisions). The call runs with YOUR vaulted GitHub token; another principal calling the same consumer gets their own consent flow."
-              }
-            },
-            {
-              "name": "Disconnect GitHub (revoke vaulted token)",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "url": "{{mcp_url}}/oauth/disconnect/github?ticket={{connect_ticket}}",
-                "description": "Deletes the vaulted credential for (gateway, principal, github). The next tools call returns the -32003 consent error again."
               }
             },
             {


### PR DESCRIPTION
## Summary
- Inbound `oauth2` auths resolved the IdP `authorization_endpoint`/`token_endpoint` **only** via issuer discovery (`/.well-known/oauth-authorization-server`, `/.well-known/openid-configuration`). IdPs that publish no such metadata (e.g. **GitHub** — 404 on both) made `GET /oauth/authorize` fail with HTTP 500 (`oauth: resolve IdP endpoints ... status 404`).
- Adds optional `authorize_url` / `token_url` to the inbound `oauth2` config. When both are set, the proxy uses them directly and **skips discovery**; otherwise discovery is unchanged (Okta/Entra/Auth0/Google).
- Complements #112 (RUN-712, gateway-minted session token for opaque IdPs): that PR solved the token-format problem for GitHub but still assumed the authorize/token endpoints were discoverable. This closes that gap so GitHub works as an inbound interactive IdP end-to-end.

## Changes
- `pkg/domain/auth/config.go`: `OAuth2Config.AuthorizeURL` / `TokenURL` + validation (both-or-none, http(s), require `client_id`).
- `pkg/app/oauth/proxy.go`: `idpEndpoints` prefers explicit endpoints, falls back to discovery.
- `pkg/api/handler/http/auth/{request,response}`: expose the two fields in DTOs + mappers.
- Tests: validation cases + `TestSessionFlowGitHubExplicitEndpointsNoDiscovery` (authorize → callback → verifiable session JWT, no discovery).
- `postman/TrustGate.postman_collection.json`: Flow I step 2 now pins GitHub's authorize/token URLs.

## Test plan
- [x] `go build ./pkg/...`
- [x] `go test ./pkg/domain/auth/... ./pkg/app/oauth/... ./pkg/api/handler/http/auth/...`
- [ ] Manual: create a GitHub `oauth2` inbound auth with `authorize_url`/`token_url` and confirm `/oauth/authorize` redirects to GitHub (no 500).

Made with [Cursor](https://cursor.com)