### PR TITLE
feat(mcp): app-layer plugin runner for tools/call (RUN-832 2/3)

### DIFF
--- a/pkg/app/mcp/plugin_runner.go
+++ b/pkg/app/mcp/plugin_runner.go
@@ -1,0 +1,188 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	appconsumer "github.com/NeuralTrust/TrustGate/pkg/app/consumer"
+	appplugins "github.com/NeuralTrust/TrustGate/pkg/app/plugins"
+	"github.com/NeuralTrust/TrustGate/pkg/domain/policy"
+	infracontext "github.com/NeuralTrust/TrustGate/pkg/infra/context"
+)
+
+// codePolicyBlocked is a server-defined JSON-RPC error code (in the reserved
+// -32000..-32099 range) used when the plugin chain blocks a tools/call;
+// -32002 and -32003 are already used elsewhere in the MCP handler.
+const codePolicyBlocked int64 = -32001
+
+const (
+	directionInput  = "input"
+	directionOutput = "output"
+)
+
+// PluginRunner runs the resolved plugin chain on the native MCP tools/call
+// path, mirroring pkg/app/proxy for the LLM path. It is a thin adapter over the
+// shared plugins.Executor: it builds stage contexts from JSON-RPC values and
+// maps a plugin block to a JSON-RPC error.
+type PluginRunner struct {
+	executor appplugins.Executor
+	logger   *slog.Logger
+}
+
+// NewPluginRunner accepts the shared executor port; a nil executor makes every
+// method a no-op (plugin-free parity with today's MCP path).
+func NewPluginRunner(executor appplugins.Executor, logger *slog.Logger) *PluginRunner {
+	return &PluginRunner{executor: executor, logger: logger}
+}
+
+type mcpToolCallParams struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments,omitempty"`
+}
+
+// PreRequest runs StagePreRequest over the tools/call params. It returns nil to
+// allow the call; a non-nil *RPCError means a policy blocked it (caller skips the
+// upstream dial and writes the error). Per RUN-832 the call fails open on any
+// non-block error (guard unavailable, decode failure): it is logged and nil is
+// returned so the tools/call proceeds.
+func (r *PluginRunner) PreRequest(
+	ctx context.Context,
+	rc *appconsumer.RoutableConsumer,
+	name string,
+	arguments json.RawMessage,
+) error {
+	if r.executor == nil || rc == nil || rc.Consumer == nil {
+		return nil
+	}
+	reqCtx, err := r.buildRequestContext(ctx, rc, name, arguments)
+	if err != nil {
+		r.logFailOpen(rc, policy.StagePreRequest, directionInput, err)
+		return nil
+	}
+	outcome, err := r.executor.RunStage(ctx, appplugins.StageInput{
+		Stage:    policy.StagePreRequest,
+		Policies: rc.Policies,
+		Plan:     rc.PolicyPlan,
+		Request:  reqCtx,
+	})
+	if err != nil {
+		if pe, ok := appplugins.AsPluginError(err); ok {
+			return blockToRPCError(pe)
+		}
+		r.logFailOpen(rc, policy.StagePreRequest, directionInput, err)
+		return nil
+	}
+	if outcome != nil && outcome.ShortCircuit {
+		return blockToRPCError(&appplugins.PluginError{
+			StatusCode: outcome.StatusCode,
+			Message:    "request blocked by policy",
+			Body:       outcome.Body,
+		})
+	}
+	return nil
+}
+
+// PreResponse runs StagePreResponse over the tool result. It returns nil to keep
+// the original result; a non-nil *RPCError means the response is blocked (caller
+// discards the result and writes the error). Per RUN-832 the call fails open on
+// any non-block error in this direction too: it is logged and the original
+// result is kept.
+func (r *PluginRunner) PreResponse(
+	ctx context.Context,
+	rc *appconsumer.RoutableConsumer,
+	name string,
+	arguments json.RawMessage,
+	result json.RawMessage,
+) error {
+	if r.executor == nil || rc == nil || rc.Consumer == nil {
+		return nil
+	}
+	reqCtx, err := r.buildRequestContext(ctx, rc, name, arguments)
+	if err != nil {
+		r.logFailOpen(rc, policy.StagePreResponse, directionOutput, err)
+		return nil
+	}
+	respCtx := &infracontext.ResponseContext{
+		Context:   ctx,
+		GatewayID: rc.Consumer.GatewayID.String(),
+		Body:      result,
+		Streaming: false,
+	}
+	if _, err := r.executor.RunStage(ctx, appplugins.StageInput{
+		Stage:    policy.StagePreResponse,
+		Policies: rc.Policies,
+		Plan:     rc.PolicyPlan,
+		Request:  reqCtx,
+		Response: respCtx,
+	}); err != nil {
+		if pe, ok := appplugins.AsPluginError(err); ok {
+			return blockToRPCError(pe)
+		}
+		r.logFailOpen(rc, policy.StagePreResponse, directionOutput, err)
+	}
+	return nil
+}
+
+// logFailOpen records a guard/plugin failure that the runner deliberately does
+// not surface. RUN-832 requires a tools/call to proceed on guard errors in both
+// directions; only ids and outcome are logged, never tool payloads.
+func (r *PluginRunner) logFailOpen(rc *appconsumer.RoutableConsumer, stage policy.Stage, direction string, err error) {
+	if r.logger == nil {
+		return
+	}
+	r.logger.Warn("mcp plugin stage failed, failing open",
+		slog.String("stage", string(stage)),
+		slog.String("direction", direction),
+		slog.String("outcome", "failed_open"),
+		slog.String("gateway_id", rc.Consumer.GatewayID.String()),
+		slog.String("error", err.Error()),
+	)
+}
+
+func (r *PluginRunner) buildRequestContext(
+	ctx context.Context,
+	rc *appconsumer.RoutableConsumer,
+	name string,
+	arguments json.RawMessage,
+) (*infracontext.RequestContext, error) {
+	body, err := json.Marshal(mcpToolCallParams{Name: name, Arguments: arguments})
+	if err != nil {
+		return nil, fmt.Errorf("mcp: marshal tools/call params: %w", err)
+	}
+	return &infracontext.RequestContext{
+		Context:        ctx,
+		GatewayID:      rc.Consumer.GatewayID.String(),
+		ConsumerID:     rc.Consumer.ID.String(),
+		ConsumerType:   string(rc.Consumer.Type),
+		SessionID:      "",
+		Provider:       "",
+		SourceFormat:   "",
+		RequestedModel: "",
+		MCP:            true,
+		Body:           body,
+	}, nil
+}
+
+func blockToRPCError(pe *appplugins.PluginError) *RPCError {
+	return &RPCError{
+		Code:    codePolicyBlocked,
+		Message: pe.Message,
+		Data:    pe.Body,
+	}
+}

--- a/pkg/app/mcp/plugin_runner.go
+++ b/pkg/app/mcp/plugin_runner.go
@@ -124,17 +124,26 @@ func (r *PluginRunner) PreResponse(
 		Body:      result,
 		Streaming: false,
 	}
-	if _, err := r.executor.RunStage(ctx, appplugins.StageInput{
+	outcome, err := r.executor.RunStage(ctx, appplugins.StageInput{
 		Stage:    policy.StagePreResponse,
 		Policies: rc.Policies,
 		Plan:     rc.PolicyPlan,
 		Request:  reqCtx,
 		Response: respCtx,
-	}); err != nil {
+	})
+	if err != nil {
 		if pe, ok := appplugins.AsPluginError(err); ok {
 			return blockToRPCError(pe)
 		}
 		r.logFailOpen(rc, policy.StagePreResponse, directionOutput, err)
+		return nil
+	}
+	if outcome != nil && outcome.ShortCircuit {
+		return blockToRPCError(&appplugins.PluginError{
+			StatusCode: outcome.StatusCode,
+			Message:    "response blocked by policy",
+			Body:       outcome.Body,
+		})
 	}
 	return nil
 }

--- a/pkg/app/mcp/plugin_runner_test.go
+++ b/pkg/app/mcp/plugin_runner_test.go
@@ -1,0 +1,243 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	appconsumer "github.com/NeuralTrust/TrustGate/pkg/app/consumer"
+	appplugins "github.com/NeuralTrust/TrustGate/pkg/app/plugins"
+	pluginmocks "github.com/NeuralTrust/TrustGate/pkg/app/plugins/mocks"
+	consumerdomain "github.com/NeuralTrust/TrustGate/pkg/domain/consumer"
+	policydomain "github.com/NeuralTrust/TrustGate/pkg/domain/policy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testToolName = "search"
+	testToolArgs = `{"q":"hello"}`
+	testResult   = `{"content":[{"type":"text","text":"world"}]}`
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func routableMCPConsumer(policies ...*policydomain.Policy) *appconsumer.RoutableConsumer {
+	return &appconsumer.RoutableConsumer{
+		Consumer: &consumerdomain.Consumer{Type: consumerdomain.TypeMCP},
+		Policies: policies,
+	}
+}
+
+func preResponsePolicy(stages ...policydomain.Stage) *policydomain.Policy {
+	return &policydomain.Policy{
+		Enabled: true,
+		Mode:    policydomain.ModeEnforce,
+		Stages:  stages,
+	}
+}
+
+func TestPluginRunner_PreRequest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		outcome     *appplugins.StageOutcome
+		execErr     error
+		wantRPCCode int64
+		wantRPCData string
+		wantNil     bool
+	}{
+		{
+			name:    "allow",
+			outcome: &appplugins.StageOutcome{},
+			wantNil: true,
+		},
+		{
+			name:    "report does not block",
+			outcome: &appplugins.StageOutcome{ShortCircuit: false},
+			wantNil: true,
+		},
+		{
+			name:        "enforce block via plugin error",
+			execErr:     &appplugins.PluginError{StatusCode: 403, Message: "blocked", Body: []byte(`{"trace_id":"t1"}`)},
+			wantRPCCode: codePolicyBlocked,
+			wantRPCData: `{"trace_id":"t1"}`,
+		},
+		{
+			name:        "enforce block via short circuit",
+			outcome:     &appplugins.StageOutcome{ShortCircuit: true, StatusCode: 403, Body: []byte(`{"trace_id":"t2"}`)},
+			wantRPCCode: codePolicyBlocked,
+			wantRPCData: `{"trace_id":"t2"}`,
+		},
+		{
+			name:    "generic executor error fails open",
+			execErr: errors.New("boom"),
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			exec := pluginmocks.NewExecutor(t)
+			var captured appplugins.StageInput
+			exec.EXPECT().RunStage(mock.Anything, mock.Anything).
+				Run(func(_ context.Context, in appplugins.StageInput) { captured = in }).
+				Return(tt.outcome, tt.execErr)
+
+			rc := routableMCPConsumer(preResponsePolicy(policydomain.StagePreRequest))
+			runner := NewPluginRunner(exec, discardLogger())
+
+			err := runner.PreRequest(context.Background(), rc, testToolName, json.RawMessage(testToolArgs))
+
+			assertStageInput(t, captured, policydomain.StagePreRequest, rc)
+			assert.Nil(t, captured.Response)
+
+			switch {
+			case tt.wantNil:
+				require.NoError(t, err)
+			case tt.wantRPCCode != 0:
+				assertRPCError(t, err, tt.wantRPCCode, tt.wantRPCData)
+			}
+		})
+	}
+}
+
+func TestPluginRunner_PreResponse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		plan        []policydomain.Stage
+		execErr     error
+		wantRPCCode int64
+		wantRPCData string
+		wantNil     bool
+	}{
+		{
+			name:    "allow",
+			plan:    []policydomain.Stage{policydomain.StagePreResponse},
+			wantNil: true,
+		},
+		{
+			name:    "report does not block",
+			plan:    []policydomain.Stage{policydomain.StagePreResponse},
+			wantNil: true,
+		},
+		{
+			name:        "enforce block via plugin error",
+			plan:        []policydomain.Stage{policydomain.StagePreResponse},
+			execErr:     &appplugins.PluginError{StatusCode: 403, Message: "blocked", Body: []byte(`{"trace_id":"t3"}`)},
+			wantRPCCode: codePolicyBlocked,
+			wantRPCData: `{"trace_id":"t3"}`,
+		},
+		{
+			name:    "generic error fails open even when plan blocks pre_response",
+			plan:    []policydomain.Stage{policydomain.StagePreResponse},
+			execErr: errors.New("guard down"),
+			wantNil: true,
+		},
+		{
+			name:    "generic error fails open when plan does not block",
+			plan:    []policydomain.Stage{policydomain.StagePreRequest},
+			execErr: errors.New("guard down"),
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			exec := pluginmocks.NewExecutor(t)
+			var captured appplugins.StageInput
+			exec.EXPECT().RunStage(mock.Anything, mock.Anything).
+				Run(func(_ context.Context, in appplugins.StageInput) { captured = in }).
+				Return(&appplugins.StageOutcome{}, tt.execErr)
+
+			rc := routableMCPConsumer(preResponsePolicy(tt.plan...))
+			runner := NewPluginRunner(exec, discardLogger())
+
+			err := runner.PreResponse(
+				context.Background(),
+				rc,
+				testToolName,
+				json.RawMessage(testToolArgs),
+				json.RawMessage(testResult),
+			)
+
+			assertStageInput(t, captured, policydomain.StagePreResponse, rc)
+			require.NotNil(t, captured.Response)
+			assert.False(t, captured.Response.Streaming)
+			assert.JSONEq(t, testResult, string(captured.Response.Body))
+
+			switch {
+			case tt.wantNil:
+				require.NoError(t, err)
+			case tt.wantRPCCode != 0:
+				assertRPCError(t, err, tt.wantRPCCode, tt.wantRPCData)
+			}
+		})
+	}
+}
+
+func TestPluginRunner_NilExecutor(t *testing.T) {
+	t.Parallel()
+
+	runner := NewPluginRunner(nil, discardLogger())
+	rc := routableMCPConsumer()
+
+	require.NoError(t, runner.PreRequest(context.Background(), rc, testToolName, json.RawMessage(testToolArgs)))
+	require.NoError(t, runner.PreResponse(
+		context.Background(), rc, testToolName, json.RawMessage(testToolArgs), json.RawMessage(testResult),
+	))
+}
+
+func assertStageInput(t *testing.T, in appplugins.StageInput, stage policydomain.Stage, rc *appconsumer.RoutableConsumer) {
+	t.Helper()
+	assert.Equal(t, stage, in.Stage)
+	assert.Equal(t, rc.Policies, in.Policies)
+	assert.Equal(t, rc.PolicyPlan, in.Plan)
+	require.NotNil(t, in.Request)
+	assert.True(t, in.Request.MCP)
+	assert.Equal(t, "MCP", in.Request.ConsumerType)
+	assert.Equal(t, rc.Consumer.GatewayID.String(), in.Request.GatewayID)
+	assert.Equal(t, rc.Consumer.ID.String(), in.Request.ConsumerID)
+	assert.Empty(t, in.Request.Provider)
+	assert.Empty(t, in.Request.SessionID)
+	assert.JSONEq(t, `{"name":"`+testToolName+`","arguments":`+testToolArgs+`}`, string(in.Request.Body))
+}
+
+func assertRPCError(t *testing.T, err error, code int64, data string) {
+	t.Helper()
+	var rpcErr *RPCError
+	require.True(t, errors.As(err, &rpcErr), "expected *RPCError, got %v", err)
+	assert.Equal(t, code, rpcErr.Code)
+	if data != "" {
+		assert.JSONEq(t, data, string(rpcErr.Data))
+	}
+}

--- a/pkg/app/mcp/plugin_runner_test.go
+++ b/pkg/app/mcp/plugin_runner_test.go
@@ -132,6 +132,7 @@ func TestPluginRunner_PreResponse(t *testing.T) {
 	tests := []struct {
 		name        string
 		plan        []policydomain.Stage
+		outcome     *appplugins.StageOutcome
 		execErr     error
 		wantRPCCode int64
 		wantRPCData string
@@ -155,6 +156,13 @@ func TestPluginRunner_PreResponse(t *testing.T) {
 			wantRPCData: `{"trace_id":"t3"}`,
 		},
 		{
+			name:        "enforce block via short circuit",
+			plan:        []policydomain.Stage{policydomain.StagePreResponse},
+			outcome:     &appplugins.StageOutcome{ShortCircuit: true, StatusCode: 403, Body: []byte(`{"trace_id":"t4"}`)},
+			wantRPCCode: codePolicyBlocked,
+			wantRPCData: `{"trace_id":"t4"}`,
+		},
+		{
 			name:    "generic error fails open even when plan blocks pre_response",
 			plan:    []policydomain.Stage{policydomain.StagePreResponse},
 			execErr: errors.New("guard down"),
@@ -175,9 +183,13 @@ func TestPluginRunner_PreResponse(t *testing.T) {
 
 			exec := pluginmocks.NewExecutor(t)
 			var captured appplugins.StageInput
+			outcome := tt.outcome
+			if outcome == nil {
+				outcome = &appplugins.StageOutcome{}
+			}
 			exec.EXPECT().RunStage(mock.Anything, mock.Anything).
 				Run(func(_ context.Context, in appplugins.StageInput) { captured = in }).
-				Return(&appplugins.StageOutcome{}, tt.execErr)
+				Return(outcome, tt.execErr)
 
 			rc := routableMCPConsumer(preResponsePolicy(tt.plan...))
 			runner := NewPluginRunner(exec, discardLogger())


### PR DESCRIPTION
## Summary

Part **2/3** of [RUN-832](https://linear.app/neuraltrust/issue/RUN-832). Stacked on PR #156.

Adds the app-layer `mcp.PluginRunner` that runs the resolved plugin chain (via the shared `appplugins.Executor`) on the MCP `tools/call` path in both directions, using the consumer's `Policies`/`PolicyPlan`. Not yet invoked by the dispatcher (that is PR 3/3), so the feature stays inert.

- `PreRequest` (params) and `PreResponse` (tool result) delegate to the shared executor; sets the P1 `MCP` marker.
- Policy block → JSON-RPC error `-32001` (`RPCError`); a `ShortCircuit` outcome blocks in both directions.
- **Fail-open in both directions** on guard/plugin errors (per RUN-832 spec — intentional divergence from the LLM proxy's fail-closed-on-enforce-PreResponse); logs ids/direction/outcome only, never payloads.
- Nil executor makes the runner a no-op.

## Stack

1. `feat(trustguard): MCP marker + extraction` → `develop` (#156)
2. **This PR** → PR #156
3. `feat(mcp): wire plugin chain into tools/call` → this branch

## Test plan

- [x] `go build ./...`, `go vet`, `golangci-lint` clean
- [x] `go test ./pkg/app/mcp/... -race` — both directions × {allow, report, enforce block via PluginError + short-circuit, fail-open on generic error, nil executor}

Made with [Cursor](https://cursor.com)