### PR TITLE
feat: align GuardFinding with guard findings v2 (RUN-801)

### DIFF
--- a/pkg/infra/plugins/trustguard/client_test.go
+++ b/pkg/infra/plugins/trustguard/client_test.go
@@ -54,7 +54,7 @@ func TestGuardDecodesResponses(t *testing.T) {
 		{
 			name:          "block verdict",
 			statusCode:    http.StatusOK,
-			respBody:      `{"status":"block","trace_id":"t1","request_id":"r1","findings":[{"detection_type":"pii","confidence":0.9,"action":"block"}]}`,
+			respBody:      `{"status":"block","trace_id":"t1","request_id":"r1","findings":[{"source":{"kind":"detector","plugin":"data_loss_prevention"},"signal":{"type":"pii","confidence":0.9},"outcome":{"action":"block"}}]}`,
 			wantStatus:    "block",
 			wantFindings:  1,
 			wantTraceID:   "t1",

--- a/pkg/infra/plugins/trustguard/data.go
+++ b/pkg/infra/plugins/trustguard/data.go
@@ -59,15 +59,33 @@ type GuardResponse struct {
 	RequestID          string         `json:"request_id"`
 }
 
+// GuardFindingSource identifies who produced a guard finding.
+type GuardFindingSource struct {
+	Kind         string `json:"kind,omitempty"`
+	Plugin       string `json:"plugin,omitempty"`
+	DetectorID   string `json:"detector_id,omitempty"`
+	DetectorName string `json:"detector_name,omitempty"`
+	PolicyID     string `json:"policy_id,omitempty"`
+	GateName     string `json:"gate_name,omitempty"`
+}
+
+// GuardFindingSignal is the detection signal when a plugin or gate matched.
+type GuardFindingSignal struct {
+	Type       string  `json:"type,omitempty"`
+	Confidence float64 `json:"confidence,omitempty"`
+}
+
+// GuardFindingOutcome is the enforcement action applied to a real detection.
+type GuardFindingOutcome struct {
+	Action string `json:"action,omitempty"`
+}
+
+// GuardFinding is one TrustGuard finding in the v2 wire contract.
 type GuardFinding struct {
-	DetectionType string  `json:"detection_type,omitempty"`
-	Confidence    float64 `json:"confidence,omitempty"`
-	RuleName      string  `json:"rule_name,omitempty"`
-	Status        string  `json:"status,omitempty"`
-	PolicyID      string  `json:"policy_id,omitempty"`
-	DetectorID    string  `json:"detector_id,omitempty"`
-	Action        string  `json:"action,omitempty"`
-	Details       any     `json:"details,omitempty"`
+	Source   *GuardFindingSource  `json:"source,omitempty"`
+	Signal   *GuardFindingSignal  `json:"signal,omitempty"`
+	Outcome  *GuardFindingOutcome `json:"outcome,omitempty"`
+	Evidence map[string]any       `json:"evidence,omitempty"`
 }
 
 type guardData struct {

--- a/pkg/infra/plugins/trustguard/plugin_test.go
+++ b/pkg/infra/plugins/trustguard/plugin_test.go
@@ -172,7 +172,11 @@ func TestExecutePreRequestBlockReturns403(t *testing.T) {
 
 	f := &fakeGuard{response: GuardResponse{
 		Status:    statusBlock,
-		Findings:  []GuardFinding{{DetectionType: "prompt_injection", Action: "block"}},
+		Findings: []GuardFinding{{
+			Source:  &GuardFindingSource{Kind: "detector", Plugin: "prompt_guard"},
+			Signal:  &GuardFindingSignal{Type: "prompt_injection"},
+			Outcome: &GuardFindingOutcome{Action: "block"},
+		}},
 		TraceID:   "trace-1",
 		RequestID: "req-1",
 	}}

--- a/pkg/infra/plugins/trustguard/reject_test.go
+++ b/pkg/infra/plugins/trustguard/reject_test.go
@@ -25,12 +25,13 @@ func TestBlockBodyOmitsFindingsFromClientResponse(t *testing.T) {
 	raw := blockBody(&GuardResponse{
 		Status: statusBlock,
 		Findings: []GuardFinding{{
-			DetectionType: "jailbreak",
-			Confidence:    0.99,
-			PolicyID:      "policy-1",
-			DetectorID:    "detector-1",
-			Action:        "block",
-			Details:       map[string]any{"plugin": "prompt_guard"},
+			Source:  &GuardFindingSource{Kind: "detector", Plugin: "prompt_guard"},
+			Signal:  &GuardFindingSignal{Type: "jailbreak", Confidence: 0.99},
+			Outcome: &GuardFindingOutcome{Action: "block"},
+			Evidence: map[string]any{
+				"policy_id":   "policy-1",
+				"detector_id": "detector-1",
+			},
 		}},
 		TraceID:   "trace-1",
 		RequestID: "req-1",

--- a/tests/functional/trustguard_stub_test.go
+++ b/tests/functional/trustguard_stub_test.go
@@ -147,7 +147,7 @@ func (s *trustGuardStub) handleGuard(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	if strings.Contains(strings.ToLower(req.Payload.Input), trustGuardBlockWord) {
-		_, _ = io.WriteString(w, `{"status":"block","findings":[{"detection_type":"prompt_injection","action":"block"}],"trace_id":"tg-trace-1","request_id":"tg-req-1"}`)
+		_, _ = io.WriteString(w, `{"status":"block","findings":[{"source":{"kind":"detector","plugin":"prompt_guard"},"signal":{"type":"prompt_injection"},"outcome":{"action":"block"}}],"trace_id":"tg-trace-1","request_id":"tg-req-1"}`)
 		return
 	}
 	_, _ = io.WriteString(w, `{"status":"allowed","findings":[],"trace_id":"tg-trace-2","request_id":"tg-req-2"}`)


### PR DESCRIPTION
## Summary

Unmarshal TrustGuard guard response findings v2 (`source`/`signal`/`outcome`/`evidence`). Block decision still uses top-level `status`.

Pairs with TrustGuard #272 (guard v2 wire, telemetry v1).

## Linear

RUN-801 — https://linear.app/neuraltrust/issue/RUN-801

## Test plan

- [x] `go test ./pkg/infra/plugins/trustguard/...`
- [ ] CI unit + functional + gitleaks