### PR TITLE
feat(telemetry): merge file-default and per-gateway exporters by name (ENG-1017)

### DIFF
--- a/pkg/api/middleware/metrics_functional_test.go
+++ b/pkg/api/middleware/metrics_functional_test.go
@@ -25,9 +25,9 @@ import (
 	"time"
 
 	"github.com/NeuralTrust/TrustGate/pkg/api/middleware"
+	appcatalog "github.com/NeuralTrust/TrustGate/pkg/app/catalog"
 	appconsumer "github.com/NeuralTrust/TrustGate/pkg/app/consumer"
 	appgateway "github.com/NeuralTrust/TrustGate/pkg/app/gateway"
-	appcatalog "github.com/NeuralTrust/TrustGate/pkg/app/catalog"
 	appmetrics "github.com/NeuralTrust/TrustGate/pkg/app/metrics"
 	"github.com/NeuralTrust/TrustGate/pkg/config"
 	gatewaydomain "github.com/NeuralTrust/TrustGate/pkg/domain/gateway"
@@ -132,14 +132,10 @@ func newMetricsApp(t *testing.T, gw *gatewaydomain.Gateway, rec *eventRecorder) 
 		infratelemetry.WithExporter("broken", &memTemplate{name: "broken", rec: rec, fail: true}),
 	)
 	cache := appmetrics.NewExporterCache(factory, logger)
-	def, err := factory.Build(telemetrydomain.ExporterConfig{
-		Name:     "kafka",
-		Settings: map[string]interface{}{"topic": defaultTopic},
-	})
-	require.NoError(t, err)
 
 	builder := appmetrics.NewBuilder(adapter.NewRegistry(), zeroPricing{})
-	pipeline := appmetrics.NewPipeline(builder, cache, nil, logger, def)
+	pipeline := appmetrics.NewPipeline(builder, cache, nil, logger,
+		telemetrydomain.ExporterConfig{Name: "kafka", Settings: map[string]interface{}{"topic": defaultTopic}})
 	worker := appmetrics.NewWorker(logger, pipeline)
 	worker.StartWorkers(2)
 	t.Cleanup(worker.Shutdown)

--- a/pkg/app/metrics/exporter_internal_test.go
+++ b/pkg/app/metrics/exporter_internal_test.go
@@ -233,6 +233,22 @@ func TestPipeline_MergeMatrix(t *testing.T) {
 	}
 }
 
+func TestPipeline_ResolveTargetsDedupesDuplicateExplicitByName(t *testing.T) {
+	factory := &fakeFactory{}
+	cache := NewExporterCache(factory, internalTestLogger())
+	p := NewPipeline(nil, cache, nil, internalTestLogger())
+
+	targets := p.resolveTargets([]telemetrydomain.ExporterConfig{
+		{Name: "dup", Settings: map[string]interface{}{"topic": "first"}},
+		{Name: "dup", Settings: map[string]interface{}{"topic": "second"}},
+	})
+
+	require.Len(t, targets, 1)
+	built := factory.builtConfigs()
+	require.Len(t, built, 1)
+	assert.Equal(t, "second", built[0].Settings["topic"], "the last config for a duplicated name wins")
+}
+
 func TestPipeline_PublishIsolatesExporterErrors(t *testing.T) {
 	builder := NewBuilder(adapter.NewRegistry(), stubPricing{})
 	factory := &fakeFactory{publishErrByName: map[string]error{"bad": errors.New("boom")}}

--- a/pkg/app/metrics/exporter_internal_test.go
+++ b/pkg/app/metrics/exporter_internal_test.go
@@ -65,22 +65,33 @@ func (f *fakeExporter) publishedCount() int {
 }
 
 type fakeFactory struct {
-	mu       sync.Mutex
-	builds   int
-	buildErr error
+	mu               sync.Mutex
+	builds           int
+	buildErr         error
+	built            []telemetrydomain.ExporterConfig
+	publishErrByName map[string]error
 }
 
 func (f *fakeFactory) Build(cfg telemetrydomain.ExporterConfig) (Exporter, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.builds++
+	f.built = append(f.built, cfg)
 	if f.buildErr != nil {
 		return nil, f.buildErr
 	}
-	return &fakeExporter{name: cfg.Name}, nil
+	return &fakeExporter{name: cfg.Name, publishErr: f.publishErrByName[cfg.Name]}, nil
 }
 
 func (f *fakeFactory) Validate(_ telemetrydomain.ExporterConfig) error { return nil }
+
+func (f *fakeFactory) builtConfigs() []telemetrydomain.ExporterConfig {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]telemetrydomain.ExporterConfig, len(f.built))
+	copy(out, f.built)
+	return out
+}
 
 type fakePlaygroundStore struct {
 	mu     sync.Mutex
@@ -148,15 +159,18 @@ func TestExporterCache_CloseAllClosesInstances(t *testing.T) {
 func TestPipeline_ResolveTargetsOverrideByName(t *testing.T) {
 	factory := &fakeFactory{}
 	cache := NewExporterCache(factory, internalTestLogger())
-	defaultKafka := &fakeExporter{name: "kafka"}
-	p := NewPipeline(nil, cache, nil, internalTestLogger(), defaultKafka)
+	p := NewPipeline(nil, cache, nil, internalTestLogger(),
+		telemetrydomain.ExporterConfig{Name: "kafka", Settings: map[string]interface{}{"topic": "default"}})
 
 	overridden := p.resolveTargets([]telemetrydomain.ExporterConfig{
 		{Name: "kafka", Settings: map[string]interface{}{"topic": "other"}},
 	})
 	require.Len(t, overridden, 1)
 	assert.Equal(t, "kafka", overridden[0].Name())
-	assert.NotSame(t, defaultKafka, overridden[0], "explicit kafka must replace the default kafka")
+
+	built := factory.builtConfigs()
+	require.Len(t, built, 1)
+	assert.Equal(t, "other", built[0].Settings["topic"], "kafka must be built from the gateway config, not the default")
 
 	added := p.resolveTargets([]telemetrydomain.ExporterConfig{
 		{Name: "other", Settings: map[string]interface{}{"topic": "x"}},
@@ -164,43 +178,99 @@ func TestPipeline_ResolveTargetsOverrideByName(t *testing.T) {
 	require.Len(t, added, 2, "a differently-named exporter is added on top of the default")
 }
 
-func TestPipeline_OverrideFailureKeepsDefault(t *testing.T) {
+func TestPipeline_OverrideFailureSkipsTarget(t *testing.T) {
 	factory := &fakeFactory{buildErr: errors.New("boom")}
 	cache := NewExporterCache(factory, internalTestLogger())
-	defaultKafka := &fakeExporter{name: "kafka"}
-	p := NewPipeline(nil, cache, nil, internalTestLogger(), defaultKafka)
+	p := NewPipeline(nil, cache, nil, internalTestLogger(),
+		telemetrydomain.ExporterConfig{Name: "kafka", Settings: map[string]interface{}{"topic": "default"}})
 
 	targets := p.resolveTargets([]telemetrydomain.ExporterConfig{
 		{Name: "kafka", Settings: map[string]interface{}{"topic": "bad"}},
 	})
 
-	require.Len(t, targets, 1)
-	assert.Same(t, defaultKafka, targets[0], "default must survive when the overriding exporter fails to build")
+	require.Empty(t, targets, "a failed override is skipped with no default fallback")
+	assert.Equal(t, 1, factory.buildCount(), "only the single merged kafka config is attempted")
+}
+
+func TestPipeline_MergeMatrix(t *testing.T) {
+	t.Parallel()
+	cfg := func(name string) telemetrydomain.ExporterConfig {
+		return telemetrydomain.ExporterConfig{Name: name, Settings: map[string]interface{}{"topic": name}}
+	}
+	tests := []struct {
+		name     string
+		defaults []telemetrydomain.ExporterConfig
+		explicit []telemetrydomain.ExporterConfig
+		want     []string
+	}{
+		{name: "empty defaults and no gateway exporters yield no targets", defaults: nil, explicit: nil, want: nil},
+		{name: "default only", defaults: []telemetrydomain.ExporterConfig{cfg("otlp-a")}, explicit: nil, want: []string{"otlp-a"}},
+		{name: "gateway only", defaults: nil, explicit: []telemetrydomain.ExporterConfig{cfg("otlp-a")}, want: []string{"otlp-a"}},
+		{name: "override same name gateway wins", defaults: []telemetrydomain.ExporterConfig{cfg("otlp-a")}, explicit: []telemetrydomain.ExporterConfig{cfg("otlp-a")}, want: []string{"otlp-a"}},
+		{name: "same type different name both run in file-then-gateway order", defaults: []telemetrydomain.ExporterConfig{cfg("otlp-a")}, explicit: []telemetrydomain.ExporterConfig{cfg("otlp-b")}, want: []string{"otlp-a", "otlp-b"}},
+		{name: "override by name keeps other defaults", defaults: []telemetrydomain.ExporterConfig{cfg("otlp-a"), cfg("kafka-x")}, explicit: []telemetrydomain.ExporterConfig{cfg("otlp-a")}, want: []string{"otlp-a", "kafka-x"}},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			factory := &fakeFactory{}
+			cache := NewExporterCache(factory, internalTestLogger())
+			p := NewPipeline(nil, cache, nil, internalTestLogger(), tt.defaults...)
+
+			targets := p.resolveTargets(tt.explicit)
+
+			if tt.want == nil {
+				require.Nil(t, targets)
+				return
+			}
+			got := make([]string, len(targets))
+			for i, e := range targets {
+				got[i] = e.Name()
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func TestPipeline_PublishIsolatesExporterErrors(t *testing.T) {
 	builder := NewBuilder(adapter.NewRegistry(), stubPricing{})
-	bad := &fakeExporter{name: "bad", publishErr: errors.New("boom")}
-	good := &fakeExporter{name: "good"}
-	p := NewPipeline(builder, nil, nil, internalTestLogger(), bad, good)
+	factory := &fakeFactory{publishErrByName: map[string]error{"bad": errors.New("boom")}}
+	cache := NewExporterCache(factory, internalTestLogger())
+	p := NewPipeline(builder, cache, nil, internalTestLogger(),
+		telemetrydomain.ExporterConfig{Name: "bad"},
+		telemetrydomain.ExporterConfig{Name: "good"})
 
 	req := &infracontext.RequestContext{GatewayID: "gw-1", Method: "POST", Path: "/v1/chat/completions"}
 	resp := &infracontext.ResponseContext{StatusCode: 200}
 
+	targets := p.resolveTargets(nil)
+	require.Len(t, targets, 2)
+	byName := make(map[string]*fakeExporter, len(targets))
+	for _, tgt := range targets {
+		byName[tgt.Name()] = tgt.(*fakeExporter)
+	}
+
 	p.publish(nil, req, resp, time.Now(), time.Now(), nil)
 
-	assert.Equal(t, 1, bad.publishedCount())
-	assert.Equal(t, 1, good.publishedCount(), "a failing exporter must not prevent the others from publishing")
+	assert.Equal(t, 1, byName["bad"].publishedCount())
+	assert.Equal(t, 1, byName["good"].publishedCount(), "a failing exporter must not prevent the others from publishing")
 }
 
 func TestPipeline_PublishCallsPlaygroundStore(t *testing.T) {
 	builder := NewBuilder(adapter.NewRegistry(), stubPricing{})
-	exporter := &fakeExporter{name: "kafka"}
+	factory := &fakeFactory{}
+	cache := NewExporterCache(factory, internalTestLogger())
 	store := &fakePlaygroundStore{}
-	p := NewPipeline(builder, nil, store, internalTestLogger(), exporter)
+	p := NewPipeline(builder, cache, store, internalTestLogger(),
+		telemetrydomain.ExporterConfig{Name: "kafka"})
 
 	req := &infracontext.RequestContext{GatewayID: "gw-1", Method: "POST", Path: "/v1/chat/completions"}
 	resp := &infracontext.ResponseContext{StatusCode: 200}
+
+	targets := p.resolveTargets(nil)
+	require.Len(t, targets, 1)
+	exporter := targets[0].(*fakeExporter)
 
 	p.publish(nil, req, resp, time.Now(), time.Now(), nil)
 

--- a/pkg/app/metrics/pipeline.go
+++ b/pkg/app/metrics/pipeline.go
@@ -39,11 +39,11 @@ type PlaygroundTraceStore interface {
 }
 
 type Pipeline struct {
-	builder          *Builder
-	defaultExporters []Exporter
-	cache            *ExporterCache
-	playgroundStore  PlaygroundTraceStore
-	logger           *slog.Logger
+	builder         *Builder
+	defaultConfigs  []telemetrydomain.ExporterConfig
+	cache           *ExporterCache
+	playgroundStore PlaygroundTraceStore
+	logger          *slog.Logger
 }
 
 func NewPipeline(
@@ -51,14 +51,14 @@ func NewPipeline(
 	cache *ExporterCache,
 	playgroundStore PlaygroundTraceStore,
 	logger *slog.Logger,
-	defaults ...Exporter,
+	defaults ...telemetrydomain.ExporterConfig,
 ) *Pipeline {
 	return &Pipeline{
-		builder:          builder,
-		defaultExporters: defaults,
-		cache:            cache,
-		playgroundStore:  playgroundStore,
-		logger:           logger,
+		builder:         builder,
+		defaultConfigs:  defaults,
+		cache:           cache,
+		playgroundStore: playgroundStore,
+		logger:          logger,
 	}
 }
 
@@ -92,30 +92,42 @@ func (p *Pipeline) publish(
 }
 
 func (p *Pipeline) resolveTargets(explicit []telemetrydomain.ExporterConfig) []Exporter {
-	var resolved []Exporter
-	if len(explicit) > 0 && p.cache != nil {
-		resolved = p.cache.Resolve(explicit)
+	if p.cache == nil {
+		return nil
 	}
-	resolvedNames := make(map[string]struct{}, len(resolved))
-	for _, e := range resolved {
-		resolvedNames[e.Name()] = struct{}{}
+	overrides := make(map[string]telemetrydomain.ExporterConfig, len(explicit))
+	for _, e := range explicit {
+		overrides[e.Name] = e
 	}
-	targets := make([]Exporter, 0, len(resolved)+len(p.defaultExporters))
-	targets = append(targets, resolved...)
-	for _, d := range p.defaultExporters {
-		if _, replaced := resolvedNames[d.Name()]; !replaced {
-			targets = append(targets, d)
+	merged := make([]telemetrydomain.ExporterConfig, 0, len(p.defaultConfigs)+len(explicit))
+	seen := make(map[string]struct{}, len(p.defaultConfigs)+len(explicit))
+	for _, d := range p.defaultConfigs {
+		if _, dup := seen[d.Name]; dup {
+			continue
 		}
+		seen[d.Name] = struct{}{}
+		if override, ok := overrides[d.Name]; ok {
+			merged = append(merged, override)
+			continue
+		}
+		merged = append(merged, d)
 	}
-	return targets
+	for _, e := range explicit {
+		if _, dup := seen[e.Name]; dup {
+			continue
+		}
+		seen[e.Name] = struct{}{}
+		merged = append(merged, e)
+	}
+	if len(merged) == 0 {
+		return nil
+	}
+	return p.cache.Resolve(merged)
 }
 
 func (p *Pipeline) close() {
 	if p == nil {
 		return
-	}
-	for _, d := range p.defaultExporters {
-		d.Close()
 	}
 	if p.cache != nil {
 		p.cache.CloseAll()

--- a/pkg/app/metrics/pipeline.go
+++ b/pkg/app/metrics/pipeline.go
@@ -117,7 +117,7 @@ func (p *Pipeline) resolveTargets(explicit []telemetrydomain.ExporterConfig) []E
 			continue
 		}
 		seen[e.Name] = struct{}{}
-		merged = append(merged, e)
+		merged = append(merged, overrides[e.Name])
 	}
 	if len(merged) == 0 {
 		return nil

--- a/pkg/app/metrics/worker_test.go
+++ b/pkg/app/metrics/worker_test.go
@@ -24,6 +24,7 @@ import (
 
 	appcatalog "github.com/NeuralTrust/TrustGate/pkg/app/catalog"
 	appmetrics "github.com/NeuralTrust/TrustGate/pkg/app/metrics"
+	telemetrydomain "github.com/NeuralTrust/TrustGate/pkg/domain/telemetry"
 	infracontext "github.com/NeuralTrust/TrustGate/pkg/infra/context"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics/events"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/adapter"
@@ -58,6 +59,16 @@ func (c *captureExporter) snapshot() []*events.Event {
 	return append([]*events.Event(nil), c.events...)
 }
 
+type captureFactory struct {
+	exporter appmetrics.Exporter
+}
+
+func (f captureFactory) Build(_ telemetrydomain.ExporterConfig) (appmetrics.Exporter, error) {
+	return f.exporter, nil
+}
+
+func (f captureFactory) Validate(_ telemetrydomain.ExporterConfig) error { return nil }
+
 type stubPricingResolver struct {
 	price appcatalog.Pricing
 }
@@ -74,7 +85,9 @@ func TestWorker_PublishesConsolidatedEvent(t *testing.T) {
 	builder := appmetrics.NewBuilder(adapter.NewRegistry(), stubPricingResolver{
 		price: appcatalog.Pricing{ModelLabel: "GPT-4o", InputPrice: 0.0000025, OutputPrice: 0.00001, Found: true},
 	})
-	pipeline := appmetrics.NewPipeline(builder, nil, nil, newTestLogger(), capture)
+	cache := appmetrics.NewExporterCache(captureFactory{exporter: capture}, newTestLogger())
+	pipeline := appmetrics.NewPipeline(builder, cache, nil, newTestLogger(),
+		telemetrydomain.ExporterConfig{Name: "capture"})
 
 	w := appmetrics.NewWorker(newTestLogger(), pipeline)
 	w.StartWorkers(1)

--- a/pkg/container/modules/telemetry.go
+++ b/pkg/container/modules/telemetry.go
@@ -22,6 +22,7 @@ import (
 	appmetrics "github.com/NeuralTrust/TrustGate/pkg/app/metrics"
 	"github.com/NeuralTrust/TrustGate/pkg/config"
 	"github.com/NeuralTrust/TrustGate/pkg/container"
+	telemetrydomain "github.com/NeuralTrust/TrustGate/pkg/domain/telemetry"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/bootlog"
 	infracache "github.com/NeuralTrust/TrustGate/pkg/infra/cache"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics/playground"
@@ -94,7 +95,7 @@ func newDefaultExporters(
 	logger *slog.Logger,
 	factory appmetrics.ExporterFactory,
 	path string,
-) ([]appmetrics.Exporter, error) {
+) ([]telemetrydomain.ExporterConfig, error) {
 	configs, err := exportersfile.Load(path)
 	if err != nil {
 		if errors.Is(err, exportersfile.ErrFileNotFound) {
@@ -109,21 +110,15 @@ func newDefaultExporters(
 			slog.String("path", path))
 		return nil, nil
 	}
-	defaults := make([]appmetrics.Exporter, 0, len(configs))
 	for _, cfg := range configs {
 		if err := factory.Validate(cfg); err != nil {
 			return nil, fmt.Errorf("default telemetry exporter %q: %w", cfg.Name, err)
 		}
-		exporter, err := factory.Build(cfg)
-		if err != nil {
-			return nil, fmt.Errorf("default telemetry exporter %q: %w", cfg.Name, err)
-		}
-		logger.Info("default telemetry exporter initialized",
+		logger.Info("default telemetry exporter registered",
 			slog.String("name", cfg.Name),
 			slog.String("type", cfg.EffectiveType()))
-		defaults = append(defaults, exporter)
 	}
-	return defaults, nil
+	return configs, nil
 }
 
 // MetricsWorkerParams collects everything StartMetricsWorker needs.

--- a/pkg/container/modules/telemetry_test.go
+++ b/pkg/container/modules/telemetry_test.go
@@ -15,7 +15,6 @@
 package modules
 
 import (
-	"context"
 	"errors"
 	"io"
 	"log/slog"
@@ -23,22 +22,12 @@ import (
 	"path/filepath"
 	"testing"
 
-	appmetrics "github.com/NeuralTrust/TrustGate/pkg/app/metrics"
 	"github.com/NeuralTrust/TrustGate/pkg/app/metrics/mocks"
 	telemetrydomain "github.com/NeuralTrust/TrustGate/pkg/domain/telemetry"
-	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics/events"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
-
-type fakeExporter struct {
-	name string
-}
-
-func (f *fakeExporter) Name() string                                 { return f.name }
-func (f *fakeExporter) Publish(context.Context, *events.Event) error { return nil }
-func (f *fakeExporter) Close()                                       {}
 
 func TestNewDefaultExporters(t *testing.T) {
 	t.Parallel()
@@ -48,10 +37,10 @@ func TestNewDefaultExporters(t *testing.T) {
 		write   bool
 		content string
 		setup   func(factory *mocks.ExporterFactory)
-		assert  func(t *testing.T, exporters []appmetrics.Exporter, err error)
+		assert  func(t *testing.T, configs []telemetrydomain.ExporterConfig, err error)
 	}{
 		{
-			name:  "valid entries are built in file order",
+			name:  "valid entries are returned as configs in file order and not built",
 			write: true,
 			content: `exporters:
   - name: otlp
@@ -61,15 +50,11 @@ func TestNewDefaultExporters(t *testing.T) {
 `,
 			setup: func(factory *mocks.ExporterFactory) {
 				factory.EXPECT().Validate(mock.Anything).Return(nil)
-				factory.EXPECT().Build(mock.Anything).RunAndReturn(
-					func(cfg telemetrydomain.ExporterConfig) (appmetrics.Exporter, error) {
-						return &fakeExporter{name: cfg.Name}, nil
-					})
 			},
-			assert: func(t *testing.T, exporters []appmetrics.Exporter, err error) {
+			assert: func(t *testing.T, configs []telemetrydomain.ExporterConfig, err error) {
 				require.NoError(t, err)
-				require.Len(t, exporters, 2)
-				assert.Equal(t, []string{"otlp", "kafka"}, []string{exporters[0].Name(), exporters[1].Name()})
+				require.Len(t, configs, 2)
+				assert.Equal(t, []string{"otlp", "kafka"}, []string{configs[0].Name, configs[1].Name})
 			},
 		},
 		{
@@ -82,36 +67,19 @@ func TestNewDefaultExporters(t *testing.T) {
 			setup: func(factory *mocks.ExporterFactory) {
 				factory.EXPECT().Validate(mock.Anything).Return(errors.New("invalid settings"))
 			},
-			assert: func(t *testing.T, exporters []appmetrics.Exporter, err error) {
+			assert: func(t *testing.T, configs []telemetrydomain.ExporterConfig, err error) {
 				require.Error(t, err)
 				assert.ErrorContains(t, err, "brokenexporter")
-				assert.Nil(t, exporters)
-			},
-		},
-		{
-			name:  "build failure aborts boot naming the entry",
-			write: true,
-			content: `exporters:
-  - name: otlp
-    type: otlp
-`,
-			setup: func(factory *mocks.ExporterFactory) {
-				factory.EXPECT().Validate(mock.Anything).Return(nil)
-				factory.EXPECT().Build(mock.Anything).Return(nil, errors.New("dial failed"))
-			},
-			assert: func(t *testing.T, exporters []appmetrics.Exporter, err error) {
-				require.Error(t, err)
-				assert.ErrorContains(t, err, "otlp")
-				assert.Nil(t, exporters)
+				assert.Nil(t, configs)
 			},
 		},
 		{
 			name:  "missing file yields no defaults and no error",
 			write: false,
 			setup: func(factory *mocks.ExporterFactory) {},
-			assert: func(t *testing.T, exporters []appmetrics.Exporter, err error) {
+			assert: func(t *testing.T, configs []telemetrydomain.ExporterConfig, err error) {
 				require.NoError(t, err)
-				assert.Empty(t, exporters)
+				assert.Empty(t, configs)
 			},
 		},
 		{
@@ -119,9 +87,9 @@ func TestNewDefaultExporters(t *testing.T) {
 			write:   true,
 			content: "",
 			setup:   func(factory *mocks.ExporterFactory) {},
-			assert: func(t *testing.T, exporters []appmetrics.Exporter, err error) {
+			assert: func(t *testing.T, configs []telemetrydomain.ExporterConfig, err error) {
 				require.NoError(t, err)
-				assert.Empty(t, exporters)
+				assert.Empty(t, configs)
 			},
 		},
 	}
@@ -140,8 +108,8 @@ func TestNewDefaultExporters(t *testing.T) {
 			tt.setup(factory)
 
 			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-			exporters, err := newDefaultExporters(logger, factory, path)
-			tt.assert(t, exporters, err)
+			configs, err := newDefaultExporters(logger, factory, path)
+			tt.assert(t, configs, err)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Extends the telemetry pipeline to merge the **list** of YAML file-default exporters (from ENG-1016) with per-gateway exporters, deduped by instance **name** (per-gateway wins on collision). Replaces the old single-default merge.

Linear: **ENG-1017** (parent epic ENG-1013). **Stacked on [#161 (ENG-1016)](https://github.com/NeuralTrust/TrustGate/pull/161)** — review/merge that first; base auto-retargets to `develop`.

## What changed
- **`pkg/app/metrics/pipeline.go`**: `Pipeline` stores `defaultConfigs []ExporterConfig`; `NewPipeline(...)` takes `defaults ...ExporterConfig`. `resolveTargets` merges defaults (file order) + per-gateway configs, **deduped by `ExporterConfig.Name`** (gateway wins), then builds via the instance-aware `ExporterCache` (`Resolve`); empty merged set → no targets. `close()` delegates to `cache.CloseAll()`.
- **`pkg/container/modules/telemetry.go`**: `newDefaultExporters` returns `[]ExporterConfig` — keeps boot-time `factory.Validate` fail-fast, drops the eager `Build` loop (build is now lazy via the cache).

## Merge matrix (behavior)
- No gateway exporters → all file defaults run.
- Gateway `X` collides with default `X` → gateway's `X` runs, default `X` dropped (dedupe by name, no dup).
- Gateway new `Y` → defaults + `Y` run.
- Default `otlp "a"` + gateway `otlp "b"` (same type, different name) → **both** run.
- Empty defaults + no gateway exporters → zero targets (no implicit Kafka).

## Behavior change (intentional)
Previously a per-gateway override that failed to build fell back to the overridden default. Now the failed override is **skipped and logged**; the overridden default does **not** run. `TestPipeline_OverrideFailureKeepsDefault` is replaced by `TestPipeline_OverrideFailureSkipsTarget`.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues)
- [x] `go test -race ./pkg/...` green (metrics, container/modules, middleware)
- [x] `TestPipeline_MergeMatrix` (6-row table) + override-skip test
- [x] Bugbot: no bugs

## Notes
- Out of scope: OTLP metadata split (ENG-1019), postgres exporter (ENG-1020).
- ~182 changed lines (prod ~72, tests ~110) — single PR.

Made with [Cursor](https://cursor.com)