### PR TITLE
feat(telemetry): data-class routing in pipeline + rename raw table (ENG-1021)

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,8 +409,14 @@ gateway declares its own) are loaded at boot from a declarative YAML file,
 selected by `TELEMETRY_EXPORTERS_FILE` (default `config/telemetry.yaml`).
 Exporters are grouped by data class, and the class is intrinsic to the `type`:
 **metadata** exporters (e.g. `otlp`) ship sanitized request metadata to an
-external backend, while **raw** exporters (only `postgres`, arriving with
-ENG-1020) persist sensitive payloads inside your own boundary.
+external backend, while **raw** exporters (only `postgres`) persist sensitive
+payloads inside your own boundary.
+
+At publish time each event is **projected by class**: a `postgres` exporter
+receives only the request/response bodies, and every other exporter receives
+sanitized metadata with the bodies stripped. The class is fixed by the exporter
+type, so a metadata exporter can never receive raw payloads and `postgres` can
+never receive metadata — the split is structural, not a config flag.
 
 ```yaml
 exporters:
@@ -427,6 +433,7 @@ exporters:
 Behaviour:
 
 - **`postgres` under `metadata`, or any other type under `raw` → boot aborts.**
+- **Routing is by data class:** raw payloads go only to `postgres`; every other exporter gets metadata with bodies stripped.
 - **Invalid or unknown declared exporter → boot aborts (fail-fast).**
 - **File missing or empty → warning logged, pipeline starts with no defaults.**
 - There is no hardcoded default exporter; Kafka runs as a default only if declared.

--- a/config/telemetry.example.yaml
+++ b/config/telemetry.example.yaml
@@ -32,11 +32,10 @@ exporters:
 
   # postgres is the only raw sink. dsn_env names the environment variable holding
   # the connection string, so secrets stay out of this file. Enabling it opens a
-  # pool and runs the sensible-store migrations on first use.
-  raw: []
-#  raw:
-#    - name: sensible-pg
-#      type: postgres
-#      settings:
-#        dsn_env: SENSIBLE_PG_DSN
-#        table: sensible_records
+  # pool and runs the sensible-store migrations on first use. Remove this entry
+  # (raw: []) if you do not want to persist raw payloads.
+  raw:
+    - name: sensible-pg
+      type: postgres
+      settings:
+        dsn_env: SENSIBLE_PG_DSN

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -5923,6 +5923,9 @@ const docTemplate = `{
                 "settings": {
                     "type": "object",
                     "additionalProperties": true
+                },
+                "type": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -6728,6 +6728,9 @@
                     "settings": {
                         "type": "object",
                         "additionalProperties": true
+                    },
+                    "type": {
+                        "type": "string"
                     }
                 }
             },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -5916,6 +5916,9 @@
                 "settings": {
                     "type": "object",
                     "additionalProperties": true
+                },
+                "type": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1806,6 +1806,8 @@ definitions:
       settings:
         additionalProperties: true
         type: object
+      type:
+        type: string
     type: object
   github_com_NeuralTrust_TrustGate_pkg_domain_telemetry.Telemetry:
     properties:

--- a/docs/telemetry-exporter-split.md
+++ b/docs/telemetry-exporter-split.md
@@ -150,7 +150,7 @@ exporters:
     type: postgres
     settings:
       dsn_env: SENSIBLE_PG_DSN   # env var NAME, not the DSN — keeps secrets out of the file
-      table: sensible_records
+      table: trustgate_data
 ```
 
 **Loader (ENG-1016):** new YAML loader (add `gopkg.in/yaml.v3`) → `[]telemetrydomain.ExporterConfig`;
@@ -217,7 +217,7 @@ type Migration struct { ID, Name, UpSQL, DownSQL string }
 **Sensible table (v1):**
 
 ```sql
-CREATE TABLE IF NOT EXISTS sensible_records (
+CREATE TABLE IF NOT EXISTS trustgate_data (
     trace_id         TEXT        NOT NULL,
     gateway_id       TEXT        NOT NULL,
     team_id          TEXT,
@@ -228,7 +228,7 @@ CREATE TABLE IF NOT EXISTS sensible_records (
     created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     PRIMARY KEY (trace_id)
 );
-CREATE INDEX IF NOT EXISTS idx_sensible_gateway_time ON sensible_records (gateway_id, occurred_on);
+CREATE INDEX IF NOT EXISTS idx_trustgate_data_gateway_time ON trustgate_data (gateway_id, occurred_on);
 ```
 
 `trace_id` is the join key back to the metadata record in ClickHouse. `INSERT` is built from the

--- a/pkg/api/middleware/metrics_functional_test.go
+++ b/pkg/api/middleware/metrics_functional_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics/events"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/adapter"
 	infratelemetry "github.com/NeuralTrust/TrustGate/pkg/infra/telemetry"
+	metricsschema "github.com/NeuralTrust/TrustGate/pkg/metrics"
 	"github.com/gofiber/fiber/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -81,6 +82,8 @@ type memExporter struct {
 }
 
 func (e *memExporter) Name() string { return e.name }
+
+func (e *memExporter) DataClass() metricsschema.DataClass { return metricsschema.Metadata }
 
 func (e *memExporter) Publish(_ context.Context, evt *events.Event) error {
 	if e.fail {

--- a/pkg/app/metrics/exporter_internal_test.go
+++ b/pkg/app/metrics/exporter_internal_test.go
@@ -288,7 +288,7 @@ func TestPipeline_RoutesByDataClass(t *testing.T) {
 	builder := NewBuilder(adapter.NewRegistry(), stubPricing{})
 	factory := &fakeFactory{classByName: map[string]metricsschema.DataClass{
 		"meta": metricsschema.Metadata,
-		"sens": metricsschema.Sensible,
+		"sens": metricsschema.Raw,
 	}}
 	cache := NewExporterCache(factory, internalTestLogger())
 	p := NewPipeline(builder, cache, nil, internalTestLogger(),

--- a/pkg/app/metrics/exporter_internal_test.go
+++ b/pkg/app/metrics/exporter_internal_test.go
@@ -27,6 +27,7 @@ import (
 	infracontext "github.com/NeuralTrust/TrustGate/pkg/infra/context"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics/events"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/adapter"
+	metricsschema "github.com/NeuralTrust/TrustGate/pkg/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -37,18 +38,23 @@ func internalTestLogger() *slog.Logger {
 
 type fakeExporter struct {
 	name       string
+	class      metricsschema.DataClass
 	publishErr error
 	mu         sync.Mutex
 	published  int
+	lastEvent  *events.Event
 	closed     bool
 }
 
 func (f *fakeExporter) Name() string { return f.name }
 
-func (f *fakeExporter) Publish(_ context.Context, _ *events.Event) error {
+func (f *fakeExporter) DataClass() metricsschema.DataClass { return f.class }
+
+func (f *fakeExporter) Publish(_ context.Context, evt *events.Event) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.published++
+	f.lastEvent = evt
 	return f.publishErr
 }
 
@@ -70,6 +76,7 @@ type fakeFactory struct {
 	buildErr         error
 	built            []telemetrydomain.ExporterConfig
 	publishErrByName map[string]error
+	classByName      map[string]metricsschema.DataClass
 }
 
 func (f *fakeFactory) Build(cfg telemetrydomain.ExporterConfig) (Exporter, error) {
@@ -80,7 +87,11 @@ func (f *fakeFactory) Build(cfg telemetrydomain.ExporterConfig) (Exporter, error
 	if f.buildErr != nil {
 		return nil, f.buildErr
 	}
-	return &fakeExporter{name: cfg.Name, publishErr: f.publishErrByName[cfg.Name]}, nil
+	return &fakeExporter{
+		name:       cfg.Name,
+		class:      f.classByName[cfg.Name],
+		publishErr: f.publishErrByName[cfg.Name],
+	}, nil
 }
 
 func (f *fakeFactory) Validate(_ telemetrydomain.ExporterConfig) error { return nil }
@@ -271,6 +282,47 @@ func TestPipeline_PublishIsolatesExporterErrors(t *testing.T) {
 
 	assert.Equal(t, 1, byName["bad"].publishedCount())
 	assert.Equal(t, 1, byName["good"].publishedCount(), "a failing exporter must not prevent the others from publishing")
+}
+
+func TestPipeline_RoutesByDataClass(t *testing.T) {
+	builder := NewBuilder(adapter.NewRegistry(), stubPricing{})
+	factory := &fakeFactory{classByName: map[string]metricsschema.DataClass{
+		"meta": metricsschema.Metadata,
+		"sens": metricsschema.Sensible,
+	}}
+	cache := NewExporterCache(factory, internalTestLogger())
+	p := NewPipeline(builder, cache, nil, internalTestLogger(),
+		telemetrydomain.ExporterConfig{Name: "meta"},
+		telemetrydomain.ExporterConfig{Name: "sens"})
+
+	req := &infracontext.RequestContext{
+		GatewayID: "gw-1", Method: "POST", Path: "/v1/chat/completions",
+		Body: []byte(`{"model":"gpt","messages":[{"role":"user","content":"secret prompt"}]}`),
+	}
+	resp := &infracontext.ResponseContext{
+		StatusCode: 200,
+		Body:       []byte(`{"choices":[{"message":{"content":"secret answer"}}]}`),
+	}
+
+	targets := p.resolveTargets(nil)
+	require.Len(t, targets, 2)
+	byName := make(map[string]*fakeExporter, len(targets))
+	for _, tgt := range targets {
+		byName[tgt.Name()] = tgt.(*fakeExporter)
+	}
+
+	p.publish(nil, req, resp, time.Now(), time.Now(), nil)
+
+	sens := byName["sens"].lastEvent
+	require.NotNil(t, sens)
+	assert.NotEmpty(t, sens.Request.Body, "sensible exporter must receive the request body")
+	require.NotNil(t, sens.Response.Body)
+	assert.NotEmpty(t, *sens.Response.Body, "sensible exporter must receive the response body")
+
+	meta := byName["meta"].lastEvent
+	require.NotNil(t, meta)
+	assert.Empty(t, meta.Request.Body, "metadata exporter must never receive the request body")
+	assert.Nil(t, meta.Response.Body, "metadata exporter must never receive the response body")
 }
 
 func TestPipeline_PublishCallsPlaygroundStore(t *testing.T) {

--- a/pkg/app/metrics/pipeline.go
+++ b/pkg/app/metrics/pipeline.go
@@ -100,7 +100,7 @@ func viewForClass(evt *events.Event, class metricsschema.DataClass) *events.Even
 	if evt == nil {
 		return nil
 	}
-	if class == metricsschema.Sensible {
+	if class == metricsschema.Raw {
 		v := evt.SensibleView()
 		return &v
 	}

--- a/pkg/app/metrics/pipeline.go
+++ b/pkg/app/metrics/pipeline.go
@@ -23,10 +23,12 @@ import (
 	infracontext "github.com/NeuralTrust/TrustGate/pkg/infra/context"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics/events"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/trace"
+	metricsschema "github.com/NeuralTrust/TrustGate/pkg/metrics"
 )
 
 type Exporter interface {
 	Name() string
+	DataClass() metricsschema.DataClass
 	Publish(ctx context.Context, evt *events.Event) error
 	Close()
 }
@@ -79,7 +81,7 @@ func (p *Pipeline) publish(
 	ctx := context.Background()
 	evt := p.builder.Build(ctx, requestTrace, req, resp, startTime, endTime)
 	for _, exporter := range targets {
-		if err := exporter.Publish(ctx, evt); err != nil {
+		if err := exporter.Publish(ctx, viewForClass(evt, exporter.DataClass())); err != nil {
 			p.logger.Error("failed to publish metrics event",
 				slog.String("gateway_id", req.GatewayID),
 				slog.String("exporter", exporter.Name()),
@@ -89,6 +91,21 @@ func (p *Pipeline) publish(
 	if p.playgroundStore != nil {
 		p.playgroundStore.Save(ctx, req, evt)
 	}
+}
+
+// viewForClass projects the event to the class the exporter is fixed to, so a
+// sensible sink only ever sees request/response bodies and every other exporter
+// only sees sanitized metadata (ENG-1021).
+func viewForClass(evt *events.Event, class metricsschema.DataClass) *events.Event {
+	if evt == nil {
+		return nil
+	}
+	if class == metricsschema.Sensible {
+		v := evt.SensibleView()
+		return &v
+	}
+	v := evt.MetadataView()
+	return &v
 }
 
 func (p *Pipeline) resolveTargets(explicit []telemetrydomain.ExporterConfig) []Exporter {

--- a/pkg/app/metrics/worker_test.go
+++ b/pkg/app/metrics/worker_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics/events"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/adapter"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/trace"
+	metricsschema "github.com/NeuralTrust/TrustGate/pkg/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -43,6 +44,8 @@ type captureExporter struct {
 }
 
 func (c *captureExporter) Name() string { return "capture" }
+
+func (c *captureExporter) DataClass() metricsschema.DataClass { return metricsschema.Metadata }
 
 func (c *captureExporter) Publish(_ context.Context, evt *events.Event) error {
 	c.mu.Lock()

--- a/pkg/infra/telemetry/exporter_locator_test.go
+++ b/pkg/infra/telemetry/exporter_locator_test.go
@@ -23,6 +23,7 @@ import (
 	telemetrydomain "github.com/NeuralTrust/TrustGate/pkg/domain/telemetry"
 	infratelemetry "github.com/NeuralTrust/TrustGate/pkg/infra/telemetry"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/telemetry/kafka"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/telemetry/postgres"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -34,6 +35,7 @@ func testLogger() *slog.Logger {
 func newLocator() *infratelemetry.ExporterLocator {
 	return infratelemetry.NewExporterLocator(
 		infratelemetry.WithExporter(kafka.ExporterName, kafka.NewKafkaTemplate(testLogger(), config.KafkaConfig{Brokers: []string{"localhost:9092"}})),
+		infratelemetry.WithExporter(postgres.ExporterName, postgres.NewTemplate(testLogger())),
 	)
 }
 
@@ -56,6 +58,22 @@ func TestExporterLocator_Validate(t *testing.T) {
 	t.Run("valid kafka config", func(t *testing.T) {
 		err := locator.Validate(telemetrydomain.ExporterConfig{Name: kafka.ExporterName, Settings: map[string]interface{}{"topic": "events"}})
 		require.NoError(t, err)
+	})
+
+	t.Run("postgres resolved through the optional type field", func(t *testing.T) {
+		err := locator.Validate(telemetrydomain.ExporterConfig{
+			Name: "sensible-pg",
+			Type: postgres.ExporterName,
+			Settings: map[string]interface{}{
+				"dsn": "postgres://user:pass@localhost:5432/telemetry?sslmode=disable",
+			},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("postgres without a dsn is rejected", func(t *testing.T) {
+		err := locator.Validate(telemetrydomain.ExporterConfig{Name: postgres.ExporterName, Settings: map[string]interface{}{}})
+		require.Error(t, err)
 	})
 }
 

--- a/pkg/infra/telemetry/kafka/exporter.go
+++ b/pkg/infra/telemetry/kafka/exporter.go
@@ -25,6 +25,7 @@ import (
 	appmetrics "github.com/NeuralTrust/TrustGate/pkg/app/metrics"
 	"github.com/NeuralTrust/TrustGate/pkg/config"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics/events"
+	"github.com/NeuralTrust/TrustGate/pkg/metrics"
 	infratelemetry "github.com/NeuralTrust/TrustGate/pkg/infra/telemetry"
 )
 
@@ -42,6 +43,13 @@ func NewKafkaTemplate(logger *slog.Logger, kafkaCfg config.KafkaConfig) *Exporte
 
 func (p *Exporter) Name() string {
 	return ExporterName
+}
+
+// DataClass fixes this exporter to the metadata class; the pipeline routes only
+// the sanitized metadata view here, so the full-event marshal never carries
+// sensible bodies (ENG-1021).
+func (p *Exporter) DataClass() metrics.DataClass {
+	return metrics.Metadata
 }
 
 func (p *Exporter) ValidateConfig(settings map[string]interface{}) error {

--- a/pkg/infra/telemetry/otlp/exporter.go
+++ b/pkg/infra/telemetry/otlp/exporter.go
@@ -23,6 +23,7 @@ import (
 
 	appmetrics "github.com/NeuralTrust/TrustGate/pkg/app/metrics"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics/events"
+	"github.com/NeuralTrust/TrustGate/pkg/metrics"
 	otellog "go.opentelemetry.io/otel/log"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 )
@@ -69,6 +70,12 @@ func newExporterWithProvider(
 
 func (e *Exporter) Name() string {
 	return ExporterName
+}
+
+// DataClass fixes this exporter to the metadata class; the pipeline uses it to
+// route only the sanitized metadata view here (ENG-1021).
+func (e *Exporter) DataClass() metrics.DataClass {
+	return metrics.Metadata
 }
 
 // Publish maps the event to an OTLP log record and enqueues it into the batch

--- a/pkg/infra/telemetry/postgres/exporter.go
+++ b/pkg/infra/telemetry/postgres/exporter.go
@@ -65,7 +65,7 @@ func (e *Exporter) Name() string {
 // DataClass fixes this exporter to the sensible class; the pipeline uses it to
 // route only the sensible view here (ENG-1021).
 func (e *Exporter) DataClass() metrics.DataClass {
-	return metrics.Sensible
+	return metrics.Raw
 }
 
 // Publish writes the sensible projection of the event as one row. The write is

--- a/pkg/infra/telemetry/postgres/exporter_test.go
+++ b/pkg/infra/telemetry/postgres/exporter_test.go
@@ -31,7 +31,7 @@ func TestDataClassIsSensible(t *testing.T) {
 
 func TestBuildInsertSQL(t *testing.T) {
 	t.Parallel()
-	want := "INSERT INTO sensible_records (trace_id, gateway_id, team_id, occurred_on, schema_version, request_body, response_body) " +
+	want := "INSERT INTO " + metrics.TableName + " (trace_id, gateway_id, team_id, occurred_on, schema_version, request_body, response_body) " +
 		"VALUES ($1, $2, $3, $4, $5, $6, $7) ON CONFLICT (trace_id) DO NOTHING"
 	assert.Equal(t, want, buildInsertSQL(metrics.TableName))
 }

--- a/pkg/infra/telemetry/postgres/exporter_test.go
+++ b/pkg/infra/telemetry/postgres/exporter_test.go
@@ -24,9 +24,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDataClassIsSensible(t *testing.T) {
+func TestDataClassIsRaw(t *testing.T) {
 	t.Parallel()
-	assert.Equal(t, metrics.Sensible, (&Exporter{}).DataClass())
+	assert.Equal(t, metrics.Raw, (&Exporter{}).DataClass())
 }
 
 func TestBuildInsertSQL(t *testing.T) {

--- a/pkg/infra/telemetry/postgres/migrate_integration_test.go
+++ b/pkg/infra/telemetry/postgres/migrate_integration_test.go
@@ -86,13 +86,13 @@ func TestExporterInsertsSensibleRowIdempotently(t *testing.T) {
 	var respBody *string
 	var schemaVer int
 	require.NoError(t, pool.QueryRow(ctx,
-		"SELECT request_body, response_body, schema_version FROM sensible_records WHERE trace_id=$1", trace,
+		"SELECT request_body, response_body, schema_version FROM "+metrics.TableName+" WHERE trace_id=$1", trace,
 	).Scan(&reqBody, &respBody, &schemaVer))
 	require.Equal(t, "hello-req", reqBody)
 	require.NotNil(t, respBody)
 	require.Equal(t, "hello-resp", *respBody)
 	require.Equal(t, metrics.SchemaVersion, schemaVer)
 
-	_, err = pool.Exec(ctx, "DELETE FROM sensible_records WHERE trace_id=$1", trace)
+	_, err = pool.Exec(ctx, "DELETE FROM "+metrics.TableName+" WHERE trace_id=$1", trace)
 	require.NoError(t, err)
 }

--- a/pkg/metrics/doc.go
+++ b/pkg/metrics/doc.go
@@ -12,5 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package metrics is the dependency-light contract for the sensible telemetry store.
 package metrics

--- a/pkg/metrics/migrations/migration.go
+++ b/pkg/metrics/migrations/migration.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package migrations holds the ordered schema history for the sensible store.
 package migrations
 
 import "sort"

--- a/pkg/metrics/migrations/migration_0001_create_trustgate_data.go
+++ b/pkg/metrics/migrations/migration_0001_create_trustgate_data.go
@@ -17,8 +17,8 @@ package migrations
 func init() {
 	register(Migration{
 		ID:   "0001",
-		Name: "create_sensible_records",
-		UpSQL: `CREATE TABLE IF NOT EXISTS sensible_records (
+		Name: "create_trustgate_data",
+		UpSQL: `CREATE TABLE IF NOT EXISTS trustgate_data (
     trace_id         TEXT        NOT NULL,
     gateway_id       TEXT        NOT NULL,
     team_id          TEXT,
@@ -29,7 +29,7 @@ func init() {
     created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     PRIMARY KEY (trace_id)
 );
-CREATE INDEX IF NOT EXISTS idx_sensible_gateway_time ON sensible_records (gateway_id, occurred_on);`,
-		DownSQL: `DROP TABLE IF EXISTS sensible_records;`,
+CREATE INDEX IF NOT EXISTS idx_trustgate_data_gateway_time ON trustgate_data (gateway_id, occurred_on);`,
+		DownSQL: `DROP TABLE IF EXISTS trustgate_data;`,
 	})
 }

--- a/pkg/metrics/schema.go
+++ b/pkg/metrics/schema.go
@@ -16,7 +16,7 @@ package metrics
 
 import "github.com/NeuralTrust/TrustGate/pkg/metrics/migrations"
 
-const TableName = "sensible_records"
+const TableName = "trustgate_data"
 
 const (
 	ColumnTraceID       = "trace_id"

--- a/pkg/metrics/version.go
+++ b/pkg/metrics/version.go
@@ -20,5 +20,5 @@ type DataClass string
 
 const (
 	Metadata DataClass = "metadata"
-	Sensible DataClass = "sensible"
+	Raw      DataClass = "raw"
 )


### PR DESCRIPTION
## Summary
- Route each telemetry event by **data class** at publish time: add `DataClass()` to the exporter interface and project events so `postgres` exporters receive only request/response bodies while every other exporter receives sanitized metadata (bodies stripped). The split is structural (fixed by exporter type), not a config flag.
- Extend exporter validation and locator tests for the `postgres` (raw) type, and refresh docs: Swagger `ExporterConfig.type`, README data-class routing note, and the `metadata`/`raw` example config.
- Rename the raw payload table `sensible_records` → `trustgate_data` (constant, create migration `0001_create_trustgate_data`, index `idx_trustgate_data_gateway_time`, design doc); tests reference `metrics.TableName` so they follow the rename.
- Drop leftover package doc comments in `pkg/metrics` per the repo comment policy.

## Linear
- ENG-1021 (routing/validation/docs) — https://linear.app/neuraltrust/issue/ENG-1021
- Table rename belongs to ENG-1020's schema and is included here since ENG-1020 (#165) already merged.

## Test plan
- [x] `go build ./...`
- [x] `go test -race ./pkg/app/metrics/... ./pkg/infra/telemetry/...` (incl. new `TestPipeline_RoutesByDataClass`)
- [x] `pkg/metrics` nested module: `go test ./...`
- [ ] CI green

Base: stacked on `feat/eng-1016-load-default-exporters-yaml` (the telemetry accumulation branch; PR #161 → develop).

Made with [Cursor](https://cursor.com)