### PR TITLE
feat(trustguard): MCP marker + MCP text-extraction branch (RUN-832 1/3)

### DIFF
--- a/pkg/infra/context/request_context.go
+++ b/pkg/infra/context/request_context.go
@@ -51,6 +51,9 @@ type RequestContext struct {
 	AllowedModels      []string
 	DefaultModel       string
 	RequestedModel     string
+	// MCP marks a native MCP tools/call payload so protocol-aware plugins
+	// inspect it via the MCP text path instead of the LLM canonical decoders.
+	MCP bool
 }
 
 // HeaderValue returns the first non-empty value of the named header, matched

--- a/pkg/infra/plugins/trustguard/mcp.go
+++ b/pkg/infra/plugins/trustguard/mcp.go
@@ -1,0 +1,119 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trustguard
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+)
+
+type mcpToolCall struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+type mcpToolResult struct {
+	Content []mcpContentBlock `json:"content"`
+	IsError bool              `json:"isError"`
+}
+
+type mcpContentBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// mcpInputText returns the tool name plus every string value flattened from the
+// arguments tree, newline-joined. It falls back to the raw arguments string when
+// the arguments are not decodable, and returns "" when nothing is inspectable.
+func mcpInputText(body []byte) string {
+	var call mcpToolCall
+	if err := json.Unmarshal(body, &call); err != nil {
+		return ""
+	}
+	parts := make([]string, 0, 4)
+	if name := strings.TrimSpace(call.Name); name != "" {
+		parts = append(parts, name)
+	}
+	parts = append(parts, flattenArgumentStrings(call.Arguments)...)
+	return strings.Join(parts, "\n")
+}
+
+// mcpOutputText concatenates the text of every text content block in a
+// CallToolResult, ignoring non-text blocks (image/audio/resource). The isError
+// flag does not change extraction. It returns "" when there is no text.
+func mcpOutputText(body []byte) string {
+	var result mcpToolResult
+	if err := json.Unmarshal(body, &result); err != nil {
+		return ""
+	}
+	parts := make([]string, 0, len(result.Content))
+	for _, block := range result.Content {
+		if !blockIsText(block) || strings.TrimSpace(block.Text) == "" {
+			continue
+		}
+		parts = append(parts, block.Text)
+	}
+	return strings.Join(parts, "\n")
+}
+
+// flattenArgumentStrings walks the decoded arguments value and collects string
+// leaves (recursing maps and arrays); numbers, bools and nulls are skipped. Map
+// keys are visited in sorted order for deterministic output. When arguments are
+// not valid JSON it returns the raw trimmed arguments so free-form input stays
+// inspectable.
+func flattenArgumentStrings(raw json.RawMessage) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	var decoded any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		if trimmed := strings.TrimSpace(string(raw)); trimmed != "" {
+			return []string{trimmed}
+		}
+		return nil
+	}
+	return collectStrings(decoded, nil)
+}
+
+func collectStrings(value any, acc []string) []string {
+	switch v := value.(type) {
+	case string:
+		if strings.TrimSpace(v) != "" {
+			acc = append(acc, v)
+		}
+	case map[string]any:
+		keys := make([]string, 0, len(v))
+		for k := range v {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			acc = collectStrings(v[k], acc)
+		}
+	case []any:
+		for _, item := range v {
+			acc = collectStrings(item, acc)
+		}
+	}
+	return acc
+}
+
+func blockIsText(block mcpContentBlock) bool {
+	if block.Type == "" {
+		return block.Text != ""
+	}
+	return block.Type == "text"
+}

--- a/pkg/infra/plugins/trustguard/mcp_test.go
+++ b/pkg/infra/plugins/trustguard/mcp_test.go
@@ -1,0 +1,169 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trustguard
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestMCPInputText(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "name and nested arguments",
+			body: `{"name":"search","arguments":{"query":"secret token","filters":{"lang":"en"},"tags":["a","b"],"limit":10,"safe":true}}`,
+			want: "search\nen\nsecret token\na\nb",
+		},
+		{
+			name: "arguments only",
+			body: `{"name":"","arguments":{"prompt":"hello"}}`,
+			want: "hello",
+		},
+		{
+			name: "name only with empty arguments",
+			body: `{"name":"ping","arguments":{}}`,
+			want: "ping",
+		},
+		{
+			name: "name only with no arguments field",
+			body: `{"name":"ping"}`,
+			want: "ping",
+		},
+		{
+			name: "undecodable arguments fall back to raw",
+			body: `{"name":"tool","arguments":"not-json"}`,
+			want: "tool\nnot-json",
+		},
+		{
+			name: "non-string leaves skipped",
+			body: `{"name":"calc","arguments":{"a":1,"b":2.5,"c":null,"d":false}}`,
+			want: "calc",
+		},
+		{
+			name: "empty body",
+			body: ``,
+			want: "",
+		},
+		{
+			name: "malformed body",
+			body: `{`,
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := mcpInputText([]byte(tc.body)); got != tc.want {
+				t.Fatalf("mcpInputText(%s) = %q, want %q", tc.body, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMCPOutputText(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "single text block",
+			body: `{"content":[{"type":"text","text":"hello"}],"isError":false}`,
+			want: "hello",
+		},
+		{
+			name: "multiple text blocks concatenated",
+			body: `{"content":[{"type":"text","text":"line one"},{"type":"text","text":"line two"}]}`,
+			want: "line one\nline two",
+		},
+		{
+			name: "isError true still extracts",
+			body: `{"content":[{"type":"text","text":"boom"}],"isError":true}`,
+			want: "boom",
+		},
+		{
+			name: "non-text blocks ignored",
+			body: `{"content":[{"type":"image","text":"ignored"},{"type":"resource"}]}`,
+			want: "",
+		},
+		{
+			name: "mixed text and non-text",
+			body: `{"content":[{"type":"image"},{"type":"text","text":"keep"}]}`,
+			want: "keep",
+		},
+		{
+			name: "empty content",
+			body: `{"content":[],"isError":false}`,
+			want: "",
+		},
+		{
+			name: "malformed json",
+			body: `{"content":`,
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := mcpOutputText([]byte(tc.body)); got != tc.want {
+				t.Fatalf("mcpOutputText(%s) = %q, want %q", tc.body, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFlattenArgumentStrings(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{name: "flat map sorted by key", raw: `{"b":"second","a":"first"}`, want: []string{"first", "second"}},
+		{name: "nested map", raw: `{"outer":{"inner":"deep"}}`, want: []string{"deep"}},
+		{name: "array of strings", raw: `["x","y","z"]`, want: []string{"x", "y", "z"}},
+		{name: "mixed types skip non-strings", raw: `{"s":"keep","n":42,"b":true,"z":null}`, want: []string{"keep"}},
+		{name: "empty object", raw: `{}`, want: nil},
+		{name: "empty raw", raw: ``, want: nil},
+		{name: "undecodable raw fallback", raw: `not-json`, want: []string{"not-json"}},
+		{name: "whitespace strings skipped", raw: `{"a":"  ","b":"real"}`, want: []string{"real"}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := flattenArgumentStrings(json.RawMessage(tc.raw))
+			if len(got) != len(tc.want) {
+				t.Fatalf("flattenArgumentStrings(%s) = %v, want %v", tc.raw, got, tc.want)
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Fatalf("flattenArgumentStrings(%s)[%d] = %q, want %q", tc.raw, i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}

--- a/pkg/infra/plugins/trustguard/plugin.go
+++ b/pkg/infra/plugins/trustguard/plugin.go
@@ -130,7 +130,11 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 		return passThrough(), nil
 	}
 
-	if in.Request == nil || p.registry == nil || in.Request.Provider == "" {
+	if in.Request == nil {
+		return passThrough(), nil
+	}
+	mcpMode := in.Request.MCP
+	if !mcpMode && (p.registry == nil || in.Request.Provider == "") {
 		return passThrough(), nil
 	}
 
@@ -149,39 +153,56 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 		return passThrough(), nil
 	}
 
-	format, err := adapter.ResolveAgentFormat(in.Request.Provider, in.Request.SourceFormat, nil)
-	if err != nil {
-		return passThrough(), nil
-	}
-
 	var text string
-	if direction == directionInput {
-		if len(in.Request.Body) == 0 {
-			return passThrough(), nil
+	if mcpMode {
+		if direction == directionInput {
+			if len(in.Request.Body) == 0 {
+				return passThrough(), nil
+			}
+			text = mcpInputText(in.Request.Body)
+		} else {
+			if in.Response == nil || in.Response.Streaming || len(in.Response.Body) == 0 {
+				return passThrough(), nil
+			}
+			text = mcpOutputText(in.Response.Body)
 		}
-		creq, decErr := p.registry.DecodeRequestFor(in.Request.Body, format)
-		if decErr != nil || creq == nil {
-			return passThrough(), nil
-		}
-		text = joinRequestText(creq)
 	} else {
-		if in.Response == nil || in.Response.Streaming || len(in.Response.Body) == 0 {
+		format, err := adapter.ResolveAgentFormat(in.Request.Provider, in.Request.SourceFormat, nil)
+		if err != nil {
 			return passThrough(), nil
 		}
-		cresp, decErr := p.registry.DecodeResponseFor(in.Response.Body, format)
-		if decErr != nil || cresp == nil {
-			return passThrough(), nil
+		if direction == directionInput {
+			if len(in.Request.Body) == 0 {
+				return passThrough(), nil
+			}
+			creq, decErr := p.registry.DecodeRequestFor(in.Request.Body, format)
+			if decErr != nil || creq == nil {
+				return passThrough(), nil
+			}
+			text = joinRequestText(creq)
+		} else {
+			if in.Response == nil || in.Response.Streaming || len(in.Response.Body) == 0 {
+				return passThrough(), nil
+			}
+			cresp, decErr := p.registry.DecodeResponseFor(in.Response.Body, format)
+			if decErr != nil || cresp == nil {
+				return passThrough(), nil
+			}
+			text = cresp.Content
 		}
-		text = cresp.Content
 	}
 	if strings.TrimSpace(text) == "" {
 		return passThrough(), nil
 	}
 
+	protocol := protocolFor(in.Request.ConsumerType)
+	if mcpMode {
+		protocol = protocolMCP
+	}
 	body := GuardRequest{
 		Payload:    GuardPayload{Input: text},
 		Direction:  direction,
-		Protocol:   protocolFor(in.Request.ConsumerType),
+		Protocol:   protocol,
 		GatewayID:  in.Request.GatewayID,
 		SessionID:  in.Request.SessionID,
 		ConsumerID: in.Request.ConsumerID,

--- a/pkg/infra/plugins/trustguard/plugin_test.go
+++ b/pkg/infra/plugins/trustguard/plugin_test.go
@@ -171,7 +171,7 @@ func TestExecutePreRequestBlockReturns403(t *testing.T) {
 	t.Parallel()
 
 	f := &fakeGuard{response: GuardResponse{
-		Status:    statusBlock,
+		Status: statusBlock,
 		Findings: []GuardFinding{{
 			Source:  &GuardFindingSource{Kind: "detector", Plugin: "prompt_guard"},
 			Signal:  &GuardFindingSignal{Type: "prompt_injection"},
@@ -668,6 +668,278 @@ func TestExecuteRetriesOnceOn401(t *testing.T) {
 	}
 	if got := atomic.LoadInt32(&tokenHits); got != 2 {
 		t.Fatalf("token hits = %d, want 2 (initial + refresh after 401)", got)
+	}
+}
+
+func mcpToolCallJSON() []byte {
+	return []byte(`{"name":"search","arguments":{"query":"find me"}}`)
+}
+
+func mcpResultJSON() []byte {
+	return []byte(`{"content":[{"type":"text","text":"the answer"}],"isError":false}`)
+}
+
+func mcpRequestContext() *infracontext.RequestContext {
+	return &infracontext.RequestContext{
+		MCP:          true,
+		ConsumerType: "MCP",
+		GatewayID:    "gw-test",
+		SessionID:    "sess-mcp",
+		ConsumerID:   "consumer-mcp",
+		Body:         mcpToolCallJSON(),
+	}
+}
+
+func TestExecuteMCPInputBlock(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: GuardResponse{Status: statusBlock, TraceID: "trace-mcp-in"}}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	in := execInput(policy.StagePreRequest, policy.ModeEnforce, settings(""), mcpRequestContext(), nil)
+	res, err := p.Execute(context.Background(), in)
+	if res != nil {
+		t.Fatalf("expected nil result on block, got %+v", res)
+	}
+	if _, ok := appplugins.AsPluginError(err); !ok {
+		t.Fatalf("expected *PluginError, got %v", err)
+	}
+	got := f.captured()
+	if got.Protocol != protocolMCP {
+		t.Fatalf("protocol = %q, want %q", got.Protocol, protocolMCP)
+	}
+	if got.Direction != directionInput {
+		t.Fatalf("direction = %q, want %q", got.Direction, directionInput)
+	}
+	if got.Attributes.Model.Provider != "" {
+		t.Fatalf("provider = %q, want empty", got.Attributes.Model.Provider)
+	}
+	if got.Payload.Input != "search\nfind me" {
+		t.Fatalf("input = %q, want %q", got.Payload.Input, "search\nfind me")
+	}
+}
+
+func TestExecuteMCPInputObservePassesThrough(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: GuardResponse{Status: statusBlock, TraceID: "trace-mcp-obs"}}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	event, span := newEvent()
+	in := execInputWithEvent(policy.StagePreRequest, policy.ModeObserve, settings(""), mcpRequestContext(), nil, event)
+	res, err := p.Execute(context.Background(), in)
+	if err != nil {
+		t.Fatalf("observe mode must not error, got %v", err)
+	}
+	if res == nil || res.StatusCode != http.StatusOK || res.StopUpstream {
+		t.Fatalf("expected pass-through in observe mode, got %+v", res)
+	}
+	if attrs := span.PluginAttrsCopy(); attrs.Decision != decisionReported {
+		t.Fatalf("decision = %q, want %q", attrs.Decision, decisionReported)
+	}
+}
+
+func TestExecuteMCPOutputBlock(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: GuardResponse{Status: statusBlock, TraceID: "trace-mcp-out"}}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	resp := &infracontext.ResponseContext{StatusCode: 200, Body: mcpResultJSON()}
+	in := execInput(policy.StagePreResponse, policy.ModeEnforce, settings(""), mcpRequestContext(), resp)
+	res, err := p.Execute(context.Background(), in)
+	if res != nil {
+		t.Fatalf("expected nil result on block, got %+v", res)
+	}
+	if _, ok := appplugins.AsPluginError(err); !ok {
+		t.Fatalf("expected *PluginError, got %v", err)
+	}
+	got := f.captured()
+	if got.Direction != directionOutput {
+		t.Fatalf("direction = %q, want %q", got.Direction, directionOutput)
+	}
+	if got.Protocol != protocolMCP {
+		t.Fatalf("protocol = %q, want %q", got.Protocol, protocolMCP)
+	}
+	if got.Payload.Input != "the answer" {
+		t.Fatalf("input = %q, want %q", got.Payload.Input, "the answer")
+	}
+}
+
+func TestExecuteMCPOutputReportPassesThrough(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: GuardResponse{Status: statusReport, TraceID: "trace-mcp-rep"}}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	event, span := newEvent()
+	resp := &infracontext.ResponseContext{StatusCode: 200, Body: mcpResultJSON()}
+	in := execInputWithEvent(policy.StagePreResponse, policy.ModeEnforce, settings(""), mcpRequestContext(), resp, event)
+	res, err := p.Execute(context.Background(), in)
+	if err != nil {
+		t.Fatalf("report mode must not error, got %v", err)
+	}
+	if res == nil || res.StatusCode != http.StatusOK {
+		t.Fatalf("expected pass-through, got %+v", res)
+	}
+	if attrs := span.PluginAttrsCopy(); attrs.Decision != decisionReported {
+		t.Fatalf("decision = %q, want %q", attrs.Decision, decisionReported)
+	}
+}
+
+func TestExecuteMCPProtocolFromMarkerIgnoresConsumerType(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: GuardResponse{Status: statusReport, TraceID: "trace-mcp-proto"}}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	req := mcpRequestContext()
+	req.ConsumerType = ""
+	in := execInput(policy.StagePreRequest, policy.ModeEnforce, settings(""), req, nil)
+	if _, err := p.Execute(context.Background(), in); err != nil {
+		t.Fatalf("report mode must not error, got %v", err)
+	}
+	if got := f.captured(); got.Protocol != protocolMCP {
+		t.Fatalf("protocol = %q, want %q", got.Protocol, protocolMCP)
+	}
+}
+
+func TestExecuteMCPInputBlockWithNilRegistry(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: GuardResponse{Status: statusBlock, TraceID: "trace-mcp-nilreg"}}
+	srv := newServer(t, f)
+	p := New(nil, srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	in := execInput(policy.StagePreRequest, policy.ModeEnforce, settings(""), mcpRequestContext(), nil)
+	res, err := p.Execute(context.Background(), in)
+	if res != nil {
+		t.Fatalf("expected nil result on block, got %+v", res)
+	}
+	if _, ok := appplugins.AsPluginError(err); !ok {
+		t.Fatalf("expected *PluginError, got %v", err)
+	}
+	if got := f.captured(); got.Payload.Input != "search\nfind me" {
+		t.Fatalf("input = %q, want %q", got.Payload.Input, "search\nfind me")
+	}
+}
+
+func TestExecuteMCPOutputStreamingPassesThrough(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: GuardResponse{Status: statusBlock}}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	resp := &infracontext.ResponseContext{StatusCode: 200, Streaming: true, Body: mcpResultJSON()}
+	in := execInput(policy.StagePreResponse, policy.ModeEnforce, settings(""), mcpRequestContext(), resp)
+	res, err := p.Execute(context.Background(), in)
+	if err != nil {
+		t.Fatalf("streaming must not error, got %v", err)
+	}
+	if res == nil || res.StatusCode != http.StatusOK {
+		t.Fatalf("expected pass-through for streaming, got %+v", res)
+	}
+	if f.count() != 0 {
+		t.Fatalf("guard must not be called for streaming, got %d calls", f.count())
+	}
+}
+
+func TestExecuteMCPMissingGatewayIDFailsOpen(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: GuardResponse{Status: statusBlock}}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	req := mcpRequestContext()
+	req.GatewayID = ""
+	in := execInput(policy.StagePreRequest, policy.ModeEnforce, settings(""), req, nil)
+	res, err := p.Execute(context.Background(), in)
+	if err != nil {
+		t.Fatalf("expected fail-open pass, got error %v", err)
+	}
+	if res == nil || res.StatusCode != http.StatusOK || res.StopUpstream {
+		t.Fatalf("expected pass-through on missing gateway id, got %+v", res)
+	}
+	if f.count() != 0 {
+		t.Fatalf("expected no guard call when gateway id missing, got %d hits", f.count())
+	}
+}
+
+func TestExecuteMCPGuardErrorFailsOpen(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{status: http.StatusInternalServerError, response: GuardResponse{Status: statusBlock}}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	event, span := newEvent()
+	in := execInputWithEvent(policy.StagePreRequest, policy.ModeEnforce, settings(""), mcpRequestContext(), nil, event)
+	res, err := p.Execute(context.Background(), in)
+	if err != nil {
+		t.Fatalf("expected fail-open pass, got error %v", err)
+	}
+	if res == nil || res.StatusCode != http.StatusOK || res.StopUpstream {
+		t.Fatalf("expected pass-through on guard error, got %+v", res)
+	}
+	attrs := span.PluginAttrsCopy()
+	extras, ok := attrs.Extras.(guardData)
+	if !ok {
+		t.Fatalf("extras type = %T, want guardData", attrs.Extras)
+	}
+	if !extras.FailedOpen || extras.Decision != decisionFailedOpen {
+		t.Fatalf("extras = %+v, want failed_open decision", extras)
+	}
+}
+
+func TestExecuteMCPEmptyExtractedTextPassesThrough(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: GuardResponse{Status: statusBlock}}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	req := mcpRequestContext()
+	req.Body = []byte(`{"name":"","arguments":{}}`)
+	in := execInput(policy.StagePreRequest, policy.ModeEnforce, settings(""), req, nil)
+	res, err := p.Execute(context.Background(), in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res == nil || res.StatusCode != http.StatusOK {
+		t.Fatalf("expected pass-through, got %+v", res)
+	}
+	if f.count() != 0 {
+		t.Fatalf("expected guard not called for empty text, got %d hits", f.count())
+	}
+}
+
+func TestExecuteMarkerOffWithoutProviderPassesThrough(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: GuardResponse{Status: statusBlock}}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	req := mcpRequestContext()
+	req.MCP = false
+	req.Provider = ""
+	in := execInput(policy.StagePreRequest, policy.ModeEnforce, settings(""), req, nil)
+	res, err := p.Execute(context.Background(), in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res == nil || res.StatusCode != http.StatusOK {
+		t.Fatalf("expected pass-through when marker off and provider empty, got %+v", res)
+	}
+	if f.count() != 0 {
+		t.Fatalf("expected guard not called on LLM gate, got %d hits", f.count())
 	}
 }
 


### PR DESCRIPTION
## Summary

Part **1/3** of [RUN-832](https://linear.app/neuraltrust/issue/RUN-832) — run the plugin chain (TrustGuard) on the native MCP endpoint.

This slice makes TrustGuard able to inspect MCP `tools/call` content, but stays **inert** (nothing sets the marker yet).

- Adds a dormant `RequestContext.MCP bool` marker (survives the executor's request isolation).
- Adds a TrustGuard MCP text-extraction branch: input = tool name + flattened `tools/call` arguments; output = concatenated `CallToolResult` `content[].text`; bypasses the LLM canonical decoders. Forces `protocol=mcp` when the marker is set.
- Restructures the `Provider==""` gate so MCP no longer short-circuits, while the LLM path is byte-for-byte unchanged.

## Stack (chained PRs)

1. **This PR** → `develop`
2. `feat(mcp): app-layer plugin runner` → this branch
3. `feat(mcp): wire plugin chain into tools/call` → PR 2

## Test plan

- [x] `go build ./...`, `go vet`, `golangci-lint` clean
- [x] `go test ./pkg/infra/plugins/trustguard/... ./pkg/infra/context/... -race`
- [x] LLM path regression test (`TestExecuteMarkerOffWithoutProviderPassesThrough`)

Made with [Cursor](https://cursor.com)