### PR TITLE
ci(metrics): auto-tag pkg/metrics module on merge to main (ENG-1034)

### DIFF
--- a/.github/scripts/next-metrics-version.sh
+++ b/.github/scripts/next-metrics-version.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# Computes the next semantic version for the nested pkg/metrics Go module from
+# the latest path-prefixed tag (pkg/metrics/vX.Y.Z) and the conventional-commit
+# messages that touched the module since that tag. It is side-effect free: it
+# only writes version/tag/bump to GITHUB_OUTPUT (or stdout when run locally).
+# The workflow (.github/workflows/metrics-module-release.yml) creates the tag.
+#
+# Bump rules (ENG-1034; breaking → major per the expand-contract policy in ENG-1033):
+#   - BREAKING CHANGE footer or a "type!:" subject → major
+#   - feat: subject                                → minor
+#   - anything else                                → patch
+#   - no prior tag                                 → 0.1.0 (initial release)
+set -euo pipefail
+
+TAG_PREFIX="${TAG_PREFIX:-pkg/metrics/v}"
+MODULE_PATH="${MODULE_PATH:-pkg/metrics}"
+
+detect_level() {
+	local msgs
+	msgs="$(cat)"
+	if grep -qE '(^|[[:space:]])BREAKING[ -]CHANGE' <<<"$msgs" \
+		|| grep -qE '^[a-z]+(\([^)]+\))?!:' <<<"$msgs"; then
+		echo major
+		return
+	fi
+	if grep -qE '^feat(\([^)]+\))?:' <<<"$msgs"; then
+		echo minor
+		return
+	fi
+	echo patch
+}
+
+compute_next() {
+	local prev="${1#v}" level="$2"
+	local x y z
+	IFS=. read -r x y z <<<"$prev"
+	case "$level" in
+	major) echo "$((x + 1)).0.0" ;;
+	minor) echo "$x.$((y + 1)).0" ;;
+	patch) echo "$x.$y.$((z + 1))" ;;
+	*)
+		echo "unknown bump level: $level" >&2
+		return 1
+		;;
+	esac
+}
+
+emit() {
+	local out="${GITHUB_OUTPUT:-/dev/stdout}"
+	{ printf '%s\n' "$@"; } >>"$out"
+}
+
+main() {
+	local latest
+	latest="$(git tag -l "${TAG_PREFIX}*" | sort -V | tail -1)"
+
+	if [ -z "$latest" ]; then
+		local version="0.1.0"
+		echo "no ${TAG_PREFIX}* tag found; seeding initial ${TAG_PREFIX}${version}" >&2
+		emit "changed=true" "version=${version}" "tag=${TAG_PREFIX}${version}" "bump=initial"
+		return 0
+	fi
+
+	local msgs
+	msgs="$(git log --format='%B' "${latest}..HEAD" -- "$MODULE_PATH" 2>/dev/null || true)"
+	if [ -z "${msgs//[[:space:]]/}" ]; then
+		echo "no ${MODULE_PATH} changes since ${latest}; nothing to release" >&2
+		emit "changed=false"
+		return 0
+	fi
+
+	local bump version
+	bump="$(detect_level <<<"$msgs")"
+	version="$(compute_next "${latest#"$TAG_PREFIX"}" "$bump")"
+	echo "next module version: ${TAG_PREFIX}${version} (bump=${bump}, from ${latest})" >&2
+	emit "changed=true" "version=${version}" "tag=${TAG_PREFIX}${version}" "bump=${bump}"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+	main "$@"
+fi

--- a/.github/scripts/next-metrics-version.test.sh
+++ b/.github/scripts/next-metrics-version.test.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Unit tests for the pure bump helpers in next-metrics-version.sh.
+# Run: bash .github/scripts/next-metrics-version.test.sh
+set -uo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=next-metrics-version.sh
+source "$DIR/next-metrics-version.sh"
+
+fail=0
+assert_eq() {
+	if [ "$1" != "$2" ]; then
+		echo "FAIL: $3 — expected '$2', got '$1'"
+		fail=1
+	else
+		echo "ok: $3"
+	fi
+}
+
+assert_eq "$(compute_next 1.2.3 major)" "2.0.0" "major resets minor/patch"
+assert_eq "$(compute_next 1.2.3 minor)" "1.3.0" "minor resets patch"
+assert_eq "$(compute_next 1.2.3 patch)" "1.2.4" "patch increments"
+assert_eq "$(compute_next v0.1.0 minor)" "0.2.0" "leading v is tolerated"
+
+assert_eq "$(printf 'feat: add exporter\n' | detect_level)" "minor" "feat -> minor"
+assert_eq "$(printf 'feat(metrics): scope\n' | detect_level)" "minor" "scoped feat -> minor"
+assert_eq "$(printf 'fix: bug\n' | detect_level)" "patch" "fix -> patch"
+assert_eq "$(printf 'chore: deps\n' | detect_level)" "patch" "chore -> patch"
+assert_eq "$(printf 'feat!: drop column\n' | detect_level)" "major" "type! -> major"
+assert_eq "$(printf 'refactor(metrics)!: rename\n' | detect_level)" "major" "scoped type! -> major"
+assert_eq "$(printf 'fix: x\n\nBREAKING CHANGE: drops table\n' | detect_level)" "major" "breaking footer -> major"
+
+if [ "$fail" -ne 0 ]; then
+	echo "TESTS FAILED"
+	exit 1
+fi
+echo "ALL TESTS PASSED"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,13 @@ jobs:
           go vet ./...
           go test -race ./...
       - name: Lint pkg/metrics
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
+          version: v2.12.2
+          # Released golangci-lint binaries are built with go1.25 and refuse to
+          # lint this module's go1.26.4 directive; goinstall recompiles it with
+          # the active setup-go toolchain so the versions match.
+          install-mode: goinstall
           working-directory: pkg/metrics
 
   functional-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,14 @@ jobs:
           SENSIBLE_PG_TEST_DSN: postgres://postgres:postgres@localhost:5432/sensible_pg_test?sslmode=disable
         run: go test -tags integration -race -count=1 ./pkg/infra/telemetry/postgres/...
 
+  scripts-tests:
+    name: CI Scripts Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test metrics module version bump
+        run: bash .github/scripts/next-metrics-version.test.sh
+
   security:
     uses: NeuralTrust/workflows/.github/workflows/sast.yml@main
     with:

--- a/.github/workflows/metrics-module-release.yml
+++ b/.github/workflows/metrics-module-release.yml
@@ -1,0 +1,51 @@
+# Auto-tags the nested pkg/metrics Go module on merge to main (ENG-1034).
+#
+# When a change to pkg/metrics/** lands on main, this computes the next
+# semantic version from the latest pkg/metrics/vX.Y.Z tag + conventional
+# commits and pushes the path-prefixed tag. The push uses GH_TOKEN (PAT) so it
+# triggers downstream consumer automation (ENG-1033); the default GITHUB_TOKEN
+# would not. The module tag namespace (pkg/metrics/v*) never collides with the
+# root release namespace (v*), and the concurrency guard serializes runs.
+
+name: Metrics Module Release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'pkg/metrics/**'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: metrics-module-release
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    name: Tag pkg/metrics
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Compute next module version
+        id: version
+        run: bash .github/scripts/next-metrics-version.sh
+
+      - name: Create and push tag
+        if: steps.version.outputs.changed == 'true'
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "tag ${TAG} already exists; nothing to do"
+            exit 0
+          fi
+          git config user.name "neuraltrust-bot"
+          git config user.email "bot@neuraltrust.ai"
+          git tag -a "${TAG}" -m "release ${TAG}"
+          git push origin "refs/tags/${TAG}"


### PR DESCRIPTION
## Summary
- Add `.github/workflows/metrics-module-release.yml`: on `push` to `main` touching `pkg/metrics/**`, compute the next module version and push the path-prefixed tag `pkg/metrics/vX.Y.Z`.
- Tag push uses `GH_TOKEN` (PAT) + `fetch-depth: 0` so it triggers downstream consumer automation (ENG-1033); the default `GITHUB_TOKEN` would not. `concurrency` serializes runs; the `pkg/metrics/v*` namespace never collides with the root `v*` release namespace.
- Version bump lives in a side-effect-free script `.github/scripts/next-metrics-version.sh` (writes to `GITHUB_OUTPUT`): latest `pkg/metrics/v*` tag + conventional commits scoped to `pkg/metrics/` → `BREAKING CHANGE`/`type!:` = major, `feat:` = minor, else patch; no prior tag seeds `v0.1.0`; no module changes since the tag = no tag.
- Pure bump helpers covered by `next-metrics-version.test.sh`, executed in CI via a new `scripts-tests` job.

## Linear
- ENG-1034 — https://linear.app/neuraltrust/issue/ENG-1034
- Depends on ENG-1020 (module exists; merges via the telemetry stack). Related to ENG-1033 (consumer bump / downstream trigger) — out of scope here.

## Test plan
- [x] `bash .github/scripts/next-metrics-version.test.sh` (all pass)
- [x] Dry-run with no tag → `pkg/metrics/v0.1.0`
- [x] Workflow + ci.yml YAML parse
- [ ] On first `pkg/metrics/**` merge to main: a `pkg/metrics/v*` tag is created
- [ ] A main merge not touching the module creates no module tag

## Notes
The workflow is inert until `pkg/metrics/**` reaches `main` (arrives with the telemetry stack). Root `auto-release.yml` left untouched (separate tag namespace).

Made with [Cursor](https://cursor.com)