### PR TITLE
feat(telemetry): allow otlp as a raw sink via declared class

### DIFF
--- a/config/telemetry.example.yaml
+++ b/config/telemetry.example.yaml
@@ -8,11 +8,13 @@
 #
 # Copy this file to config/telemetry.yaml to get started.
 #
-# Exporters are grouped by data class, and the class is intrinsic to the type:
+# Exporters are grouped by data class, and the group selects the class:
 #   - metadata: ships sanitized, non-sensitive request metadata to an external
 #     backend. Accepts every type EXCEPT postgres (e.g. otlp).
-#   - raw: persists sensitive request/response payloads inside your own
-#     boundary. Accepts ONLY postgres.
+#   - raw: carries sensitive request/response payloads. Accepts postgres (to
+#     persist inside your own boundary) or otlp (to ship payloads to an OTel
+#     Collector). An otlp exporter declared here emits the payloads instead of
+#     the sanitized metadata view.
 # Declaring postgres under metadata, or any other type under raw, aborts boot.
 
 exporters:
@@ -30,12 +32,19 @@ exporters:
         headers:
           x-scope-orgid: "trustgate"
 
-  # postgres is the only raw sink. dsn_env names the environment variable holding
-  # the connection string, so secrets stay out of this file. Enabling it opens a
-  # pool and runs the sensible-store migrations on first use. Remove this entry
-  # (raw: []) if you do not want to persist raw payloads.
+  # raw sinks accept postgres or otlp. dsn_env names the environment variable
+  # holding the postgres connection string, so secrets stay out of this file;
+  # enabling it opens a pool and runs the sensible-store migrations on first use.
+  # An otlp entry here ships the raw payloads to an OTel Collector. Remove the
+  # group (raw: []) if you do not want to move raw payloads at all.
   raw:
     - name: sensible-pg
       type: postgres
       settings:
         dsn_env: SENSIBLE_PG_DSN
+    # - name: raw-otlp
+    #   type: otlp
+    #   settings:
+    #     endpoint: "otel-collector:4317"
+    #     protocol: "grpc"
+    #     signal: "logs"

--- a/pkg/domain/telemetry/telemetry.go
+++ b/pkg/domain/telemetry/telemetry.go
@@ -18,6 +18,8 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
+
+	metricsschema "github.com/NeuralTrust/TrustGate/pkg/metrics"
 )
 
 type Telemetry struct {
@@ -32,6 +34,10 @@ type ExporterConfig struct {
 	Name     string                 `json:"name"`
 	Type     string                 `json:"type"`
 	Settings map[string]interface{} `json:"settings"`
+
+	// Class binds the exporter to a data class, set from the group it is declared
+	// under in the defaults file. Empty for per-gateway configs.
+	Class metricsschema.DataClass `json:"class,omitempty"`
 }
 
 func (c ExporterConfig) EffectiveType() string {

--- a/pkg/infra/telemetry/exporter_locator.go
+++ b/pkg/infra/telemetry/exporter_locator.go
@@ -19,12 +19,17 @@ import (
 
 	appmetrics "github.com/NeuralTrust/TrustGate/pkg/app/metrics"
 	telemetrydomain "github.com/NeuralTrust/TrustGate/pkg/domain/telemetry"
+	metricsschema "github.com/NeuralTrust/TrustGate/pkg/metrics"
 )
 
 type ExporterTemplate interface {
 	Name() string
 	ValidateConfig(settings map[string]interface{}) error
 	WithSettings(settings map[string]interface{}) (appmetrics.Exporter, error)
+}
+
+type dataClassAware interface {
+	SetDataClass(metricsschema.DataClass)
 }
 
 type ExporterLocator struct {
@@ -55,7 +60,16 @@ func (l *ExporterLocator) Build(cfg telemetrydomain.ExporterConfig) (appmetrics.
 	if err := template.ValidateConfig(cfg.Settings); err != nil {
 		return nil, fmt.Errorf("exporter %q: %w", cfg.EffectiveType(), err)
 	}
-	return template.WithSettings(cfg.Settings)
+	exporter, err := template.WithSettings(cfg.Settings)
+	if err != nil {
+		return nil, err
+	}
+	if cfg.Class != "" {
+		if aware, ok := exporter.(dataClassAware); ok {
+			aware.SetDataClass(cfg.Class)
+		}
+	}
+	return exporter, nil
 }
 
 func (l *ExporterLocator) Validate(cfg telemetrydomain.ExporterConfig) error {

--- a/pkg/infra/telemetry/exporter_locator_test.go
+++ b/pkg/infra/telemetry/exporter_locator_test.go
@@ -15,18 +15,44 @@
 package telemetry_test
 
 import (
+	"context"
 	"io"
 	"log/slog"
 	"testing"
 
+	appmetrics "github.com/NeuralTrust/TrustGate/pkg/app/metrics"
 	"github.com/NeuralTrust/TrustGate/pkg/config"
 	telemetrydomain "github.com/NeuralTrust/TrustGate/pkg/domain/telemetry"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics/events"
 	infratelemetry "github.com/NeuralTrust/TrustGate/pkg/infra/telemetry"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/telemetry/kafka"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/telemetry/postgres"
+	metricsschema "github.com/NeuralTrust/TrustGate/pkg/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type classAwareExporter struct {
+	class    metricsschema.DataClass
+	setCalls int
+}
+
+func (e *classAwareExporter) Name() string                                 { return "fake" }
+func (e *classAwareExporter) DataClass() metricsschema.DataClass           { return e.class }
+func (e *classAwareExporter) Publish(context.Context, *events.Event) error { return nil }
+func (e *classAwareExporter) Close()                                       {}
+func (e *classAwareExporter) SetDataClass(c metricsschema.DataClass) {
+	e.class = c
+	e.setCalls++
+}
+
+type classAwareTemplate struct{ exp *classAwareExporter }
+
+func (t *classAwareTemplate) Name() string                                { return "fake" }
+func (t *classAwareTemplate) ValidateConfig(map[string]interface{}) error { return nil }
+func (t *classAwareTemplate) WithSettings(map[string]interface{}) (appmetrics.Exporter, error) {
+	return t.exp, nil
+}
 
 func testLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -84,4 +110,28 @@ func TestExporterLocator_BuildUnknownExporter(t *testing.T) {
 	exporter, err := locator.Build(telemetrydomain.ExporterConfig{Name: "datadog"})
 	require.Error(t, err)
 	assert.Nil(t, exporter)
+}
+
+func TestExporterLocator_BuildInjectsDeclaredClass(t *testing.T) {
+	t.Parallel()
+
+	t.Run("declared class is injected into class-aware exporters", func(t *testing.T) {
+		exp := &classAwareExporter{}
+		locator := infratelemetry.NewExporterLocator(infratelemetry.WithExporter("fake", &classAwareTemplate{exp: exp}))
+
+		_, err := locator.Build(telemetrydomain.ExporterConfig{Name: "fake", Class: metricsschema.Raw})
+		require.NoError(t, err)
+		assert.Equal(t, metricsschema.Raw, exp.DataClass())
+		assert.Equal(t, 1, exp.setCalls)
+	})
+
+	t.Run("empty class leaves the exporter untouched", func(t *testing.T) {
+		exp := &classAwareExporter{class: metricsschema.Metadata}
+		locator := infratelemetry.NewExporterLocator(infratelemetry.WithExporter("fake", &classAwareTemplate{exp: exp}))
+
+		_, err := locator.Build(telemetrydomain.ExporterConfig{Name: "fake"})
+		require.NoError(t, err)
+		assert.Equal(t, metricsschema.Metadata, exp.DataClass())
+		assert.Equal(t, 0, exp.setCalls)
+	})
 }

--- a/pkg/infra/telemetry/exportersfile/loader.go
+++ b/pkg/infra/telemetry/exportersfile/loader.go
@@ -20,12 +20,16 @@ import (
 	"os"
 
 	telemetrydomain "github.com/NeuralTrust/TrustGate/pkg/domain/telemetry"
+	metricsschema "github.com/NeuralTrust/TrustGate/pkg/metrics"
 	"gopkg.in/yaml.v3"
 )
 
 var ErrFileNotFound = errors.New("telemetry exporters file not found")
 
-const rawExporterType = "postgres"
+const (
+	postgresExporterType = "postgres"
+	otelExporterType     = "otlp"
+)
 
 type fileSpec struct {
 	Exporters exporterGroups `yaml:"exporters"`
@@ -58,16 +62,20 @@ func Load(path string) ([]telemetrydomain.ExporterConfig, error) {
 	configs := make([]telemetrydomain.ExporterConfig, 0, len(spec.Exporters.Metadata)+len(spec.Exporters.Raw))
 	for _, e := range spec.Exporters.Metadata {
 		cfg := e.toConfig()
-		if cfg.EffectiveType() == rawExporterType {
-			return nil, fmt.Errorf("telemetry exporter %q: %q is raw-only and cannot be declared under exporters.metadata", cfg.Name, rawExporterType)
+		if cfg.EffectiveType() == postgresExporterType {
+			return nil, fmt.Errorf("telemetry exporter %q: %q is raw-only and cannot be declared under exporters.metadata", cfg.Name, postgresExporterType)
 		}
+		cfg.Class = metricsschema.Metadata
 		configs = append(configs, cfg)
 	}
 	for _, e := range spec.Exporters.Raw {
 		cfg := e.toConfig()
-		if cfg.EffectiveType() != rawExporterType {
-			return nil, fmt.Errorf("telemetry exporter %q: exporters.raw only accepts %q, got %q", cfg.Name, rawExporterType, cfg.EffectiveType())
+		switch cfg.EffectiveType() {
+		case postgresExporterType, otelExporterType:
+		default:
+			return nil, fmt.Errorf("telemetry exporter %q: exporters.raw only accepts %q or %q, got %q", cfg.Name, postgresExporterType, otelExporterType, cfg.EffectiveType())
 		}
+		cfg.Class = metricsschema.Raw
 		configs = append(configs, cfg)
 	}
 	return configs, nil

--- a/pkg/infra/telemetry/exportersfile/loader_test.go
+++ b/pkg/infra/telemetry/exportersfile/loader_test.go
@@ -22,6 +22,7 @@ import (
 
 	telemetrydomain "github.com/NeuralTrust/TrustGate/pkg/domain/telemetry"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/telemetry/exportersfile"
+	metricsschema "github.com/NeuralTrust/TrustGate/pkg/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -51,6 +52,7 @@ func TestLoad(t *testing.T) {
 				require.Len(t, configs, 1)
 				assert.Equal(t, "otlp", configs[0].Name)
 				assert.Equal(t, "otlp", configs[0].Type)
+				assert.Equal(t, metricsschema.Metadata, configs[0].Class)
 				assert.Equal(t, "otel-collector:4317", configs[0].Settings["endpoint"])
 				assert.Equal(t, "grpc", configs[0].Settings["protocol"])
 			},
@@ -91,12 +93,12 @@ func TestLoad(t *testing.T) {
 			},
 		},
 		{
-			name:  "non-postgres under raw aborts",
+			name:  "disallowed type under raw aborts",
 			write: true,
 			content: `exporters:
   raw:
     - name: leaky
-      type: otlp
+      type: kafka
 `,
 			assert: func(t *testing.T, configs []telemetrydomain.ExporterConfig, err error) {
 				require.Error(t, err)
@@ -120,6 +122,25 @@ func TestLoad(t *testing.T) {
 				require.Len(t, configs, 1)
 				assert.Equal(t, "raw-pg", configs[0].Name)
 				assert.Equal(t, "postgres", configs[0].Type)
+				assert.Equal(t, metricsschema.Raw, configs[0].Class)
+			},
+		},
+		{
+			name:  "otlp under raw parses as raw class",
+			write: true,
+			content: `exporters:
+  raw:
+    - name: raw-otlp
+      type: otlp
+      settings:
+        endpoint: "otel-collector:4317"
+`,
+			assert: func(t *testing.T, configs []telemetrydomain.ExporterConfig, err error) {
+				require.NoError(t, err)
+				require.Len(t, configs, 1)
+				assert.Equal(t, "raw-otlp", configs[0].Name)
+				assert.Equal(t, "otlp", configs[0].Type)
+				assert.Equal(t, metricsschema.Raw, configs[0].Class)
 			},
 		},
 		{

--- a/pkg/infra/telemetry/otlp/exporter.go
+++ b/pkg/infra/telemetry/otlp/exporter.go
@@ -37,13 +37,15 @@ var _ appmetrics.Exporter = (*Exporter)(nil)
 
 var errExporterClosed = errors.New("otlp: exporter is closed")
 
-// Exporter ships sanitized business events to an OTel Collector as OTLP log
-// records through a dedicated, non-global LoggerProvider.
+// Exporter ships business events to an OTel Collector as OTLP log records
+// through a dedicated, non-global LoggerProvider. It serves the metadata class by
+// default and the raw class when declared under exporters.raw.
 type Exporter struct {
 	provider        *sdklog.LoggerProvider
 	logger          otellog.Logger
 	slog            *slog.Logger
 	shutdownTimeout time.Duration
+	class           metrics.DataClass
 	closed          atomic.Bool
 }
 
@@ -72,21 +74,34 @@ func (e *Exporter) Name() string {
 	return ExporterName
 }
 
-// DataClass fixes this exporter to the metadata class; the pipeline uses it to
-// route only the sanitized metadata view here (ENG-1021).
+// DataClass reports the class this exporter is bound to. It defaults to metadata
+// and becomes raw when SetDataClass is called at build time.
 func (e *Exporter) DataClass() metrics.DataClass {
+	if e.class == metrics.Raw {
+		return metrics.Raw
+	}
 	return metrics.Metadata
 }
 
-// Publish maps the event to an OTLP log record and enqueues it into the batch
-// processor without blocking on Collector latency. It returns an error only if
-// the exporter has already been closed.
+// SetDataClass binds the exporter to a data class before it serves traffic.
+func (e *Exporter) SetDataClass(class metrics.DataClass) {
+	e.class = class
+}
+
+// Publish maps the event to an OTLP log record and enqueues it without blocking
+// on Collector latency. A raw-class exporter emits request/response payloads;
+// other classes emit sanitized metadata. It errors only if already closed.
 func (e *Exporter) Publish(ctx context.Context, evt *events.Event) error {
 	if evt == nil {
 		return nil
 	}
 	if e.closed.Load() {
 		return errExporterClosed
+	}
+	if e.class == metrics.Raw {
+		raw := evt.SensibleView()
+		e.logger.Emit(ctx, rawEventToRecord(&raw))
+		return nil
 	}
 	metadata := evt.MetadataView()
 	e.logger.Emit(ctx, eventToRecord(&metadata))

--- a/pkg/infra/telemetry/otlp/exporter_test.go
+++ b/pkg/infra/telemetry/otlp/exporter_test.go
@@ -25,6 +25,7 @@ import (
 	otellog "go.opentelemetry.io/otel/log"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 
+	"github.com/NeuralTrust/TrustGate/pkg/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -105,6 +106,43 @@ func TestExporter_PublishNeverEmitsBodies(t *testing.T) {
 	assert.Empty(t, records[0].Body().AsString())
 	_, hasRequestBody := recordAttr(records[0], "trustgate.request.body")
 	assert.False(t, hasRequestBody)
+}
+
+func TestExporter_DataClassDefaultsToMetadata(t *testing.T) {
+	t.Parallel()
+	exp := newExporterWithProvider(sdklog.NewLoggerProvider(), testLogger(), time.Second)
+	defer exp.Close()
+	assert.Equal(t, metrics.Metadata, exp.DataClass())
+}
+
+func TestExporter_RawClassEmitsBodies(t *testing.T) {
+	t.Parallel()
+	mem := &memExporter{}
+	provider := sdklog.NewLoggerProvider(sdklog.WithProcessor(sdklog.NewSimpleProcessor(mem)))
+	exp := newExporterWithProvider(provider, testLogger(), time.Second)
+	defer exp.Close()
+
+	exp.SetDataClass(metrics.Raw)
+	assert.Equal(t, metrics.Raw, exp.DataClass())
+	require.NoError(t, exp.Publish(context.Background(), fullEvent()))
+
+	records := mem.all()
+	require.Len(t, records, 1)
+	assert.Equal(t, rawEventName, records[0].EventName())
+
+	reqBody, ok := recordAttr(records[0], attrRequestBody)
+	require.True(t, ok)
+	assert.Equal(t, "request-body", reqBody.AsString())
+	respBody, ok := recordAttr(records[0], attrResponseBody)
+	require.True(t, ok)
+	assert.Equal(t, "hello world", respBody.AsString())
+
+	trace, ok := recordAttr(records[0], attrTraceID)
+	require.True(t, ok)
+	assert.Equal(t, "trace-123", trace.AsString())
+
+	_, hasMethod := recordAttr(records[0], "http.request.method")
+	assert.False(t, hasMethod, "raw record must not carry sanitized metadata attributes")
 }
 
 func TestExporter_NilEventIsNoOp(t *testing.T) {

--- a/pkg/infra/telemetry/otlp/mapping.go
+++ b/pkg/infra/telemetry/otlp/mapping.go
@@ -77,7 +77,11 @@ const (
 	attrPolicyChain          = "trustgate.policy_chain"
 	attrAttempts             = "trustgate.attempts"
 	attrAttemptsCount        = "trustgate.attempts.count"
+	attrRequestBody          = "trustgate.request.body"
+	attrResponseBody         = "trustgate.response.body"
 )
+
+const rawEventName = "gateway.request.raw"
 
 // eventToRecord is the single, semconv-pinned (semconv/v1.41.0) mapping from a
 // sanitized business Event to an OTLP log record. Standard fields use GenAI/HTTP
@@ -197,6 +201,38 @@ func eventToRecord(evt *events.Event) otellog.Record {
 			attrs = append(attrs, otellog.String(attrAttempts, encoded))
 		}
 		attrs = append(attrs, otellog.Int(attrAttemptsCount, len(evt.Attempts)))
+	}
+
+	rec.AddAttributes(attrs...)
+	return rec
+}
+
+func rawEventToRecord(evt *events.Event) otellog.Record {
+	var rec otellog.Record
+	if evt == nil {
+		return rec
+	}
+
+	rec.SetEventName(rawEventName)
+	if evt.OccurredOn > 0 {
+		rec.SetTimestamp(time.UnixMilli(evt.OccurredOn))
+	}
+	rec.SetObservedTimestamp(time.Now())
+
+	attrs := make([]otellog.KeyValue, 0, 6)
+	appendStr := func(key, value string) {
+		if value != "" {
+			attrs = append(attrs, otellog.String(key, value))
+		}
+	}
+
+	attrs = append(attrs, otellog.Int(attrSchemaVersion, evt.SchemaVersion))
+	appendStr(attrTraceID, evt.TraceID)
+	appendStr(attrGatewayID, evt.GatewayID)
+	appendStr(attrTeamID, evt.TeamID)
+	appendStr(attrRequestBody, evt.Request.Body)
+	if evt.Response.Body != nil {
+		appendStr(attrResponseBody, *evt.Response.Body)
 	}
 
 	rec.AddAttributes(attrs...)


### PR DESCRIPTION
## Summary
- Data class is no longer intrinsic to the exporter type. The group an exporter is declared under in the defaults file (`metadata` vs `raw`) now selects its class, making `otlp` **dual-class**: `raw -> {postgres, otlp}`, `metadata -> everything except postgres`.
- A **raw-class OTLP** exporter emits request/response payloads over OTLP (`gateway.request.raw` record with `trustgate.request.body` / `trustgate.response.body` + correlation keys) instead of the sanitized metadata view.
- Scope: **defaults file only** (`config/telemetry.yaml`). The per-gateway/API path is unchanged and keeps the exporter's intrinsic class.

## Changes
- `domain/telemetry`: `ExporterConfig` carries the declared `Class` (empty for per-gateway configs).
- `exportersfile/loader`: `raw` accepts `postgres` or `otlp`; `metadata` still rejects `postgres`; each entry is stamped with its group's class.
- `infra/telemetry` locator: injects the declared class into class-aware exporters at build time (single build choke point; no `ExporterTemplate` interface change).
- `otlp` exporter: stores its class, honors it in `DataClass`/`Publish`, with a dedicated raw record mapping.
- `config/telemetry.example.yaml`: documents `otlp` as a raw sink.

## Test plan
- [x] `go build ./...`
- [x] `go vet` + `golangci-lint run` on touched packages (0 issues)
- [x] `go test` for `domain/telemetry`, `infra/telemetry(/...)`, `app/metrics`
- [x] New tests: otlp parses as raw class in the loader; locator injects the declared class; raw-class OTLP emits bodies without metadata attrs

Stacked on `feat/eng-1016-load-default-exporters-yaml` (part of the OTEL connectors/exporters epic).

Made with [Cursor](https://cursor.com)