### PR TITLE
feat(telemetry): producer-owned postgres sensible exporter (ENG-1020)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,10 +149,20 @@ jobs:
           PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres -d postgres \
             -c "CREATE DATABASE trustgate_repo_test;" || true
 
+      - name: Create sensible exporter integration test database
+        run: |
+          PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres -d postgres \
+            -c "CREATE DATABASE sensible_pg_test;" || true
+
       - name: Run Functional tests
         env:
           PG_TEST_URL: postgres://postgres:postgres@localhost:5432/trustgate_repo_test?sslmode=disable
         run: go test -tags functional -v -race -count=1 -p 1 ./tests/functional/...
+
+      - name: Run Postgres exporter integration tests
+        env:
+          SENSIBLE_PG_TEST_DSN: postgres://postgres:postgres@localhost:5432/sensible_pg_test?sslmode=disable
+        run: go test -tags integration -race -count=1 ./pkg/infra/telemetry/postgres/...
 
   security:
     uses: NeuralTrust/workflows/.github/workflows/sast.yml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,26 @@ jobs:
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
+  metrics-module:
+    name: Metrics Schema Module
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26.4"
+          cache: true
+      - name: Build, vet and test pkg/metrics
+        working-directory: pkg/metrics
+        run: |
+          go build ./...
+          go vet ./...
+          go test -race ./...
+      - name: Lint pkg/metrics
+        uses: golangci/golangci-lint-action@v6
+        with:
+          working-directory: pkg/metrics
+
   functional-tests:
     name: Functional Tests
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 COPY go.mod go.sum ./
+COPY pkg/metrics/go.mod ./pkg/metrics/go.mod
 
 ARG GITHUB_TOKEN
 RUN if [ -n "$GITHUB_TOKEN" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -75,10 +75,12 @@ logs: ## Tail logs from the full stack
 test: ## Run unit tests
 	@$(info $(M) Running unit tests ...)
 	go test -cover -v ./pkg/...
+	cd pkg/metrics && go test -cover ./...
 
 test-race: ## Run unit tests with the race detector
 	@$(info $(M) Running unit tests with -race ...)
 	go test -race ./pkg/...
+	cd pkg/metrics && go test -race ./...
 
 test-cover: ## Run unit tests with coverage profile
 	@$(info $(M) Running unit tests with coverage ...)
@@ -96,6 +98,7 @@ test-repositories: ## Run repository integration tests (requires PG_TEST_URL poi
 lint: ## Run golangci-lint
 	@$(info $(M) Running golangci-lint ...)
 	@PATH="$$HOME/go/bin:$$PATH" golangci-lint run ./...
+	@cd pkg/metrics && PATH="$$HOME/go/bin:$$PATH" golangci-lint run ./...
 
 fmt: ## Run gofmt + go vet
 	@$(info $(M) Running gofmt + go vet ...)

--- a/config/telemetry.example.yaml
+++ b/config/telemetry.example.yaml
@@ -30,13 +30,13 @@ exporters:
         headers:
           x-scope-orgid: "trustgate"
 
-  # postgres is the raw sink documented for ENG-1020 and is NOT registered yet.
-  # Uncommenting it today aborts boot at factory.Validate (unknown exporter
-  # "postgres"). It persists sensitive telemetry payloads inside your own store.
+  # postgres is the only raw sink. dsn_env names the environment variable holding
+  # the connection string, so secrets stay out of this file. Enabling it opens a
+  # pool and runs the sensible-store migrations on first use.
   raw: []
 #  raw:
-#    - name: postgres
+#    - name: sensible-pg
 #      type: postgres
 #      settings:
-#        dsn: "postgres://user:pass@localhost:5432/telemetry?sslmode=disable"
-#        table: "telemetry_events"
+#        dsn_env: SENSIBLE_PG_DSN
+#        table: sensible_records

--- a/go.mod
+++ b/go.mod
@@ -133,4 +133,8 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
+require github.com/NeuralTrust/TrustGate/pkg/metrics v0.0.0
+
+replace github.com/NeuralTrust/TrustGate/pkg/metrics => ./pkg/metrics
+
 tool google.golang.org/grpc/cmd/protoc-gen-go-grpc

--- a/pkg/container/modules/telemetry.go
+++ b/pkg/container/modules/telemetry.go
@@ -32,6 +32,7 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/infra/telemetry/exportersfile"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/telemetry/kafka"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/telemetry/otlp"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/telemetry/postgres"
 	"go.uber.org/dig"
 )
 
@@ -73,6 +74,7 @@ func newExporterFactory(logger *slog.Logger, cfg *config.Config) appmetrics.Expo
 	return infratelemetry.NewExporterLocator(
 		infratelemetry.WithExporter(kafka.ExporterName, kafka.NewKafkaTemplate(logger, cfg.Kafka)),
 		infratelemetry.WithExporter(otlp.ExporterName, otlp.NewTemplate(logger, cfg.Telemetry.OTLP)),
+		infratelemetry.WithExporter(postgres.ExporterName, postgres.NewTemplate(logger)),
 	)
 }
 

--- a/pkg/infra/telemetry/postgres/exporter.go
+++ b/pkg/infra/telemetry/postgres/exporter.go
@@ -1,0 +1,127 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync/atomic"
+
+	appmetrics "github.com/NeuralTrust/TrustGate/pkg/app/metrics"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics/events"
+	"github.com/NeuralTrust/TrustGate/pkg/metrics"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+var _ appmetrics.Exporter = (*Exporter)(nil)
+
+var errExporterClosed = errors.New("postgres: exporter is closed")
+
+// Exporter persists the sensible view of an event (request and response bodies
+// only) into the owner-controlled Postgres store. It is sensible-only and can
+// never be reused as a metadata sink.
+type Exporter struct {
+	pool      *pgxpool.Pool
+	insertSQL string
+	logger    *slog.Logger
+	closed    atomic.Bool
+}
+
+func newExporter(pool *pgxpool.Pool, table string, logger *slog.Logger) *Exporter {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Exporter{
+		pool:      pool,
+		insertSQL: buildInsertSQL(table),
+		logger:    logger,
+	}
+}
+
+func (e *Exporter) Name() string {
+	return ExporterName
+}
+
+// DataClass fixes this exporter to the sensible class; the pipeline uses it to
+// route only the sensible view here (ENG-1021).
+func (e *Exporter) DataClass() metrics.DataClass {
+	return metrics.Sensible
+}
+
+// Publish writes the sensible projection of the event as one row. The write is
+// idempotent on trace_id so a retried event does not duplicate a row.
+func (e *Exporter) Publish(ctx context.Context, evt *events.Event) error {
+	if evt == nil {
+		return nil
+	}
+	if e.closed.Load() {
+		return errExporterClosed
+	}
+	rec := toRecord(evt.SensibleView())
+	if _, err := e.pool.Exec(ctx, e.insertSQL,
+		rec.TraceID,
+		rec.GatewayID,
+		rec.TeamID,
+		rec.OccurredOn,
+		rec.SchemaVersion,
+		rec.RequestBody,
+		rec.ResponseBody,
+	); err != nil {
+		return fmt.Errorf("postgres: insert sensible record: %w", err)
+	}
+	return nil
+}
+
+// Close releases the connection pool exactly once; further Publish calls fail
+// fast rather than touching a closed pool.
+func (e *Exporter) Close() {
+	if e.pool == nil || !e.closed.CompareAndSwap(false, true) {
+		return
+	}
+	e.pool.Close()
+}
+
+func toRecord(view events.Event) metrics.SensibleRecord {
+	rec := metrics.SensibleRecord{
+		TraceID:       view.TraceID,
+		GatewayID:     view.GatewayID,
+		OccurredOn:    view.OccurredOn,
+		SchemaVersion: metrics.SchemaVersion,
+		RequestBody:   view.Request.Body,
+		ResponseBody:  view.Response.Body,
+	}
+	if team := strings.TrimSpace(view.TeamID); team != "" {
+		rec.TeamID = &team
+	}
+	return rec
+}
+
+func buildInsertSQL(table string) string {
+	cols := metrics.InsertColumns()
+	placeholders := make([]string, len(cols))
+	for i := range cols {
+		placeholders[i] = fmt.Sprintf("$%d", i+1)
+	}
+	return fmt.Sprintf(
+		"INSERT INTO %s (%s) VALUES (%s) ON CONFLICT (%s) DO NOTHING",
+		table,
+		strings.Join(cols, ", "),
+		strings.Join(placeholders, ", "),
+		metrics.ColumnTraceID,
+	)
+}

--- a/pkg/infra/telemetry/postgres/exporter.go
+++ b/pkg/infra/telemetry/postgres/exporter.go
@@ -21,6 +21,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	appmetrics "github.com/NeuralTrust/TrustGate/pkg/app/metrics"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics/events"
@@ -31,6 +32,10 @@ import (
 var _ appmetrics.Exporter = (*Exporter)(nil)
 
 var errExporterClosed = errors.New("postgres: exporter is closed")
+
+// writeTimeout bounds a single insert so a slow or hung sensible DB cannot stall
+// the metrics worker goroutine that drives Publish.
+const writeTimeout = 10 * time.Second
 
 // Exporter persists the sensible view of an event (request and response bodies
 // only) into the owner-controlled Postgres store. It is sensible-only and can
@@ -73,6 +78,8 @@ func (e *Exporter) Publish(ctx context.Context, evt *events.Event) error {
 		return errExporterClosed
 	}
 	rec := toRecord(evt.SensibleView())
+	ctx, cancel := context.WithTimeout(ctx, writeTimeout)
+	defer cancel()
 	if _, err := e.pool.Exec(ctx, e.insertSQL,
 		rec.TraceID,
 		rec.GatewayID,

--- a/pkg/infra/telemetry/postgres/exporter_test.go
+++ b/pkg/infra/telemetry/postgres/exporter_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"context"
+	"testing"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics/events"
+	"github.com/NeuralTrust/TrustGate/pkg/metrics"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDataClassIsSensible(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, metrics.Sensible, (&Exporter{}).DataClass())
+}
+
+func TestBuildInsertSQL(t *testing.T) {
+	t.Parallel()
+	want := "INSERT INTO sensible_records (trace_id, gateway_id, team_id, occurred_on, schema_version, request_body, response_body) " +
+		"VALUES ($1, $2, $3, $4, $5, $6, $7) ON CONFLICT (trace_id) DO NOTHING"
+	assert.Equal(t, want, buildInsertSQL(metrics.TableName))
+}
+
+func TestToRecordMapsSensibleViewAndStampsSchemaVersion(t *testing.T) {
+	t.Parallel()
+
+	resp := "resp-body"
+	evt := events.Event{
+		SchemaVersion: events.SchemaVersion,
+		TraceID:       "t1",
+		GatewayID:     "g1",
+		TeamID:        "team1",
+		OccurredOn:    42,
+		IP:            "1.2.3.4",
+		Request:       events.Request{Body: "req-body", Headers: map[string][]string{"h": {"v"}}},
+		Response:      events.Response{Body: &resp, StatusCode: 200},
+	}
+
+	rec := toRecord(evt.SensibleView())
+
+	assert.Equal(t, "t1", rec.TraceID)
+	assert.Equal(t, "g1", rec.GatewayID)
+	require.NotNil(t, rec.TeamID)
+	assert.Equal(t, "team1", *rec.TeamID)
+	assert.Equal(t, int64(42), rec.OccurredOn)
+	assert.Equal(t, metrics.SchemaVersion, rec.SchemaVersion)
+	assert.Equal(t, "req-body", rec.RequestBody)
+	require.NotNil(t, rec.ResponseBody)
+	assert.Equal(t, "resp-body", *rec.ResponseBody)
+}
+
+func TestToRecordNilTeamAndResponse(t *testing.T) {
+	t.Parallel()
+
+	evt := events.Event{TraceID: "t2", GatewayID: "g2", Request: events.Request{Body: ""}}
+
+	rec := toRecord(evt.SensibleView())
+
+	assert.Nil(t, rec.TeamID)
+	assert.Nil(t, rec.ResponseBody)
+	assert.Empty(t, rec.RequestBody)
+}
+
+func TestPublishOnClosedExporterFails(t *testing.T) {
+	t.Parallel()
+
+	e := &Exporter{}
+	e.closed.Store(true)
+
+	err := e.Publish(context.Background(), &events.Event{TraceID: "x"})
+	require.ErrorIs(t, err, errExporterClosed)
+}
+
+func TestPublishNilEventIsNoop(t *testing.T) {
+	t.Parallel()
+	require.NoError(t, (&Exporter{}).Publish(context.Background(), nil))
+}
+
+func TestCloseWithoutPoolIsSafe(t *testing.T) {
+	t.Parallel()
+	(&Exporter{}).Close()
+}

--- a/pkg/infra/telemetry/postgres/migrate.go
+++ b/pkg/infra/telemetry/postgres/migrate.go
@@ -1,0 +1,102 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/NeuralTrust/TrustGate/pkg/metrics"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// advisoryLockKey serializes first-time DDL across replicas that enable the
+// exporter concurrently. The value is arbitrary but must stay stable (ENG-1020).
+const advisoryLockKey int64 = 942_020
+
+func runMigrations(ctx context.Context, pool *pgxpool.Pool, logger *slog.Logger) error {
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		return fmt.Errorf("postgres: acquire migration connection: %w", err)
+	}
+	defer conn.Release()
+
+	if _, err := conn.Exec(ctx, "SELECT pg_advisory_lock($1)", advisoryLockKey); err != nil {
+		return fmt.Errorf("postgres: acquire advisory lock: %w", err)
+	}
+	defer func() {
+		if _, unlockErr := conn.Exec(ctx, "SELECT pg_advisory_unlock($1)", advisoryLockKey); unlockErr != nil {
+			logger.Warn("postgres: release advisory lock failed", slog.String("error", unlockErr.Error()))
+		}
+	}()
+
+	if _, err := conn.Exec(ctx, ensureMigrationsTableSQL); err != nil {
+		return fmt.Errorf("postgres: ensure schema_migrations: %w", err)
+	}
+	applied, err := appliedMigrations(ctx, conn)
+	if err != nil {
+		return err
+	}
+	for _, m := range metrics.Migrations() {
+		if applied[m.ID] {
+			continue
+		}
+		if err := applyMigration(ctx, conn, m); err != nil {
+			return fmt.Errorf("postgres: apply migration %q: %w", m.ID, err)
+		}
+	}
+	return nil
+}
+
+const ensureMigrationsTableSQL = `CREATE TABLE IF NOT EXISTS schema_migrations (
+    id         TEXT        PRIMARY KEY,
+    name       TEXT        NOT NULL,
+    applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);`
+
+func appliedMigrations(ctx context.Context, conn *pgxpool.Conn) (map[string]bool, error) {
+	rows, err := conn.Query(ctx, "SELECT id FROM schema_migrations")
+	if err != nil {
+		return nil, fmt.Errorf("postgres: load applied migrations: %w", err)
+	}
+	defer rows.Close()
+
+	applied := make(map[string]bool)
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("postgres: scan migration id: %w", err)
+		}
+		applied[id] = true
+	}
+	return applied, rows.Err()
+}
+
+func applyMigration(ctx context.Context, conn *pgxpool.Conn, m metrics.Migration) error {
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx, m.UpSQL); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(ctx, "INSERT INTO schema_migrations (id, name) VALUES ($1, $2)", m.ID, m.Name); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}

--- a/pkg/infra/telemetry/postgres/migrate.go
+++ b/pkg/infra/telemetry/postgres/migrate.go
@@ -18,10 +18,13 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/NeuralTrust/TrustGate/pkg/metrics"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+const unlockTimeout = 5 * time.Second
 
 // advisoryLockKey serializes first-time DDL across replicas that enable the
 // exporter concurrently. The value is arbitrary but must stay stable (ENG-1020).
@@ -32,19 +35,28 @@ func runMigrations(ctx context.Context, pool *pgxpool.Pool, logger *slog.Logger)
 	if err != nil {
 		return fmt.Errorf("postgres: acquire migration connection: %w", err)
 	}
-	defer conn.Release()
 
 	if _, err := conn.Exec(ctx, "SELECT pg_advisory_lock($1)", advisoryLockKey); err != nil {
+		conn.Release()
 		return fmt.Errorf("postgres: acquire advisory lock: %w", err)
 	}
 	defer func() {
-		if _, unlockErr := conn.Exec(ctx, "SELECT pg_advisory_unlock($1)", advisoryLockKey); unlockErr != nil {
+		// Release on a fresh context so cleanup is not tied to a possibly-expired
+		// build deadline. If unlock fails, drop the connection so the pool never
+		// hands back one that still holds the session lock.
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), unlockTimeout)
+		defer cancel()
+		if _, unlockErr := conn.Exec(cleanupCtx, "SELECT pg_advisory_unlock($1)", advisoryLockKey); unlockErr != nil {
 			logger.Warn("postgres: release advisory lock failed", slog.String("error", unlockErr.Error()))
+			if closeErr := conn.Conn().Close(cleanupCtx); closeErr != nil {
+				logger.Warn("postgres: discard locked connection failed", slog.String("error", closeErr.Error()))
+			}
 		}
+		conn.Release()
 	}()
 
-	if _, err := conn.Exec(ctx, ensureMigrationsTableSQL); err != nil {
-		return fmt.Errorf("postgres: ensure schema_migrations: %w", err)
+	if _, err := conn.Exec(ctx, metrics.MigrationVersionTableDDL); err != nil {
+		return fmt.Errorf("postgres: ensure %s: %w", metrics.MigrationVersionTable, err)
 	}
 	applied, err := appliedMigrations(ctx, conn)
 	if err != nil {
@@ -61,14 +73,8 @@ func runMigrations(ctx context.Context, pool *pgxpool.Pool, logger *slog.Logger)
 	return nil
 }
 
-const ensureMigrationsTableSQL = `CREATE TABLE IF NOT EXISTS schema_migrations (
-    id         TEXT        PRIMARY KEY,
-    name       TEXT        NOT NULL,
-    applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);`
-
 func appliedMigrations(ctx context.Context, conn *pgxpool.Conn) (map[string]bool, error) {
-	rows, err := conn.Query(ctx, "SELECT id FROM schema_migrations")
+	rows, err := conn.Query(ctx, "SELECT id FROM "+metrics.MigrationVersionTable)
 	if err != nil {
 		return nil, fmt.Errorf("postgres: load applied migrations: %w", err)
 	}
@@ -95,7 +101,7 @@ func applyMigration(ctx context.Context, conn *pgxpool.Conn, m metrics.Migration
 	if _, err := tx.Exec(ctx, m.UpSQL); err != nil {
 		return err
 	}
-	if _, err := tx.Exec(ctx, "INSERT INTO schema_migrations (id, name) VALUES ($1, $2)", m.ID, m.Name); err != nil {
+	if _, err := tx.Exec(ctx, "INSERT INTO "+metrics.MigrationVersionTable+" (id, name) VALUES ($1, $2)", m.ID, m.Name); err != nil {
 		return err
 	}
 	return tx.Commit(ctx)

--- a/pkg/infra/telemetry/postgres/migrate_integration_test.go
+++ b/pkg/infra/telemetry/postgres/migrate_integration_test.go
@@ -1,0 +1,98 @@
+//go:build integration
+
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics/events"
+	"github.com/NeuralTrust/TrustGate/pkg/metrics"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+)
+
+// integrationDSN returns the DSN for the sensible-store test database, or skips
+// the test when it is not configured so unit CI stays offline.
+func integrationDSN(t *testing.T) string {
+	t.Helper()
+	dsn := os.Getenv("SENSIBLE_PG_TEST_DSN")
+	if dsn == "" {
+		t.Skip("SENSIBLE_PG_TEST_DSN not set; skipping postgres integration test")
+	}
+	return dsn
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestRunMigrationsIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, integrationDSN(t))
+	require.NoError(t, err)
+	defer pool.Close()
+
+	require.NoError(t, runMigrations(ctx, pool, discardLogger()))
+	require.NoError(t, runMigrations(ctx, pool, discardLogger()))
+
+	var count int
+	require.NoError(t, pool.QueryRow(ctx, "SELECT count(*) FROM schema_migrations").Scan(&count))
+	require.Equal(t, len(metrics.Migrations()), count)
+}
+
+func TestExporterInsertsSensibleRowIdempotently(t *testing.T) {
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, integrationDSN(t))
+	require.NoError(t, err)
+	require.NoError(t, runMigrations(ctx, pool, discardLogger()))
+
+	e := newExporter(pool, metrics.TableName, discardLogger())
+	defer e.Close()
+
+	resp := "hello-resp"
+	trace := "trace-" + time.Now().Format("150405.000000000")
+	evt := &events.Event{
+		TraceID:    trace,
+		GatewayID:  "g",
+		TeamID:     "tm",
+		OccurredOn: time.Now().UnixMilli(),
+		Request:    events.Request{Body: "hello-req"},
+		Response:   events.Response{Body: &resp},
+	}
+
+	require.NoError(t, e.Publish(ctx, evt))
+	require.NoError(t, e.Publish(ctx, evt))
+
+	var reqBody string
+	var respBody *string
+	var schemaVer int
+	require.NoError(t, pool.QueryRow(ctx,
+		"SELECT request_body, response_body, schema_version FROM sensible_records WHERE trace_id=$1", trace,
+	).Scan(&reqBody, &respBody, &schemaVer))
+	require.Equal(t, "hello-req", reqBody)
+	require.NotNil(t, respBody)
+	require.Equal(t, "hello-resp", *respBody)
+	require.Equal(t, metrics.SchemaVersion, schemaVer)
+
+	_, err = pool.Exec(ctx, "DELETE FROM sensible_records WHERE trace_id=$1", trace)
+	require.NoError(t, err)
+}

--- a/pkg/infra/telemetry/postgres/migrate_integration_test.go
+++ b/pkg/infra/telemetry/postgres/migrate_integration_test.go
@@ -55,7 +55,7 @@ func TestRunMigrationsIsIdempotent(t *testing.T) {
 	require.NoError(t, runMigrations(ctx, pool, discardLogger()))
 
 	var count int
-	require.NoError(t, pool.QueryRow(ctx, "SELECT count(*) FROM schema_migrations").Scan(&count))
+	require.NoError(t, pool.QueryRow(ctx, "SELECT count(*) FROM "+metrics.MigrationVersionTable).Scan(&count))
 	require.Equal(t, len(metrics.Migrations()), count)
 }
 

--- a/pkg/infra/telemetry/postgres/settings.go
+++ b/pkg/infra/telemetry/postgres/settings.go
@@ -1,0 +1,76 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/NeuralTrust/TrustGate/pkg/metrics"
+	"github.com/mitchellh/mapstructure"
+)
+
+// ExporterName is the registered name of the postgres exporter template. It is
+// the only sink allowed to carry sensible data.
+const ExporterName = "postgres"
+
+// Settings is the per-gateway configuration for the postgres exporter, decoded
+// from the telemetry exporter Settings map. The DSN is referenced by env-var
+// name so secrets stay out of the config file; a literal dsn is accepted for
+// local development only.
+type Settings struct {
+	DSN    string `mapstructure:"dsn"`
+	DSNEnv string `mapstructure:"dsn_env"`
+	Table  string `mapstructure:"table"`
+}
+
+func parseSettings(raw map[string]interface{}) (Settings, error) {
+	var s Settings
+	if len(raw) > 0 {
+		if err := mapstructure.Decode(raw, &s); err != nil {
+			return Settings{}, fmt.Errorf("postgres: invalid settings: %w", err)
+		}
+	}
+	if s.Table == "" {
+		s.Table = metrics.TableName
+	}
+	return s, nil
+}
+
+func (s Settings) validate() error {
+	if strings.TrimSpace(s.DSN) == "" && strings.TrimSpace(s.DSNEnv) == "" {
+		return errors.New("postgres: one of settings.dsn or settings.dsn_env is required")
+	}
+	if s.Table != metrics.TableName {
+		return fmt.Errorf("postgres: table %q is not the owned sensible table %q", s.Table, metrics.TableName)
+	}
+	return nil
+}
+
+// resolveDSN prefers a literal dsn (dev only); otherwise it reads the env var
+// named by dsn_env so secrets stay out of the config file.
+func (s Settings) resolveDSN() (string, error) {
+	if dsn := strings.TrimSpace(s.DSN); dsn != "" {
+		return dsn, nil
+	}
+	name := strings.TrimSpace(s.DSNEnv)
+	dsn := strings.TrimSpace(os.Getenv(name))
+	if dsn == "" {
+		return "", fmt.Errorf("postgres: env var %q referenced by dsn_env is unset or empty", name)
+	}
+	return dsn, nil
+}

--- a/pkg/infra/telemetry/postgres/settings.go
+++ b/pkg/infra/telemetry/postgres/settings.go
@@ -35,7 +35,9 @@ const ExporterName = "postgres"
 type Settings struct {
 	DSN    string `mapstructure:"dsn"`
 	DSNEnv string `mapstructure:"dsn_env"`
-	Table  string `mapstructure:"table"`
+	// Table is validated against the module-owned table name; it is an explicit,
+	// forward-compatible knob and is not allowed to point anywhere else.
+	Table string `mapstructure:"table"`
 }
 
 func parseSettings(raw map[string]interface{}) (Settings, error) {

--- a/pkg/infra/telemetry/postgres/settings_test.go
+++ b/pkg/infra/telemetry/postgres/settings_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"testing"
+
+	"github.com/NeuralTrust/TrustGate/pkg/metrics"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSettingsDefaultsTable(t *testing.T) {
+	t.Parallel()
+
+	s, err := parseSettings(map[string]interface{}{"dsn_env": "SENSIBLE_PG_DSN"})
+	require.NoError(t, err)
+	assert.Equal(t, metrics.TableName, s.Table)
+	assert.Equal(t, "SENSIBLE_PG_DSN", s.DSNEnv)
+}
+
+func TestValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		s       Settings
+		wantErr string
+	}{
+		{"dsn_env accepted", Settings{DSNEnv: "SENSIBLE_PG_DSN", Table: metrics.TableName}, ""},
+		{"literal dsn accepted", Settings{DSN: "postgres://localhost/db", Table: metrics.TableName}, ""},
+		{"neither dsn nor dsn_env", Settings{Table: metrics.TableName}, "dsn"},
+		{"foreign table rejected", Settings{DSNEnv: "SENSIBLE_PG_DSN", Table: "other_table"}, "owned"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.s.validate()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestResolveDSNPrefersLiteral(t *testing.T) {
+	got, err := Settings{DSN: "postgres://literal", DSNEnv: "IGNORED"}.resolveDSN()
+	require.NoError(t, err)
+	assert.Equal(t, "postgres://literal", got)
+}
+
+func TestResolveDSNReadsEnv(t *testing.T) {
+	t.Setenv("SENSIBLE_PG_TEST_ENV", "postgres://from-env")
+	got, err := Settings{DSNEnv: "SENSIBLE_PG_TEST_ENV"}.resolveDSN()
+	require.NoError(t, err)
+	assert.Equal(t, "postgres://from-env", got)
+}
+
+func TestResolveDSNMissingEnvFails(t *testing.T) {
+	_, err := Settings{DSNEnv: "SENSIBLE_PG_DSN_DOES_NOT_EXIST"}.resolveDSN()
+	require.Error(t, err)
+}

--- a/pkg/infra/telemetry/postgres/template.go
+++ b/pkg/infra/telemetry/postgres/template.go
@@ -1,0 +1,84 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	appmetrics "github.com/NeuralTrust/TrustGate/pkg/app/metrics"
+	infratelemetry "github.com/NeuralTrust/TrustGate/pkg/infra/telemetry"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+var _ infratelemetry.ExporterTemplate = (*Template)(nil)
+
+// buildTimeout bounds pool creation plus first-build migrations so an
+// unreachable sensible DB cannot block the pipeline's ExporterCache indefinitely.
+const buildTimeout = 30 * time.Second
+
+// Template builds postgres.Exporter instances and runs the sensible-store
+// migrations the first time the exporter is built.
+type Template struct {
+	logger *slog.Logger
+}
+
+// NewTemplate returns a postgres ExporterTemplate bound to the given logger.
+func NewTemplate(logger *slog.Logger) *Template {
+	return &Template{logger: logger}
+}
+
+func (t *Template) Name() string {
+	return ExporterName
+}
+
+// ValidateConfig performs structural validation only; it never opens a
+// connection or resolves the DSN env var.
+func (t *Template) ValidateConfig(settings map[string]interface{}) error {
+	s, err := parseSettings(settings)
+	if err != nil {
+		return err
+	}
+	return s.validate()
+}
+
+// WithSettings validates the settings, opens a dedicated pool, and applies the
+// schema migrations (advisory-locked) before returning the exporter.
+func (t *Template) WithSettings(settings map[string]interface{}) (appmetrics.Exporter, error) {
+	s, err := parseSettings(settings)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.validate(); err != nil {
+		return nil, err
+	}
+	dsn, err := s.resolveDSN()
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), buildTimeout)
+	defer cancel()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		return nil, fmt.Errorf("postgres: open pool: %w", err)
+	}
+	if err := runMigrations(ctx, pool, t.logger); err != nil {
+		pool.Close()
+		return nil, err
+	}
+	return newExporter(pool, s.Table, t.logger), nil
+}

--- a/pkg/metrics/allowlist.go
+++ b/pkg/metrics/allowlist.go
@@ -14,9 +14,6 @@
 
 package metrics
 
-// ReadColumns is the allow-list of columns a reader may select from the
-// sensible store. It exists so the read path selects an explicit set instead of
-// `SELECT *`, keeping consumers stable across additive schema changes.
 func ReadColumns() []string {
 	return []string{
 		ColumnTraceID,

--- a/pkg/metrics/allowlist.go
+++ b/pkg/metrics/allowlist.go
@@ -1,0 +1,31 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+// ReadColumns is the allow-list of columns a reader may select from the
+// sensible store. It exists so the read path selects an explicit set instead of
+// `SELECT *`, keeping consumers stable across additive schema changes.
+func ReadColumns() []string {
+	return []string{
+		ColumnTraceID,
+		ColumnGatewayID,
+		ColumnTeamID,
+		ColumnOccurredOn,
+		ColumnSchemaVersion,
+		ColumnRequestBody,
+		ColumnResponseBody,
+		ColumnCreatedAt,
+	}
+}

--- a/pkg/metrics/doc.go
+++ b/pkg/metrics/doc.go
@@ -12,9 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package metrics is the dependency-light, producer-owned contract for the
-// sensible telemetry store: row types, the table/column contract, the migration
-// DDL, the read-path column allow-list, and version/data-class constants. It
-// carries no database driver so consumers (the gateway write path and external
-// readers) can import it without pulling transport dependencies.
+// Package metrics is the dependency-light contract for the sensible telemetry store.
 package metrics

--- a/pkg/metrics/doc.go
+++ b/pkg/metrics/doc.go
@@ -1,0 +1,20 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package metrics is the dependency-light, producer-owned contract for the
+// sensible telemetry store: row types, the table/column contract, the migration
+// DDL, the read-path column allow-list, and version/data-class constants. It
+// carries no database driver so consumers (the gateway write path and external
+// readers) can import it without pulling transport dependencies.
+package metrics

--- a/pkg/metrics/go.mod
+++ b/pkg/metrics/go.mod
@@ -1,0 +1,3 @@
+module github.com/NeuralTrust/TrustGate/pkg/metrics
+
+go 1.26.4

--- a/pkg/metrics/migrations/migration.go
+++ b/pkg/metrics/migrations/migration.go
@@ -1,0 +1,64 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package migrations holds the ordered schema history for the sensible store.
+// Each change lives in its own migration_<id>_<name>.go file that self-registers
+// via register in an init; All returns the full set ordered by ID.
+package migrations
+
+import "sort"
+
+// VersionTableName is the bookkeeping table that records which migrations have
+// been applied so a runner can skip them on the next start.
+const VersionTableName = "migration_versions"
+
+// VersionTableDDL creates VersionTableName. It is idempotent so a runner can
+// execute it on every start before consulting the applied set.
+const VersionTableDDL = `CREATE TABLE IF NOT EXISTS migration_versions (
+    id         TEXT        PRIMARY KEY,
+    name       TEXT        NOT NULL,
+    applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);`
+
+// Migration is a driver-free unit of schema change: forward and rollback SQL
+// kept as strings so the module stays dependency-light. The pgx-based runner
+// that executes these lives in the consuming write path, not here.
+type Migration struct {
+	ID      string
+	Name    string
+	UpSQL   string
+	DownSQL string
+}
+
+var registry []Migration
+
+// register adds a migration to the set. A duplicate ID is a build-time
+// programmer error, so it panics rather than silently shadowing.
+func register(m Migration) {
+	for _, existing := range registry {
+		if existing.ID == m.ID {
+			panic("migrations: duplicate migration ID " + m.ID)
+		}
+	}
+	registry = append(registry, m)
+}
+
+// All returns every registered migration ordered by ID as a fresh slice, so
+// callers cannot mutate the shared registry. Every statement is idempotent.
+func All() []Migration {
+	out := make([]Migration, len(registry))
+	copy(out, registry)
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}

--- a/pkg/metrics/migrations/migration.go
+++ b/pkg/metrics/migrations/migration.go
@@ -13,27 +13,18 @@
 // limitations under the License.
 
 // Package migrations holds the ordered schema history for the sensible store.
-// Each change lives in its own migration_<id>_<name>.go file that self-registers
-// via register in an init; All returns the full set ordered by ID.
 package migrations
 
 import "sort"
 
-// VersionTableName is the bookkeeping table that records which migrations have
-// been applied so a runner can skip them on the next start.
 const VersionTableName = "migration_versions"
 
-// VersionTableDDL creates VersionTableName. It is idempotent so a runner can
-// execute it on every start before consulting the applied set.
 const VersionTableDDL = `CREATE TABLE IF NOT EXISTS migration_versions (
     id         TEXT        PRIMARY KEY,
     name       TEXT        NOT NULL,
     applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );`
 
-// Migration is a driver-free unit of schema change: forward and rollback SQL
-// kept as strings so the module stays dependency-light. The pgx-based runner
-// that executes these lives in the consuming write path, not here.
 type Migration struct {
 	ID      string
 	Name    string
@@ -43,8 +34,6 @@ type Migration struct {
 
 var registry []Migration
 
-// register adds a migration to the set. A duplicate ID is a build-time
-// programmer error, so it panics rather than silently shadowing.
 func register(m Migration) {
 	for _, existing := range registry {
 		if existing.ID == m.ID {
@@ -54,8 +43,6 @@ func register(m Migration) {
 	registry = append(registry, m)
 }
 
-// All returns every registered migration ordered by ID as a fresh slice, so
-// callers cannot mutate the shared registry. Every statement is idempotent.
 func All() []Migration {
 	out := make([]Migration, len(registry))
 	copy(out, registry)

--- a/pkg/metrics/migrations/migration_0001_create_sensible_records.go
+++ b/pkg/metrics/migrations/migration_0001_create_sensible_records.go
@@ -1,0 +1,35 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrations
+
+func init() {
+	register(Migration{
+		ID:   "0001",
+		Name: "create_sensible_records",
+		UpSQL: `CREATE TABLE IF NOT EXISTS sensible_records (
+    trace_id         TEXT        NOT NULL,
+    gateway_id       TEXT        NOT NULL,
+    team_id          TEXT,
+    occurred_on      BIGINT      NOT NULL,
+    schema_version   INT         NOT NULL,
+    request_body     TEXT,
+    response_body    TEXT,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (trace_id)
+);
+CREATE INDEX IF NOT EXISTS idx_sensible_gateway_time ON sensible_records (gateway_id, occurred_on);`,
+		DownSQL: `DROP TABLE IF EXISTS sensible_records;`,
+	})
+}

--- a/pkg/metrics/migrations/migration_test.go
+++ b/pkg/metrics/migrations/migration_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrations
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestAllRegisteredMigrationsAreOrderedAndUnique(t *testing.T) {
+	migs := All()
+	if len(migs) == 0 {
+		t.Fatal("expected at least one registered migration")
+	}
+	seen := make(map[string]bool, len(migs))
+	ids := make([]string, 0, len(migs))
+	for i, m := range migs {
+		if m.ID == "" {
+			t.Errorf("migration %d has empty ID", i)
+		}
+		if m.Name == "" {
+			t.Errorf("migration %q has empty name", m.ID)
+		}
+		if strings.TrimSpace(m.UpSQL) == "" {
+			t.Errorf("migration %q has empty UpSQL", m.ID)
+		}
+		if seen[m.ID] {
+			t.Errorf("duplicate migration ID %q", m.ID)
+		}
+		seen[m.ID] = true
+		ids = append(ids, m.ID)
+	}
+	if !sort.StringsAreSorted(ids) {
+		t.Errorf("migrations are not ordered by ID: %v", ids)
+	}
+}
+
+func TestAllReturnsIndependentSlices(t *testing.T) {
+	first := All()
+	first[0].UpSQL = "mutated"
+	if All()[0].UpSQL == "mutated" {
+		t.Error("All must return a fresh slice, not shared mutable state")
+	}
+}
+
+func TestRegisterPanicsOnDuplicateID(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("expected register to panic on duplicate ID")
+		}
+	}()
+	register(Migration{ID: "0001", Name: "dup", UpSQL: "SELECT 1;"})
+}
+
+func TestVersionTableDDLTargetsVersionTable(t *testing.T) {
+	if !strings.Contains(VersionTableDDL, VersionTableName) {
+		t.Errorf("version DDL does not reference %q", VersionTableName)
+	}
+}

--- a/pkg/metrics/record.go
+++ b/pkg/metrics/record.go
@@ -1,0 +1,28 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+// SensibleRecord is one row of the sensible store: the raw request/response
+// bodies plus the identifiers needed to correlate back to the metadata record.
+// TeamID and ResponseBody are pointers because their columns are nullable.
+type SensibleRecord struct {
+	TraceID       string  `db:"trace_id" json:"trace_id"`
+	GatewayID     string  `db:"gateway_id" json:"gateway_id"`
+	TeamID        *string `db:"team_id" json:"team_id,omitempty"`
+	OccurredOn    int64   `db:"occurred_on" json:"occurred_on"`
+	SchemaVersion int     `db:"schema_version" json:"schema_version"`
+	RequestBody   string  `db:"request_body" json:"request_body"`
+	ResponseBody  *string `db:"response_body" json:"response_body,omitempty"`
+}

--- a/pkg/metrics/record.go
+++ b/pkg/metrics/record.go
@@ -14,9 +14,6 @@
 
 package metrics
 
-// SensibleRecord is one row of the sensible store: the raw request/response
-// bodies plus the identifiers needed to correlate back to the metadata record.
-// TeamID and ResponseBody are pointers because their columns are nullable.
 type SensibleRecord struct {
 	TraceID       string  `db:"trace_id" json:"trace_id"`
 	GatewayID     string  `db:"gateway_id" json:"gateway_id"`

--- a/pkg/metrics/schema.go
+++ b/pkg/metrics/schema.go
@@ -1,0 +1,79 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+// TableName is the sensible store table owned by this module.
+const TableName = "sensible_records"
+
+const (
+	ColumnTraceID       = "trace_id"
+	ColumnGatewayID     = "gateway_id"
+	ColumnTeamID        = "team_id"
+	ColumnOccurredOn    = "occurred_on"
+	ColumnSchemaVersion = "schema_version"
+	ColumnRequestBody   = "request_body"
+	ColumnResponseBody  = "response_body"
+	ColumnCreatedAt     = "created_at"
+)
+
+// Migration is a driver-free unit of schema change: forward and rollback SQL
+// kept as strings so the module stays dependency-light. The pgx-based runner
+// that executes these lives in the consuming write path, not here.
+type Migration struct {
+	ID      string
+	Name    string
+	UpSQL   string
+	DownSQL string
+}
+
+// Migrations returns the ordered, additive schema history for the sensible
+// store. Each statement is idempotent so a runner can apply the set safely on
+// every start.
+func Migrations() []Migration {
+	return []Migration{
+		{
+			ID:   "0001",
+			Name: "create_sensible_records",
+			UpSQL: `CREATE TABLE IF NOT EXISTS sensible_records (
+    trace_id         TEXT        NOT NULL,
+    gateway_id       TEXT        NOT NULL,
+    team_id          TEXT,
+    occurred_on      BIGINT      NOT NULL,
+    schema_version   INT         NOT NULL,
+    request_body     TEXT,
+    response_body    TEXT,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (trace_id)
+);
+CREATE INDEX IF NOT EXISTS idx_sensible_gateway_time ON sensible_records (gateway_id, occurred_on);`,
+			DownSQL: `DROP TABLE IF EXISTS sensible_records;`,
+		},
+	}
+}
+
+// InsertColumns is the ordered column contract a writer must bind when
+// inserting a SensibleRecord. created_at is omitted because it is defaulted by
+// the database.
+func InsertColumns() []string {
+	return []string{
+		ColumnTraceID,
+		ColumnGatewayID,
+		ColumnTeamID,
+		ColumnOccurredOn,
+		ColumnSchemaVersion,
+		ColumnRequestBody,
+		ColumnResponseBody,
+	}
+}

--- a/pkg/metrics/schema.go
+++ b/pkg/metrics/schema.go
@@ -14,6 +14,8 @@
 
 package metrics
 
+import "github.com/NeuralTrust/TrustGate/pkg/metrics/migrations"
+
 // TableName is the sensible store table owned by this module.
 const TableName = "sensible_records"
 
@@ -28,39 +30,23 @@ const (
 	ColumnCreatedAt     = "created_at"
 )
 
-// Migration is a driver-free unit of schema change: forward and rollback SQL
-// kept as strings so the module stays dependency-light. The pgx-based runner
-// that executes these lives in the consuming write path, not here.
-type Migration struct {
-	ID      string
-	Name    string
-	UpSQL   string
-	DownSQL string
-}
+// Migration is a driver-free unit of schema change owned by the migrations
+// subpackage; it is re-exported here so consumers keep a single import.
+type Migration = migrations.Migration
+
+// MigrationVersionTable is the table that records which migrations have been
+// applied. A runner ensures it exists before consulting the applied set.
+const MigrationVersionTable = migrations.VersionTableName
+
+// MigrationVersionTableDDL is the idempotent DDL that creates
+// MigrationVersionTable.
+const MigrationVersionTableDDL = migrations.VersionTableDDL
 
 // Migrations returns the ordered, additive schema history for the sensible
-// store. Each statement is idempotent so a runner can apply the set safely on
-// every start.
+// store, sourced from the migrations subpackage where each change lives in its
+// own file.
 func Migrations() []Migration {
-	return []Migration{
-		{
-			ID:   "0001",
-			Name: "create_sensible_records",
-			UpSQL: `CREATE TABLE IF NOT EXISTS sensible_records (
-    trace_id         TEXT        NOT NULL,
-    gateway_id       TEXT        NOT NULL,
-    team_id          TEXT,
-    occurred_on      BIGINT      NOT NULL,
-    schema_version   INT         NOT NULL,
-    request_body     TEXT,
-    response_body    TEXT,
-    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    PRIMARY KEY (trace_id)
-);
-CREATE INDEX IF NOT EXISTS idx_sensible_gateway_time ON sensible_records (gateway_id, occurred_on);`,
-			DownSQL: `DROP TABLE IF EXISTS sensible_records;`,
-		},
-	}
+	return migrations.All()
 }
 
 // InsertColumns is the ordered column contract a writer must bind when

--- a/pkg/metrics/schema.go
+++ b/pkg/metrics/schema.go
@@ -16,7 +16,6 @@ package metrics
 
 import "github.com/NeuralTrust/TrustGate/pkg/metrics/migrations"
 
-// TableName is the sensible store table owned by this module.
 const TableName = "sensible_records"
 
 const (
@@ -30,28 +29,16 @@ const (
 	ColumnCreatedAt     = "created_at"
 )
 
-// Migration is a driver-free unit of schema change owned by the migrations
-// subpackage; it is re-exported here so consumers keep a single import.
 type Migration = migrations.Migration
 
-// MigrationVersionTable is the table that records which migrations have been
-// applied. A runner ensures it exists before consulting the applied set.
 const MigrationVersionTable = migrations.VersionTableName
 
-// MigrationVersionTableDDL is the idempotent DDL that creates
-// MigrationVersionTable.
 const MigrationVersionTableDDL = migrations.VersionTableDDL
 
-// Migrations returns the ordered, additive schema history for the sensible
-// store, sourced from the migrations subpackage where each change lives in its
-// own file.
 func Migrations() []Migration {
 	return migrations.All()
 }
 
-// InsertColumns is the ordered column contract a writer must bind when
-// inserting a SensibleRecord. created_at is omitted because it is defaulted by
-// the database.
 func InsertColumns() []string {
 	return []string{
 		ColumnTraceID,

--- a/pkg/metrics/schema_test.go
+++ b/pkg/metrics/schema_test.go
@@ -1,0 +1,80 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMigrationsOrderedUniqueAndTargetTable(t *testing.T) {
+	migs := Migrations()
+	if len(migs) == 0 {
+		t.Fatal("expected at least one migration")
+	}
+	seen := make(map[string]bool, len(migs))
+	for i, m := range migs {
+		if m.ID == "" {
+			t.Errorf("migration %d has empty ID", i)
+		}
+		if seen[m.ID] {
+			t.Errorf("duplicate migration ID %q", m.ID)
+		}
+		seen[m.ID] = true
+		if strings.TrimSpace(m.UpSQL) == "" {
+			t.Errorf("migration %q has empty UpSQL", m.ID)
+		}
+	}
+	if !strings.Contains(migs[0].UpSQL, TableName) {
+		t.Errorf("first migration UpSQL does not reference table %q", TableName)
+	}
+}
+
+func TestMigrationsReturnsIndependentSlices(t *testing.T) {
+	first := Migrations()
+	first[0].UpSQL = "mutated"
+	if Migrations()[0].UpSQL == "mutated" {
+		t.Error("Migrations() must return a fresh slice, not shared mutable state")
+	}
+}
+
+func TestInsertColumnsSubsetOfReadColumns(t *testing.T) {
+	read := make(map[string]bool)
+	for _, c := range ReadColumns() {
+		read[c] = true
+	}
+	for _, c := range InsertColumns() {
+		if !read[c] {
+			t.Errorf("insert column %q missing from read allow-list", c)
+		}
+	}
+}
+
+func TestReadColumnsIncludeCreatedAt(t *testing.T) {
+	for _, c := range ReadColumns() {
+		if c == ColumnCreatedAt {
+			return
+		}
+	}
+	t.Errorf("read columns must include %q", ColumnCreatedAt)
+}
+
+func TestInsertColumnsExcludeDefaultedCreatedAt(t *testing.T) {
+	for _, c := range InsertColumns() {
+		if c == ColumnCreatedAt {
+			t.Errorf("insert columns must not include database-defaulted %q", ColumnCreatedAt)
+		}
+	}
+}

--- a/pkg/metrics/version.go
+++ b/pkg/metrics/version.go
@@ -1,0 +1,31 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+// SchemaVersion is the version of the sensible-store schema owned by this
+// module. It is written into every row so readers can adapt across versions,
+// and it is bumped whenever a migration changes the row contract.
+const SchemaVersion = 1
+
+// DataClass partitions telemetry by sensitivity. It is intrinsic to an exporter
+// type, never a per-record configuration value.
+type DataClass string
+
+const (
+	// Metadata is sanitized, non-sensitive telemetry shipped to external backends.
+	Metadata DataClass = "metadata"
+	// Sensible is the raw request/response body pair persisted inside the owner boundary.
+	Sensible DataClass = "sensible"
+)

--- a/pkg/metrics/version.go
+++ b/pkg/metrics/version.go
@@ -14,18 +14,11 @@
 
 package metrics
 
-// SchemaVersion is the version of the sensible-store schema owned by this
-// module. It is written into every row so readers can adapt across versions,
-// and it is bumped whenever a migration changes the row contract.
 const SchemaVersion = 1
 
-// DataClass partitions telemetry by sensitivity. It is intrinsic to an exporter
-// type, never a per-record configuration value.
 type DataClass string
 
 const (
-	// Metadata is sanitized, non-sensitive telemetry shipped to external backends.
 	Metadata DataClass = "metadata"
-	// Sensible is the raw request/response body pair persisted inside the owner boundary.
 	Sensible DataClass = "sensible"
 )


### PR DESCRIPTION
## Summary

Adds the `postgres` exporter as the **single sensible-data sink** for the telemetry pipeline (ENG-1020). It persists the sensible view of an event (**request and response bodies only**) into an owner-controlled Postgres store and provisions its schema on first use.

- **Nested schema module `pkg/metrics`** (own `go.mod`, **stdlib only — no pgx, no gateway imports**): `SensibleRecord` row type, table/column contract, migration DDL as strings, read-path column allow-list, and `SchemaVersion` + `DataClass` consts. Dependency-light so DataCore/DataAgent can import it on the read path without pulling the gateway.
- **`postgres` exporter** (`pkg/infra/telemetry/postgres/`): implements `appmetrics.Exporter` + `infratelemetry.ExporterTemplate`. `Publish` maps `evt.SensibleView()` to a **parameterized, idempotent** INSERT (`ON CONFLICT (trace_id) DO NOTHING`); `DataClass()` is fixed to `sensible`; `Close()` is idempotent. Table/column identifiers come only from the trusted module contract.
- **Advisory-locked migration runner** (`migrate.go`): opens a dedicated pool, takes a `pg_advisory_lock`, ensures its own `schema_migrations` table, and applies the module's DDL idempotently — **run on first build**, not at global boot. Does **not** reuse the control-plane `MigrationsManager`.
- **DSN via env-var name** (`dsn_env: SENSIBLE_PG_DSN`) so secrets stay out of the YAML; a literal `dsn` is accepted for local dev only.
- **Registration** in `newExporterFactory` (`pkg/container/modules/telemetry.go`).
- **Build wiring**: root `go.mod` `require` + local `replace ./pkg/metrics`; dedicated `metrics-module` CI job; `Makefile` `test`/`test-race`/`lint` extended (root `./pkg/...` does not traverse a nested module); `Dockerfile` copies the nested `go.mod` before `go mod download`; `config/telemetry.example.yaml` shows `raw: postgres` with `dsn_env`.

## Out of scope (ENG-1021)

- Data-class routing in the pipeline (`postgres` → `SensibleView`, others → `MetadataView`) and gateway create/update API validation for the `postgres` type. This PR makes the exporter sensible-only by projecting `SensibleView()` inside `Publish` as a guardrail; the formal routing lands in ENG-1021.

## Test plan

- [x] `pkg/metrics` builds/tests standalone (`cd pkg/metrics && go build/vet/test`).
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run` (root + nested) — 0 issues.
- [x] `go test -race ./pkg/infra/telemetry/postgres/... ./pkg/container/modules/...`.
- [x] Unit tests cover settings validation, `buildInsertSQL`, and `toRecord` mapping (sensible-only, nullable team/response, module `SchemaVersion` stamping), closed-exporter fast-fail.
- [x] DB round-trip + migration idempotency covered by `migrate_integration_test.go` (behind `//go:build integration`, gated on `SENSIBLE_PG_TEST_DSN`; skipped in unit CI). Run locally with a disposable Postgres.
- [x] `make license-check`, `gofmt`, comment-policy guard clean.

## Notes

- **Size:exception** — this PR exceeds the 400-line budget because the nested module, the exporter, the migration runner, their tests, and the build wiring form one shippable slice (per the approved plan for a single PR).

## Stacking

Stacked on `feat/eng-1016-load-default-exporters-yaml` (PR #161, which now includes ENG-1017 and ENG-1018) → #149.

Linear: ENG-1020 — https://linear.app/neuraltrust/issue/ENG-1020

Made with [Cursor](https://cursor.com)
