### PR TITLE
test: GuardFinding JSON round-trip coverage (RUN-801)

### DIFF
--- a/pkg/infra/plugins/trustguard/client_test.go
+++ b/pkg/infra/plugins/trustguard/client_test.go
@@ -130,6 +130,18 @@ func TestGuardDecodesResponses(t *testing.T) {
 			if len(resp.Findings) != tt.wantFindings {
 				t.Errorf("findings = %d, want %d", len(resp.Findings), tt.wantFindings)
 			}
+			if tt.name == "block verdict" {
+				f := resp.Findings[0]
+				if f.Source == nil || f.Source.Kind != "detector" || f.Source.Plugin != "data_loss_prevention" {
+					t.Errorf("finding source = %+v, want detector/data_loss_prevention", f.Source)
+				}
+				if f.Signal == nil || f.Signal.Type != "pii" || f.Signal.Confidence != 0.9 {
+					t.Errorf("finding signal = %+v, want type=pii confidence=0.9", f.Signal)
+				}
+				if f.Outcome == nil || f.Outcome.Action != "block" {
+					t.Errorf("finding outcome = %+v, want action=block", f.Outcome)
+				}
+			}
 			if resp.TraceID != tt.wantTraceID {
 				t.Errorf("trace_id = %q, want %q", resp.TraceID, tt.wantTraceID)
 			}

--- a/pkg/infra/plugins/trustguard/data.go
+++ b/pkg/infra/plugins/trustguard/data.go
@@ -80,7 +80,7 @@ type GuardFindingOutcome struct {
 	Action string `json:"action,omitempty"`
 }
 
-// GuardFinding is one TrustGuard finding in the v2 wire contract.
+// GuardFinding is one TrustGuard finding in the guard wire contract.
 type GuardFinding struct {
 	Source   *GuardFindingSource  `json:"source,omitempty"`
 	Signal   *GuardFindingSignal  `json:"signal,omitempty"`

--- a/pkg/infra/plugins/trustguard/data_test.go
+++ b/pkg/infra/plugins/trustguard/data_test.go
@@ -15,10 +15,45 @@
 package trustguard
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/NeuralTrust/TrustGate/pkg/domain/policy"
 )
+
+func TestGuardFindingJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	raw := `{"source":{"kind":"gate","gate_name":"max_tokens","policy_id":"pol-1"},"signal":{"type":"gate_block"},"outcome":{"action":"block"},"evidence":{"matched":"true"}}`
+	var f GuardFinding
+	if err := json.Unmarshal([]byte(raw), &f); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if f.Source == nil || f.Source.Kind != "gate" || f.Source.GateName != "max_tokens" || f.Source.PolicyID != "pol-1" {
+		t.Fatalf("source = %+v", f.Source)
+	}
+	if f.Signal == nil || f.Signal.Type != "gate_block" {
+		t.Fatalf("signal = %+v", f.Signal)
+	}
+	if f.Outcome == nil || f.Outcome.Action != "block" {
+		t.Fatalf("outcome = %+v", f.Outcome)
+	}
+	if f.Evidence["matched"] != "true" {
+		t.Fatalf("evidence = %+v", f.Evidence)
+	}
+
+	encoded, err := json.Marshal(f)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var again GuardFinding
+	if err := json.Unmarshal(encoded, &again); err != nil {
+		t.Fatalf("round-trip unmarshal: %v", err)
+	}
+	if again.Source == nil || again.Source.GateName != "max_tokens" {
+		t.Fatalf("round-trip source = %+v", again.Source)
+	}
+}
 
 func TestGuardOutcomeDecision(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary
Follow-up to merged #152. Test-only PR on infra HTTP DTOs (`pkg/infra/plugins/trustguard`).

- `TestGuardFindingJSONRoundTrip` — nested findings JSON decode/marshal
- `TestGuardDecodesResponses` — asserts source/signal/outcome on block verdict

Rebased on develop (no merge conflicts, no k8s image drift).

## Linear
RUN-801 — https://linear.app/neuraltrust/issue/RUN-801