### PR TITLE
fix: demote graceful control-plane disconnects to WARN in config-sync

### DIFF
--- a/pkg/infra/configsync/grpc/client.go
+++ b/pkg/infra/configsync/grpc/client.go
@@ -24,8 +24,11 @@ import (
 
 	"github.com/NeuralTrust/TrustGate/pkg/config"
 	snapshotpb "github.com/NeuralTrust/TrustGate/pkg/infra/configsnapshot/proto"
+	configsync "github.com/NeuralTrust/TrustGate/pkg/runtimeconfig/sync"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/keepalive"
+	"google.golang.org/grpc/status"
 )
 
 // Client is the data-plane end of the config-sync transport. It implements
@@ -155,7 +158,7 @@ func (c *Client) Watch(_ context.Context) (string, error) {
 		msg, err := stream.Recv()
 		if err != nil {
 			c.resetStream()
-			return "", fmt.Errorf("configsync: watch recv: %w", err)
+			return "", streamErr("watch recv", err)
 		}
 		if notice := msg.GetNotice(); notice != nil {
 			return notice.GetVersion(), nil
@@ -188,14 +191,14 @@ func (c *Client) ensureStream() (snapshotpb.ConfigSync_SyncClient, error) {
 	}
 	stream, err := c.cli.Sync(c.streamCtx)
 	if err != nil {
-		return nil, fmt.Errorf("configsync: open sync stream: %w", err)
+		return nil, streamErr("open sync stream", err)
 	}
 	hello := &snapshotpb.ClientMessage{Msg: &snapshotpb.ClientMessage_Hello{Hello: &snapshotpb.Hello{
 		InstanceId:         c.instanceID,
 		LastAppliedVersion: c.lastApplied,
 	}}}
 	if err := stream.Send(hello); err != nil {
-		return nil, fmt.Errorf("configsync: send hello: %w", err)
+		return nil, streamErr("send hello", err)
 	}
 	c.stream = stream
 	return stream, nil
@@ -205,4 +208,29 @@ func (c *Client) resetStream() {
 	c.mu.Lock()
 	c.stream = nil
 	c.mu.Unlock()
+}
+
+// streamErr wraps a broken Sync-stream error under op, tagging it with
+// configsync.ErrTransportUnavailable when the disconnect is expected and
+// self-healing so the worker logs a reconnect at WARN instead of ERROR.
+func streamErr(op string, err error) error {
+	if recoverableStreamErr(err) {
+		return fmt.Errorf("configsync: %s: %w: %w", op, configsync.ErrTransportUnavailable, err)
+	}
+	return fmt.Errorf("configsync: %s: %w", op, err)
+}
+
+// recoverableStreamErr reports whether a Sync-stream error is an expected,
+// self-healing disconnect: a control-plane restart/rollout (graceful GOAWAY
+// surfaces as codes.Unavailable), a cancelled stream, or a clean EOF.
+func recoverableStreamErr(err error) bool {
+	if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) {
+		return true
+	}
+	switch status.Code(err) {
+	case codes.Unavailable, codes.Canceled:
+		return true
+	default:
+		return false
+	}
 }

--- a/pkg/infra/configsync/grpc/client_test.go
+++ b/pkg/infra/configsync/grpc/client_test.go
@@ -17,6 +17,8 @@ package grpc
 import (
 	"bytes"
 	"context"
+	"errors"
+	"io"
 	"net"
 	"sync"
 	"testing"
@@ -25,7 +27,9 @@ import (
 	snapshotpb "github.com/NeuralTrust/TrustGate/pkg/infra/configsnapshot/proto"
 	configsync "github.com/NeuralTrust/TrustGate/pkg/runtimeconfig/sync"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 )
 
@@ -212,14 +216,44 @@ func TestClient_WatchReconnectsOnStreamBreak(t *testing.T) {
 
 	gsrv.Stop()
 
-	if _, err := client.Watch(ctx); err == nil {
+	_, err := client.Watch(ctx)
+	if err == nil {
 		t.Fatal("Watch after stream break: nil error, want failure")
+	}
+	if !errors.Is(err, configsync.ErrTransportUnavailable) {
+		t.Fatalf("Watch after stream break: err = %v, want configsync.ErrTransportUnavailable", err)
 	}
 	client.mu.Lock()
 	streamReset := client.stream == nil
 	client.mu.Unlock()
 	if !streamReset {
 		t.Fatal("stream was not reset after break; reconnect would reuse a dead stream")
+	}
+}
+
+func TestStreamErr_ClassifiesRecoverableDisconnects(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         error
+		recoverable bool
+	}{
+		{name: "graceful goaway unavailable", err: status.Error(codes.Unavailable, "closing transport due to graceful_stop"), recoverable: true},
+		{name: "canceled code", err: status.Error(codes.Canceled, "context canceled"), recoverable: true},
+		{name: "stream eof", err: io.EOF, recoverable: true},
+		{name: "context canceled", err: context.Canceled, recoverable: true},
+		{name: "internal fault", err: status.Error(codes.Internal, "boom"), recoverable: false},
+		{name: "plain error", err: errors.New("boom"), recoverable: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := streamErr("watch recv", tc.err)
+			if errors.Is(got, configsync.ErrTransportUnavailable) != tc.recoverable {
+				t.Fatalf("streamErr(%v) recoverable = %v, want %v", tc.err, !tc.recoverable, tc.recoverable)
+			}
+			if !errors.Is(got, tc.err) {
+				t.Fatalf("streamErr must wrap the original error %v", tc.err)
+			}
+		})
 	}
 }
 

--- a/pkg/runtimeconfig/sync/errors.go
+++ b/pkg/runtimeconfig/sync/errors.go
@@ -23,3 +23,11 @@ var ErrReadOnly = errors.New("configsync: store is read-only")
 var ErrNotReady = errors.New("configsync: snapshot not ready")
 
 var ErrIntegrity = errors.New("configsync: snapshot integrity mismatch")
+
+// ErrTransportUnavailable marks a config-sync transport disconnect that is
+// expected and self-healing: a control-plane restart or rollout (graceful
+// GOAWAY, surfaced by gRPC as codes.Unavailable), a transient network blip, or
+// a clean stream EOF. Adapters wrap such errors with this sentinel so the watch
+// loop demotes them to WARN and simply reconnects, instead of raising ERROR
+// alarms on routine control-plane rollouts.
+var ErrTransportUnavailable = errors.New("configsync: transport unavailable")

--- a/pkg/runtimeconfig/sync/worker.go
+++ b/pkg/runtimeconfig/sync/worker.go
@@ -229,8 +229,7 @@ func (w *Worker[T]) watchLoop(ctx context.Context) {
 			if ctx.Err() != nil {
 				return
 			}
-			w.logger.Error("change stream watch failed",
-				slog.String("component", component), slog.String("error", err.Error()))
+			w.logWatchError(err)
 			if !sleep(ctx, backoff) {
 				return
 			}
@@ -243,6 +242,20 @@ func (w *Worker[T]) watchLoop(ctx context.Context) {
 				slog.String("component", component), slog.String("error", err.Error()))
 		}
 	}
+}
+
+// logWatchError records a broken watch stream, demoting expected, self-healing
+// disconnects (control-plane rollout GOAWAY, transient unavailability) to WARN
+// so routine control-plane restarts do not raise ERROR alarms; unexpected
+// failures stay at ERROR.
+func (w *Worker[T]) logWatchError(err error) {
+	if errors.Is(err, ErrTransportUnavailable) {
+		w.logger.Warn("config stream disconnected; reconnecting",
+			slog.String("component", component), slog.String("error", err.Error()))
+		return
+	}
+	w.logger.Error("change stream watch failed",
+		slog.String("component", component), slog.String("error", err.Error()))
 }
 
 func (w *Worker[T]) backstopLoop(ctx context.Context) {

--- a/pkg/runtimeconfig/sync/worker_test.go
+++ b/pkg/runtimeconfig/sync/worker_test.go
@@ -17,6 +17,8 @@ package configsync
 import (
 	"context"
 	"errors"
+	"fmt"
+	"log/slog"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -25,6 +27,35 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type recordingHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *recordingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *recordingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	h.records = append(h.records, r)
+	h.mu.Unlock()
+	return nil
+}
+
+func (h *recordingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+
+func (h *recordingHandler) WithGroup(string) slog.Handler { return h }
+
+func (h *recordingHandler) levelFor(msg string) (slog.Level, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, r := range h.records {
+		if r.Message == msg {
+			return r.Level, true
+		}
+	}
+	return 0, false
+}
 
 type fetchResult struct {
 	raw         []byte
@@ -440,6 +471,35 @@ func TestWorker_RestoreLKGCorruptDiscarded(t *testing.T) {
 
 	_, ok := store.Load()
 	assert.False(t, ok)
+}
+
+func TestWorker_LogWatchErrorDemotesTransportUnavailable(t *testing.T) {
+	t.Parallel()
+
+	h := &recordingHandler{}
+	worker := NewWorker[string](&fakeFetcher{}, NewMemoryStore[string](), &fakeTransport{}, nil, stringCodec{}, slog.New(h), WorkerConfig{})
+
+	worker.logWatchError(fmt.Errorf("configsync: watch recv: %w: transport is closing", ErrTransportUnavailable))
+
+	level, ok := h.levelFor("config stream disconnected; reconnecting")
+	require.True(t, ok, "expected recoverable disconnect to be logged as a reconnect")
+	assert.Equal(t, slog.LevelWarn, level)
+
+	_, alarmed := h.levelFor("change stream watch failed")
+	assert.False(t, alarmed, "recoverable disconnect must not log an ERROR alarm")
+}
+
+func TestWorker_LogWatchErrorKeepsUnexpectedAtError(t *testing.T) {
+	t.Parallel()
+
+	h := &recordingHandler{}
+	worker := NewWorker[string](&fakeFetcher{}, NewMemoryStore[string](), &fakeTransport{}, nil, stringCodec{}, slog.New(h), WorkerConfig{})
+
+	worker.logWatchError(errors.New("unexpected boom"))
+
+	level, ok := h.levelFor("change stream watch failed")
+	require.True(t, ok, "expected unexpected failure to be logged")
+	assert.Equal(t, slog.LevelError, level)
 }
 
 func TestJittered_StaysWithinSpread(t *testing.T) {


### PR DESCRIPTION
## Summary

Control-plane restarts/rollouts send a graceful `GOAWAY` (`NO_ERROR`, debug data `graceful_stop`) that breaks the long-lived config-sync `Sync` stream. The data plane sees this as `codes.Unavailable`, reconnects with backoff and re-converges (self-healing) — but it logged the expected disconnect at **ERROR**, raising false alarms on every routine rollout.

This change classifies recoverable transport disconnects and logs them at **WARN** as reconnects; genuinely unexpected failures stay at **ERROR**.

- New `ErrTransportUnavailable` sentinel owned by the config-sync port (`pkg/runtimeconfig/sync`).
- gRPC adapter (`pkg/infra/configsync/grpc/client.go`) maps recoverable codes (`Unavailable`, `Canceled`, `io.EOF`, `context.Canceled`) to the sentinel in `Watch` and `ensureStream` (stream open + hello).
- Worker `watchLoop` demotes sentinel-tagged errors to WARN (`config stream disconnected; reconnecting`).

## Observed log (before)

```
{"component":"configsync","level":"ERROR","msg":"change stream watch failed","error":"configsync: watch recv: rpc error: code = Unavailable ... received prior goaway: code: NO_ERROR, debug data: \"graceful_stop\""}
```

## Test plan

- [x] `go build ./...`
- [x] `go vet` + `go test -race` on `pkg/runtimeconfig/sync/...` and `pkg/infra/configsync/grpc/...`
- [x] `golangci-lint run` (0 issues)
- [x] New unit tests: worker log-level classification + client table-driven recoverable-error classification

## Notes

Not tracked in Linear yet — happy to link a `RUN-###`/`ENG-###` if you want it referenced here.

Made with [Cursor](https://cursor.com)