### PR TITLE
ci(metrics): schema versioning & compatibility gate for pkg/metrics (ENG-1033)

### DIFF
--- a/.github/scripts/metrics-compat-gate.sh
+++ b/.github/scripts/metrics-compat-gate.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# Compatibility gate for the nested pkg/metrics Go module (ENG-1033). It fails a
+# PR that changes the producer schema in a way consumers (DataCore/DataAgent)
+# cannot absorb: an apidiff-incompatible change that neither bumps SchemaVersion
+# nor carries a Conventional Commit breaking-change marker, a SchemaVersion that
+# goes backwards, or a go.mod that stops being dependency-light. It self-skips
+# when the PR does not touch pkg/metrics, so it can be a required status on every
+# PR. The pure policy helpers live in metrics-compat-lib.sh (unit-tested); this
+# file only wires them to git and apidiff.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=metrics-compat-lib.sh
+source "$SCRIPT_DIR/metrics-compat-lib.sh"
+
+TAG_PREFIX="${TAG_PREFIX:-pkg/metrics/v}"
+MODULE_DIR="${MODULE_DIR:-pkg/metrics}"
+MODULE_PATH="${MODULE_PATH:-github.com/NeuralTrust/TrustGate/pkg/metrics}"
+BASE_REF="${BASE_REF:-}"
+APIDIFF_BIN="${APIDIFF_BIN:-apidiff}"
+
+diff_base() {
+	local mb=""
+	if [ -n "$BASE_REF" ]; then
+		mb="$(git merge-base "$BASE_REF" HEAD 2>/dev/null || true)"
+	fi
+	if [ -n "$mb" ]; then
+		printf '%s\n' "$mb"
+	else
+		printf '%s\n' "HEAD~1"
+	fi
+}
+
+resolve_baseline() {
+	local tag
+	tag="$(git tag -l "${TAG_PREFIX}*" | mc_select_latest_tag)"
+	if [ -n "$tag" ]; then
+		printf '%s\n' "$tag"
+		return 0
+	fi
+	local mb=""
+	if [ -n "$BASE_REF" ]; then
+		mb="$(git merge-base "$BASE_REF" HEAD 2>/dev/null || true)"
+	fi
+	if [ -n "$mb" ]; then
+		printf '%s\n' "$mb"
+	else
+		printf '%s\n' "__bootstrap__"
+	fi
+}
+
+schema_version_at() {
+	git show "$1:${MODULE_DIR}/version.go" 2>/dev/null | mc_parse_schema_version || true
+}
+
+scoped_msgs() {
+	git log --format='%B' "$1..HEAD" -- "$MODULE_DIR" 2>/dev/null || true
+}
+
+run_apidiff() {
+	local baseline="$1"
+	if ! git cat-file -e "${baseline}:${MODULE_DIR}/go.mod" 2>/dev/null; then
+		echo "false"
+		return 0
+	fi
+
+	local wt base_api head_api
+	wt="$(mktemp -d)"
+	base_api="$(mktemp)"
+	head_api="$(mktemp)"
+	# shellcheck disable=SC2329,SC2317 # invoked indirectly via the RETURN trap
+	cleanup() {
+		git worktree remove --force "$wt" >/dev/null 2>&1 || true
+		rm -rf "$wt" "$base_api" "$head_api"
+	}
+	trap cleanup RETURN
+
+	if ! git worktree add -q --detach "$wt" "$baseline" >/dev/null 2>&1; then
+		echo "compat gate: cannot check out baseline ${baseline}; skipping apidiff" >&2
+		echo "false"
+		return 0
+	fi
+	if ! (cd "$wt/$MODULE_DIR" && "$APIDIFF_BIN" -m -w "$base_api" "$MODULE_PATH") >/dev/null 2>&1; then
+		echo "compat gate: apidiff could not export baseline API; skipping apidiff" >&2
+		echo "false"
+		return 0
+	fi
+	if ! (cd "$MODULE_DIR" && "$APIDIFF_BIN" -m -w "$head_api" "$MODULE_PATH") >/dev/null 2>&1; then
+		echo "compat gate: apidiff could not export HEAD API; skipping apidiff" >&2
+		echo "false"
+		return 0
+	fi
+	"$APIDIFF_BIN" -m -incompatible "$base_api" "$head_api" 2>/dev/null | mc_apidiff_incompatible
+}
+
+main() {
+	cd "$(git rev-parse --show-toplevel)"
+
+	local dbase changed
+	dbase="$(diff_base)"
+	changed="$(git diff --name-only "$dbase" HEAD 2>/dev/null || true)"
+	if [ "$(printf '%s\n' "$changed" | mc_changed_touches_metrics)" != "true" ]; then
+		echo "compat gate: no ${MODULE_DIR} changes vs ${dbase}; skipping"
+		return 0
+	fi
+
+	if [ "$(mc_gomod_dependency_light <"$MODULE_DIR/go.mod")" != "true" ]; then
+		echo "compat gate FAILED: ${MODULE_DIR}/go.mod must stay dependency-light (no require/replace/exclude directives)" >&2
+		return 1
+	fi
+
+	local baseline
+	baseline="$(resolve_baseline)"
+	if [ "$baseline" = "__bootstrap__" ]; then
+		echo "compat gate: no baseline tag or merge-base; bootstrap pass"
+		return 0
+	fi
+	echo "compat gate: baseline=${baseline}" >&2
+
+	local incompatible base_ver head_ver marker decision
+	incompatible="$(run_apidiff "$baseline")"
+	base_ver="$(schema_version_at "$baseline")"
+	head_ver="$(schema_version_at HEAD)"
+	marker="$(scoped_msgs "$baseline" | mc_has_breaking_marker)"
+
+	echo "compat gate: incompatible=${incompatible} base_ver=${base_ver:-<none>} head_ver=${head_ver:-<none>} breaking_marker=${marker}" >&2
+
+	if decision="$(mc_gate_decision "$incompatible" "${base_ver:-}" "${head_ver:-}" "$marker")"; then
+		echo "compat gate: ${decision}"
+		return 0
+	fi
+	echo "compat gate FAILED: ${decision}" >&2
+	return 1
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+	main "$@"
+fi

--- a/.github/scripts/metrics-compat-lib.sh
+++ b/.github/scripts/metrics-compat-lib.sh
@@ -1,0 +1,109 @@
+# shellcheck shell=bash
+#
+# Pure helpers for the pkg/metrics compatibility gate (ENG-1033). Every function
+# reads from stdin or arguments and writes a decision to stdout; none touch git,
+# the filesystem, or apidiff. The orchestrator (metrics-compat-gate.sh) wires
+# these to real inputs; the unit tests (metrics-compat-lib.test.sh) exercise them
+# in isolation. Source this file; it defines functions only and has no main.
+
+# mc_select_latest_tag reads a newline-separated list of tags on stdin and prints
+# the highest by version order, or nothing when the list is empty.
+mc_select_latest_tag() {
+	sort -V | tail -1
+}
+
+# mc_apidiff_incompatible reads the output of `apidiff -incompatible` on stdin and
+# prints "true" when it contains any change entry, "false" otherwise.
+mc_apidiff_incompatible() {
+	if grep -qE '[^[:space:]]'; then
+		echo true
+	else
+		echo false
+	fi
+}
+
+# mc_parse_schema_version reads a version.go on stdin and prints the integer value
+# of the SchemaVersion constant. It returns non-zero when the constant is absent.
+mc_parse_schema_version() {
+	local line
+	line="$(grep -E '^const SchemaVersion = [0-9]+' || true)"
+	if [ -z "$line" ]; then
+		return 1
+	fi
+	printf '%s\n' "$line" | grep -oE '[0-9]+' | head -1
+}
+
+# mc_has_breaking_marker reads commit messages on stdin and prints "true" when any
+# carries a Conventional Commit breaking marker (a "type!:" subject or a
+# BREAKING CHANGE footer), "false" otherwise.
+mc_has_breaking_marker() {
+	local msgs
+	msgs="$(cat)"
+	if grep -qE '(^|[[:space:]])BREAKING[ -]CHANGE' <<<"$msgs" \
+		|| grep -qE '^[a-z]+(\([^)]+\))?!:' <<<"$msgs"; then
+		echo true
+	else
+		echo false
+	fi
+}
+
+# mc_gomod_dependency_light reads a go.mod on stdin and prints "true" when the
+# module declares no external dependencies (no require/replace/exclude directives
+# and no indirect markers), "false" otherwise.
+mc_gomod_dependency_light() {
+	local mod
+	mod="$(cat)"
+	if grep -qE '^[[:space:]]*require([[:space:]]|\()' <<<"$mod" \
+		|| grep -qE '^[[:space:]]*replace[[:space:]]' <<<"$mod" \
+		|| grep -qE '^[[:space:]]*exclude[[:space:]]' <<<"$mod" \
+		|| grep -qE '//[[:space:]]*indirect' <<<"$mod"; then
+		echo false
+	else
+		echo true
+	fi
+}
+
+# mc_changed_touches_metrics reads a newline-separated list of changed paths on
+# stdin and prints "true" when any path is under pkg/metrics/, "false" otherwise.
+mc_changed_touches_metrics() {
+	if grep -qE '^pkg/metrics/'; then
+		echo true
+	else
+		echo false
+	fi
+}
+
+# mc_gate_decision applies the compatibility policy to already-computed inputs and
+# prints "pass" or "fail:<reason>". It returns non-zero on a fail so callers can
+# branch on the exit code. Arguments:
+#   $1 incompatible  "true" when apidiff reported incompatible changes
+#   $2 base_ver      SchemaVersion at the baseline, or "__bootstrap__" when there
+#                    is no baseline to compare against, or empty when unknown
+#   $3 head_ver      SchemaVersion at HEAD
+#   $4 marker        "true" when the diff carries a breaking-change marker
+mc_gate_decision() {
+	local incompatible="$1" base_ver="$2" head_ver="$3" marker="$4"
+
+	if [ "$base_ver" = "__bootstrap__" ]; then
+		echo pass
+		return 0
+	fi
+	if [ -z "$head_ver" ]; then
+		echo "fail:cannot parse SchemaVersion at HEAD"
+		return 1
+	fi
+	if [ -z "$base_ver" ]; then
+		echo pass
+		return 0
+	fi
+	if [ "$head_ver" -lt "$base_ver" ]; then
+		echo "fail:SchemaVersion decreased ($base_ver -> $head_ver)"
+		return 1
+	fi
+	if [ "$incompatible" = "true" ] && [ "$head_ver" = "$base_ver" ] && [ "$marker" != "true" ]; then
+		echo "fail:incompatible API change without a SchemaVersion bump or breaking-change marker"
+		return 1
+	fi
+	echo pass
+	return 0
+}

--- a/.github/scripts/metrics-compat-lib.test.sh
+++ b/.github/scripts/metrics-compat-lib.test.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Unit tests for the pure helpers in metrics-compat-lib.sh (ENG-1033).
+# Run: bash .github/scripts/metrics-compat-lib.test.sh
+set -uo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=metrics-compat-lib.sh
+source "$DIR/metrics-compat-lib.sh"
+
+fail=0
+assert_eq() {
+	if [ "$1" != "$2" ]; then
+		echo "FAIL: $3 — expected '$2', got '$1'"
+		fail=1
+	else
+		echo "ok: $3"
+	fi
+}
+
+# mc_select_latest_tag
+assert_eq "$(printf 'pkg/metrics/v0.1.0\npkg/metrics/v0.10.0\npkg/metrics/v0.2.0\n' | mc_select_latest_tag)" \
+	"pkg/metrics/v0.10.0" "select_latest_tag picks highest semver"
+assert_eq "$(printf '' | mc_select_latest_tag)" "" "select_latest_tag empty list -> empty"
+
+# mc_apidiff_incompatible
+assert_eq "$(printf '' | mc_apidiff_incompatible)" "false" "apidiff empty -> false"
+assert_eq "$(printf '\n  \n' | mc_apidiff_incompatible)" "false" "apidiff whitespace -> false"
+assert_eq "$(printf -- '- Metadata: removed\n' | mc_apidiff_incompatible)" "true" "apidiff entry -> true"
+
+# mc_parse_schema_version
+assert_eq "$(printf 'package metrics\n\nconst SchemaVersion = 1\n' | mc_parse_schema_version)" \
+	"1" "parse_schema_version reads constant"
+assert_eq "$(printf 'const SchemaVersion = 42\n' | mc_parse_schema_version)" "42" "parse_schema_version multi-digit"
+assert_eq "$(printf 'package metrics\n' | mc_parse_schema_version)" "" "parse_schema_version missing -> empty"
+
+# mc_has_breaking_marker
+assert_eq "$(printf 'feat: add field\n' | mc_has_breaking_marker)" "false" "marker feat -> false"
+assert_eq "$(printf 'fix!: drop column\n' | mc_has_breaking_marker)" "true" "marker type! -> true"
+assert_eq "$(printf 'refactor(metrics)!: rename\n' | mc_has_breaking_marker)" "true" "marker scoped type! -> true"
+assert_eq "$(printf 'fix: x\n\nBREAKING CHANGE: drops table\n' | mc_has_breaking_marker)" "true" "marker footer -> true"
+
+# mc_gomod_dependency_light
+assert_eq "$(printf 'module m\n\ngo 1.26\n' | mc_gomod_dependency_light)" "true" "gomod bare -> true"
+assert_eq "$(printf 'module m\n\ngo 1.26\n\nrequire foo v1.0.0\n' | mc_gomod_dependency_light)" "false" "gomod single require -> false"
+assert_eq "$(printf 'module m\n\nrequire (\n\tfoo v1.0.0\n)\n' | mc_gomod_dependency_light)" "false" "gomod require block -> false"
+assert_eq "$(printf 'module m\n\nreplace a => b v1.0.0\n' | mc_gomod_dependency_light)" "false" "gomod replace -> false"
+assert_eq "$(printf 'module m\n\nrequire (\n\tfoo v1.0.0 // indirect\n)\n' | mc_gomod_dependency_light)" "false" "gomod indirect -> false"
+
+# mc_changed_touches_metrics
+assert_eq "$(printf 'README.md\npkg/metrics/version.go\n' | mc_changed_touches_metrics)" "true" "changed touches metrics -> true"
+assert_eq "$(printf 'README.md\npkg/app/foo.go\n' | mc_changed_touches_metrics)" "false" "changed elsewhere -> false"
+assert_eq "$(printf '' | mc_changed_touches_metrics)" "false" "changed empty -> false"
+
+# mc_gate_decision
+assert_eq "$(mc_gate_decision false __bootstrap__ 1 false)" "pass" "gate bootstrap -> pass"
+assert_eq "$(mc_gate_decision false 1 '' false)" "fail:cannot parse SchemaVersion at HEAD" "gate unparseable head -> fail"
+assert_eq "$(mc_gate_decision true '' 1 false)" "pass" "gate unknown base -> pass"
+assert_eq "$(mc_gate_decision false 2 1 false)" "fail:SchemaVersion decreased (2 -> 1)" "gate decrease -> fail"
+assert_eq "$(mc_gate_decision true 1 1 false)" "fail:incompatible API change without a SchemaVersion bump or breaking-change marker" "gate silent break -> fail"
+assert_eq "$(mc_gate_decision true 1 2 false)" "pass" "gate break with version bump -> pass"
+assert_eq "$(mc_gate_decision true 1 1 true)" "pass" "gate break with marker -> pass"
+assert_eq "$(mc_gate_decision false 1 1 false)" "pass" "gate compatible same version -> pass"
+
+# mc_gate_decision exit codes
+mc_gate_decision false 1 2 false >/dev/null
+assert_eq "$?" "0" "gate pass exit 0"
+mc_gate_decision true 1 1 false >/dev/null
+assert_eq "$?" "1" "gate fail exit 1"
+
+if [ "$fail" -ne 0 ]; then
+	echo "TESTS FAILED"
+	exit 1
+fi
+echo "ALL TESTS PASSED"

--- a/docs/schema-versioning.md
+++ b/docs/schema-versioning.md
@@ -1,0 +1,133 @@
+# Producer schema versioning & compatibility (`pkg/metrics`)
+
+`pkg/metrics` is a **nested, independently versioned Go module** that carries the
+producer-owned data contract for the raw telemetry store: the table name, the
+row shape (`RawRecord`), the `SchemaVersion` constant, the `DataClass` values,
+and the ordered migrations. TrustGate writes rows through it; downstream
+consumers (DataCore / DataAgent, once they read the residency store) import it to
+decode those rows. Because producer and consumers deploy independently, a change
+here can break a consumer that is still running the previous version.
+
+This document is the policy that keeps that from happening silently, plus the CI
+gate that enforces it.
+
+## Module boundary
+
+- **Path:** `pkg/metrics` (own `go.mod`, module
+  `github.com/NeuralTrust/TrustGate/pkg/metrics`).
+- **Dependency-light:** the module must not depend on the DB driver or any of the
+  service's dependencies. Consumers should inherit the contract, not TrustGate's
+  runtime. The gate fails any `go.mod` that gains a `require`, `replace`, or
+  `exclude` directive.
+- **Versioning:** semver via **path-prefixed tags** `pkg/metrics/vX.Y.Z`, created
+  automatically on merge to `main` by
+  [`metrics-module-release.yml`](../.github/workflows/metrics-module-release.yml)
+  (ENG-1034). The bump level is derived from the Conventional Commit messages
+  that touched the module (`feat` → minor, `type!:`/`BREAKING CHANGE` → major,
+  otherwise patch).
+
+## The two version numbers
+
+| Number | Where | Meaning |
+|---|---|---|
+| Module semver (`pkg/metrics/vX.Y.Z`) | git tag | The Go API contract of the module. Bumps whenever the exported API changes. |
+| `SchemaVersion` (int) | `pkg/metrics/version.go` | The wire/row schema generation stamped on every emitted record. Bumps when the persisted row shape changes in a way consumers must branch on. |
+
+They move together for schema changes but answer different questions: semver
+protects the *Go import*, `SchemaVersion` protects the *stored data*.
+
+## Compatibility rules
+
+1. **N / N-1 support window.** A consumer running schema version `N-1` must keep
+   working against a producer at version `N`. Do not remove or repurpose a field
+   that an in-window consumer still reads.
+2. **Expand → migrate → contract.** Never change a column or field in place:
+   - **Expand:** add the new column/field (nullable / optional). Additive changes
+     are backward-compatible.
+   - **Migrate:** backfill and switch readers/writers to the new shape; bump
+     `SchemaVersion`.
+   - **Contract:** only after no supported consumer needs the old shape, remove
+     it (this is the breaking step and requires a major module bump).
+3. **A breaking change must be acknowledged.** An API-incompatible change is only
+   allowed together with either a `SchemaVersion` bump or a Conventional Commit
+   breaking marker (`type!:` subject or a `BREAKING CHANGE` footer). The gate
+   rejects an incompatible change that has neither.
+4. **`SchemaVersion` never decreases.**
+
+## The CI compatibility gate
+
+Job **`metrics-compat-gate`** in [`ci.yml`](../.github/workflows/ci.yml) runs on
+every PR (it is safe to make it a required status). It self-skips when the PR does
+not touch `pkg/metrics`.
+
+When `pkg/metrics` changes, the gate:
+
+1. Verifies `pkg/metrics/go.mod` is still dependency-light.
+2. Picks a baseline: the latest `pkg/metrics/v*` tag, else the PR merge-base.
+3. Runs [`apidiff`](https://pkg.go.dev/golang.org/x/exp/cmd/apidiff) in module mode
+   between baseline and HEAD and looks for **incompatible** changes.
+4. Reads `SchemaVersion` at both revisions and inspects the commit messages that
+   touched the module for a breaking marker.
+5. Applies the decision table below.
+
+| apidiff | `SchemaVersion` | breaking marker | Result |
+|---|---|---|---|
+| compatible | any (not lower) | — | **pass** |
+| incompatible | bumped | — | **pass** |
+| incompatible | unchanged | present | **pass** |
+| incompatible | unchanged | absent | **fail** |
+| — | decreased | — | **fail** |
+
+The pure decision logic lives in
+[`.github/scripts/metrics-compat-lib.sh`](../.github/scripts/metrics-compat-lib.sh)
+and is unit-tested by `metrics-compat-lib.test.sh` (run in the `scripts-tests`
+job). The orchestration (git, worktrees, apidiff) lives in
+[`.github/scripts/metrics-compat-gate.sh`](../.github/scripts/metrics-compat-gate.sh).
+
+### Making a breaking change on purpose
+
+Do the contract step, then acknowledge it so the gate stays green and the module
+gets a major tag on merge:
+
+- Bump `SchemaVersion` in `pkg/metrics/version.go`, **or**
+- Land it under a breaking Conventional Commit (`feat(metrics)!: …` or a
+  `BREAKING CHANGE:` footer).
+
+Prefer bumping `SchemaVersion` whenever the *stored row shape* changed; use the
+commit marker for Go-API-only breaks that do not alter persisted data.
+
+## Deploy ordering
+
+For a schema change that consumers must absorb:
+
+1. Ship the **expand** migration (additive, backward-compatible).
+2. Roll out the **producers** (TrustGate) writing the new shape.
+3. **Bump the pinned `pkg/metrics` version in consumers** and roll them out.
+4. Ship the **contract** migration only once every supported consumer is at the
+   new version.
+
+## Local multi-module workflow
+
+`pkg/metrics` is its own module, so test and lint it on its own:
+
+```bash
+cd pkg/metrics
+go build ./...
+go vet ./...
+go test -race ./...
+```
+
+The root module resolves it via a `replace` directive
+(`replace github.com/NeuralTrust/TrustGate/pkg/metrics => ./pkg/metrics`) in the
+root `go.mod`; run `go mod vendor` at the root after changing the nested module so
+the vendored copy stays in sync.
+
+## Consumer pinning (future)
+
+Once DataCore / DataAgent import `pkg/metrics`, they pin an explicit
+`pkg/metrics/vX.Y.Z` in their `go.mod` and bump it deliberately (via an explicit
+PR or Renovate). At that point a **consumer-side build gate** — building the
+consumer against the pinned producer version in the consumer's CI — becomes the
+strongest guarantee and should be added there. Until a consumer imports the
+module, this producer-side gate (API compatibility + version discipline +
+dependency-light + written policy) is the enforceable contract.


### PR DESCRIPTION
## Summary

Self-contained producer-side compatibility gate for the nested `pkg/metrics` module, plus the written versioning policy. Closes the enforceable part of ENG-1033 now (the consumer-side build gate stays deferred until DataCore/DataAgent import the module — documented as such).

- **Gate logic (pure, unit-tested):** `.github/scripts/metrics-compat-lib.sh` + `metrics-compat-lib.test.sh` (30 asserts, run in the `scripts-tests` job). Decides pass/fail from apidiff result, `SchemaVersion`, breaking-change marker, and the dependency-light `go.mod` invariant.
- **Orchestrator + CI job:** `.github/scripts/metrics-compat-gate.sh` wires git/worktrees/`apidiff -m -incompatible` to the pure logic. New always-on `metrics-compat-gate` job self-skips when a PR does not touch `pkg/metrics`, so it can be a required status.
- **Policy doc:** `docs/schema-versioning.md` (semver via `pkg/metrics/vX.Y.Z`, N/N-1 window, expand→migrate→contract, deploy ordering, decision table, deferred consumer gate).

### Gate decision

| apidiff | SchemaVersion | breaking marker | Result |
|---|---|---|---|
| compatible | not lower | — | pass |
| incompatible | bumped | — | pass |
| incompatible | unchanged | present | pass |
| incompatible | unchanged | absent | **fail** |
| — | decreased | — | **fail** |

## Test plan

- [x] `bash .github/scripts/metrics-compat-lib.test.sh` — 30/30 pass
- [x] `shellcheck` lib + gate clean (only benign SC1091/SC2329 info, annotated)
- [x] `actionlint .github/workflows/ci.yml` clean (2 pre-existing SC2086 infos in `functional-tests`)
- [x] Local e2e against real `apidiff`: skip→0, compatible→0, **silent break→1 (red)**, break+version-bump→0, break+marker→0
- [ ] CI green on this PR (gate self-skips: no `pkg/metrics` change here)

Linear: https://linear.app/neuraltrust/issue/ENG-1033
Stacked on `feat/eng-1016-load-default-exporters-yaml` (same base as #162–#171).

Made with [Cursor](https://cursor.com)