### PR TITLE
feat: align OTLP export with TrustGuard resource.version.verb

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,11 +349,13 @@ See [`.env.example`](.env.example) for the full set with safe defaults.
 Every completed request is turned into a sanitized business event and fanned out
 to one or more exporters. **Kafka is the config-driven default** (feeds
 `kafka-connect → ClickHouse → data-plane-api`). A gateway can additionally opt
-into the **`otlp`** exporter, which ships the same event to an external
+into the **`otlp`** exporter, which ships the event to an external
 [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) as a single
-OTLP **log record** per request (`event.name="gateway.request"`); the Collector
-fans out to any vendor backend. Enabling `otlp` does not replace Kafka — both
-fire (explicit exporters merge with the global defaults).
+OTLP **log record** per request (`EventName: trustgate.<version>.<class>`, e.g.
+`trustgate.3.metadata` / `trustgate.3.raw`); the Collector fans out to any vendor
+backend. Contract details: [`docs/telemetry/otlp-metadata-contract.md`](docs/telemetry/otlp-metadata-contract.md).
+Enabling `otlp` does not replace Kafka — both fire (explicit exporters merge with the
+global defaults).
 
 Add it to a gateway's `telemetry.exporters`:
 
@@ -363,6 +365,7 @@ Add it to a gateway's `telemetry.exporters`:
     "exporters": [
       {
         "name": "otlp",
+        "class": "metadata",
         "settings": {
           "endpoint": "collector:4317",
           "protocol": "grpc",
@@ -379,6 +382,14 @@ Add it to a gateway's `telemetry.exporters`:
 
 With Kafka still configured, the event is delivered to the Collector **and**
 Kafka (the ClickHouse path keeps populating with `schema_version=2` intact).
+
+**Exporter fields**
+
+| Key | Type | Default | Notes |
+|-----|------|---------|-------|
+| `name` | string | — | Exporter type: `otlp`, `kafka` |
+| `class` | string | `metadata` | `metadata` (no bodies) or `raw` (includes body attributes) |
+| `settings` | object | — | Exporter-specific settings |
 
 **`otlp` settings**
 

--- a/docs/telemetry/otlp-metadata-contract.md
+++ b/docs/telemetry/otlp-metadata-contract.md
@@ -1,0 +1,71 @@
+# OTLP metadata export contract
+
+TrustGate emits one OTLP **log record** per gateway request. This contract describes the
+**metadata** data class: the pipeline passes `events.MetadataView(evt)` so request/response
+**bodies are not exported**. Raw bodies are available when an `otlp` exporter is declared
+with `"class": "raw"` on the gateway — see dual-export below.
+
+## Event name
+
+`trustgate.<version>.<verb>` (`resource.version.verb`):
+
+| Class | EventName example |
+|-------|-------------------|
+| metadata | `trustgate.3.metadata` |
+| raw | `trustgate.3.raw` |
+
+Version tracks `schema_version` on the event (currently `3`). Downstream consumers route on
+`EventName`.
+
+## Invariants
+
+| Rule | Detail |
+|------|--------|
+| Log body | Always empty |
+| Bodies (metadata) | Not emitted (no `trustgate.request.body` / `trustgate.response.body`) |
+| Bodies (raw) | Emitted as attributes when exporter `class` is `raw` |
+| `policy_chain` | AlertEngine-facing projection (`source.plugin`, `signal`, `outcome`, `report_only`) |
+| `plugin_chain` | Full plugin chain without `extras` (debug / HyperDX) |
+| `is_flagged` | `trustgate.is_flagged` (bool), computed at event build time |
+
+## Dual export (gateway config)
+
+Unlike TrustGuard's YAML groups, TrustGate configures exporters per gateway in
+`telemetry.exporters[]`. Set `class` on each exporter:
+
+```json
+{
+  "telemetry": {
+    "exporters": [
+      {
+        "name": "otlp",
+        "class": "metadata",
+        "settings": { "endpoint": "collector:4318", "protocol": "http/protobuf" }
+      },
+      {
+        "name": "otlp",
+        "class": "raw",
+        "settings": { "endpoint": "collector:4318", "protocol": "http/protobuf" }
+      }
+    ]
+  }
+}
+```
+
+When `class` is omitted, it defaults to **`metadata`** (no bodies).
+
+The process-level **Kafka** default exporter uses `class: raw` so the full event JSON is
+unchanged for the ClickHouse path.
+
+## Routing
+
+```text
+POST /gateway
+       │
+       ▼
+  events.Event (full, sanitized)
+       │
+       ├── exporter class metadata  →  MetadataView  →  trustgate.3.metadata
+       ├── exporter class raw       →  full event    →  trustgate.3.raw
+       └── kafka (default, raw)     →  full JSON to topic
+```

--- a/pkg/api/middleware/metrics_functional_test.go
+++ b/pkg/api/middleware/metrics_functional_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics/events"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/adapter"
 	infratelemetry "github.com/NeuralTrust/TrustGate/pkg/infra/telemetry"
+	"github.com/NeuralTrust/TrustGate/pkg/metrics"
 	"github.com/gofiber/fiber/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -81,6 +82,8 @@ type memExporter struct {
 }
 
 func (e *memExporter) Name() string { return e.name }
+
+func (e *memExporter) DataClass() metrics.DataClass { return metrics.Metadata }
 
 func (e *memExporter) Publish(_ context.Context, evt *events.Event) error {
 	if e.fail {

--- a/pkg/app/metrics/exporter_internal_test.go
+++ b/pkg/app/metrics/exporter_internal_test.go
@@ -27,6 +27,7 @@ import (
 	infracontext "github.com/NeuralTrust/TrustGate/pkg/infra/context"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics/events"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/adapter"
+	"github.com/NeuralTrust/TrustGate/pkg/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -44,6 +45,8 @@ type fakeExporter struct {
 }
 
 func (f *fakeExporter) Name() string { return f.name }
+
+func (f *fakeExporter) DataClass() metrics.DataClass { return metrics.Metadata }
 
 func (f *fakeExporter) Publish(_ context.Context, _ *events.Event) error {
 	f.mu.Lock()

--- a/pkg/app/metrics/pipeline.go
+++ b/pkg/app/metrics/pipeline.go
@@ -23,10 +23,12 @@ import (
 	infracontext "github.com/NeuralTrust/TrustGate/pkg/infra/context"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics/events"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/trace"
+	"github.com/NeuralTrust/TrustGate/pkg/metrics"
 )
 
 type Exporter interface {
 	Name() string
+	DataClass() metrics.DataClass
 	Publish(ctx context.Context, evt *events.Event) error
 	Close()
 }
@@ -79,7 +81,7 @@ func (p *Pipeline) publish(
 	ctx := context.Background()
 	evt := p.builder.Build(ctx, requestTrace, req, resp, startTime, endTime)
 	for _, exporter := range targets {
-		if err := exporter.Publish(ctx, evt); err != nil {
+		if err := exporter.Publish(ctx, viewForClass(evt, exporter.DataClass())); err != nil {
 			p.logger.Error("failed to publish metrics event",
 				slog.String("gateway_id", req.GatewayID),
 				slog.String("exporter", exporter.Name()),
@@ -108,6 +110,13 @@ func (p *Pipeline) resolveTargets(explicit []telemetrydomain.ExporterConfig) []E
 		}
 	}
 	return targets
+}
+
+func viewForClass(evt *events.Event, class metrics.DataClass) *events.Event {
+	if class == metrics.Raw {
+		return evt
+	}
+	return events.MetadataView(evt)
 }
 
 func (p *Pipeline) close() {

--- a/pkg/app/metrics/worker_test.go
+++ b/pkg/app/metrics/worker_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics/events"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/adapter"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/trace"
+	"github.com/NeuralTrust/TrustGate/pkg/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -42,6 +43,8 @@ type captureExporter struct {
 }
 
 func (c *captureExporter) Name() string { return "capture" }
+
+func (c *captureExporter) DataClass() metrics.DataClass { return metrics.Metadata }
 
 func (c *captureExporter) Publish(_ context.Context, evt *events.Event) error {
 	c.mu.Lock()

--- a/pkg/container/modules/telemetry.go
+++ b/pkg/container/modules/telemetry.go
@@ -29,6 +29,7 @@ import (
 	infratelemetry "github.com/NeuralTrust/TrustGate/pkg/infra/telemetry"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/telemetry/kafka"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/telemetry/otlp"
+	"github.com/NeuralTrust/TrustGate/pkg/metrics"
 	"go.uber.org/dig"
 )
 
@@ -90,6 +91,7 @@ func buildPipeline(
 	var defaults []appmetrics.Exporter
 	exporter, err := factory.Build(telemetrydomain.ExporterConfig{
 		Name:     kafka.ExporterName,
+		Class:    metrics.Raw,
 		Settings: map[string]interface{}{"topic": cfg.Telemetry.KafkaTopic},
 	})
 	if err != nil {

--- a/pkg/domain/telemetry/telemetry.go
+++ b/pkg/domain/telemetry/telemetry.go
@@ -18,6 +18,8 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
+
+	"github.com/NeuralTrust/TrustGate/pkg/metrics"
 )
 
 type Telemetry struct {
@@ -29,8 +31,33 @@ type Telemetry struct {
 }
 
 type ExporterConfig struct {
-	Name     string                 `json:"name"`
+	Name string `json:"name"`
+	Type string `json:"type,omitempty"`
+	// Class fixes which projection of the event this exporter receives. When
+	// empty it defaults to metadata for every exporter type.
+	Class    metrics.DataClass      `json:"class,omitempty"`
 	Settings map[string]interface{} `json:"settings"`
+}
+
+func (c ExporterConfig) EffectiveType() string {
+	if c.Type != "" {
+		return c.Type
+	}
+	return c.Name
+}
+
+func (c ExporterConfig) EffectiveClass() metrics.DataClass {
+	if c.Class != "" {
+		return c.Class
+	}
+	return metrics.Metadata
+}
+
+func (c ExporterConfig) ValidateClass() error {
+	if c.Class != "" && c.Class != metrics.Metadata && c.Class != metrics.Raw {
+		return fmt.Errorf("telemetry exporter %q: invalid data class %q", c.Name, c.Class)
+	}
+	return nil
 }
 
 func (t Telemetry) Value() (driver.Value, error) {

--- a/pkg/infra/metrics/events/views.go
+++ b/pkg/infra/metrics/events/views.go
@@ -1,0 +1,27 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+// MetadataView returns a shallow copy of the event with request and response
+// bodies stripped so metadata sinks never receive payload content.
+func MetadataView(evt *Event) *Event {
+	if evt == nil {
+		return nil
+	}
+	meta := *evt
+	meta.Request.Body = ""
+	meta.Response.Body = nil
+	return &meta
+}

--- a/pkg/infra/metrics/events/views_test.go
+++ b/pkg/infra/metrics/events/views_test.go
@@ -1,0 +1,40 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetadataView_StripsBodies(t *testing.T) {
+	t.Parallel()
+	body := "response"
+	evt := &Event{
+		TraceID: "t-1",
+		Request: Request{Body: "request"},
+		Response: Response{
+			Body: &body,
+		},
+	}
+	meta := MetadataView(evt)
+	require.NotNil(t, meta)
+	assert.Equal(t, "", meta.Request.Body)
+	assert.Nil(t, meta.Response.Body)
+	assert.Equal(t, "t-1", meta.TraceID)
+	assert.Equal(t, "request", evt.Request.Body)
+}

--- a/pkg/infra/telemetry/exporter_locator.go
+++ b/pkg/infra/telemetry/exporter_locator.go
@@ -19,6 +19,7 @@ import (
 
 	appmetrics "github.com/NeuralTrust/TrustGate/pkg/app/metrics"
 	telemetrydomain "github.com/NeuralTrust/TrustGate/pkg/domain/telemetry"
+	"github.com/NeuralTrust/TrustGate/pkg/metrics"
 )
 
 type ExporterTemplate interface {
@@ -48,18 +49,28 @@ func NewExporterLocator(opts ...ExporterLocatorOption) *ExporterLocator {
 }
 
 func (l *ExporterLocator) Build(cfg telemetrydomain.ExporterConfig) (appmetrics.Exporter, error) {
-	template, ok := l.templates[cfg.Name]
+	if err := cfg.ValidateClass(); err != nil {
+		return nil, err
+	}
+	template, ok := l.templates[cfg.EffectiveType()]
 	if !ok {
 		return nil, fmt.Errorf("unknown exporter %q", cfg.Name)
 	}
 	if err := template.ValidateConfig(cfg.Settings); err != nil {
 		return nil, fmt.Errorf("exporter %q: %w", cfg.Name, err)
 	}
-	return template.WithSettings(cfg.Settings)
+	exporter, err := template.WithSettings(cfg.Settings)
+	if err != nil {
+		return nil, err
+	}
+	return withDataClass(exporter, cfg.EffectiveClass()), nil
 }
 
 func (l *ExporterLocator) Validate(cfg telemetrydomain.ExporterConfig) error {
-	template, ok := l.templates[cfg.Name]
+	if err := cfg.ValidateClass(); err != nil {
+		return err
+	}
+	template, ok := l.templates[cfg.EffectiveType()]
 	if !ok {
 		return fmt.Errorf("unknown exporter %q", cfg.Name)
 	}
@@ -67,4 +78,29 @@ func (l *ExporterLocator) Validate(cfg telemetrydomain.ExporterConfig) error {
 		return fmt.Errorf("exporter %q: %w", cfg.Name, err)
 	}
 	return nil
+}
+
+type classSetter interface {
+	SetDataClass(metrics.DataClass)
+}
+
+type classOverride struct {
+	appmetrics.Exporter
+	class metrics.DataClass
+}
+
+func (c classOverride) DataClass() metrics.DataClass { return c.class }
+
+func withDataClass(exporter appmetrics.Exporter, class metrics.DataClass) appmetrics.Exporter {
+	if exporter == nil {
+		return exporter
+	}
+	if setter, ok := exporter.(classSetter); ok {
+		setter.SetDataClass(class)
+		return exporter
+	}
+	if exporter.DataClass() == class {
+		return exporter
+	}
+	return classOverride{Exporter: exporter, class: class}
 }

--- a/pkg/infra/telemetry/exporter_locator_test.go
+++ b/pkg/infra/telemetry/exporter_locator_test.go
@@ -53,6 +53,12 @@ func TestExporterLocator_Validate(t *testing.T) {
 		assert.Contains(t, err.Error(), "topic")
 	})
 
+	t.Run("invalid data class", func(t *testing.T) {
+		err := locator.Validate(telemetrydomain.ExporterConfig{Name: kafka.ExporterName, Class: "bogus", Settings: map[string]interface{}{"topic": "events"}})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid data class")
+	})
+
 	t.Run("valid kafka config", func(t *testing.T) {
 		err := locator.Validate(telemetrydomain.ExporterConfig{Name: kafka.ExporterName, Settings: map[string]interface{}{"topic": "events"}})
 		require.NoError(t, err)

--- a/pkg/infra/telemetry/kafka/exporter.go
+++ b/pkg/infra/telemetry/kafka/exporter.go
@@ -26,6 +26,7 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/config"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics/events"
 	infratelemetry "github.com/NeuralTrust/TrustGate/pkg/infra/telemetry"
+	"github.com/NeuralTrust/TrustGate/pkg/metrics"
 )
 
 const ExporterName = "kafka"
@@ -43,6 +44,8 @@ func NewKafkaTemplate(logger *slog.Logger, kafkaCfg config.KafkaConfig) *Exporte
 func (p *Exporter) Name() string {
 	return ExporterName
 }
+
+func (p *Exporter) DataClass() metrics.DataClass { return metrics.Metadata }
 
 func (p *Exporter) ValidateConfig(settings map[string]interface{}) error {
 	cfg, err := p.ResolveBaseConfig(settings)

--- a/pkg/infra/telemetry/otlp/exporter.go
+++ b/pkg/infra/telemetry/otlp/exporter.go
@@ -23,6 +23,7 @@ import (
 
 	appmetrics "github.com/NeuralTrust/TrustGate/pkg/app/metrics"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics/events"
+	"github.com/NeuralTrust/TrustGate/pkg/metrics"
 	otellog "go.opentelemetry.io/otel/log"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 )
@@ -44,6 +45,7 @@ type Exporter struct {
 	slog            *slog.Logger
 	maxBodyBytes    int
 	shutdownTimeout time.Duration
+	class           metrics.DataClass
 	closed          atomic.Bool
 }
 
@@ -67,12 +69,17 @@ func newExporterWithProvider(
 		slog:            logger,
 		maxBodyBytes:    maxBodyBytes,
 		shutdownTimeout: shutdownTimeout,
+		class:           metrics.Metadata,
 	}
 }
 
 func (e *Exporter) Name() string {
 	return ExporterName
 }
+
+func (e *Exporter) DataClass() metrics.DataClass { return e.class }
+
+func (e *Exporter) SetDataClass(class metrics.DataClass) { e.class = class }
 
 // Publish maps the event to an OTLP log record and enqueues it into the batch
 // processor without blocking on Collector latency. It returns an error only if
@@ -84,7 +91,7 @@ func (e *Exporter) Publish(ctx context.Context, evt *events.Event) error {
 	if e.closed.Load() {
 		return errExporterClosed
 	}
-	e.logger.Emit(ctx, eventToRecord(evt, e.maxBodyBytes))
+	e.logger.Emit(ctx, eventToRecord(evt, e.class, e.maxBodyBytes))
 	return nil
 }
 

--- a/pkg/infra/telemetry/otlp/exporter_test.go
+++ b/pkg/infra/telemetry/otlp/exporter_test.go
@@ -25,6 +25,7 @@ import (
 	otellog "go.opentelemetry.io/otel/log"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 
+	"github.com/NeuralTrust/TrustGate/pkg/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -83,12 +84,27 @@ func TestExporter_PublishEmitsOneRecord(t *testing.T) {
 
 	records := mem.all()
 	require.Len(t, records, 1)
-	assert.Equal(t, eventName, records[0].EventName())
+	assert.Equal(t, "trustgate.3.metadata", records[0].EventName())
 	assert.Equal(t, otellog.SeverityInfo, records[0].Severity())
 
 	trace, ok := recordAttr(records[0], attrTraceID)
 	require.True(t, ok)
 	assert.Equal(t, "trace-123", trace.AsString())
+}
+
+func TestExporter_RawClassEmitsRawEventName(t *testing.T) {
+	t.Parallel()
+	mem := &memExporter{}
+	provider := sdklog.NewLoggerProvider(sdklog.WithProcessor(sdklog.NewSimpleProcessor(mem)))
+	exp := newExporterWithProvider(provider, testLogger(), 4096, time.Second)
+	defer exp.Close()
+
+	exp.SetDataClass(metrics.Raw)
+	require.NoError(t, exp.Publish(context.Background(), fullEvent()))
+
+	records := mem.all()
+	require.Len(t, records, 1)
+	assert.Equal(t, "trustgate.3.raw", records[0].EventName())
 }
 
 func TestExporter_NilEventIsNoOp(t *testing.T) {

--- a/pkg/infra/telemetry/otlp/mapping.go
+++ b/pkg/infra/telemetry/otlp/mapping.go
@@ -16,15 +16,23 @@ package otlp
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 	"time"
 	"unicode/utf8"
 
 	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics/events"
+	"github.com/NeuralTrust/TrustGate/pkg/metrics"
 	otellog "go.opentelemetry.io/otel/log"
 	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
 )
 
-const eventName = "gateway.request"
+func eventName(schemaVersion int, class metrics.DataClass) string {
+	if schemaVersion <= 0 {
+		schemaVersion = events.SchemaVersion
+	}
+	return fmt.Sprintf("trustgate.%d.%s", schemaVersion, class)
+}
 
 // genAIRequestStreamKey is not part of stable semconv; it is kept local so a
 // semconv bump does not silently move it.
@@ -76,7 +84,9 @@ const (
 	attrIsFlagged            = "trustgate.is_flagged"
 	attrSecurity             = "trustgate.security"
 	attrRequestBody          = "trustgate.request.body"
+	attrResponseBody         = "trustgate.response.body"
 	attrPolicyChain          = "trustgate.policy_chain"
+	attrPluginChain          = "trustgate.plugin_chain"
 	attrAttempts             = "trustgate.attempts"
 	attrAttemptsCount        = "trustgate.attempts.count"
 )
@@ -84,22 +94,18 @@ const (
 // eventToRecord is the single, semconv-pinned (semconv/v1.41.0) mapping from a
 // sanitized business Event to an OTLP log record. Standard fields use GenAI/HTTP
 // semantic conventions; gateway-specific fields use the trustgate.* namespace.
-func eventToRecord(evt *events.Event, maxBodyBytes int) otellog.Record {
+func eventToRecord(evt *events.Event, class metrics.DataClass, maxBodyBytes int) otellog.Record {
 	var rec otellog.Record
 	if evt == nil {
 		return rec
 	}
 
-	rec.SetEventName(eventName)
+	rec.SetEventName(eventName(evt.SchemaVersion, class))
 	if evt.OccurredOn > 0 {
 		rec.SetTimestamp(time.UnixMilli(evt.OccurredOn))
 	}
 	rec.SetObservedTimestamp(time.Now())
 	rec.SetSeverity(severityForStatus(evt.Status.Code))
-
-	if body := responseBody(evt, maxBodyBytes); body != "" {
-		rec.SetBody(otellog.StringValue(body))
-	}
 
 	attrs := make([]otellog.KeyValue, 0, 32)
 	appendStr := func(key, value string) {
@@ -193,12 +199,20 @@ func eventToRecord(evt *events.Event, maxBodyBytes int) otellog.Record {
 	if len(evt.Security) > 0 {
 		attrs = append(attrs, otellog.Slice(attrSecurity, stringValues(evt.Security)...))
 	}
-	if requestBody := truncate(evt.Request.Body, maxBodyBytes); requestBody != "" {
-		attrs = append(attrs, otellog.String(attrRequestBody, requestBody))
+	if class == metrics.Raw {
+		if requestBody := truncate(evt.Request.Body, maxBodyBytes); requestBody != "" {
+			attrs = append(attrs, otellog.String(attrRequestBody, requestBody))
+		}
+		if body := responseBody(evt, maxBodyBytes); body != "" {
+			attrs = append(attrs, otellog.String(attrResponseBody, body))
+		}
 	}
 	if len(evt.PolicyChain) > 0 {
-		if encoded := jsonString(evt.PolicyChain); encoded != "" {
+		if encoded := jsonString(policyChain(evt.PolicyChain)); encoded != "" && encoded != "null" {
 			attrs = append(attrs, otellog.String(attrPolicyChain, encoded))
+		}
+		if encoded := jsonString(pluginChainForOTLP(evt.PolicyChain)); encoded != "" && encoded != "null" {
+			attrs = append(attrs, otellog.String(attrPluginChain, encoded))
 		}
 	}
 	if len(evt.Attempts) > 0 {
@@ -210,6 +224,64 @@ func eventToRecord(evt *events.Event, maxBodyBytes int) otellog.Record {
 
 	rec.AddAttributes(attrs...)
 	return rec
+}
+
+type policyChainElement struct {
+	Source     policyChainSource  `json:"source"`
+	Signal     policyChainSignal  `json:"signal"`
+	Outcome    policyChainOutcome `json:"outcome"`
+	ReportOnly bool               `json:"report_only"`
+}
+
+type policyChainSource struct {
+	Plugin string `json:"plugin"`
+}
+
+type policyChainSignal struct {
+	Type       string  `json:"type"`
+	Confidence float64 `json:"confidence"`
+}
+
+type policyChainOutcome struct {
+	Action string `json:"action"`
+}
+
+func policyChain(chain []events.PolicyEntry) []policyChainElement {
+	out := make([]policyChainElement, 0, len(chain))
+	for _, entry := range chain {
+		element := policyChainElement{
+			Source:     policyChainSource{Plugin: entry.Name},
+			ReportOnly: isReportOnlyDecision(entry.Decision),
+		}
+		confidence := 0.0
+		if entry.Score != nil {
+			confidence = *entry.Score
+		}
+		element.Signal = policyChainSignal{Type: entry.ScoreLabel, Confidence: confidence}
+		if entry.Decision != "" {
+			element.Outcome = policyChainOutcome{Action: entry.Decision}
+		}
+		out = append(out, element)
+	}
+	return out
+}
+
+func pluginChainForOTLP(chain []events.PolicyEntry) []events.PolicyEntry {
+	out := make([]events.PolicyEntry, len(chain))
+	for i, entry := range chain {
+		out[i] = entry
+		out[i].Extras = nil
+	}
+	return out
+}
+
+func isReportOnlyDecision(decision string) bool {
+	switch strings.ToLower(decision) {
+	case "report", "reported":
+		return true
+	default:
+		return false
+	}
 }
 
 func severityForStatus(code int) otellog.Severity {

--- a/pkg/infra/telemetry/otlp/mapping_mcp_test.go
+++ b/pkg/infra/telemetry/otlp/mapping_mcp_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics/events"
+	"github.com/NeuralTrust/TrustGate/pkg/metrics"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -50,7 +51,7 @@ func TestEventToRecord_MCPAttributes(t *testing.T) {
 		},
 	}
 
-	rec := eventToRecord(evt, 4096)
+	rec := eventToRecord(evt, metrics.Metadata, 4096)
 	attrs := attrsOf(rec)
 
 	assert.Equal(t, events.KindMCP, attrs[attrKind].AsString())
@@ -71,7 +72,7 @@ func TestEventToRecord_LLMKindNoMCP(t *testing.T) {
 	evt := fullEvent()
 	evt.Kind = events.KindLLM
 
-	rec := eventToRecord(evt, 4096)
+	rec := eventToRecord(evt, metrics.Metadata, 4096)
 	attrs := attrsOf(rec)
 
 	assert.Equal(t, events.KindLLM, attrs[attrKind].AsString())

--- a/pkg/infra/telemetry/otlp/mapping_test.go
+++ b/pkg/infra/telemetry/otlp/mapping_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics/events"
+	"github.com/NeuralTrust/TrustGate/pkg/metrics"
 	"github.com/stretchr/testify/assert"
 	otellog "go.opentelemetry.io/otel/log"
 )
@@ -72,18 +73,18 @@ func fullEvent() *events.Event {
 			{Provider: "openai", Attempt: 1, StatusCode: 200},
 		},
 		PolicyChain: []events.PolicyEntry{
-			{Name: "rate-limit", Stage: "pre", Decision: "allow"},
+			{Name: "rate-limit", Stage: "pre", Decision: "allow", Extras: map[string]string{"detail": "secret"}},
 		},
 	}
 }
 
 func TestEventToRecord_StandardAndProprietaryCoexist(t *testing.T) {
 	t.Parallel()
-	rec := eventToRecord(fullEvent(), 4096)
+	rec := eventToRecord(fullEvent(), metrics.Metadata, 4096)
 
-	assert.Equal(t, eventName, rec.EventName())
+	assert.Equal(t, "trustgate.3.metadata", rec.EventName())
 	assert.Equal(t, otellog.SeverityInfo, rec.Severity())
-	assert.Equal(t, "hello world", rec.Body().AsString())
+	assert.Equal(t, "", rec.Body().AsString())
 
 	attrs := attrsOf(rec)
 
@@ -110,10 +111,51 @@ func TestEventToRecord_StandardAndProprietaryCoexist(t *testing.T) {
 	assert.Equal(t, int64(15), attrs["trustgate.usage.total_tokens"].AsInt64())
 	assert.Equal(t, int64(120), attrs["trustgate.latency.total_ms"].AsInt64())
 
-	assert.Contains(t, attrs["trustgate.policy_chain"].AsString(), "rate-limit")
+	policyChainJSON := attrs["trustgate.policy_chain"].AsString()
+	assert.Contains(t, policyChainJSON, `"plugin":"rate-limit"`)
+	assert.NotContains(t, policyChainJSON, "secret")
+
+	pluginChainJSON := attrs["trustgate.plugin_chain"].AsString()
+	assert.Contains(t, pluginChainJSON, "rate-limit")
+	assert.NotContains(t, pluginChainJSON, `"extras"`)
+
 	assert.Equal(t, int64(1), attrs["trustgate.attempts.count"].AsInt64())
 	assert.Contains(t, attrs["trustgate.attempts"].AsString(), "openai")
+	_, hasRequestBody := attrs["trustgate.request.body"]
+	_, hasResponseBody := attrs["trustgate.response.body"]
+	assert.False(t, hasRequestBody)
+	assert.False(t, hasResponseBody)
+}
+
+func TestEventToRecord_RawIncludesBodies(t *testing.T) {
+	t.Parallel()
+	rec := eventToRecord(fullEvent(), metrics.Raw, 4096)
+	attrs := attrsOf(rec)
+
+	assert.Equal(t, "trustgate.3.raw", rec.EventName())
+	assert.Equal(t, "", rec.Body().AsString())
 	assert.Equal(t, "request-body", attrs["trustgate.request.body"].AsString())
+	assert.Equal(t, "hello world", attrs["trustgate.response.body"].AsString())
+}
+
+func TestEventToRecord_MetadataViewHasNoBodies(t *testing.T) {
+	t.Parallel()
+	meta := events.MetadataView(fullEvent())
+	rec := eventToRecord(meta, metrics.Metadata, 4096)
+	attrs := attrsOf(rec)
+
+	assert.Equal(t, "trustgate.3.metadata", rec.EventName())
+	_, hasRequestBody := attrs["trustgate.request.body"]
+	_, hasResponseBody := attrs["trustgate.response.body"]
+	assert.False(t, hasRequestBody)
+	assert.False(t, hasResponseBody)
+}
+
+func TestEventName_ResourceVersionVerb(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "trustgate.3.metadata", eventName(3, metrics.Metadata))
+	assert.Equal(t, "trustgate.3.raw", eventName(3, metrics.Raw))
+	assert.Equal(t, "trustgate.3.metadata", eventName(0, metrics.Metadata))
 }
 
 func TestEventToRecord_Severity(t *testing.T) {
@@ -133,7 +175,7 @@ func TestEventToRecord_Severity(t *testing.T) {
 			t.Parallel()
 			evt := fullEvent()
 			evt.Status.Code = tc.code
-			rec := eventToRecord(evt, 4096)
+			rec := eventToRecord(evt, metrics.Metadata, 4096)
 			assert.Equal(t, tc.want, rec.Severity())
 		})
 	}
@@ -143,7 +185,7 @@ func TestEventToRecord_StatusFields(t *testing.T) {
 	t.Parallel()
 	evt := fullEvent()
 	evt.Status = events.Status{Code: 504, IsTimeout: true, Outcome: "timeout", Reason: "upstream deadline"}
-	rec := eventToRecord(evt, 4096)
+	rec := eventToRecord(evt, metrics.Metadata, 4096)
 	attrs := attrsOf(rec)
 
 	assert.Equal(t, "timeout", attrs["trustgate.status.outcome"].AsString())
@@ -153,7 +195,7 @@ func TestEventToRecord_StatusFields(t *testing.T) {
 
 func TestEventToRecord_StatusTimeoutOmittedWhenFalse(t *testing.T) {
 	t.Parallel()
-	rec := eventToRecord(fullEvent(), 4096)
+	rec := eventToRecord(fullEvent(), metrics.Metadata, 4096)
 	attrs := attrsOf(rec)
 	_, ok := attrs["trustgate.status.is_timeout"]
 	assert.False(t, ok)
@@ -164,7 +206,7 @@ func TestEventToRecord_NoUsage(t *testing.T) {
 	evt := fullEvent()
 	evt.Usage = nil
 	evt.Cost = nil
-	rec := eventToRecord(evt, 4096)
+	rec := eventToRecord(evt, metrics.Metadata, 4096)
 	attrs := attrsOf(rec)
 
 	_, hasInput := attrs["gen_ai.usage.input_tokens"]
@@ -179,7 +221,7 @@ func TestEventToRecord_Streaming(t *testing.T) {
 	t.Parallel()
 	evt := fullEvent()
 	evt.Request.Stream = true
-	rec := eventToRecord(evt, 4096)
+	rec := eventToRecord(evt, metrics.Metadata, 4096)
 	attrs := attrsOf(rec)
 	assert.True(t, attrs["gen_ai.request.stream"].AsBool())
 }
@@ -188,23 +230,24 @@ func TestEventToRecord_BodyTruncation(t *testing.T) {
 	t.Parallel()
 	evt := fullEvent()
 	evt.Response.Body = strptr(strings.Repeat("x", 100))
-	rec := eventToRecord(evt, 10)
-	assert.Equal(t, 10, len(rec.Body().AsString()))
+	rec := eventToRecord(evt, metrics.Raw, 10)
+	attrs := attrsOf(rec)
+	assert.Equal(t, 10, len(attrs["trustgate.response.body"].AsString()))
 }
 
 func TestEventToRecord_EmptyTrace(t *testing.T) {
 	t.Parallel()
 	evt := fullEvent()
 	evt.TraceID = ""
-	rec := eventToRecord(evt, 4096)
+	rec := eventToRecord(evt, metrics.Metadata, 4096)
 	attrs := attrsOf(rec)
 	_, ok := attrs["trustgate.trace_id"]
 	assert.False(t, ok)
-	assert.Equal(t, eventName, rec.EventName())
+	assert.Equal(t, "trustgate.3.metadata", rec.EventName())
 }
 
 func TestEventToRecord_Nil(t *testing.T) {
 	t.Parallel()
-	rec := eventToRecord(nil, 4096)
+	rec := eventToRecord(nil, metrics.Metadata, 4096)
 	assert.Equal(t, "", rec.EventName())
 }

--- a/pkg/metrics/version.go
+++ b/pkg/metrics/version.go
@@ -1,0 +1,22 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+type DataClass string
+
+const (
+	Metadata DataClass = "metadata"
+	Raw      DataClass = "raw"
+)


### PR DESCRIPTION
## Summary
- Align TrustGate's OTLP telemetry export with TrustGuard's dual-export contract.
- Event names follow `resource.version.verb` (`trustgate.<version>.metadata` / `trustgate.<version>.raw`) per data class.
- Metadata vs raw views: metadata strips request/response bodies; raw includes them.
- `policy_chain` projected to AlertEngine-compatible shape; `plugin_chain` for debug (no evidence/extras).
- Data-class routing wired through the pipeline and exporter locator.

## Test plan
- [ ] `go build ./...`
- [ ] `go test ./pkg/... ./internal/...` (telemetry + pipeline)
- [ ] Verify metadata event has no bodies and raw event includes them.