### PR TITLE
feat(mcp): run plugin chain (TrustGuard) on native MCP tools/call endpoint (RUN-832)

### DIFF
--- a/pkg/api/handler/http/mcp/mcp_handler_test.go
+++ b/pkg/api/handler/http/mcp/mcp_handler_test.go
@@ -17,6 +17,7 @@ package mcp_test
 import (
 	"encoding/json"
 	"io"
+	"log/slog"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -35,6 +36,15 @@ import (
 const mcpPath = "/virtual/mcp"
 
 func newApp(t *testing.T, composer appmcp.Composer, consumerType consumerdomain.Type, authorized bool) *fiber.App {
+	t.Helper()
+	return newAppWithRunner(t, composer, noopRunner(), consumerType, authorized)
+}
+
+func noopRunner() *appmcp.PluginRunner {
+	return appmcp.NewPluginRunner(nil, discardLogger())
+}
+
+func newAppWithRunner(t *testing.T, composer appmcp.Composer, plugins *appmcp.PluginRunner, consumerType consumerdomain.Type, authorized bool) *fiber.App {
 	t.Helper()
 	authID := ids.New[ids.AuthKind]()
 	gwID := ids.New[ids.GatewayKind]()
@@ -58,10 +68,14 @@ func newApp(t *testing.T, composer appmcp.Composer, consumerType consumerdomain.
 		c.SetUserContext(ctx)
 		return c.Next()
 	})
-	handler := mcphttp.NewHandler(mcphttp.NewRPCGateway(composer), appmcp.NewRoleScoper(approle.NewOIDCResolver()))
+	handler := mcphttp.NewHandler(mcphttp.NewRPCGateway(composer, plugins), appmcp.NewRoleScoper(approle.NewOIDCResolver()))
 	app.Post(mcpPath, handler.Handle)
 	app.Get(mcpPath, handler.MethodNotAllowed)
 	return app
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
 func rpcCall(t *testing.T, app *fiber.App, body string) (int, map[string]any) {

--- a/pkg/api/handler/http/mcp/rpc_dispatcher.go
+++ b/pkg/api/handler/http/mcp/rpc_dispatcher.go
@@ -35,10 +35,11 @@ func (e *InvalidParamsError) Error() string { return "mcp: invalid params: " + e
 
 type RPCGateway struct {
 	composer appmcp.Composer
+	plugins  *appmcp.PluginRunner
 }
 
-func NewRPCGateway(composer appmcp.Composer) *RPCGateway {
-	return &RPCGateway{composer: composer}
+func NewRPCGateway(composer appmcp.Composer, plugins *appmcp.PluginRunner) *RPCGateway {
+	return &RPCGateway{composer: composer, plugins: plugins}
 }
 
 func (g *RPCGateway) Dispatch(ctx context.Context, rc *appconsumer.RoutableConsumer, method string, params json.RawMessage) (any, error) {
@@ -133,7 +134,17 @@ func (g *RPCGateway) dispatch(ctx context.Context, rc *appconsumer.RoutableConsu
 		if err := json.Unmarshal(params, &p); err != nil || p.Name == "" {
 			return nil, &InvalidParamsError{Reason: "tools/call requires params.name"}
 		}
-		return g.composer.CallTool(ctx, rc, p.Name, p.Arguments)
+		if err := g.plugins.PreRequest(ctx, rc, p.Name, p.Arguments); err != nil {
+			return nil, err
+		}
+		result, err := g.composer.CallTool(ctx, rc, p.Name, p.Arguments)
+		if err != nil {
+			return nil, err
+		}
+		if err := g.plugins.PreResponse(ctx, rc, p.Name, p.Arguments, result); err != nil {
+			return nil, err
+		}
+		return result, nil
 	case "resources/list":
 		resources, err := g.composer.ListResources(ctx, rc)
 		if err != nil {

--- a/pkg/api/handler/http/mcp/rpc_dispatcher_span_test.go
+++ b/pkg/api/handler/http/mcp/rpc_dispatcher_span_test.go
@@ -40,7 +40,7 @@ func TestRPCGateway_Dispatch_RecordsToolSpan(t *testing.T) {
 	rt := trace.New("t-1", trace.Metadata{Kind: events.KindMCP})
 	ctx := trace.NewContext(context.Background(), rt)
 
-	g := mcphttp.NewRPCGateway(composer)
+	g := mcphttp.NewRPCGateway(composer, noopRunner())
 	_, err := g.Dispatch(ctx, &appconsumer.RoutableConsumer{}, "tools/call", json.RawMessage(`{"name":"echo"}`))
 	require.NoError(t, err)
 
@@ -65,7 +65,7 @@ func TestRPCGateway_Dispatch_RecordsErrorStatus(t *testing.T) {
 	rt := trace.New("t-2", trace.Metadata{Kind: events.KindMCP})
 	ctx := trace.NewContext(context.Background(), rt)
 
-	g := mcphttp.NewRPCGateway(composer)
+	g := mcphttp.NewRPCGateway(composer, noopRunner())
 	_, err := g.Dispatch(ctx, &appconsumer.RoutableConsumer{}, "tools/list", nil)
 	require.Error(t, err)
 

--- a/pkg/api/handler/http/mcp/rpc_dispatcher_test.go
+++ b/pkg/api/handler/http/mcp/rpc_dispatcher_test.go
@@ -22,8 +22,16 @@ import (
 
 	mcphttp "github.com/NeuralTrust/TrustGate/pkg/api/handler/http/mcp"
 	appconsumer "github.com/NeuralTrust/TrustGate/pkg/app/consumer"
+	appmcp "github.com/NeuralTrust/TrustGate/pkg/app/mcp"
 	"github.com/NeuralTrust/TrustGate/pkg/app/mcp/mocks"
+	appplugins "github.com/NeuralTrust/TrustGate/pkg/app/plugins"
+	pluginmocks "github.com/NeuralTrust/TrustGate/pkg/app/plugins/mocks"
+	consumerdomain "github.com/NeuralTrust/TrustGate/pkg/domain/consumer"
+	policydomain "github.com/NeuralTrust/TrustGate/pkg/domain/policy"
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRPCGateway_ToolsList_DefaultsToEmptySlice(t *testing.T) {
@@ -31,7 +39,7 @@ func TestRPCGateway_ToolsList_DefaultsToEmptySlice(t *testing.T) {
 	composer := mocks.NewComposer(t)
 	composer.EXPECT().ListTools(mock.Anything, mock.Anything).Return(nil, nil).Once()
 
-	g := mcphttp.NewRPCGateway(composer)
+	g := mcphttp.NewRPCGateway(composer, noopRunner())
 	res, err := g.Dispatch(context.Background(), &appconsumer.RoutableConsumer{}, "tools/list", nil)
 	if err != nil {
 		t.Fatalf("Dispatch: %v", err)
@@ -44,7 +52,7 @@ func TestRPCGateway_ToolsList_DefaultsToEmptySlice(t *testing.T) {
 
 func TestRPCGateway_ToolsCall_RequiresName(t *testing.T) {
 	t.Parallel()
-	g := mcphttp.NewRPCGateway(mocks.NewComposer(t))
+	g := mcphttp.NewRPCGateway(mocks.NewComposer(t), noopRunner())
 	_, err := g.Dispatch(context.Background(), &appconsumer.RoutableConsumer{}, "tools/call", json.RawMessage(`{}`))
 	var invalid *mcphttp.InvalidParamsError
 	if !errors.As(err, &invalid) {
@@ -60,7 +68,7 @@ func TestRPCGateway_ToolsCall_ForwardsRawResult(t *testing.T) {
 		CallTool(mock.Anything, mock.Anything, "echo", mock.Anything).
 		Return(raw, nil).Once()
 
-	g := mcphttp.NewRPCGateway(composer)
+	g := mcphttp.NewRPCGateway(composer, noopRunner())
 	res, err := g.Dispatch(context.Background(), &appconsumer.RoutableConsumer{}, "tools/call", json.RawMessage(`{"name":"echo"}`))
 	if err != nil {
 		t.Fatalf("Dispatch: %v", err)
@@ -73,7 +81,7 @@ func TestRPCGateway_ToolsCall_ForwardsRawResult(t *testing.T) {
 
 func TestRPCGateway_ResourcesRead_RequiresURI(t *testing.T) {
 	t.Parallel()
-	g := mcphttp.NewRPCGateway(mocks.NewComposer(t))
+	g := mcphttp.NewRPCGateway(mocks.NewComposer(t), noopRunner())
 	_, err := g.Dispatch(context.Background(), &appconsumer.RoutableConsumer{}, "resources/read", json.RawMessage(`{}`))
 	var invalid *mcphttp.InvalidParamsError
 	if !errors.As(err, &invalid) {
@@ -83,7 +91,7 @@ func TestRPCGateway_ResourcesRead_RequiresURI(t *testing.T) {
 
 func TestRPCGateway_UnknownMethod(t *testing.T) {
 	t.Parallel()
-	g := mcphttp.NewRPCGateway(mocks.NewComposer(t))
+	g := mcphttp.NewRPCGateway(mocks.NewComposer(t), noopRunner())
 	_, err := g.Dispatch(context.Background(), &appconsumer.RoutableConsumer{}, "tools/subscribe", nil)
 	if !errors.Is(err, mcphttp.ErrMethodNotFound) {
 		t.Fatalf("error = %v, want mcphttp.ErrMethodNotFound", err)
@@ -92,10 +100,115 @@ func TestRPCGateway_UnknownMethod(t *testing.T) {
 
 func TestRPCGateway_PromptsGet_RequiresName(t *testing.T) {
 	t.Parallel()
-	g := mcphttp.NewRPCGateway(mocks.NewComposer(t))
+	g := mcphttp.NewRPCGateway(mocks.NewComposer(t), noopRunner())
 	_, err := g.Dispatch(context.Background(), &appconsumer.RoutableConsumer{}, "prompts/get", json.RawMessage(`{"arguments":{}}`))
 	var invalid *mcphttp.InvalidParamsError
 	if !errors.As(err, &invalid) {
 		t.Fatalf("error = %v, want mcphttp.InvalidParamsError", err)
 	}
+}
+
+func mcpRoutableConsumer() *appconsumer.RoutableConsumer {
+	return &appconsumer.RoutableConsumer{
+		Consumer: &consumerdomain.Consumer{Type: consumerdomain.TypeMCP},
+	}
+}
+
+func blockErr(traceID string) *appplugins.PluginError {
+	return &appplugins.PluginError{
+		StatusCode: 403,
+		Message:    "request blocked due to a policy infraction",
+		Body:       []byte(`{"trace_id":"` + traceID + `"}`),
+	}
+}
+
+func TestRPCGateway_ToolsCall_PreRequestBlock_SkipsUpstream(t *testing.T) {
+	t.Parallel()
+	composer := mocks.NewComposer(t)
+	exec := pluginmocks.NewExecutor(t)
+	exec.EXPECT().RunStage(mock.Anything, mock.Anything).Return(nil, blockErr("pre")).Once()
+
+	g := mcphttp.NewRPCGateway(composer, appmcp.NewPluginRunner(exec, discardLogger()))
+	res, err := g.Dispatch(
+		context.Background(),
+		mcpRoutableConsumer(),
+		"tools/call",
+		json.RawMessage(`{"name":"echo","arguments":{"q":"x"}}`),
+	)
+
+	assert.Nil(t, res)
+	var rpcErr *appmcp.RPCError
+	require.True(t, errors.As(err, &rpcErr), "want *appmcp.RPCError, got %v", err)
+	assert.Equal(t, int64(-32001), rpcErr.Code)
+	composer.AssertNotCalled(t, "CallTool", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestRPCGateway_ToolsCall_PreResponseBlock_DiscardsResult(t *testing.T) {
+	t.Parallel()
+	raw := json.RawMessage(`{"content":[{"type":"text","text":"secret"}]}`)
+	composer := mocks.NewComposer(t)
+	composer.EXPECT().CallTool(mock.Anything, mock.Anything, "echo", mock.Anything).Return(raw, nil).Once()
+
+	exec := pluginmocks.NewExecutor(t)
+	exec.EXPECT().RunStage(mock.Anything, mock.MatchedBy(func(in appplugins.StageInput) bool {
+		return in.Stage == policydomain.StagePreRequest
+	})).Return(&appplugins.StageOutcome{}, nil).Once()
+	exec.EXPECT().RunStage(mock.Anything, mock.MatchedBy(func(in appplugins.StageInput) bool {
+		return in.Stage == policydomain.StagePreResponse
+	})).Return(nil, blockErr("post")).Once()
+
+	g := mcphttp.NewRPCGateway(composer, appmcp.NewPluginRunner(exec, discardLogger()))
+	res, err := g.Dispatch(
+		context.Background(),
+		mcpRoutableConsumer(),
+		"tools/call",
+		json.RawMessage(`{"name":"echo"}`),
+	)
+
+	assert.Nil(t, res)
+	var rpcErr *appmcp.RPCError
+	require.True(t, errors.As(err, &rpcErr), "want *appmcp.RPCError, got %v", err)
+	assert.Equal(t, int64(-32001), rpcErr.Code)
+}
+
+func TestRPCGateway_ToolsCall_Allow_ReturnsResultUnchanged(t *testing.T) {
+	t.Parallel()
+	raw := json.RawMessage(`{"content":[{"type":"text","text":"ok"}]}`)
+	composer := mocks.NewComposer(t)
+	composer.EXPECT().CallTool(mock.Anything, mock.Anything, "echo", mock.Anything).Return(raw, nil).Once()
+
+	exec := pluginmocks.NewExecutor(t)
+	exec.EXPECT().RunStage(mock.Anything, mock.Anything).Return(&appplugins.StageOutcome{}, nil).Twice()
+
+	g := mcphttp.NewRPCGateway(composer, appmcp.NewPluginRunner(exec, discardLogger()))
+	res, err := g.Dispatch(
+		context.Background(),
+		mcpRoutableConsumer(),
+		"tools/call",
+		json.RawMessage(`{"name":"echo"}`),
+	)
+
+	require.NoError(t, err)
+	got, ok := res.(json.RawMessage)
+	require.True(t, ok, "result = %#v, want json.RawMessage", res)
+	assert.Equal(t, string(raw), string(got))
+}
+
+func TestHandler_ToolsCall_PreRequestBlock_RendersJSONRPCErrorAt200(t *testing.T) {
+	t.Parallel()
+	composer := mocks.NewComposer(t)
+	exec := pluginmocks.NewExecutor(t)
+	exec.EXPECT().RunStage(mock.Anything, mock.Anything).Return(nil, blockErr("e2e")).Once()
+
+	app := newAppWithRunner(t, composer, appmcp.NewPluginRunner(exec, discardLogger()), consumerdomain.TypeMCP, true)
+	status, body := rpcCall(t, app, `{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"echo"}}`)
+
+	if status != fiber.StatusOK {
+		t.Fatalf("JSON-RPC errors must ride on HTTP 200, got %d", status)
+	}
+	rpcErr := body["error"].(map[string]any)
+	if rpcErr["code"].(float64) != -32001 {
+		t.Fatalf("code = %v, want -32001 policy blocked", rpcErr["code"])
+	}
+	composer.AssertNotCalled(t, "CallTool", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }

--- a/pkg/api/middleware/mcp_pipeline_integration_test.go
+++ b/pkg/api/middleware/mcp_pipeline_integration_test.go
@@ -26,9 +26,10 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/api/middleware"
 	appcatalog "github.com/NeuralTrust/TrustGate/pkg/app/catalog"
 	appconsumer "github.com/NeuralTrust/TrustGate/pkg/app/consumer"
+	appmcp "github.com/NeuralTrust/TrustGate/pkg/app/mcp"
+	mcpmocks "github.com/NeuralTrust/TrustGate/pkg/app/mcp/mocks"
 	appmetrics "github.com/NeuralTrust/TrustGate/pkg/app/metrics"
 	appmetricsmocks "github.com/NeuralTrust/TrustGate/pkg/app/metrics/mocks"
-	mcpmocks "github.com/NeuralTrust/TrustGate/pkg/app/mcp/mocks"
 	"github.com/NeuralTrust/TrustGate/pkg/config"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
 	telemetrydomain "github.com/NeuralTrust/TrustGate/pkg/domain/telemetry"
@@ -78,7 +79,7 @@ func TestMCPPipeline_ToolsCallBuildsMCPEvent(t *testing.T) {
 		CallTool(mock.Anything, mock.Anything, "echo", mock.Anything).
 		Return(json.RawMessage(`{"content":[]}`), nil).
 		Once()
-	gateway := mcphttp.NewRPCGateway(composer)
+	gateway := mcphttp.NewRPCGateway(composer, appmcp.NewPluginRunner(nil, nil))
 
 	gatewayID := ids.New[ids.GatewayKind]()
 	app := fiber.New()

--- a/pkg/app/mcp/plugin_runner.go
+++ b/pkg/app/mcp/plugin_runner.go
@@ -1,0 +1,188 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	appconsumer "github.com/NeuralTrust/TrustGate/pkg/app/consumer"
+	appplugins "github.com/NeuralTrust/TrustGate/pkg/app/plugins"
+	"github.com/NeuralTrust/TrustGate/pkg/domain/policy"
+	infracontext "github.com/NeuralTrust/TrustGate/pkg/infra/context"
+)
+
+// codePolicyBlocked is a server-defined JSON-RPC error code (in the reserved
+// -32000..-32099 range) used when the plugin chain blocks a tools/call;
+// -32002 and -32003 are already used elsewhere in the MCP handler.
+const codePolicyBlocked int64 = -32001
+
+const (
+	directionInput  = "input"
+	directionOutput = "output"
+)
+
+// PluginRunner runs the resolved plugin chain on the native MCP tools/call
+// path, mirroring pkg/app/proxy for the LLM path. It is a thin adapter over the
+// shared plugins.Executor: it builds stage contexts from JSON-RPC values and
+// maps a plugin block to a JSON-RPC error.
+type PluginRunner struct {
+	executor appplugins.Executor
+	logger   *slog.Logger
+}
+
+// NewPluginRunner accepts the shared executor port; a nil executor makes every
+// method a no-op (plugin-free parity with today's MCP path).
+func NewPluginRunner(executor appplugins.Executor, logger *slog.Logger) *PluginRunner {
+	return &PluginRunner{executor: executor, logger: logger}
+}
+
+type mcpToolCallParams struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments,omitempty"`
+}
+
+// PreRequest runs StagePreRequest over the tools/call params. It returns nil to
+// allow the call; a non-nil *RPCError means a policy blocked it (caller skips the
+// upstream dial and writes the error). Per RUN-832 the call fails open on any
+// non-block error (guard unavailable, decode failure): it is logged and nil is
+// returned so the tools/call proceeds.
+func (r *PluginRunner) PreRequest(
+	ctx context.Context,
+	rc *appconsumer.RoutableConsumer,
+	name string,
+	arguments json.RawMessage,
+) error {
+	if r.executor == nil || rc == nil || rc.Consumer == nil {
+		return nil
+	}
+	reqCtx, err := r.buildRequestContext(ctx, rc, name, arguments)
+	if err != nil {
+		r.logFailOpen(rc, policy.StagePreRequest, directionInput, err)
+		return nil
+	}
+	outcome, err := r.executor.RunStage(ctx, appplugins.StageInput{
+		Stage:    policy.StagePreRequest,
+		Policies: rc.Policies,
+		Plan:     rc.PolicyPlan,
+		Request:  reqCtx,
+	})
+	if err != nil {
+		if pe, ok := appplugins.AsPluginError(err); ok {
+			return blockToRPCError(pe)
+		}
+		r.logFailOpen(rc, policy.StagePreRequest, directionInput, err)
+		return nil
+	}
+	if outcome != nil && outcome.ShortCircuit {
+		return blockToRPCError(&appplugins.PluginError{
+			StatusCode: outcome.StatusCode,
+			Message:    "request blocked by policy",
+			Body:       outcome.Body,
+		})
+	}
+	return nil
+}
+
+// PreResponse runs StagePreResponse over the tool result. It returns nil to keep
+// the original result; a non-nil *RPCError means the response is blocked (caller
+// discards the result and writes the error). Per RUN-832 the call fails open on
+// any non-block error in this direction too: it is logged and the original
+// result is kept.
+func (r *PluginRunner) PreResponse(
+	ctx context.Context,
+	rc *appconsumer.RoutableConsumer,
+	name string,
+	arguments json.RawMessage,
+	result json.RawMessage,
+) error {
+	if r.executor == nil || rc == nil || rc.Consumer == nil {
+		return nil
+	}
+	reqCtx, err := r.buildRequestContext(ctx, rc, name, arguments)
+	if err != nil {
+		r.logFailOpen(rc, policy.StagePreResponse, directionOutput, err)
+		return nil
+	}
+	respCtx := &infracontext.ResponseContext{
+		Context:   ctx,
+		GatewayID: rc.Consumer.GatewayID.String(),
+		Body:      result,
+		Streaming: false,
+	}
+	if _, err := r.executor.RunStage(ctx, appplugins.StageInput{
+		Stage:    policy.StagePreResponse,
+		Policies: rc.Policies,
+		Plan:     rc.PolicyPlan,
+		Request:  reqCtx,
+		Response: respCtx,
+	}); err != nil {
+		if pe, ok := appplugins.AsPluginError(err); ok {
+			return blockToRPCError(pe)
+		}
+		r.logFailOpen(rc, policy.StagePreResponse, directionOutput, err)
+	}
+	return nil
+}
+
+// logFailOpen records a guard/plugin failure that the runner deliberately does
+// not surface. RUN-832 requires a tools/call to proceed on guard errors in both
+// directions; only ids and outcome are logged, never tool payloads.
+func (r *PluginRunner) logFailOpen(rc *appconsumer.RoutableConsumer, stage policy.Stage, direction string, err error) {
+	if r.logger == nil {
+		return
+	}
+	r.logger.Warn("mcp plugin stage failed, failing open",
+		slog.String("stage", string(stage)),
+		slog.String("direction", direction),
+		slog.String("outcome", "failed_open"),
+		slog.String("gateway_id", rc.Consumer.GatewayID.String()),
+		slog.String("error", err.Error()),
+	)
+}
+
+func (r *PluginRunner) buildRequestContext(
+	ctx context.Context,
+	rc *appconsumer.RoutableConsumer,
+	name string,
+	arguments json.RawMessage,
+) (*infracontext.RequestContext, error) {
+	body, err := json.Marshal(mcpToolCallParams{Name: name, Arguments: arguments})
+	if err != nil {
+		return nil, fmt.Errorf("mcp: marshal tools/call params: %w", err)
+	}
+	return &infracontext.RequestContext{
+		Context:        ctx,
+		GatewayID:      rc.Consumer.GatewayID.String(),
+		ConsumerID:     rc.Consumer.ID.String(),
+		ConsumerType:   string(rc.Consumer.Type),
+		SessionID:      "",
+		Provider:       "",
+		SourceFormat:   "",
+		RequestedModel: "",
+		MCP:            true,
+		Body:           body,
+	}, nil
+}
+
+func blockToRPCError(pe *appplugins.PluginError) *RPCError {
+	return &RPCError{
+		Code:    codePolicyBlocked,
+		Message: pe.Message,
+		Data:    pe.Body,
+	}
+}

--- a/pkg/app/mcp/plugin_runner.go
+++ b/pkg/app/mcp/plugin_runner.go
@@ -124,17 +124,26 @@ func (r *PluginRunner) PreResponse(
 		Body:      result,
 		Streaming: false,
 	}
-	if _, err := r.executor.RunStage(ctx, appplugins.StageInput{
+	outcome, err := r.executor.RunStage(ctx, appplugins.StageInput{
 		Stage:    policy.StagePreResponse,
 		Policies: rc.Policies,
 		Plan:     rc.PolicyPlan,
 		Request:  reqCtx,
 		Response: respCtx,
-	}); err != nil {
+	})
+	if err != nil {
 		if pe, ok := appplugins.AsPluginError(err); ok {
 			return blockToRPCError(pe)
 		}
 		r.logFailOpen(rc, policy.StagePreResponse, directionOutput, err)
+		return nil
+	}
+	if outcome != nil && outcome.ShortCircuit {
+		return blockToRPCError(&appplugins.PluginError{
+			StatusCode: outcome.StatusCode,
+			Message:    "response blocked by policy",
+			Body:       outcome.Body,
+		})
 	}
 	return nil
 }

--- a/pkg/app/mcp/plugin_runner_test.go
+++ b/pkg/app/mcp/plugin_runner_test.go
@@ -1,0 +1,243 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	appconsumer "github.com/NeuralTrust/TrustGate/pkg/app/consumer"
+	appplugins "github.com/NeuralTrust/TrustGate/pkg/app/plugins"
+	pluginmocks "github.com/NeuralTrust/TrustGate/pkg/app/plugins/mocks"
+	consumerdomain "github.com/NeuralTrust/TrustGate/pkg/domain/consumer"
+	policydomain "github.com/NeuralTrust/TrustGate/pkg/domain/policy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testToolName = "search"
+	testToolArgs = `{"q":"hello"}`
+	testResult   = `{"content":[{"type":"text","text":"world"}]}`
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func routableMCPConsumer(policies ...*policydomain.Policy) *appconsumer.RoutableConsumer {
+	return &appconsumer.RoutableConsumer{
+		Consumer: &consumerdomain.Consumer{Type: consumerdomain.TypeMCP},
+		Policies: policies,
+	}
+}
+
+func preResponsePolicy(stages ...policydomain.Stage) *policydomain.Policy {
+	return &policydomain.Policy{
+		Enabled: true,
+		Mode:    policydomain.ModeEnforce,
+		Stages:  stages,
+	}
+}
+
+func TestPluginRunner_PreRequest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		outcome     *appplugins.StageOutcome
+		execErr     error
+		wantRPCCode int64
+		wantRPCData string
+		wantNil     bool
+	}{
+		{
+			name:    "allow",
+			outcome: &appplugins.StageOutcome{},
+			wantNil: true,
+		},
+		{
+			name:    "report does not block",
+			outcome: &appplugins.StageOutcome{ShortCircuit: false},
+			wantNil: true,
+		},
+		{
+			name:        "enforce block via plugin error",
+			execErr:     &appplugins.PluginError{StatusCode: 403, Message: "blocked", Body: []byte(`{"trace_id":"t1"}`)},
+			wantRPCCode: codePolicyBlocked,
+			wantRPCData: `{"trace_id":"t1"}`,
+		},
+		{
+			name:        "enforce block via short circuit",
+			outcome:     &appplugins.StageOutcome{ShortCircuit: true, StatusCode: 403, Body: []byte(`{"trace_id":"t2"}`)},
+			wantRPCCode: codePolicyBlocked,
+			wantRPCData: `{"trace_id":"t2"}`,
+		},
+		{
+			name:    "generic executor error fails open",
+			execErr: errors.New("boom"),
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			exec := pluginmocks.NewExecutor(t)
+			var captured appplugins.StageInput
+			exec.EXPECT().RunStage(mock.Anything, mock.Anything).
+				Run(func(_ context.Context, in appplugins.StageInput) { captured = in }).
+				Return(tt.outcome, tt.execErr)
+
+			rc := routableMCPConsumer(preResponsePolicy(policydomain.StagePreRequest))
+			runner := NewPluginRunner(exec, discardLogger())
+
+			err := runner.PreRequest(context.Background(), rc, testToolName, json.RawMessage(testToolArgs))
+
+			assertStageInput(t, captured, policydomain.StagePreRequest, rc)
+			assert.Nil(t, captured.Response)
+
+			switch {
+			case tt.wantNil:
+				require.NoError(t, err)
+			case tt.wantRPCCode != 0:
+				assertRPCError(t, err, tt.wantRPCCode, tt.wantRPCData)
+			}
+		})
+	}
+}
+
+func TestPluginRunner_PreResponse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		plan        []policydomain.Stage
+		execErr     error
+		wantRPCCode int64
+		wantRPCData string
+		wantNil     bool
+	}{
+		{
+			name:    "allow",
+			plan:    []policydomain.Stage{policydomain.StagePreResponse},
+			wantNil: true,
+		},
+		{
+			name:    "report does not block",
+			plan:    []policydomain.Stage{policydomain.StagePreResponse},
+			wantNil: true,
+		},
+		{
+			name:        "enforce block via plugin error",
+			plan:        []policydomain.Stage{policydomain.StagePreResponse},
+			execErr:     &appplugins.PluginError{StatusCode: 403, Message: "blocked", Body: []byte(`{"trace_id":"t3"}`)},
+			wantRPCCode: codePolicyBlocked,
+			wantRPCData: `{"trace_id":"t3"}`,
+		},
+		{
+			name:    "generic error fails open even when plan blocks pre_response",
+			plan:    []policydomain.Stage{policydomain.StagePreResponse},
+			execErr: errors.New("guard down"),
+			wantNil: true,
+		},
+		{
+			name:    "generic error fails open when plan does not block",
+			plan:    []policydomain.Stage{policydomain.StagePreRequest},
+			execErr: errors.New("guard down"),
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			exec := pluginmocks.NewExecutor(t)
+			var captured appplugins.StageInput
+			exec.EXPECT().RunStage(mock.Anything, mock.Anything).
+				Run(func(_ context.Context, in appplugins.StageInput) { captured = in }).
+				Return(&appplugins.StageOutcome{}, tt.execErr)
+
+			rc := routableMCPConsumer(preResponsePolicy(tt.plan...))
+			runner := NewPluginRunner(exec, discardLogger())
+
+			err := runner.PreResponse(
+				context.Background(),
+				rc,
+				testToolName,
+				json.RawMessage(testToolArgs),
+				json.RawMessage(testResult),
+			)
+
+			assertStageInput(t, captured, policydomain.StagePreResponse, rc)
+			require.NotNil(t, captured.Response)
+			assert.False(t, captured.Response.Streaming)
+			assert.JSONEq(t, testResult, string(captured.Response.Body))
+
+			switch {
+			case tt.wantNil:
+				require.NoError(t, err)
+			case tt.wantRPCCode != 0:
+				assertRPCError(t, err, tt.wantRPCCode, tt.wantRPCData)
+			}
+		})
+	}
+}
+
+func TestPluginRunner_NilExecutor(t *testing.T) {
+	t.Parallel()
+
+	runner := NewPluginRunner(nil, discardLogger())
+	rc := routableMCPConsumer()
+
+	require.NoError(t, runner.PreRequest(context.Background(), rc, testToolName, json.RawMessage(testToolArgs)))
+	require.NoError(t, runner.PreResponse(
+		context.Background(), rc, testToolName, json.RawMessage(testToolArgs), json.RawMessage(testResult),
+	))
+}
+
+func assertStageInput(t *testing.T, in appplugins.StageInput, stage policydomain.Stage, rc *appconsumer.RoutableConsumer) {
+	t.Helper()
+	assert.Equal(t, stage, in.Stage)
+	assert.Equal(t, rc.Policies, in.Policies)
+	assert.Equal(t, rc.PolicyPlan, in.Plan)
+	require.NotNil(t, in.Request)
+	assert.True(t, in.Request.MCP)
+	assert.Equal(t, "MCP", in.Request.ConsumerType)
+	assert.Equal(t, rc.Consumer.GatewayID.String(), in.Request.GatewayID)
+	assert.Equal(t, rc.Consumer.ID.String(), in.Request.ConsumerID)
+	assert.Empty(t, in.Request.Provider)
+	assert.Empty(t, in.Request.SessionID)
+	assert.JSONEq(t, `{"name":"`+testToolName+`","arguments":`+testToolArgs+`}`, string(in.Request.Body))
+}
+
+func assertRPCError(t *testing.T, err error, code int64, data string) {
+	t.Helper()
+	var rpcErr *RPCError
+	require.True(t, errors.As(err, &rpcErr), "expected *RPCError, got %v", err)
+	assert.Equal(t, code, rpcErr.Code)
+	if data != "" {
+		assert.JSONEq(t, data, string(rpcErr.Data))
+	}
+}

--- a/pkg/app/mcp/plugin_runner_test.go
+++ b/pkg/app/mcp/plugin_runner_test.go
@@ -132,6 +132,7 @@ func TestPluginRunner_PreResponse(t *testing.T) {
 	tests := []struct {
 		name        string
 		plan        []policydomain.Stage
+		outcome     *appplugins.StageOutcome
 		execErr     error
 		wantRPCCode int64
 		wantRPCData string
@@ -155,6 +156,13 @@ func TestPluginRunner_PreResponse(t *testing.T) {
 			wantRPCData: `{"trace_id":"t3"}`,
 		},
 		{
+			name:        "enforce block via short circuit",
+			plan:        []policydomain.Stage{policydomain.StagePreResponse},
+			outcome:     &appplugins.StageOutcome{ShortCircuit: true, StatusCode: 403, Body: []byte(`{"trace_id":"t4"}`)},
+			wantRPCCode: codePolicyBlocked,
+			wantRPCData: `{"trace_id":"t4"}`,
+		},
+		{
 			name:    "generic error fails open even when plan blocks pre_response",
 			plan:    []policydomain.Stage{policydomain.StagePreResponse},
 			execErr: errors.New("guard down"),
@@ -175,9 +183,13 @@ func TestPluginRunner_PreResponse(t *testing.T) {
 
 			exec := pluginmocks.NewExecutor(t)
 			var captured appplugins.StageInput
+			outcome := tt.outcome
+			if outcome == nil {
+				outcome = &appplugins.StageOutcome{}
+			}
 			exec.EXPECT().RunStage(mock.Anything, mock.Anything).
 				Run(func(_ context.Context, in appplugins.StageInput) { captured = in }).
-				Return(&appplugins.StageOutcome{}, tt.execErr)
+				Return(outcome, tt.execErr)
 
 			rc := routableMCPConsumer(preResponsePolicy(tt.plan...))
 			runner := NewPluginRunner(exec, discardLogger())

--- a/pkg/container/modules/mcp.go
+++ b/pkg/container/modules/mcp.go
@@ -128,6 +128,9 @@ func MCP(c *container.Container) error {
 	if err := c.Provide(registryhttp.NewListRegistryToolsHandler); err != nil {
 		return err
 	}
+	if err := c.Provide(appmcp.NewPluginRunner); err != nil {
+		return err
+	}
 	if err := c.Provide(mcphttp.NewRPCGateway); err != nil {
 		return err
 	}

--- a/pkg/infra/context/request_context.go
+++ b/pkg/infra/context/request_context.go
@@ -51,6 +51,9 @@ type RequestContext struct {
 	AllowedModels      []string
 	DefaultModel       string
 	RequestedModel     string
+	// MCP marks a native MCP tools/call payload so protocol-aware plugins
+	// inspect it via the MCP text path instead of the LLM canonical decoders.
+	MCP bool
 }
 
 // HeaderValue returns the first non-empty value of the named header, matched

--- a/pkg/infra/plugins/trustguard/mcp.go
+++ b/pkg/infra/plugins/trustguard/mcp.go
@@ -1,0 +1,119 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trustguard
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+)
+
+type mcpToolCall struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+type mcpToolResult struct {
+	Content []mcpContentBlock `json:"content"`
+	IsError bool              `json:"isError"`
+}
+
+type mcpContentBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// mcpInputText returns the tool name plus every string value flattened from the
+// arguments tree, newline-joined. It falls back to the raw arguments string when
+// the arguments are not decodable, and returns "" when nothing is inspectable.
+func mcpInputText(body []byte) string {
+	var call mcpToolCall
+	if err := json.Unmarshal(body, &call); err != nil {
+		return ""
+	}
+	parts := make([]string, 0, 4)
+	if name := strings.TrimSpace(call.Name); name != "" {
+		parts = append(parts, name)
+	}
+	parts = append(parts, flattenArgumentStrings(call.Arguments)...)
+	return strings.Join(parts, "\n")
+}
+
+// mcpOutputText concatenates the text of every text content block in a
+// CallToolResult, ignoring non-text blocks (image/audio/resource). The isError
+// flag does not change extraction. It returns "" when there is no text.
+func mcpOutputText(body []byte) string {
+	var result mcpToolResult
+	if err := json.Unmarshal(body, &result); err != nil {
+		return ""
+	}
+	parts := make([]string, 0, len(result.Content))
+	for _, block := range result.Content {
+		if !blockIsText(block) || strings.TrimSpace(block.Text) == "" {
+			continue
+		}
+		parts = append(parts, block.Text)
+	}
+	return strings.Join(parts, "\n")
+}
+
+// flattenArgumentStrings walks the decoded arguments value and collects string
+// leaves (recursing maps and arrays); numbers, bools and nulls are skipped. Map
+// keys are visited in sorted order for deterministic output. When arguments are
+// not valid JSON it returns the raw trimmed arguments so free-form input stays
+// inspectable.
+func flattenArgumentStrings(raw json.RawMessage) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	var decoded any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		if trimmed := strings.TrimSpace(string(raw)); trimmed != "" {
+			return []string{trimmed}
+		}
+		return nil
+	}
+	return collectStrings(decoded, nil)
+}
+
+func collectStrings(value any, acc []string) []string {
+	switch v := value.(type) {
+	case string:
+		if strings.TrimSpace(v) != "" {
+			acc = append(acc, v)
+		}
+	case map[string]any:
+		keys := make([]string, 0, len(v))
+		for k := range v {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			acc = collectStrings(v[k], acc)
+		}
+	case []any:
+		for _, item := range v {
+			acc = collectStrings(item, acc)
+		}
+	}
+	return acc
+}
+
+func blockIsText(block mcpContentBlock) bool {
+	if block.Type == "" {
+		return block.Text != ""
+	}
+	return block.Type == "text"
+}

--- a/pkg/infra/plugins/trustguard/mcp_test.go
+++ b/pkg/infra/plugins/trustguard/mcp_test.go
@@ -1,0 +1,169 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trustguard
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestMCPInputText(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "name and nested arguments",
+			body: `{"name":"search","arguments":{"query":"secret token","filters":{"lang":"en"},"tags":["a","b"],"limit":10,"safe":true}}`,
+			want: "search\nen\nsecret token\na\nb",
+		},
+		{
+			name: "arguments only",
+			body: `{"name":"","arguments":{"prompt":"hello"}}`,
+			want: "hello",
+		},
+		{
+			name: "name only with empty arguments",
+			body: `{"name":"ping","arguments":{}}`,
+			want: "ping",
+		},
+		{
+			name: "name only with no arguments field",
+			body: `{"name":"ping"}`,
+			want: "ping",
+		},
+		{
+			name: "undecodable arguments fall back to raw",
+			body: `{"name":"tool","arguments":"not-json"}`,
+			want: "tool\nnot-json",
+		},
+		{
+			name: "non-string leaves skipped",
+			body: `{"name":"calc","arguments":{"a":1,"b":2.5,"c":null,"d":false}}`,
+			want: "calc",
+		},
+		{
+			name: "empty body",
+			body: ``,
+			want: "",
+		},
+		{
+			name: "malformed body",
+			body: `{`,
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := mcpInputText([]byte(tc.body)); got != tc.want {
+				t.Fatalf("mcpInputText(%s) = %q, want %q", tc.body, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMCPOutputText(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "single text block",
+			body: `{"content":[{"type":"text","text":"hello"}],"isError":false}`,
+			want: "hello",
+		},
+		{
+			name: "multiple text blocks concatenated",
+			body: `{"content":[{"type":"text","text":"line one"},{"type":"text","text":"line two"}]}`,
+			want: "line one\nline two",
+		},
+		{
+			name: "isError true still extracts",
+			body: `{"content":[{"type":"text","text":"boom"}],"isError":true}`,
+			want: "boom",
+		},
+		{
+			name: "non-text blocks ignored",
+			body: `{"content":[{"type":"image","text":"ignored"},{"type":"resource"}]}`,
+			want: "",
+		},
+		{
+			name: "mixed text and non-text",
+			body: `{"content":[{"type":"image"},{"type":"text","text":"keep"}]}`,
+			want: "keep",
+		},
+		{
+			name: "empty content",
+			body: `{"content":[],"isError":false}`,
+			want: "",
+		},
+		{
+			name: "malformed json",
+			body: `{"content":`,
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := mcpOutputText([]byte(tc.body)); got != tc.want {
+				t.Fatalf("mcpOutputText(%s) = %q, want %q", tc.body, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFlattenArgumentStrings(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{name: "flat map sorted by key", raw: `{"b":"second","a":"first"}`, want: []string{"first", "second"}},
+		{name: "nested map", raw: `{"outer":{"inner":"deep"}}`, want: []string{"deep"}},
+		{name: "array of strings", raw: `["x","y","z"]`, want: []string{"x", "y", "z"}},
+		{name: "mixed types skip non-strings", raw: `{"s":"keep","n":42,"b":true,"z":null}`, want: []string{"keep"}},
+		{name: "empty object", raw: `{}`, want: nil},
+		{name: "empty raw", raw: ``, want: nil},
+		{name: "undecodable raw fallback", raw: `not-json`, want: []string{"not-json"}},
+		{name: "whitespace strings skipped", raw: `{"a":"  ","b":"real"}`, want: []string{"real"}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := flattenArgumentStrings(json.RawMessage(tc.raw))
+			if len(got) != len(tc.want) {
+				t.Fatalf("flattenArgumentStrings(%s) = %v, want %v", tc.raw, got, tc.want)
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Fatalf("flattenArgumentStrings(%s)[%d] = %q, want %q", tc.raw, i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}

--- a/pkg/infra/plugins/trustguard/plugin.go
+++ b/pkg/infra/plugins/trustguard/plugin.go
@@ -130,7 +130,11 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 		return passThrough(), nil
 	}
 
-	if in.Request == nil || p.registry == nil || in.Request.Provider == "" {
+	if in.Request == nil {
+		return passThrough(), nil
+	}
+	mcpMode := in.Request.MCP
+	if !mcpMode && (p.registry == nil || in.Request.Provider == "") {
 		return passThrough(), nil
 	}
 
@@ -149,39 +153,56 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 		return passThrough(), nil
 	}
 
-	format, err := adapter.ResolveAgentFormat(in.Request.Provider, in.Request.SourceFormat, nil)
-	if err != nil {
-		return passThrough(), nil
-	}
-
 	var text string
-	if direction == directionInput {
-		if len(in.Request.Body) == 0 {
-			return passThrough(), nil
+	if mcpMode {
+		if direction == directionInput {
+			if len(in.Request.Body) == 0 {
+				return passThrough(), nil
+			}
+			text = mcpInputText(in.Request.Body)
+		} else {
+			if in.Response == nil || in.Response.Streaming || len(in.Response.Body) == 0 {
+				return passThrough(), nil
+			}
+			text = mcpOutputText(in.Response.Body)
 		}
-		creq, decErr := p.registry.DecodeRequestFor(in.Request.Body, format)
-		if decErr != nil || creq == nil {
-			return passThrough(), nil
-		}
-		text = joinRequestText(creq)
 	} else {
-		if in.Response == nil || in.Response.Streaming || len(in.Response.Body) == 0 {
+		format, err := adapter.ResolveAgentFormat(in.Request.Provider, in.Request.SourceFormat, nil)
+		if err != nil {
 			return passThrough(), nil
 		}
-		cresp, decErr := p.registry.DecodeResponseFor(in.Response.Body, format)
-		if decErr != nil || cresp == nil {
-			return passThrough(), nil
+		if direction == directionInput {
+			if len(in.Request.Body) == 0 {
+				return passThrough(), nil
+			}
+			creq, decErr := p.registry.DecodeRequestFor(in.Request.Body, format)
+			if decErr != nil || creq == nil {
+				return passThrough(), nil
+			}
+			text = joinRequestText(creq)
+		} else {
+			if in.Response == nil || in.Response.Streaming || len(in.Response.Body) == 0 {
+				return passThrough(), nil
+			}
+			cresp, decErr := p.registry.DecodeResponseFor(in.Response.Body, format)
+			if decErr != nil || cresp == nil {
+				return passThrough(), nil
+			}
+			text = cresp.Content
 		}
-		text = cresp.Content
 	}
 	if strings.TrimSpace(text) == "" {
 		return passThrough(), nil
 	}
 
+	protocol := protocolFor(in.Request.ConsumerType)
+	if mcpMode {
+		protocol = protocolMCP
+	}
 	body := GuardRequest{
 		Payload:    GuardPayload{Input: text},
 		Direction:  direction,
-		Protocol:   protocolFor(in.Request.ConsumerType),
+		Protocol:   protocol,
 		GatewayID:  in.Request.GatewayID,
 		SessionID:  in.Request.SessionID,
 		ConsumerID: in.Request.ConsumerID,

--- a/pkg/infra/plugins/trustguard/plugin_test.go
+++ b/pkg/infra/plugins/trustguard/plugin_test.go
@@ -171,7 +171,7 @@ func TestExecutePreRequestBlockReturns403(t *testing.T) {
 	t.Parallel()
 
 	f := &fakeGuard{response: GuardResponse{
-		Status:    statusBlock,
+		Status: statusBlock,
 		Findings: []GuardFinding{{
 			Source:  &GuardFindingSource{Kind: "detector", Plugin: "prompt_guard"},
 			Signal:  &GuardFindingSignal{Type: "prompt_injection"},
@@ -668,6 +668,278 @@ func TestExecuteRetriesOnceOn401(t *testing.T) {
 	}
 	if got := atomic.LoadInt32(&tokenHits); got != 2 {
 		t.Fatalf("token hits = %d, want 2 (initial + refresh after 401)", got)
+	}
+}
+
+func mcpToolCallJSON() []byte {
+	return []byte(`{"name":"search","arguments":{"query":"find me"}}`)
+}
+
+func mcpResultJSON() []byte {
+	return []byte(`{"content":[{"type":"text","text":"the answer"}],"isError":false}`)
+}
+
+func mcpRequestContext() *infracontext.RequestContext {
+	return &infracontext.RequestContext{
+		MCP:          true,
+		ConsumerType: "MCP",
+		GatewayID:    "gw-test",
+		SessionID:    "sess-mcp",
+		ConsumerID:   "consumer-mcp",
+		Body:         mcpToolCallJSON(),
+	}
+}
+
+func TestExecuteMCPInputBlock(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: GuardResponse{Status: statusBlock, TraceID: "trace-mcp-in"}}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	in := execInput(policy.StagePreRequest, policy.ModeEnforce, settings(""), mcpRequestContext(), nil)
+	res, err := p.Execute(context.Background(), in)
+	if res != nil {
+		t.Fatalf("expected nil result on block, got %+v", res)
+	}
+	if _, ok := appplugins.AsPluginError(err); !ok {
+		t.Fatalf("expected *PluginError, got %v", err)
+	}
+	got := f.captured()
+	if got.Protocol != protocolMCP {
+		t.Fatalf("protocol = %q, want %q", got.Protocol, protocolMCP)
+	}
+	if got.Direction != directionInput {
+		t.Fatalf("direction = %q, want %q", got.Direction, directionInput)
+	}
+	if got.Attributes.Model.Provider != "" {
+		t.Fatalf("provider = %q, want empty", got.Attributes.Model.Provider)
+	}
+	if got.Payload.Input != "search\nfind me" {
+		t.Fatalf("input = %q, want %q", got.Payload.Input, "search\nfind me")
+	}
+}
+
+func TestExecuteMCPInputObservePassesThrough(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: GuardResponse{Status: statusBlock, TraceID: "trace-mcp-obs"}}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	event, span := newEvent()
+	in := execInputWithEvent(policy.StagePreRequest, policy.ModeObserve, settings(""), mcpRequestContext(), nil, event)
+	res, err := p.Execute(context.Background(), in)
+	if err != nil {
+		t.Fatalf("observe mode must not error, got %v", err)
+	}
+	if res == nil || res.StatusCode != http.StatusOK || res.StopUpstream {
+		t.Fatalf("expected pass-through in observe mode, got %+v", res)
+	}
+	if attrs := span.PluginAttrsCopy(); attrs.Decision != decisionReported {
+		t.Fatalf("decision = %q, want %q", attrs.Decision, decisionReported)
+	}
+}
+
+func TestExecuteMCPOutputBlock(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: GuardResponse{Status: statusBlock, TraceID: "trace-mcp-out"}}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	resp := &infracontext.ResponseContext{StatusCode: 200, Body: mcpResultJSON()}
+	in := execInput(policy.StagePreResponse, policy.ModeEnforce, settings(""), mcpRequestContext(), resp)
+	res, err := p.Execute(context.Background(), in)
+	if res != nil {
+		t.Fatalf("expected nil result on block, got %+v", res)
+	}
+	if _, ok := appplugins.AsPluginError(err); !ok {
+		t.Fatalf("expected *PluginError, got %v", err)
+	}
+	got := f.captured()
+	if got.Direction != directionOutput {
+		t.Fatalf("direction = %q, want %q", got.Direction, directionOutput)
+	}
+	if got.Protocol != protocolMCP {
+		t.Fatalf("protocol = %q, want %q", got.Protocol, protocolMCP)
+	}
+	if got.Payload.Input != "the answer" {
+		t.Fatalf("input = %q, want %q", got.Payload.Input, "the answer")
+	}
+}
+
+func TestExecuteMCPOutputReportPassesThrough(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: GuardResponse{Status: statusReport, TraceID: "trace-mcp-rep"}}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	event, span := newEvent()
+	resp := &infracontext.ResponseContext{StatusCode: 200, Body: mcpResultJSON()}
+	in := execInputWithEvent(policy.StagePreResponse, policy.ModeEnforce, settings(""), mcpRequestContext(), resp, event)
+	res, err := p.Execute(context.Background(), in)
+	if err != nil {
+		t.Fatalf("report mode must not error, got %v", err)
+	}
+	if res == nil || res.StatusCode != http.StatusOK {
+		t.Fatalf("expected pass-through, got %+v", res)
+	}
+	if attrs := span.PluginAttrsCopy(); attrs.Decision != decisionReported {
+		t.Fatalf("decision = %q, want %q", attrs.Decision, decisionReported)
+	}
+}
+
+func TestExecuteMCPProtocolFromMarkerIgnoresConsumerType(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: GuardResponse{Status: statusReport, TraceID: "trace-mcp-proto"}}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	req := mcpRequestContext()
+	req.ConsumerType = ""
+	in := execInput(policy.StagePreRequest, policy.ModeEnforce, settings(""), req, nil)
+	if _, err := p.Execute(context.Background(), in); err != nil {
+		t.Fatalf("report mode must not error, got %v", err)
+	}
+	if got := f.captured(); got.Protocol != protocolMCP {
+		t.Fatalf("protocol = %q, want %q", got.Protocol, protocolMCP)
+	}
+}
+
+func TestExecuteMCPInputBlockWithNilRegistry(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: GuardResponse{Status: statusBlock, TraceID: "trace-mcp-nilreg"}}
+	srv := newServer(t, f)
+	p := New(nil, srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	in := execInput(policy.StagePreRequest, policy.ModeEnforce, settings(""), mcpRequestContext(), nil)
+	res, err := p.Execute(context.Background(), in)
+	if res != nil {
+		t.Fatalf("expected nil result on block, got %+v", res)
+	}
+	if _, ok := appplugins.AsPluginError(err); !ok {
+		t.Fatalf("expected *PluginError, got %v", err)
+	}
+	if got := f.captured(); got.Payload.Input != "search\nfind me" {
+		t.Fatalf("input = %q, want %q", got.Payload.Input, "search\nfind me")
+	}
+}
+
+func TestExecuteMCPOutputStreamingPassesThrough(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: GuardResponse{Status: statusBlock}}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	resp := &infracontext.ResponseContext{StatusCode: 200, Streaming: true, Body: mcpResultJSON()}
+	in := execInput(policy.StagePreResponse, policy.ModeEnforce, settings(""), mcpRequestContext(), resp)
+	res, err := p.Execute(context.Background(), in)
+	if err != nil {
+		t.Fatalf("streaming must not error, got %v", err)
+	}
+	if res == nil || res.StatusCode != http.StatusOK {
+		t.Fatalf("expected pass-through for streaming, got %+v", res)
+	}
+	if f.count() != 0 {
+		t.Fatalf("guard must not be called for streaming, got %d calls", f.count())
+	}
+}
+
+func TestExecuteMCPMissingGatewayIDFailsOpen(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: GuardResponse{Status: statusBlock}}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	req := mcpRequestContext()
+	req.GatewayID = ""
+	in := execInput(policy.StagePreRequest, policy.ModeEnforce, settings(""), req, nil)
+	res, err := p.Execute(context.Background(), in)
+	if err != nil {
+		t.Fatalf("expected fail-open pass, got error %v", err)
+	}
+	if res == nil || res.StatusCode != http.StatusOK || res.StopUpstream {
+		t.Fatalf("expected pass-through on missing gateway id, got %+v", res)
+	}
+	if f.count() != 0 {
+		t.Fatalf("expected no guard call when gateway id missing, got %d hits", f.count())
+	}
+}
+
+func TestExecuteMCPGuardErrorFailsOpen(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{status: http.StatusInternalServerError, response: GuardResponse{Status: statusBlock}}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	event, span := newEvent()
+	in := execInputWithEvent(policy.StagePreRequest, policy.ModeEnforce, settings(""), mcpRequestContext(), nil, event)
+	res, err := p.Execute(context.Background(), in)
+	if err != nil {
+		t.Fatalf("expected fail-open pass, got error %v", err)
+	}
+	if res == nil || res.StatusCode != http.StatusOK || res.StopUpstream {
+		t.Fatalf("expected pass-through on guard error, got %+v", res)
+	}
+	attrs := span.PluginAttrsCopy()
+	extras, ok := attrs.Extras.(guardData)
+	if !ok {
+		t.Fatalf("extras type = %T, want guardData", attrs.Extras)
+	}
+	if !extras.FailedOpen || extras.Decision != decisionFailedOpen {
+		t.Fatalf("extras = %+v, want failed_open decision", extras)
+	}
+}
+
+func TestExecuteMCPEmptyExtractedTextPassesThrough(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: GuardResponse{Status: statusBlock}}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	req := mcpRequestContext()
+	req.Body = []byte(`{"name":"","arguments":{}}`)
+	in := execInput(policy.StagePreRequest, policy.ModeEnforce, settings(""), req, nil)
+	res, err := p.Execute(context.Background(), in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res == nil || res.StatusCode != http.StatusOK {
+		t.Fatalf("expected pass-through, got %+v", res)
+	}
+	if f.count() != 0 {
+		t.Fatalf("expected guard not called for empty text, got %d hits", f.count())
+	}
+}
+
+func TestExecuteMarkerOffWithoutProviderPassesThrough(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: GuardResponse{Status: statusBlock}}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	req := mcpRequestContext()
+	req.MCP = false
+	req.Provider = ""
+	in := execInput(policy.StagePreRequest, policy.ModeEnforce, settings(""), req, nil)
+	res, err := p.Execute(context.Background(), in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res == nil || res.StatusCode != http.StatusOK {
+		t.Fatalf("expected pass-through when marker off and provider empty, got %+v", res)
+	}
+	if f.count() != 0 {
+		t.Fatalf("expected guard not called on LLM gate, got %d hits", f.count())
 	}
 }
 

--- a/tests/functional/mcp_plugin_chain_test.go
+++ b/tests/functional/mcp_plugin_chain_test.go
@@ -1,0 +1,175 @@
+//go:build functional
+
+package functional_test
+
+import (
+	"context"
+	"encoding/json"
+	"sync/atomic"
+	"testing"
+
+	sdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+const rpcCodePolicyBlocked = float64(-32001)
+
+func addCountingEchoTool(server *sdk.Server, name string, calls *int64) {
+	server.AddTool(
+		&sdk.Tool{Name: name, InputSchema: json.RawMessage(`{"type":"object"}`)},
+		func(_ context.Context, req *sdk.CallToolRequest) (*sdk.CallToolResult, error) {
+			atomic.AddInt64(calls, 1)
+			var args struct {
+				Message string `json:"message"`
+			}
+			_ = json.Unmarshal(req.Params.Arguments, &args)
+			return &sdk.CallToolResult{
+				Content: []sdk.Content{&sdk.TextContent{Text: name + ":" + args.Message}},
+			}, nil
+		},
+	)
+}
+
+func addCountingFixedTool(server *sdk.Server, name, text string, calls *int64) {
+	server.AddTool(
+		&sdk.Tool{Name: name, InputSchema: json.RawMessage(`{"type":"object"}`)},
+		func(_ context.Context, _ *sdk.CallToolRequest) (*sdk.CallToolResult, error) {
+			atomic.AddInt64(calls, 1)
+			return &sdk.CallToolResult{
+				Content: []sdk.Content{&sdk.TextContent{Text: text}},
+			}, nil
+		},
+	)
+}
+
+func attachTrustGuardMCPPolicy(t *testing.T, gatewayID, consumerID, inspect, mode string) {
+	t.Helper()
+	payload := map[string]any{
+		"name":     uniqueName("mcp-tg-pol"),
+		"slug":     "trustguard",
+		"enabled":  true,
+		"priority": 0,
+		"settings": map[string]any{
+			"collector_id": trustGuardFunctionalCollectorID,
+			"inspect":      inspect,
+		},
+	}
+	if mode != "" {
+		payload["mode"] = mode
+	}
+	policyID := CreatePolicy(t, gatewayID, payload)
+	AttachPolicy(t, gatewayID, consumerID, policyID)
+}
+
+func setupMCPPluginChain(t *testing.T, configure func(*sdk.Server), inspect, mode string) (string, string, map[string]string) {
+	t.Helper()
+	upstream := startMCPUpstream(t, configure)
+	gatewayID := CreateGateway(t, map[string]any{"slug": uniqueName("mcp-gw")})
+	registryID := CreateRegistry(t, gatewayID, mcpRegistryPayload(uniqueName("mcp-reg"), upstream.URL))
+	consumerID, key := createMCPConsumer(t, gatewayID, []string{registryID}, nil, "")
+	attachTrustGuardMCPPolicy(t, gatewayID, consumerID, inspect, mode)
+	return gatewayID, consumerID, apiKeyHeaders(key)
+}
+
+func TestMCPPluginChain_PreRequestEnforceBlockSkipsUpstream(t *testing.T) {
+	require.NotNil(t, TrustGuardFunctionalStub, "TrustGuard stub must be started in TestMain")
+	TrustGuardFunctionalStub.Reset()
+
+	var calls int64
+	gatewayID, consumerID, headers := setupMCPPluginChain(t,
+		func(s *sdk.Server) { addCountingEchoTool(s, "echo", &calls) },
+		"request", "")
+
+	status, body := mcpRPC(t, gatewayID, consumerID, headers, "tools/call",
+		map[string]any{"name": "echo", "arguments": map[string]any{"message": "please run " + trustGuardBlockWord}})
+
+	require.Equal(t, rpcCodePolicyBlocked, rpcErrorCode(t, status, body))
+	require.Zero(t, atomic.LoadInt64(&calls), "upstream tool must not be invoked when PreRequest blocks")
+}
+
+func TestMCPPluginChain_PreResponseEnforceBlockDiscardsResult(t *testing.T) {
+	require.NotNil(t, TrustGuardFunctionalStub, "TrustGuard stub must be started in TestMain")
+	TrustGuardFunctionalStub.Reset()
+
+	var calls int64
+	gatewayID, consumerID, headers := setupMCPPluginChain(t,
+		func(s *sdk.Server) { addCountingFixedTool(s, "leak", "leaked "+trustGuardBlockWord+" content", &calls) },
+		"response", "")
+
+	status, body := mcpRPC(t, gatewayID, consumerID, headers, "tools/call",
+		map[string]any{"name": "leak", "arguments": map[string]any{"message": "benign"}})
+
+	require.Equal(t, rpcCodePolicyBlocked, rpcErrorCode(t, status, body))
+	require.Equal(t, int64(1), atomic.LoadInt64(&calls), "upstream tool must run once before PreResponse blocks its result")
+}
+
+func TestMCPPluginChain_ObserveModeNeverBlocks(t *testing.T) {
+	require.NotNil(t, TrustGuardFunctionalStub, "TrustGuard stub must be started in TestMain")
+
+	cases := []struct {
+		name         string
+		inspect      string
+		toolName     string
+		configure    func(*sdk.Server, *int64)
+		arguments    map[string]any
+		wantContains string
+	}{
+		{
+			name:         "input direction",
+			inspect:      "request",
+			toolName:     "echo",
+			configure:    func(s *sdk.Server, c *int64) { addCountingEchoTool(s, "echo", c) },
+			arguments:    map[string]any{"message": trustGuardBlockWord},
+			wantContains: "echo:" + trustGuardBlockWord,
+		},
+		{
+			name:         "output direction",
+			inspect:      "response",
+			toolName:     "leak",
+			configure:    func(s *sdk.Server, c *int64) { addCountingFixedTool(s, "leak", "leaked "+trustGuardBlockWord, c) },
+			arguments:    map[string]any{"message": "benign"},
+			wantContains: "leaked " + trustGuardBlockWord,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			TrustGuardFunctionalStub.Reset()
+
+			var calls int64
+			gatewayID, consumerID, headers := setupMCPPluginChain(t,
+				func(s *sdk.Server) { tc.configure(s, &calls) },
+				tc.inspect, "observe")
+
+			status, body := mcpRPC(t, gatewayID, consumerID, headers, "tools/call",
+				map[string]any{"name": tc.toolName, "arguments": tc.arguments})
+
+			result := rpcResult(t, status, body)
+			raw, err := json.Marshal(result)
+			require.NoError(t, err)
+			require.Contains(t, string(raw), tc.wantContains, "observe mode must return the tool result")
+			require.Equal(t, int64(1), atomic.LoadInt64(&calls))
+			require.GreaterOrEqual(t, TrustGuardFunctionalStub.GuardHits(), 1, "guard must be evaluated in observe mode")
+		})
+	}
+}
+
+func TestMCPPluginChain_GuardErrorFailsOpen(t *testing.T) {
+	require.NotNil(t, TrustGuardFunctionalStub, "TrustGuard stub must be started in TestMain")
+	TrustGuardFunctionalStub.Reset()
+
+	var calls int64
+	gatewayID, consumerID, headers := setupMCPPluginChain(t,
+		func(s *sdk.Server) { addCountingEchoTool(s, "echo", &calls) },
+		"request", "")
+
+	status, body := mcpRPC(t, gatewayID, consumerID, headers, "tools/call",
+		map[string]any{"name": "echo", "arguments": map[string]any{"message": "trigger " + trustGuardErrorWord}})
+
+	result := rpcResult(t, status, body)
+	raw, err := json.Marshal(result)
+	require.NoError(t, err)
+	require.Contains(t, string(raw), "echo:trigger "+trustGuardErrorWord, "guard error must fail open and return the tool result")
+	require.Equal(t, int64(1), atomic.LoadInt64(&calls), "guard error must fail open and still invoke the upstream tool")
+	require.GreaterOrEqual(t, TrustGuardFunctionalStub.GuardHits(), 1, "guard must have been attempted before failing open")
+}

--- a/tests/functional/trustguard_stub_test.go
+++ b/tests/functional/trustguard_stub_test.go
@@ -18,6 +18,7 @@ const (
 	trustGuardFunctionalCollectorID  = "11111111-1111-4111-8111-111111111111"
 	trustGuardFunctionalAccessToken  = "functional-trustguard-access-token"
 	trustGuardBlockWord              = "sql-injection-flag"
+	trustGuardErrorWord              = "guard-boom-flag"
 )
 
 var TrustGuardFunctionalStub *trustGuardStub
@@ -145,6 +146,10 @@ func (s *trustGuardStub) handleGuard(w http.ResponseWriter, r *http.Request) {
 	s.lastGuardAuth = r.Header.Get("Authorization")
 	s.mu.Unlock()
 
+	if strings.Contains(strings.ToLower(req.Payload.Input), trustGuardErrorWord) {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
 	if strings.Contains(strings.ToLower(req.Payload.Input), trustGuardBlockWord) {
 		_, _ = io.WriteString(w, `{"status":"block","findings":[{"source":{"kind":"detector","plugin":"prompt_guard"},"signal":{"type":"prompt_injection"},"outcome":{"action":"block"}}],"trace_id":"tg-trace-1","request_id":"tg-req-1"}`)


### PR DESCRIPTION
## Summary

Closes [RUN-832](https://linear.app/neuraltrust/issue/RUN-832). Runs the configured plugin chain (TrustGuard) on the **native MCP `tools/call` endpoint** in **both directions** — previously plugins only ran on the LLM proxy path.

- **TrustGuard MCP extraction** — new `RequestContext.MCP` marker + a TrustGuard branch that extracts inspectable text from JSON-RPC (`tools/call` name+arguments in; `CallToolResult.content[].text` out), bypassing the LLM canonical decoders and forcing `protocol=mcp`. LLM path unchanged.
- **App-layer `mcp.PluginRunner`** — runs the chain (via the shared `appplugins.Executor`, using the consumer's `Policies`/`PolicyPlan`) `PreRequest` on the call and `PreResponse` on the result. Policy block → JSON-RPC error `-32001`; `PluginError`/`ShortCircuit` block in both directions.
- **Dispatcher wiring** — `RPCGateway.tools/call` now runs PreRequest (no upstream dial on block) → `composer.CallTool` → PreResponse (result discarded on block). Rendered via the existing `writeAppError` path at HTTP 200. Provided through dig, reusing the shared plugins executor. Only `tools/call` is affected.
- **Fail-open in both directions** on guard/plugin errors (per RUN-832 spec — intentional divergence from the LLM proxy's fail-closed-on-enforce-PreResponse); logs ids/direction/outcome only, never payloads.

## Behavior change

MCP `tools/call` can now be reported or blocked by policy in both directions. No behavior change when no plugin/policy is configured for the MCP consumer.

## Intentional deviations

- Fail-open on enforce `PreResponse` (diverges from the LLM proxy, per spec).
- `SessionID` left empty this slice (`Mcp-Session-Id` not yet threaded into `Dispatch`) — follow-up suggested.
- Scope: only `tools/call` (both directions). `prompts/get`, `resources/read`, discovery, `initialize`/`ping`, and streaming stay plugin-free.

## Test plan

- [x] `go build ./...` / `go build ./cmd/...`, `go vet`, `golangci-lint`, `gosec` (pre-commit) clean
- [x] Unit `-race`: TrustGuard MCP extraction (name+args, content[].text, empty/isError/non-text/nested args), runner (both directions × allow/report/enforce block via PluginError + short-circuit/fail-open/nil executor), dispatcher (PreRequest block ⇒ no dial; PreResponse block ⇒ result withheld; allow ⇒ verbatim), e2e `Handler.Handle` (HTTP 200 + `-32001`)
- [x] Functional e2e (`tests/functional/mcp_plugin_chain_test.go`): PreRequest/PreResponse enforce blocks, observe mode (both directions), guard-error fail-open — all pass with `-race`
- [x] LLM proxy plugin behavior unchanged (regression test)

_Consolidated from the original chained PRs #156 / #157 (now closed) into this single PR targeting `develop`._