### PR TITLE
feat: log config-sync worker start and applied snapshots

### DIFF
--- a/cmd/trustgate/main.go
+++ b/cmd/trustgate/main.go
@@ -272,6 +272,11 @@ func startConfigSyncWorker(
 			logger.Error("config sync worker stopped", slog.String("error", err.Error()))
 		}
 	}()
+	startAttrs := []any{}
+	if client != nil {
+		startAttrs = append(startAttrs, slog.String("endpoint", client.Endpoint()))
+	}
+	logger.Info(bootlog.ConfigSyncWorkerStarted, startAttrs...)
 	return func() {
 		cancel()
 		// Closing the client cancels the Sync stream context, unblocking the

--- a/pkg/infra/bootlog/messages.go
+++ b/pkg/infra/bootlog/messages.go
@@ -23,6 +23,7 @@ const (
 	RedisPubSubConnected       = "📡 redis pubsub connected"
 	RedisPubSubShuttingDown    = "📴 redis pubsub listener shutting down"
 	CatalogSyncCompleted       = "📚 catalog sync completed"
+	ConfigSyncWorkerStarted    = "🔄 config sync worker started"
 	MetricsWorkerStarted       = "📊 metrics worker started"
 	MetricsWorkersShuttingDown = "📉 shutting down metrics workers"
 	MetricsWorkersStopped      = "✅ metrics workers stopped"

--- a/pkg/infra/configsync/grpc/client.go
+++ b/pkg/infra/configsync/grpc/client.go
@@ -36,6 +36,7 @@ type Client struct {
 	conn       *grpc.ClientConn
 	cli        snapshotpb.ConfigSyncClient
 	instanceID string
+	endpoint   string
 	logger     *slog.Logger
 
 	// streamCtx owns the lifecycle of the long-lived Sync stream so it is not
@@ -69,7 +70,14 @@ func NewClient(cfg config.ConfigSyncConfig, logger *slog.Logger) (*Client, error
 	if err != nil {
 		return nil, fmt.Errorf("configsync: dial %q: %w", cfg.GRPCEndpoint, err)
 	}
-	return newClient(conn, cfg.InstanceID, logger), nil
+	c := newClient(conn, cfg.InstanceID, logger)
+	c.endpoint = cfg.GRPCEndpoint
+	return c, nil
+}
+
+// Endpoint returns the control-plane gRPC address the client dials.
+func (c *Client) Endpoint() string {
+	return c.endpoint
 }
 
 func newClient(conn *grpc.ClientConn, instanceID string, logger *slog.Logger) *Client {

--- a/pkg/runtimeconfig/sync/worker.go
+++ b/pkg/runtimeconfig/sync/worker.go
@@ -163,6 +163,10 @@ func (w *Worker[T]) Converge(ctx context.Context) error {
 		w.onApplied(ctx)
 	}
 	w.persist(versioned)
+	w.logger.Info("applied config snapshot",
+		slog.String("component", component),
+		slog.String("version", versioned.Version),
+		slog.Int("bytes", len(raw)))
 	if err := w.transport.Ack(ctx, versioned.Version); err != nil && ctx.Err() == nil {
 		w.logger.Warn("failed to ack applied version",
 			slog.String("component", component),


### PR DESCRIPTION
## Summary
- Make config-sync activity visible in logs. The convergence worker was silent on the happy path, so config sync was invisible.
- Log worker start (with the control-plane endpoint) and each applied snapshot version, matching TrustGuard's config-sync observability.

## Notes
- No Linear ticket — small observability fix.
- Parity change: TrustGuard and this repo now emit the same config-sync logs (`🔄 config sync worker started`, `applied config snapshot`).

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/infra/configsync/... ./pkg/runtimeconfig/sync/`
- [ ] Verify in a deployed proxy/mcp data plane: `🔄 config sync worker started` + `applied config snapshot` appear

Made with [Cursor](https://cursor.com)