### PR TITLE
chore(ci): allowlist di_smoke_test fixture in gitleaks

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -7,5 +7,6 @@ useDefault = true
 description = "Curated false positives: deterministic test fixtures and historical agent transcripts/docs."
 paths = [
   '''pkg/infra/crypto/cipher_test\.go''',
+  '''pkg/container/di_smoke_test\.go''',
   '''.*cursor_phase_\d+\.md''',
 ]


### PR DESCRIPTION
## Summary

Allowlist `pkg/container/di_smoke_test.go` in `.gitleaks.toml` — ENG-950 smoke test `SERVER_SECRET_KEY` fixture triggers generic-api-key in full-history scan.

Closes path from abandoned RUN-801 v2 PR (#150).

## Test plan

- [ ] `security / Secret Detection (Gitleaks)` green