### PR TITLE
feat(telemetry): make OTLP exporter metadata-only (ENG-1019)

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,21 +406,27 @@ or unreachable Collector never affects request latency.
 
 The metrics pipeline's **default** exporters (applied to every gateway unless a
 gateway declares its own) are loaded at boot from a declarative YAML file,
-selected by `TELEMETRY_EXPORTERS_FILE` (default `config/telemetry.yaml`). An
-exporter's data class is intrinsic to its `type`: **metadata** exporters (e.g.
-`otlp`) ship sanitized request metadata to an external backend, while
-**sensible** exporters (e.g. the `postgres` example, arriving with ENG-1020)
-persist sensitive payloads inside your own boundary.
+selected by `TELEMETRY_EXPORTERS_FILE` (default `config/telemetry.yaml`).
+Exporters are grouped by data class, and the class is intrinsic to the `type`:
+**metadata** exporters (e.g. `otlp`) ship sanitized request metadata to an
+external backend, while **raw** exporters (only `postgres`, arriving with
+ENG-1020) persist sensitive payloads inside your own boundary.
 
 ```yaml
 exporters:
-  - name: otlp      # instance identity (used for dedupe against per-gateway config)
-    type: otlp      # template selector; defaults to name when omitted
-    settings: { endpoint: "otel-collector:4317", protocol: grpc, signal: logs }
+  metadata:           # every type EXCEPT postgres
+    - name: otlp      # instance identity (used for dedupe against per-gateway config)
+      type: otlp      # template selector; defaults to name when omitted
+      settings: { endpoint: "otel-collector:4317", protocol: grpc, signal: logs }
+  raw:                # postgres only
+    - name: postgres
+      type: postgres
+      settings: { dsn: "postgres://user:pass@localhost:5432/telemetry" }
 ```
 
 Behaviour:
 
+- **`postgres` under `metadata`, or any other type under `raw` → boot aborts.**
 - **Invalid or unknown declared exporter → boot aborts (fail-fast).**
 - **File missing or empty → warning logged, pipeline starts with no defaults.**
 - There is no hardcoded default exporter; Kafka runs as a default only if declared.

--- a/config/telemetry.example.yaml
+++ b/config/telemetry.example.yaml
@@ -8,30 +8,35 @@
 #
 # Copy this file to config/telemetry.yaml to get started.
 #
-# Each exporter's data class is intrinsic to its type: metadata exporters (like
-# otlp) ship sanitized, non-sensitive request metadata to an external backend,
-# while sensible exporters (like the postgres example below, arriving with
-# ENG-1020) persist sensitive payloads to a store inside your own boundary.
+# Exporters are grouped by data class, and the class is intrinsic to the type:
+#   - metadata: ships sanitized, non-sensitive request metadata to an external
+#     backend. Accepts every type EXCEPT postgres (e.g. otlp).
+#   - raw: persists sensitive request/response payloads inside your own
+#     boundary. Accepts ONLY postgres.
+# Declaring postgres under metadata, or any other type under raw, aborts boot.
 
 exporters:
-  - name: otlp
-    type: otlp
-    settings:
-      endpoint: "otel-collector:4317"
-      protocol: "grpc"
-      signal: "logs"
-      compression: "gzip"
-      timeout: "10s"
-      insecure: false
-      max_body_bytes: 4096
-      headers:
-        x-scope-orgid: "trustgate"
+  metadata:
+    - name: otlp
+      type: otlp
+      settings:
+        endpoint: "otel-collector:4317"
+        protocol: "grpc"
+        signal: "logs"
+        compression: "gzip"
+        timeout: "10s"
+        insecure: false
+        max_body_bytes: 4096
+        headers:
+          x-scope-orgid: "trustgate"
 
-# postgres is a sensible exporter documented for ENG-1020 and is NOT registered
-# yet. Uncommenting it today aborts boot at factory.Validate (unknown exporter
-# "postgres"). It persists sensitive telemetry payloads inside your own store.
-#  - name: postgres
-#    type: postgres
-#    settings:
-#      dsn: "postgres://user:pass@localhost:5432/telemetry?sslmode=disable"
-#      table: "telemetry_events"
+  # postgres is the raw sink documented for ENG-1020 and is NOT registered yet.
+  # Uncommenting it today aborts boot at factory.Validate (unknown exporter
+  # "postgres"). It persists sensitive telemetry payloads inside your own store.
+  raw: []
+#  raw:
+#    - name: postgres
+#      type: postgres
+#      settings:
+#        dsn: "postgres://user:pass@localhost:5432/telemetry?sslmode=disable"
+#        table: "telemetry_events"

--- a/pkg/container/modules/telemetry_test.go
+++ b/pkg/container/modules/telemetry_test.go
@@ -43,10 +43,11 @@ func TestNewDefaultExporters(t *testing.T) {
 			name:  "valid entries are returned as configs in file order and not built",
 			write: true,
 			content: `exporters:
-  - name: otlp
-    type: otlp
-  - name: kafka
-    type: kafka
+  metadata:
+    - name: otlp
+      type: otlp
+    - name: kafka
+      type: kafka
 `,
 			setup: func(factory *mocks.ExporterFactory) {
 				factory.EXPECT().Validate(mock.Anything).Return(nil)
@@ -61,8 +62,9 @@ func TestNewDefaultExporters(t *testing.T) {
 			name:  "entry failing validation aborts boot naming the entry",
 			write: true,
 			content: `exporters:
-  - name: brokenexporter
-    type: brokenexporter
+  metadata:
+    - name: brokenexporter
+      type: brokenexporter
 `,
 			setup: func(factory *mocks.ExporterFactory) {
 				factory.EXPECT().Validate(mock.Anything).Return(errors.New("invalid settings"))

--- a/pkg/infra/telemetry/exportersfile/loader.go
+++ b/pkg/infra/telemetry/exportersfile/loader.go
@@ -25,8 +25,17 @@ import (
 
 var ErrFileNotFound = errors.New("telemetry exporters file not found")
 
+// rawExporterType is the only type accepted for raw (sensible) payloads; the
+// data class is intrinsic to the type, so the file grouping is validated against it.
+const rawExporterType = "postgres"
+
 type fileSpec struct {
-	Exporters []exporterEntry `yaml:"exporters"`
+	Exporters exporterGroups `yaml:"exporters"`
+}
+
+type exporterGroups struct {
+	Metadata []exporterEntry `yaml:"metadata"`
+	Raw      []exporterEntry `yaml:"raw"`
 }
 
 type exporterEntry struct {
@@ -47,13 +56,29 @@ func Load(path string) ([]telemetrydomain.ExporterConfig, error) {
 	if err := yaml.Unmarshal(data, &spec); err != nil {
 		return nil, fmt.Errorf("parsing telemetry exporters file %q: %w", path, err)
 	}
-	configs := make([]telemetrydomain.ExporterConfig, 0, len(spec.Exporters))
-	for _, e := range spec.Exporters {
-		configs = append(configs, telemetrydomain.ExporterConfig{
-			Name:     e.Name,
-			Type:     e.Type,
-			Settings: e.Settings,
-		})
+
+	configs := make([]telemetrydomain.ExporterConfig, 0, len(spec.Exporters.Metadata)+len(spec.Exporters.Raw))
+	for _, e := range spec.Exporters.Metadata {
+		cfg := e.toConfig()
+		if cfg.EffectiveType() == rawExporterType {
+			return nil, fmt.Errorf("telemetry exporter %q: %q is raw-only and cannot be declared under exporters.metadata", cfg.Name, rawExporterType)
+		}
+		configs = append(configs, cfg)
+	}
+	for _, e := range spec.Exporters.Raw {
+		cfg := e.toConfig()
+		if cfg.EffectiveType() != rawExporterType {
+			return nil, fmt.Errorf("telemetry exporter %q: exporters.raw only accepts %q, got %q", cfg.Name, rawExporterType, cfg.EffectiveType())
+		}
+		configs = append(configs, cfg)
 	}
 	return configs, nil
+}
+
+func (e exporterEntry) toConfig() telemetrydomain.ExporterConfig {
+	return telemetrydomain.ExporterConfig{
+		Name:     e.Name,
+		Type:     e.Type,
+		Settings: e.Settings,
+	}
 }

--- a/pkg/infra/telemetry/exportersfile/loader.go
+++ b/pkg/infra/telemetry/exportersfile/loader.go
@@ -25,8 +25,6 @@ import (
 
 var ErrFileNotFound = errors.New("telemetry exporters file not found")
 
-// rawExporterType is the only type accepted for raw (sensible) payloads; the
-// data class is intrinsic to the type, so the file grouping is validated against it.
 const rawExporterType = "postgres"
 
 type fileSpec struct {

--- a/pkg/infra/telemetry/exportersfile/loader_test.go
+++ b/pkg/infra/telemetry/exportersfile/loader_test.go
@@ -36,14 +36,15 @@ func TestLoad(t *testing.T) {
 		assert  func(t *testing.T, configs []telemetrydomain.ExporterConfig, err error)
 	}{
 		{
-			name:  "valid single otlp",
+			name:  "valid single metadata otlp",
 			write: true,
 			content: `exporters:
-  - name: otlp
-    type: otlp
-    settings:
-      endpoint: "otel-collector:4317"
-      protocol: "grpc"
+  metadata:
+    - name: otlp
+      type: otlp
+      settings:
+        endpoint: "otel-collector:4317"
+        protocol: "grpc"
 `,
 			assert: func(t *testing.T, configs []telemetrydomain.ExporterConfig, err error) {
 				require.NoError(t, err)
@@ -55,21 +56,84 @@ func TestLoad(t *testing.T) {
 			},
 		},
 		{
-			name:  "valid multiple preserves order",
+			name:  "metadata first then raw, order preserved within groups",
 			write: true,
 			content: `exporters:
-  - name: first
-    type: otlp
-  - name: second
-    type: kafka
-  - name: third
-    type: postgres
+  metadata:
+    - name: first
+      type: otlp
+    - name: second
+      type: kafka
+  raw:
+    - name: third
+      type: postgres
 `,
 			assert: func(t *testing.T, configs []telemetrydomain.ExporterConfig, err error) {
 				require.NoError(t, err)
 				require.Len(t, configs, 3)
 				assert.Equal(t, []string{"first", "second", "third"}, []string{configs[0].Name, configs[1].Name, configs[2].Name})
 				assert.Equal(t, []string{"otlp", "kafka", "postgres"}, []string{configs[0].Type, configs[1].Type, configs[2].Type})
+			},
+		},
+		{
+			name:  "postgres under metadata aborts",
+			write: true,
+			content: `exporters:
+  metadata:
+    - name: raw-pg
+      type: postgres
+`,
+			assert: func(t *testing.T, configs []telemetrydomain.ExporterConfig, err error) {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, "raw-pg")
+				assert.ErrorContains(t, err, "metadata")
+				assert.Nil(t, configs)
+			},
+		},
+		{
+			name:  "non-postgres under raw aborts",
+			write: true,
+			content: `exporters:
+  raw:
+    - name: leaky
+      type: otlp
+`,
+			assert: func(t *testing.T, configs []telemetrydomain.ExporterConfig, err error) {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, "leaky")
+				assert.ErrorContains(t, err, "raw")
+				assert.Nil(t, configs)
+			},
+		},
+		{
+			name:  "postgres under raw parses",
+			write: true,
+			content: `exporters:
+  raw:
+    - name: raw-pg
+      type: postgres
+      settings:
+        dsn: "postgres://localhost:5432/telemetry"
+`,
+			assert: func(t *testing.T, configs []telemetrydomain.ExporterConfig, err error) {
+				require.NoError(t, err)
+				require.Len(t, configs, 1)
+				assert.Equal(t, "raw-pg", configs[0].Name)
+				assert.Equal(t, "postgres", configs[0].Type)
+			},
+		},
+		{
+			name:  "raw class derived from name when type omitted",
+			write: true,
+			content: `exporters:
+  raw:
+    - name: postgres
+`,
+			assert: func(t *testing.T, configs []telemetrydomain.ExporterConfig, err error) {
+				require.NoError(t, err)
+				require.Len(t, configs, 1)
+				assert.Equal(t, "postgres", configs[0].Name)
+				assert.Equal(t, "", configs[0].Type)
 			},
 		},
 		{
@@ -100,9 +164,9 @@ func TestLoad(t *testing.T) {
 			},
 		},
 		{
-			name:    "empty exporters list returns no entries",
+			name:    "empty exporters mapping returns no entries",
 			write:   true,
-			content: "exporters: []\n",
+			content: "exporters: {}\n",
 			assert: func(t *testing.T, configs []telemetrydomain.ExporterConfig, err error) {
 				require.NoError(t, err)
 				assert.Empty(t, configs)
@@ -119,11 +183,12 @@ func TestLoad(t *testing.T) {
 			},
 		},
 		{
-			name:  "unknown type still parses",
+			name:  "unknown metadata type still parses",
 			write: true,
 			content: `exporters:
-  - name: sink
-    type: datadog
+  metadata:
+    - name: sink
+      type: datadog
 `,
 			assert: func(t *testing.T, configs []telemetrydomain.ExporterConfig, err error) {
 				require.NoError(t, err)
@@ -133,10 +198,11 @@ func TestLoad(t *testing.T) {
 			},
 		},
 		{
-			name:  "type omitted keeps empty type and name",
+			name:  "metadata type omitted keeps empty type and name",
 			write: true,
 			content: `exporters:
-  - name: kafka
+  metadata:
+    - name: kafka
 `,
 			assert: func(t *testing.T, configs []telemetrydomain.ExporterConfig, err error) {
 				require.NoError(t, err)

--- a/pkg/infra/telemetry/otlp/exporter.go
+++ b/pkg/infra/telemetry/otlp/exporter.go
@@ -42,7 +42,6 @@ type Exporter struct {
 	provider        *sdklog.LoggerProvider
 	logger          otellog.Logger
 	slog            *slog.Logger
-	maxBodyBytes    int
 	shutdownTimeout time.Duration
 	closed          atomic.Bool
 }
@@ -52,7 +51,6 @@ type Exporter struct {
 func newExporterWithProvider(
 	provider *sdklog.LoggerProvider,
 	logger *slog.Logger,
-	maxBodyBytes int,
 	shutdownTimeout time.Duration,
 ) *Exporter {
 	if logger == nil {
@@ -65,7 +63,6 @@ func newExporterWithProvider(
 		provider:        provider,
 		logger:          provider.Logger(loggerScope),
 		slog:            logger,
-		maxBodyBytes:    maxBodyBytes,
 		shutdownTimeout: shutdownTimeout,
 	}
 }
@@ -84,7 +81,8 @@ func (e *Exporter) Publish(ctx context.Context, evt *events.Event) error {
 	if e.closed.Load() {
 		return errExporterClosed
 	}
-	e.logger.Emit(ctx, eventToRecord(evt, e.maxBodyBytes))
+	metadata := evt.MetadataView()
+	e.logger.Emit(ctx, eventToRecord(&metadata))
 	return nil
 }
 

--- a/pkg/infra/telemetry/otlp/exporter_test.go
+++ b/pkg/infra/telemetry/otlp/exporter_test.go
@@ -75,7 +75,7 @@ func TestExporter_PublishEmitsOneRecord(t *testing.T) {
 	t.Parallel()
 	mem := &memExporter{}
 	provider := sdklog.NewLoggerProvider(sdklog.WithProcessor(sdklog.NewSimpleProcessor(mem)))
-	exp := newExporterWithProvider(provider, testLogger(), 4096, time.Second)
+	exp := newExporterWithProvider(provider, testLogger(), time.Second)
 	defer exp.Close()
 
 	assert.Equal(t, ExporterName, exp.Name())
@@ -91,11 +91,27 @@ func TestExporter_PublishEmitsOneRecord(t *testing.T) {
 	assert.Equal(t, "trace-123", trace.AsString())
 }
 
+func TestExporter_PublishNeverEmitsBodies(t *testing.T) {
+	t.Parallel()
+	mem := &memExporter{}
+	provider := sdklog.NewLoggerProvider(sdklog.WithProcessor(sdklog.NewSimpleProcessor(mem)))
+	exp := newExporterWithProvider(provider, testLogger(), time.Second)
+	defer exp.Close()
+
+	require.NoError(t, exp.Publish(context.Background(), fullEvent()))
+
+	records := mem.all()
+	require.Len(t, records, 1)
+	assert.Empty(t, records[0].Body().AsString())
+	_, hasRequestBody := recordAttr(records[0], "trustgate.request.body")
+	assert.False(t, hasRequestBody)
+}
+
 func TestExporter_NilEventIsNoOp(t *testing.T) {
 	t.Parallel()
 	mem := &memExporter{}
 	provider := sdklog.NewLoggerProvider(sdklog.WithProcessor(sdklog.NewSimpleProcessor(mem)))
-	exp := newExporterWithProvider(provider, testLogger(), 4096, time.Second)
+	exp := newExporterWithProvider(provider, testLogger(), time.Second)
 	defer exp.Close()
 
 	require.NoError(t, exp.Publish(context.Background(), nil))
@@ -106,7 +122,7 @@ func TestExporter_CloseFlushesBufferedRecords(t *testing.T) {
 	t.Parallel()
 	mem := &memExporter{}
 	provider := sdklog.NewLoggerProvider(sdklog.WithProcessor(sdklog.NewBatchProcessor(mem)))
-	exp := newExporterWithProvider(provider, testLogger(), 4096, 2*time.Second)
+	exp := newExporterWithProvider(provider, testLogger(), 2*time.Second)
 
 	require.NoError(t, exp.Publish(context.Background(), fullEvent()))
 	exp.Close()
@@ -118,7 +134,7 @@ func TestExporter_PublishAfterCloseErrors(t *testing.T) {
 	t.Parallel()
 	mem := &memExporter{}
 	provider := sdklog.NewLoggerProvider(sdklog.WithProcessor(sdklog.NewSimpleProcessor(mem)))
-	exp := newExporterWithProvider(provider, testLogger(), 4096, time.Second)
+	exp := newExporterWithProvider(provider, testLogger(), time.Second)
 
 	exp.Close()
 	err := exp.Publish(context.Background(), fullEvent())

--- a/pkg/infra/telemetry/otlp/mapping.go
+++ b/pkg/infra/telemetry/otlp/mapping.go
@@ -17,7 +17,6 @@ package otlp
 import (
 	"encoding/json"
 	"time"
-	"unicode/utf8"
 
 	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics/events"
 	otellog "go.opentelemetry.io/otel/log"
@@ -75,7 +74,6 @@ const (
 	attrLatencyGatewayMs     = "trustgate.latency.gateway_ms"
 	attrIsFlagged            = "trustgate.is_flagged"
 	attrSecurity             = "trustgate.security"
-	attrRequestBody          = "trustgate.request.body"
 	attrPolicyChain          = "trustgate.policy_chain"
 	attrAttempts             = "trustgate.attempts"
 	attrAttemptsCount        = "trustgate.attempts.count"
@@ -84,7 +82,7 @@ const (
 // eventToRecord is the single, semconv-pinned (semconv/v1.41.0) mapping from a
 // sanitized business Event to an OTLP log record. Standard fields use GenAI/HTTP
 // semantic conventions; gateway-specific fields use the trustgate.* namespace.
-func eventToRecord(evt *events.Event, maxBodyBytes int) otellog.Record {
+func eventToRecord(evt *events.Event) otellog.Record {
 	var rec otellog.Record
 	if evt == nil {
 		return rec
@@ -96,10 +94,6 @@ func eventToRecord(evt *events.Event, maxBodyBytes int) otellog.Record {
 	}
 	rec.SetObservedTimestamp(time.Now())
 	rec.SetSeverity(severityForStatus(evt.Status.Code))
-
-	if body := responseBody(evt, maxBodyBytes); body != "" {
-		rec.SetBody(otellog.StringValue(body))
-	}
 
 	attrs := make([]otellog.KeyValue, 0, 32)
 	appendStr := func(key, value string) {
@@ -193,9 +187,6 @@ func eventToRecord(evt *events.Event, maxBodyBytes int) otellog.Record {
 	if len(evt.Security) > 0 {
 		attrs = append(attrs, otellog.Slice(attrSecurity, stringValues(evt.Security)...))
 	}
-	if requestBody := truncate(evt.Request.Body, maxBodyBytes); requestBody != "" {
-		attrs = append(attrs, otellog.String(attrRequestBody, requestBody))
-	}
 	if len(evt.PolicyChain) > 0 {
 		if encoded := jsonString(evt.PolicyChain); encoded != "" {
 			attrs = append(attrs, otellog.String(attrPolicyChain, encoded))
@@ -221,26 +212,6 @@ func severityForStatus(code int) otellog.Severity {
 	default:
 		return otellog.SeverityInfo
 	}
-}
-
-func responseBody(evt *events.Event, maxBodyBytes int) string {
-	if evt.Response.Body == nil {
-		return ""
-	}
-	return truncate(*evt.Response.Body, maxBodyBytes)
-}
-
-// truncate caps s at maxBytes, trimming back to the last valid UTF-8 boundary so
-// the emitted attribute is never a malformed string.
-func truncate(s string, maxBytes int) string {
-	if maxBytes <= 0 || len(s) <= maxBytes {
-		return s
-	}
-	truncated := s[:maxBytes]
-	for len(truncated) > 0 && !utf8.ValidString(truncated) {
-		truncated = truncated[:len(truncated)-1]
-	}
-	return truncated
 }
 
 func stringValues(in []string) []otellog.Value {

--- a/pkg/infra/telemetry/otlp/mapping_mcp_test.go
+++ b/pkg/infra/telemetry/otlp/mapping_mcp_test.go
@@ -50,7 +50,7 @@ func TestEventToRecord_MCPAttributes(t *testing.T) {
 		},
 	}
 
-	rec := eventToRecord(evt, 4096)
+	rec := eventToRecord(evt)
 	attrs := attrsOf(rec)
 
 	assert.Equal(t, events.KindMCP, attrs[attrKind].AsString())
@@ -71,7 +71,7 @@ func TestEventToRecord_LLMKindNoMCP(t *testing.T) {
 	evt := fullEvent()
 	evt.Kind = events.KindLLM
 
-	rec := eventToRecord(evt, 4096)
+	rec := eventToRecord(evt)
 	attrs := attrsOf(rec)
 
 	assert.Equal(t, events.KindLLM, attrs[attrKind].AsString())

--- a/pkg/infra/telemetry/otlp/mapping_test.go
+++ b/pkg/infra/telemetry/otlp/mapping_test.go
@@ -15,7 +15,6 @@
 package otlp
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics/events"
@@ -79,11 +78,10 @@ func fullEvent() *events.Event {
 
 func TestEventToRecord_StandardAndProprietaryCoexist(t *testing.T) {
 	t.Parallel()
-	rec := eventToRecord(fullEvent(), 4096)
+	rec := eventToRecord(fullEvent())
 
 	assert.Equal(t, eventName, rec.EventName())
 	assert.Equal(t, otellog.SeverityInfo, rec.Severity())
-	assert.Equal(t, "hello world", rec.Body().AsString())
 
 	attrs := attrsOf(rec)
 
@@ -113,7 +111,20 @@ func TestEventToRecord_StandardAndProprietaryCoexist(t *testing.T) {
 	assert.Contains(t, attrs["trustgate.policy_chain"].AsString(), "rate-limit")
 	assert.Equal(t, int64(1), attrs["trustgate.attempts.count"].AsInt64())
 	assert.Contains(t, attrs["trustgate.attempts"].AsString(), "openai")
-	assert.Equal(t, "request-body", attrs["trustgate.request.body"].AsString())
+}
+
+func TestEventToRecord_OmitsBodies(t *testing.T) {
+	t.Parallel()
+	evt := fullEvent()
+	evt.Request.Body = "request-body"
+	evt.Response.Body = strptr("hello world")
+
+	rec := eventToRecord(evt)
+	attrs := attrsOf(rec)
+
+	assert.Empty(t, rec.Body().AsString())
+	_, hasRequestBody := attrs["trustgate.request.body"]
+	assert.False(t, hasRequestBody)
 }
 
 func TestEventToRecord_Severity(t *testing.T) {
@@ -133,7 +144,7 @@ func TestEventToRecord_Severity(t *testing.T) {
 			t.Parallel()
 			evt := fullEvent()
 			evt.Status.Code = tc.code
-			rec := eventToRecord(evt, 4096)
+			rec := eventToRecord(evt)
 			assert.Equal(t, tc.want, rec.Severity())
 		})
 	}
@@ -143,7 +154,7 @@ func TestEventToRecord_StatusFields(t *testing.T) {
 	t.Parallel()
 	evt := fullEvent()
 	evt.Status = events.Status{Code: 504, IsTimeout: true, Outcome: "timeout", Reason: "upstream deadline"}
-	rec := eventToRecord(evt, 4096)
+	rec := eventToRecord(evt)
 	attrs := attrsOf(rec)
 
 	assert.Equal(t, "timeout", attrs["trustgate.status.outcome"].AsString())
@@ -153,7 +164,7 @@ func TestEventToRecord_StatusFields(t *testing.T) {
 
 func TestEventToRecord_StatusTimeoutOmittedWhenFalse(t *testing.T) {
 	t.Parallel()
-	rec := eventToRecord(fullEvent(), 4096)
+	rec := eventToRecord(fullEvent())
 	attrs := attrsOf(rec)
 	_, ok := attrs["trustgate.status.is_timeout"]
 	assert.False(t, ok)
@@ -164,7 +175,7 @@ func TestEventToRecord_NoUsage(t *testing.T) {
 	evt := fullEvent()
 	evt.Usage = nil
 	evt.Cost = nil
-	rec := eventToRecord(evt, 4096)
+	rec := eventToRecord(evt)
 	attrs := attrsOf(rec)
 
 	_, hasInput := attrs["gen_ai.usage.input_tokens"]
@@ -179,24 +190,16 @@ func TestEventToRecord_Streaming(t *testing.T) {
 	t.Parallel()
 	evt := fullEvent()
 	evt.Request.Stream = true
-	rec := eventToRecord(evt, 4096)
+	rec := eventToRecord(evt)
 	attrs := attrsOf(rec)
 	assert.True(t, attrs["gen_ai.request.stream"].AsBool())
-}
-
-func TestEventToRecord_BodyTruncation(t *testing.T) {
-	t.Parallel()
-	evt := fullEvent()
-	evt.Response.Body = strptr(strings.Repeat("x", 100))
-	rec := eventToRecord(evt, 10)
-	assert.Equal(t, 10, len(rec.Body().AsString()))
 }
 
 func TestEventToRecord_EmptyTrace(t *testing.T) {
 	t.Parallel()
 	evt := fullEvent()
 	evt.TraceID = ""
-	rec := eventToRecord(evt, 4096)
+	rec := eventToRecord(evt)
 	attrs := attrsOf(rec)
 	_, ok := attrs["trustgate.trace_id"]
 	assert.False(t, ok)
@@ -205,6 +208,6 @@ func TestEventToRecord_EmptyTrace(t *testing.T) {
 
 func TestEventToRecord_Nil(t *testing.T) {
 	t.Parallel()
-	rec := eventToRecord(nil, 4096)
+	rec := eventToRecord(nil)
 	assert.Equal(t, "", rec.EventName())
 }

--- a/pkg/infra/telemetry/otlp/template.go
+++ b/pkg/infra/telemetry/otlp/template.go
@@ -67,5 +67,5 @@ func (t *Template) WithSettings(settings map[string]interface{}) (appmetrics.Exp
 	if err != nil {
 		return nil, err
 	}
-	return newExporterWithProvider(provider, t.logger, s.MaxBodyBytes, s.Timeout), nil
+	return newExporterWithProvider(provider, t.logger, s.Timeout), nil
 }


### PR DESCRIPTION
## Summary

Makes the `otlp` exporter the metadata-only OTel connector: it can never ship request/response bodies.

- Remove body emission from the OTLP mapping: the response-body-as-record-body (`rec.SetBody`) and the `trustgate.request.body` attribute (plus the now-dead `truncate`/`responseBody` helpers).
- `Exporter.Publish` now consumes the event **metadata view** (`evt.MetadataView()`, from ENG-1018) as an explicit guardrail, so future mapping changes cannot leak bodies either.
- Keep the semconv (GenAI/HTTP) attributes and the whole `trustgate.*` metadata set, including MCP fields (`prompt` stays metadata per the spike).
- `max_body_bytes` is retained as the OTLP SDK attribute-value length cap (`WithAttributeValueLengthLimit`), it just no longer gates bodies.

## Also in this PR — group default exporters by data class

Reshapes the default exporters file (introduced by ENG-1016) from a flat list into two class-scoped groups, so the metadata/raw split is explicit and validated at boot:

```yaml
exporters:
  metadata:   # every type EXCEPT postgres (otlp, kafka on-demand, ...)
    - name: otlp
      type: otlp
      settings: { ... }
  raw:        # postgres only
    - name: postgres
      type: postgres
      settings: { dsn: "..." }
```

- The data class stays **intrinsic to the type** (`postgres` = raw, everything else = metadata); the file grouping is validated against it, not trusted.
- Boot aborts (fail-fast) if `postgres` is declared under `metadata`, or any other type under `raw`.
- Updated `config/telemetry.example.yaml`, the README exporters section, and the loader/container tests.

## Out of scope

- `DataClass()` on the exporter and data-class routing in the pipeline are **ENG-1021**. This PR only guarantees OTLP never emits bodies.
- Postgres (raw) exporter is **ENG-1020**.

## Test plan

- [x] `go test -race ./pkg/infra/telemetry/otlp/...`
- [x] `go test ./pkg/infra/telemetry/exportersfile/... ./pkg/container/modules/...`
- [x] `go build -mod=vendor ./...` / `go vet ./...`
- [x] `golangci-lint run ./pkg/infra/telemetry/otlp/...` — 0 issues
- [x] `scripts/check-comments.sh`
- New tests assert no record body and no `trustgate.request.body` even when the event carries both bodies, at mapping (`eventToRecord`) and exporter (`Publish`) level.
- New loader tests assert the grouped schema: `postgres` under `metadata` aborts, non-`postgres` under `raw` aborts, `postgres` under `raw` parses.

## Stacking

Stacked on `feat/eng-1016-load-default-exporters-yaml` (PR #161, which now includes ENG-1017 and ENG-1018) → #149.

Linear: ENG-1019 — https://linear.app/neuraltrust/issue/ENG-1019

Made with [Cursor](https://cursor.com)
