### PR TITLE
feat(telemetry): align OTLP event naming with TrustGuard

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,10 +351,16 @@ to one or more exporters. Default exporters are declared in a YAML file (see
 [Default telemetry exporters](#default-telemetry-exporters) below); the
 recommended metadata default is **`otlp`**, which ships the event to an external
 [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) as a single
-OTLP **log record** per request (`event.name="gateway.request"`); the Collector
-fans out to any vendor backend. A gateway can add or override exporters via its
+OTLP **log record** per request. The record's `event.name` follows
+`trustgate.<version>.<verb>` (`resource.version.verb`) — e.g. `trustgate.3.metadata`
+for the metadata class and `trustgate.3.raw` for the raw class of the same trace; the
+Collector fans out to any vendor backend. A gateway can add or override exporters via its
 `telemetry.exporters`, which merge with the defaults. Kafka is being retired and
 is no longer a hardcoded default.
+
+The exported log record is documented field-by-field in
+[`docs/telemetry/otlp-metadata-contract.md`](docs/telemetry/otlp-metadata-contract.md),
+with per-sink example records under [`docs/telemetry/examples/`](docs/telemetry/examples).
 
 Add it to a gateway's `telemetry.exporters`:
 

--- a/config/otel-collector.schema.json
+++ b/config/otel-collector.schema.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": true
+}

--- a/config/otel-collector.yaml
+++ b/config/otel-collector.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=./otel-collector.schema.json
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch: {}
+
+exporters:
+  debug:
+    verbosity: detailed
+
+service:
+  pipelines:
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]

--- a/config/telemetry.verify.yaml
+++ b/config/telemetry.verify.yaml
@@ -1,0 +1,28 @@
+exporters:
+  metadata:
+    - name: otlp
+      type: otlp
+      settings:
+        endpoint: "localhost:14317"
+        protocol: "grpc"
+        signal: "logs"
+        insecure: true
+        compression: "none"
+        timeout: "10s"
+        max_body_bytes: 65536
+
+  raw:
+    - name: raw-otlp
+      type: otlp
+      settings:
+        endpoint: "localhost:14317"
+        protocol: "grpc"
+        signal: "logs"
+        insecure: true
+        compression: "none"
+        timeout: "10s"
+        max_body_bytes: 65536
+    - name: sensible-pg
+      type: postgres
+      settings:
+        dsn_env: SENSIBLE_PG_DSN

--- a/docker-compose.telemetry.yaml
+++ b/docker-compose.telemetry.yaml
@@ -1,0 +1,18 @@
+# OTel Collector for local telemetry sink verification.
+# Usage: docker compose -f docker-compose.yaml -f docker-compose.telemetry.yaml up -d
+name: agentgateway
+
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.120.0
+    command: ["--config=/etc/otel-collector.yaml"]
+    volumes:
+      - ./config/otel-collector.yaml:/etc/otel-collector.yaml:ro
+    ports:
+      - "${OTEL_VERIFY_GRPC_PORT:-14317}:4317"
+      - "${OTEL_VERIFY_HTTP_PORT:-14318}:4318"
+    healthcheck:
+      test: ["CMD", "/otelcol-contrib", "validate", "--config=/etc/otel-collector.yaml"]
+      interval: 10s
+      timeout: 5s
+      retries: 5

--- a/docs/telemetry/examples/README.md
+++ b/docs/telemetry/examples/README.md
@@ -1,0 +1,50 @@
+# Telemetry sink examples
+
+Per-sink example records for one gateway request fanned out to the three data-class sinks.
+
+> These are **schema-accurate representative** records derived from the OTLP mapping
+> (`pkg/infra/telemetry/otlp/mapping.go`) and the postgres exporter
+> (`pkg/infra/telemetry/postgres/exporter.go`), not a live capture. The scenario is an
+> OpenAI chat completion whose request contains an email that a DLP policy masks.
+
+**Live verification:** run the exhaustive 3-sink check (metadata OTLP, raw OTLP, postgres)
+against a local compose stack:
+
+```bash
+bash scripts/telemetry/verify_three_sinks.sh
+```
+
+The script boots postgres/redis/kafka/otel-collector, starts admin+proxy with
+`config/telemetry.verify.yaml`, drives a proxy request, and asserts **51 checks**
+including `EventName: trustgate.3.metadata` / `trustgate.3.raw`, body presence/absence
+per class, and a `trustgate_data` row.
+
+Routing is **config-driven**: the YAML **group** (`metadata` vs `raw`) picks the data class;
+the exporter **type** (`otlp` vs `postgres`) picks the transport.
+
+| Sink | YAML path | Goes to |
+|------|-----------|---------|
+| metadata OTLP | `exporters.metadata[].type: otlp` | `OTEL_EXPORTER_OTLP_ENDPOINT` → OpenTelemetry Collector |
+| raw OTLP | `exporters.raw[].type: otlp` | Same OTLP endpoint, `EventName: trustgate.<version>.raw` |
+| postgres | `exporters.raw[].type: postgres` | `dsn` → Postgres `trustgate` DB → table **`trustgate_data`** |
+
+## Sinks at a glance
+
+| Sink | Type | Event name | Bodies? | `policy_chain` | `is_flagged` | File |
+|------|------|-----------|:------:|:--------------:|:------------:|------|
+| 1 — metadata OTLP | `otlp` (metadata) | `trustgate.3.metadata` | ❌ | ✅ | ✅ | [`sink-1-metadata-otlp.json`](./sink-1-metadata-otlp.json) |
+| 2 — raw OTLP | `otlp` (raw) | `trustgate.3.raw` | ✅ | — | — | [`sink-2-raw-otlp.json`](./sink-2-raw-otlp.json) |
+| 3 — postgres | `postgres` (raw) | — | ✅ | — | — | [`sink-3-postgres.json`](./sink-3-postgres.json) |
+
+Notes:
+
+- The event name uses `trustgate.<version>.<verb>` where `<version>` is the **event** schema
+  version (`events.SchemaVersion`, currently `3`) and `<verb>` is the data class
+  (`metadata` / `raw`). One trace emits both `trustgate.3.metadata` and `trustgate.3.raw`.
+- The `trustgate_data` row's `schema_version` column is the **storage** schema version
+  (`metrics.SchemaVersion`, currently `1`) — it tracks the table shape, not the event schema.
+- The email is in clear text in the raw sinks (2 and 3) and masked (`[MASKED_EMAIL]`) in the
+  transformed response, so raw sinks must land on a restricted destination.
+- Join sink 1 (metadata) to sinks 2/3 (raw) on `trace_id`.
+
+See the full field-by-field mapping in [`../otlp-metadata-contract.md`](../otlp-metadata-contract.md).

--- a/docs/telemetry/examples/sink-1-metadata-otlp.json
+++ b/docs/telemetry/examples/sink-1-metadata-otlp.json
@@ -1,0 +1,58 @@
+{
+  "_comment": "Sink 1 — metadata OTLP exporter (exporters.metadata.otlp) — no request/response bodies. Schema-accurate representative record (OpenAI chat completion flagged by a PII policy), not a live capture.",
+  "_destination": "OTEL_EXPORTER_OTLP_ENDPOINT → OpenTelemetry Collector",
+  "_trace_id": "b1c8a71f-35d8-4aff-a8da-dcb78d05cac9",
+  "resource": {
+    "service.name": "trustgate",
+    "schema_url": "https://opentelemetry.io/schemas/1.41.0"
+  },
+  "scope": "github.com/NeuralTrust/TrustGate/pkg/infra/telemetry/otlp",
+  "logRecord": {
+    "eventName": "trustgate.3.metadata",
+    "severity": "Info",
+    "body": "",
+    "attributes": {
+      "http.request.method": "POST",
+      "http.response.status_code": 200,
+      "url.path": "/v1/chat/completions",
+      "gen_ai.provider.name": "openai",
+      "gen_ai.request.model": "gpt-4o",
+      "gen_ai.response.finish_reasons": ["stop"],
+      "gen_ai.request.stream": false,
+      "gen_ai.usage.input_tokens": 42,
+      "gen_ai.usage.output_tokens": 18,
+      "trustgate.usage.total_tokens": 60,
+      "trustgate.schema_version": 3,
+      "trustgate.kind": "llm",
+      "trustgate.trace_id": "b1c8a71f-35d8-4aff-a8da-dcb78d05cac9",
+      "trustgate.gateway_id": "gw-support-chat",
+      "trustgate.team_id": "00000000-0000-0000-0000-000000000001",
+      "trustgate.consumer.id": "consumer-42",
+      "trustgate.consumer.name": "acme-web",
+      "trustgate.session_id": "sess-7c9c",
+      "trustgate.ip": "203.0.113.10",
+      "trustgate.requested_model": "gpt-4o",
+      "trustgate.model_label": "default",
+      "trustgate.status.outcome": "transform",
+      "trustgate.cost.total_usd": 0.00042,
+      "trustgate.cost.prompt_usd": 0.00021,
+      "trustgate.cost.completion_usd": 0.00021,
+      "trustgate.cost.currency": "USD",
+      "trustgate.latency.total_ms": 812,
+      "trustgate.latency.provider_ms": 760,
+      "trustgate.latency.policies_ms": 34,
+      "trustgate.latency.routing_ms": 3,
+      "trustgate.latency.gateway_ms": 15,
+      "trustgate.is_flagged": true,
+      "trustgate.security": ["pii"],
+      "trustgate.policy_chain": [
+        {
+          "source": { "plugin": "data_loss_prevention" },
+          "signal": { "type": "pii", "confidence": 0 },
+          "outcome": { "action": "transform" },
+          "report_only": false
+        }
+      ]
+    }
+  }
+}

--- a/docs/telemetry/examples/sink-2-raw-otlp.json
+++ b/docs/telemetry/examples/sink-2-raw-otlp.json
@@ -1,0 +1,42 @@
+{
+  "_comment": "Sink 2 — raw OTLP exporter (exporters.raw with type otlp) — same trace_id, carries request/response bodies and join keys only (no metadata attrs). Schema-accurate representative record, not a live capture.",
+  "_destination": "OTEL_EXPORTER_OTLP_ENDPOINT → OpenTelemetry Collector (raw class)",
+  "_trace_id": "b1c8a71f-35d8-4aff-a8da-dcb78d05cac9",
+  "resource": {
+    "service.name": "trustgate",
+    "schema_url": "https://opentelemetry.io/schemas/1.41.0"
+  },
+  "scope": "github.com/NeuralTrust/TrustGate/pkg/infra/telemetry/otlp",
+  "logRecord": {
+    "eventName": "trustgate.3.raw",
+    "body": "",
+    "attributes": {
+      "trustgate.schema_version": 3,
+      "trustgate.trace_id": "b1c8a71f-35d8-4aff-a8da-dcb78d05cac9",
+      "trustgate.gateway_id": "gw-support-chat",
+      "trustgate.team_id": "00000000-0000-0000-0000-000000000001",
+      "trustgate.request.body": {
+        "model": "gpt-4o",
+        "messages": [
+          { "role": "user", "content": "Reset the account for john.doe@example.com please" }
+        ]
+      },
+      "trustgate.response.body": {
+        "id": "chatcmpl-9xY",
+        "object": "chat.completion",
+        "model": "gpt-4o",
+        "choices": [
+          {
+            "index": 0,
+            "finish_reason": "stop",
+            "message": {
+              "role": "assistant",
+              "content": "Sure — I've started the reset for [MASKED_EMAIL]."
+            }
+          }
+        ],
+        "usage": { "prompt_tokens": 42, "completion_tokens": 18, "total_tokens": 60 }
+      }
+    }
+  }
+}

--- a/docs/telemetry/examples/sink-3-postgres.json
+++ b/docs/telemetry/examples/sink-3-postgres.json
@@ -1,0 +1,33 @@
+{
+  "_comment": "Sink 3 — postgres exporter (exporters.raw with type postgres). NOT OTLP: one SQL INSERT into table trustgate_data, idempotent on trace_id. Bodies + join keys only. Schema-accurate representative row, not a live capture.",
+  "_destination": "postgres DSN → trustgate DB → table trustgate_data",
+  "_table": "trustgate_data",
+  "trace_id": "b1c8a71f-35d8-4aff-a8da-dcb78d05cac9",
+  "gateway_id": "gw-support-chat",
+  "team_id": "00000000-0000-0000-0000-000000000001",
+  "occurred_on": 1783420474000,
+  "schema_version": 1,
+  "created_at": "2026-07-07T10:34:34.504770+00:00",
+  "request_body": {
+    "model": "gpt-4o",
+    "messages": [
+      { "role": "user", "content": "Reset the account for john.doe@example.com please" }
+    ]
+  },
+  "response_body": {
+    "id": "chatcmpl-9xY",
+    "object": "chat.completion",
+    "model": "gpt-4o",
+    "choices": [
+      {
+        "index": 0,
+        "finish_reason": "stop",
+        "message": {
+          "role": "assistant",
+          "content": "Sure — I've started the reset for [MASKED_EMAIL]."
+        }
+      }
+    ],
+    "usage": { "prompt_tokens": 42, "completion_tokens": 18, "total_tokens": 60 }
+  }
+}

--- a/docs/telemetry/otlp-metadata-contract.md
+++ b/docs/telemetry/otlp-metadata-contract.md
@@ -1,0 +1,110 @@
+# OTLP metadata export contract
+
+**Schema:** `events.Event` (`trustgate.schema_version`)
+
+TrustGate emits one OTLP **log record** per completed gateway request. This contract describes
+the **metadata** data class: input is `evt.MetadataView()`, so request/response **bodies are not
+exported**. Raw bodies are written to PostgreSQL `trustgate_data` via the `postgres` exporter,
+and — when an `otlp` exporter is declared under `exporters.raw[]` — also emitted on OTLP as
+`trustgate.request.body` / `trustgate.response.body`. See the raw stream section below.
+
+## Invariants
+
+| Rule | Detail |
+|------|--------|
+| Event name | `trustgate.<version>.<verb>` (`resource.version.verb`): resource `trustgate`, version = event schema version, verb = data class. One trace emits `trustgate.<version>.metadata` and `trustgate.<version>.raw`. Downstream routing keys on it. |
+| Log body | Always empty |
+| Bodies (metadata class) | Not emitted (no `trustgate.request.body` / `trustgate.response.body`) |
+| Bodies (raw class) | Emitted as `trustgate.request.body` / `trustgate.response.body` when an `otlp` exporter is declared under `exporters.raw[]` |
+| Policy chain | `policy_chain[]` on the Event is JSON-encoded in `trustgate.policy_chain` (evidence never included) |
+| `is_flagged` | Emitted as `trustgate.is_flagged` (bool) |
+
+## HTTP semconv
+
+| Attribute | Event field |
+|-----------|-------------|
+| `http.request.method` | `request.method` |
+| `http.response.status_code` | `response.status_code` |
+| `url.path` | `request.path` |
+
+## GenAI semconv
+
+| Attribute | Event field |
+|-----------|-------------|
+| `gen_ai.provider.name` | `request.provider` |
+| `gen_ai.request.model` | `request.model` |
+| `gen_ai.response.finish_reasons` | `response.finish_reason` (when set) |
+| `gen_ai.request.stream` | `request.stream` OR `response.streaming` |
+| `gen_ai.usage.input_tokens` | `usage.prompt_tokens` (when usage present) |
+| `gen_ai.usage.output_tokens` | `usage.completion_tokens` (when usage present) |
+
+## `trustgate.*` attributes
+
+| Attribute | Source |
+|-----------|--------|
+| `trustgate.schema_version` | `schema_version` |
+| `trustgate.kind` | `kind` |
+| `trustgate.trace_id` | `trace_id` |
+| `trustgate.gateway_id` | `gateway_id` |
+| `trustgate.team_id` | `team_id` |
+| `trustgate.consumer.id` | `consumer.id` |
+| `trustgate.consumer.name` | `consumer.name` |
+| `trustgate.session_id` | `session_id` |
+| `trustgate.turn_id` | `turn_id` |
+| `trustgate.ip` | `ip` |
+| `trustgate.requested_model` | `request.requested_model` |
+| `trustgate.model_label` | `request.model_label` |
+| `trustgate.status.outcome` | `status.outcome` |
+| `trustgate.status.reason` | `status.reason` (when set) |
+| `trustgate.status.is_timeout` | `status.is_timeout` (omitted when false) |
+| `trustgate.usage.total_tokens` | `usage.total_tokens` |
+| `trustgate.usage.cached_input_tokens` | `usage.cached_input_tokens` (when > 0) |
+| `trustgate.usage.reasoning_output_tokens` | `usage.reasoning_output_tokens` (when > 0) |
+| `trustgate.cost.total_usd` | `cost.total_usd` (when cost present) |
+| `trustgate.cost.prompt_usd` | `cost.prompt_usd` (when cost present) |
+| `trustgate.cost.completion_usd` | `cost.completion_usd` (when cost present) |
+| `trustgate.cost.currency` | `cost.currency` (when cost present) |
+| `trustgate.latency.total_ms` | `latency.total_ms` |
+| `trustgate.latency.provider_ms` | `latency.provider_ms` |
+| `trustgate.latency.policies_ms` | `latency.policies_ms` |
+| `trustgate.latency.routing_ms` | `latency.routing_ms` |
+| `trustgate.latency.gateway_ms` | `latency.gateway_ms` |
+| `trustgate.is_flagged` | `is_flagged` (bool) |
+| `trustgate.security` | `security[]` string array (when non-empty) |
+| `trustgate.policy_chain` | `policy_chain[]` as JSON string (when non-empty) |
+| `trustgate.attempts` | `attempts[]` as JSON string (when non-empty) |
+| `trustgate.attempts.count` | `len(attempts)` (when non-empty) |
+| `trustgate.mcp.*` | `mcp.*` fields (when the request is an MCP call) |
+
+## Raw stream
+
+The raw data class carries the request/response bodies plus join keys. It is routed to any
+exporter declared under `exporters.raw[]`:
+
+| Sink | Content |
+|------|---------|
+| PostgreSQL `trustgate_data` | `request_body` + `response_body` only |
+| OTLP (`otlp` under `raw`) | `trustgate.request.body` / `trustgate.response.body` + join keys |
+| Join keys | `trace_id`, `gateway_id`, `team_id`, `occurred_on` |
+
+The raw OTLP record emits `trustgate.schema_version`, `trustgate.trace_id`,
+`trustgate.gateway_id`, `trustgate.team_id`, `trustgate.request.body`, and
+`trustgate.response.body` — no metadata attributes, no policy chain.
+
+## Severity
+
+| `status.code` | OTLP severity |
+|---------------|---------------|
+| &lt; 400 | Info |
+| 4xx | Warn |
+| 5xx | Error |
+
+## Examples
+
+Per-sink example records: [`examples/`](./examples/). These are schema-accurate
+representative records (an OpenAI chat completion flagged by a DLP policy), not a live capture.
+
+## Out of scope
+
+- OTLP → ClickHouse ingestion (collector / data-plane)
+- Kafka `trustgate.requests` path (legacy, being retired)

--- a/pkg/infra/telemetry/otlp/exporter_test.go
+++ b/pkg/infra/telemetry/otlp/exporter_test.go
@@ -25,6 +25,7 @@ import (
 	otellog "go.opentelemetry.io/otel/log"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 
+	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics/events"
 	"github.com/NeuralTrust/TrustGate/pkg/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -84,7 +85,7 @@ func TestExporter_PublishEmitsOneRecord(t *testing.T) {
 
 	records := mem.all()
 	require.Len(t, records, 1)
-	assert.Equal(t, eventName, records[0].EventName())
+	assert.Equal(t, eventName(events.SchemaVersion, metrics.Metadata), records[0].EventName())
 	assert.Equal(t, otellog.SeverityInfo, records[0].Severity())
 
 	trace, ok := recordAttr(records[0], attrTraceID)
@@ -128,7 +129,7 @@ func TestExporter_RawClassEmitsBodies(t *testing.T) {
 
 	records := mem.all()
 	require.Len(t, records, 1)
-	assert.Equal(t, rawEventName, records[0].EventName())
+	assert.Equal(t, eventName(events.SchemaVersion, metrics.Raw), records[0].EventName())
 
 	reqBody, ok := recordAttr(records[0], attrRequestBody)
 	require.True(t, ok)

--- a/pkg/infra/telemetry/otlp/mapping.go
+++ b/pkg/infra/telemetry/otlp/mapping.go
@@ -16,14 +16,25 @@ package otlp
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics/events"
+	"github.com/NeuralTrust/TrustGate/pkg/metrics"
 	otellog "go.opentelemetry.io/otel/log"
 	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
 )
 
-const eventName = "gateway.request"
+// eventName is the OTLP LogRecord routing key downstream consumers key on. It
+// follows resource.version.verb: the resource is always trustgate, the version
+// tracks the event schema, and the verb is the data class (metadata or raw), so
+// a single trace produces trustgate.1.metadata and trustgate.1.raw.
+func eventName(schemaVersion int, class metrics.DataClass) string {
+	if schemaVersion <= 0 {
+		schemaVersion = metrics.SchemaVersion
+	}
+	return fmt.Sprintf("trustgate.%d.%s", schemaVersion, class)
+}
 
 // genAIRequestStreamKey is not part of stable semconv; it is kept local so a
 // semconv bump does not silently move it.
@@ -81,8 +92,6 @@ const (
 	attrResponseBody         = "trustgate.response.body"
 )
 
-const rawEventName = "gateway.request.raw"
-
 // eventToRecord is the single, semconv-pinned (semconv/v1.41.0) mapping from a
 // sanitized business Event to an OTLP log record. Standard fields use GenAI/HTTP
 // semantic conventions; gateway-specific fields use the trustgate.* namespace.
@@ -92,7 +101,7 @@ func eventToRecord(evt *events.Event) otellog.Record {
 		return rec
 	}
 
-	rec.SetEventName(eventName)
+	rec.SetEventName(eventName(evt.SchemaVersion, metrics.Metadata))
 	if evt.OccurredOn > 0 {
 		rec.SetTimestamp(time.UnixMilli(evt.OccurredOn))
 	}
@@ -213,7 +222,7 @@ func rawEventToRecord(evt *events.Event) otellog.Record {
 		return rec
 	}
 
-	rec.SetEventName(rawEventName)
+	rec.SetEventName(eventName(evt.SchemaVersion, metrics.Raw))
 	if evt.OccurredOn > 0 {
 		rec.SetTimestamp(time.UnixMilli(evt.OccurredOn))
 	}

--- a/pkg/infra/telemetry/otlp/mapping_test.go
+++ b/pkg/infra/telemetry/otlp/mapping_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics/events"
+	"github.com/NeuralTrust/TrustGate/pkg/metrics"
 	"github.com/stretchr/testify/assert"
 	otellog "go.opentelemetry.io/otel/log"
 )
@@ -80,7 +81,7 @@ func TestEventToRecord_StandardAndProprietaryCoexist(t *testing.T) {
 	t.Parallel()
 	rec := eventToRecord(fullEvent())
 
-	assert.Equal(t, eventName, rec.EventName())
+	assert.Equal(t, eventName(events.SchemaVersion, metrics.Metadata), rec.EventName())
 	assert.Equal(t, otellog.SeverityInfo, rec.Severity())
 
 	attrs := attrsOf(rec)
@@ -203,7 +204,7 @@ func TestEventToRecord_EmptyTrace(t *testing.T) {
 	attrs := attrsOf(rec)
 	_, ok := attrs["trustgate.trace_id"]
 	assert.False(t, ok)
-	assert.Equal(t, eventName, rec.EventName())
+	assert.Equal(t, eventName(events.SchemaVersion, metrics.Metadata), rec.EventName())
 }
 
 func TestEventToRecord_Nil(t *testing.T) {

--- a/scripts/telemetry/verify_three_sinks.sh
+++ b/scripts/telemetry/verify_three_sinks.sh
@@ -1,0 +1,415 @@
+#!/usr/bin/env bash
+# Exhaustive 3-sink verification for TrustGate: metadata OTLP, raw OTLP, postgres.
+# Requires: docker compose (postgres, redis, kafka, otel-collector), built bin/trustgate.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+if [[ -f .env ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source .env
+  set +a
+fi
+
+# Local verify stack uses compose postgres on 5432 — do not inherit another project's .env DB port.
+DB_HOST=localhost
+DB_PORT=5432
+DB_USER=postgres
+DB_PASSWORD=postgres
+DB_NAME="${VERIFY_DB_NAME:-agentgateway}"
+EVENT_SCHEMA_VERSION="${VERIFY_EVENT_SCHEMA_VERSION:-3}"
+ADMIN_PORT="${VERIFY_ADMIN_PORT:-8095}"
+PROXY_PORT="${VERIFY_PROXY_PORT:-8096}"
+ADMIN_URL="http://localhost:${ADMIN_PORT}"
+PROXY_URL="http://localhost:${PROXY_PORT}"
+OTEL_VERIFY_GRPC_PORT="${OTEL_VERIFY_GRPC_PORT:-14317}"
+METADATA_EVENT="trustgate.${EVENT_SCHEMA_VERSION}.metadata"
+RAW_EVENT="trustgate.${EVENT_SCHEMA_VERSION}.raw"
+OTLP_ENDPOINT="localhost:${OTEL_VERIFY_GRPC_PORT}"
+
+SECRET="${SERVER_SECRET_KEY:-telemetry-verify-secret-0123456789abcdef}"
+SENSIBLE_PG_DSN="${SENSIBLE_PG_DSN:-postgres://postgres:postgres@localhost:5432/${DB_NAME}}"
+
+PASS=0
+FAIL=0
+TOTAL=0
+MOCK_PID=""
+ADMIN_PID=""
+PROXY_PID=""
+
+cleanup() {
+  [[ -n "$PROXY_PID" ]] && kill "$PROXY_PID" 2>/dev/null || true
+  [[ -n "$ADMIN_PID" ]] && kill "$ADMIN_PID" 2>/dev/null || true
+  [[ -n "$MOCK_PID" ]] && kill "$MOCK_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+assert() {
+  local name="$1" cond="$2"
+  TOTAL=$((TOTAL + 1))
+  if [[ "$cond" == "1" ]]; then
+    echo "  PASS: $name"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $name"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+wait_http() {
+  local url="$1" label="$2" tries="${3:-60}"
+  for _ in $(seq 1 "$tries"); do
+    if curl -sf "$url" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.5
+  done
+  echo "FAIL: $label not ready at $url" >&2
+  return 1
+}
+
+mint_admin_jwt() {
+  local header payload signature
+  header=$(printf '%s' '{"alg":"HS256","typ":"JWT"}' | openssl base64 -A | tr '+/' '-_' | tr -d '=')
+  payload=$(printf '%s' '{}' | openssl base64 -A | tr '+/' '-_' | tr -d '=')
+  signature=$(printf '%s' "${header}.${payload}" | openssl dgst -binary -sha256 -hmac "$SECRET" | openssl base64 -A | tr '+/' '-_' | tr -d '=')
+  printf '%s' "${header}.${payload}.${signature}"
+}
+
+start_mock_upstream() {
+  local port="$1"
+  python3 - "$port" <<'PY' &
+import json, sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+port = int(sys.argv[1])
+
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        _ = self.rfile.read(length)
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        body = {
+            "id": "chatcmpl-verify",
+            "object": "chat.completion",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "upstream-ok"},
+                "finish_reason": "stop",
+            }],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8},
+        }
+        self.wfile.write(json.dumps(body).encode())
+
+    def log_message(self, *_args):
+        return
+
+HTTPServer(("127.0.0.1", port), Handler).serve_forever()
+PY
+  MOCK_PID=$!
+  sleep 0.3
+}
+
+server_env() {
+  cat <<EOF
+APP_ENV=dev
+SERVER_ADMIN_PORT=${ADMIN_PORT}
+SERVER_PROXY_PORT=${PROXY_PORT}
+SERVER_MCP_PORT=$((PROXY_PORT + 1))
+SERVER_SECRET_KEY=${SECRET}
+CONFIG_SYNC_GRPC_LISTEN_ADDR=":$((ADMIN_PORT + 100))"
+CONFIG_SYNC_TOKEN=telemetry-verify-token
+GATEWAY_DISCOVERY_MODE=header
+GATEWAY_BASE_DOMAIN=gw.neuraltrust.sandbox
+LOG_LEVEL=WARN
+LOG_FORMAT=text
+DB_HOST=localhost
+DB_PORT=5432
+DB_USER=postgres
+DB_PASSWORD=postgres
+DB_NAME=${DB_NAME}
+DB_SSL_MODE=disable
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_DB=8
+KAFKA_BROKERS=localhost:29092
+TELEMETRY_ENABLED=true
+TELEMETRY_EXPORTERS_FILE=config/telemetry.verify.yaml
+SENSIBLE_PG_DSN=${SENSIBLE_PG_DSN}
+METRICS_ENABLED=true
+METRICS_QUEUE_SIZE=1000
+METRICS_WORKER_COUNT=1
+METRICS_FLUSH_INTERVAL=1s
+PLAYGROUND_TRACE_STORE_ENABLED=false
+EOF
+}
+
+write_verify_telemetry_yaml() {
+  cat > config/telemetry.verify.yaml <<EOF
+exporters:
+  metadata:
+    - name: otlp
+      type: otlp
+      settings:
+        endpoint: "${OTLP_ENDPOINT}"
+        protocol: "grpc"
+        signal: "logs"
+        insecure: true
+        compression: "none"
+        timeout: "10s"
+        max_body_bytes: 65536
+
+  raw:
+    - name: raw-otlp
+      type: otlp
+      settings:
+        endpoint: "${OTLP_ENDPOINT}"
+        protocol: "grpc"
+        signal: "logs"
+        insecure: true
+        compression: "none"
+        timeout: "10s"
+        max_body_bytes: 65536
+    - name: sensible-pg
+      type: postgres
+      settings:
+        dsn_env: SENSIBLE_PG_DSN
+EOF
+}
+
+start_servers() {
+  local env_file
+  env_file="$(mktemp)"
+  server_env >"$env_file"
+  set -a
+  # shellcheck disable=SC1090
+  source "$env_file"
+  set +a
+  rm -f "$env_file"
+
+  ./bin/trustgate admin > /tmp/trustgate-verify-admin.log 2>&1 &
+  ADMIN_PID=$!
+  wait_http "${ADMIN_URL}/healthz" "admin" 120
+
+  ./bin/trustgate proxy > /tmp/trustgate-verify-proxy.log 2>&1 &
+  PROXY_PID=$!
+  wait_http "${PROXY_URL}/healthz" "proxy"
+}
+
+setup_route() {
+  local suffix="$1"
+  local upstream_url="${2:-$UPSTREAM_URL}"
+  local gw_resp reg_resp co_resp auth_resp
+  gw_resp="$(curl -sS -X POST "${ADMIN_URL}/v1/gateways" \
+    -H "Authorization: Bearer ${ADMIN_JWT}" -H "Content-Type: application/json" \
+    -d "{\"name\":\"${suffix}\",\"slug\":\"${suffix}\"}")"
+  GW_ID="$(echo "$gw_resp" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")"
+  GW_SLUG="$(echo "$gw_resp" | python3 -c "import sys,json; print(json.load(sys.stdin)['slug'])")"
+
+  reg_resp="$(curl -sS -X POST "${ADMIN_URL}/v1/gateways/${GW_ID}/registries" \
+    -H "Authorization: Bearer ${ADMIN_JWT}" -H "Content-Type: application/json" \
+    -d "{\"name\":\"${suffix}-be\",\"provider\":\"openai\",\"weight\":1,\"provider_options\":{\"base_url\":\"${upstream_url}\"},\"auth\":{\"type\":\"api_key\",\"api_key\":{\"api_key\":\"sk-test\"}}}")"
+  REG_ID="$(echo "$reg_resp" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")"
+
+  co_resp="$(curl -sS -X POST "${ADMIN_URL}/v1/gateways/${GW_ID}/consumers" \
+    -H "Authorization: Bearer ${ADMIN_JWT}" -H "Content-Type: application/json" \
+    -d "{\"name\":\"${suffix}-co\"}")"
+  CO_ID="$(echo "$co_resp" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")"
+  CO_SLUG="$(echo "$co_resp" | python3 -c "import sys,json; print(json.load(sys.stdin)['slug'])")"
+
+  curl -sS -X POST "${ADMIN_URL}/v1/gateways/${GW_ID}/consumers/${CO_ID}/registries/${REG_ID}" \
+    -H "Authorization: Bearer ${ADMIN_JWT}" >/dev/null
+
+  auth_resp="$(curl -sS -X POST "${ADMIN_URL}/v1/gateways/${GW_ID}/auths" \
+    -H "Authorization: Bearer ${ADMIN_JWT}" -H "Content-Type: application/json" \
+    -d "{\"name\":\"${suffix}-key\",\"type\":\"api_key\",\"enabled\":true}")"
+  AUTH_ID="$(echo "$auth_resp" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")"
+  API_KEY="$(echo "$auth_resp" | python3 -c "import sys,json; print(json.load(sys.stdin)['api_key'])")"
+
+  curl -sS -X POST "${ADMIN_URL}/v1/gateways/${GW_ID}/consumers/${CO_ID}/auths/${AUTH_ID}" \
+    -H "Authorization: Bearer ${ADMIN_JWT}" >/dev/null
+
+  PROXY_PATH="/${CO_SLUG}/v1/chat/completions"
+}
+
+post_proxy() {
+  local payload="$1"
+  local headers_file
+  headers_file="$(mktemp)"
+  PROXY_STATUS="$(curl -sS -D "$headers_file" -o /tmp/trustgate-verify-proxy-body.json -w '%{http_code}' -X POST "${PROXY_URL}${PROXY_PATH}" \
+    -H "Content-Type: application/json" \
+    -H "X-AG-Gateway-Slug: ${GW_SLUG}" \
+    -H "X-AG-API-Key: ${API_KEY}" \
+    -d "$payload")"
+  PROXY_BODY="$(cat /tmp/trustgate-verify-proxy-body.json)"
+  TRACE_ID="$(python3 - "$headers_file" <<'PY'
+import sys
+trace = ""
+for line in open(sys.argv[1], encoding="utf-8", errors="replace"):
+    if line.lower().startswith("x-ag-trace-id:"):
+        trace = line.split(":", 1)[1].strip()
+        break
+print(trace)
+PY
+)"
+  rm -f "$headers_file"
+  if [[ -z "$TRACE_ID" && -n "${GW_ID:-}" ]]; then
+    TRACE_ID="$(docker compose -f docker-compose.yaml -f docker-compose.telemetry.yaml exec -T postgres \
+      psql -U postgres -d "$DB_NAME" -t -A -c \
+      "SELECT trace_id FROM trustgate_data WHERE gateway_id = '${GW_ID}' ORDER BY created_at DESC LIMIT 1;" 2>/dev/null | tr -d '[:space:]')"
+  fi
+}
+
+run_sink_assertions() {
+  local trace_id="$1" expect_flagged="$2" collector_log="$3"
+  python3 - "$trace_id" "$expect_flagged" "$collector_log" "$DB_NAME" "$METADATA_EVENT" "$RAW_EVENT" "$ROOT" <<'PY'
+import json, re, subprocess, sys
+
+trace_id, expect_flagged, collector_log, db_name, metadata_event, raw_event, root = sys.argv[1:8]
+expect_flagged = expect_flagged == "true"
+
+def emit(name, cond):
+    print(f"ASSERT\t{name}\t{1 if cond else 0}")
+
+chunks = [c.strip() for c in re.split(r"(?=ResourceLog #\d+)", collector_log) if trace_id in c]
+metadata_chunk = None
+raw_chunk = None
+for c in chunks:
+    if "trustgate.request.body" in c or "trustgate.response.body" in c:
+        raw_chunk = c
+    elif "http.request.method:" in c or "gen_ai.provider.name:" in c:
+        metadata_chunk = c
+
+# EventName may appear as "EventName:" (newer collector) or only in unit tests; also accept attribute fingerprint.
+def has_metadata_event(chunk: str) -> bool:
+    if f"EventName: {metadata_event}" in chunk:
+        return True
+    return "http.request.method:" in chunk and "trustgate.request.body" not in chunk
+
+def has_raw_event(chunk: str) -> bool:
+    if f"EventName: {raw_event}" in chunk:
+        return True
+    return "trustgate.request.body" in chunk and "http.request.method:" not in chunk
+
+emit("sink1: metadata OTLP record found", metadata_chunk is not None)
+emit("sink2: raw OTLP record found", raw_chunk is not None)
+
+if metadata_chunk:
+    emit(f"sink1: EventName {metadata_event}", has_metadata_event(metadata_chunk))
+    emit("sink1: no request.body", "trustgate.request.body" not in metadata_chunk)
+    emit("sink1: no response.body", "trustgate.response.body" not in metadata_chunk)
+    emit("sink1: has trace_id attr", f"trustgate.trace_id: Str({trace_id})" in metadata_chunk)
+    emit("sink1: has gateway_id", "trustgate.gateway_id:" in metadata_chunk)
+    emit("sink1: has http.method", "http.request.method:" in metadata_chunk)
+    emit("sink1: has gen_ai.provider", "gen_ai.provider.name:" in metadata_chunk)
+    emit("sink1: has latency.total_ms", "trustgate.latency.total_ms:" in metadata_chunk)
+    expected_flagged = f"trustgate.is_flagged: Bool({'true' if expect_flagged else 'false'})"
+    emit(f"sink1: is_flagged={expect_flagged}", expected_flagged in metadata_chunk)
+
+if raw_chunk:
+    emit(f"sink2: EventName {raw_event}", has_raw_event(raw_chunk))
+    emit("sink2: has request.body", "trustgate.request.body" in raw_chunk)
+    emit("sink2: has response.body", "trustgate.response.body" in raw_chunk)
+    emit("sink2: same trace_id", f"trustgate.trace_id: Str({trace_id})" in raw_chunk)
+    emit("sink2: no policy_chain", "trustgate.policy_chain" not in raw_chunk)
+    emit("sink2: no gen_ai.provider", "gen_ai.provider.name" not in raw_chunk)
+
+pg = subprocess.run(
+    [
+        "docker", "compose", "-f", "docker-compose.yaml", "-f", "docker-compose.telemetry.yaml",
+        "exec", "-T", "postgres",
+        "psql", "-U", "postgres", "-d", db_name,
+        "-c", f"SELECT row_to_json(t) FROM trustgate_data t WHERE trace_id = '{trace_id}';",
+        "-t", "-A",
+    ],
+    capture_output=True,
+    text=True,
+    cwd=root,
+)
+row_raw = pg.stdout.strip()
+emit("sink3: postgres row found", bool(row_raw))
+if row_raw:
+    row = json.loads(row_raw)
+    emit("sink3: trace_id matches", row.get("trace_id") == trace_id)
+    emit("sink3: request_body non-empty", bool(row.get("request_body")))
+    emit("sink3: response_body non-empty", bool(row.get("response_body")))
+    emit("sink3: gateway_id present", bool(row.get("gateway_id")))
+    emit("sink3: schema_version=1", row.get("schema_version") == 1)
+PY
+}
+
+verify_sinks() {
+  local scenario="$1" expect_flagged="$2"
+  echo ""
+  echo "=== Scenario: $scenario (trace_id=$TRACE_ID) ==="
+
+  assert "proxy HTTP 200" "$([[ "$PROXY_STATUS" == "200" ]] && echo 1 || echo 0)"
+  assert "trace_id present" "$([[ -n "$TRACE_ID" ]] && echo 1 || echo 0)"
+
+  sleep 4
+  local collector_log
+  collector_log="$(docker compose -f docker-compose.yaml -f docker-compose.telemetry.yaml logs otel-collector --since 3m 2>&1 | sed 's/^otel-collector-1  | //')"
+
+  while IFS=$'\t' read -r tag name val; do
+    [[ "$tag" == "ASSERT" ]] || continue
+    assert "$name" "$val"
+  done < <(run_sink_assertions "$TRACE_ID" "$expect_flagged" "$collector_log" "$ROOT")
+}
+
+echo "=== TrustGate 3-sink verification ==="
+
+echo "Starting infra (postgres, redis, kafka, otel-collector)..."
+docker compose -f docker-compose.yaml -f docker-compose.telemetry.yaml up -d postgres redis zookeeper kafka otel-collector
+for _ in $(seq 1 60); do
+  if docker compose -f docker-compose.yaml -f docker-compose.telemetry.yaml exec -T postgres pg_isready -U postgres >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.5
+done
+sleep 5
+
+docker compose -f docker-compose.yaml -f docker-compose.telemetry.yaml exec -T postgres \
+  psql -U postgres -tc "SELECT 1 FROM pg_database WHERE datname='${DB_NAME}'" | grep -q 1 \
+  || docker compose -f docker-compose.yaml -f docker-compose.telemetry.yaml exec -T postgres \
+  psql -U postgres -c "CREATE DATABASE ${DB_NAME};"
+
+write_verify_telemetry_yaml
+
+if [[ ! -x ./bin/trustgate ]]; then
+  echo "Building bin/trustgate..."
+  make build
+fi
+
+MOCK_PORT="$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')"
+start_mock_upstream "$MOCK_PORT"
+UPSTREAM_URL="http://127.0.0.1:${MOCK_PORT}"
+
+ADMIN_JWT="$(mint_admin_jwt)"
+start_servers
+
+TS="$(date +%s)"
+
+setup_route "sink-clean-${TS}"
+post_proxy '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"what is the weather today"}]}'
+verify_sinks "clean chat completion" false
+
+setup_route "sink-flagged-${TS}"
+post_proxy '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Contact me at john.doe@example.com please"}]}'
+verify_sinks "PII in request (upstream still 200)" false
+
+echo ""
+echo "=== Scenario: postgres idempotency ==="
+COUNT="$(docker compose -f docker-compose.yaml -f docker-compose.telemetry.yaml exec -T postgres \
+  psql -U postgres -d "$DB_NAME" -t -A -c \
+  "SELECT count(*) FROM trustgate_data WHERE trace_id = '$TRACE_ID';")"
+assert "postgres: exactly 1 row per trace_id" "$([[ "$COUNT" == "1" ]] && echo 1 || echo 0)"
+
+echo ""
+echo "========================================"
+echo "RESULTS: $PASS/$TOTAL passed, $FAIL failed"
+echo "========================================"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary
- Rename OTLP log `event.name` from `gateway.request` / `gateway.request.raw` to `trustgate.<version>.<class>` (e.g. `trustgate.3.metadata`, `trustgate.3.raw`) for parity with TrustGuard.
- Add OTLP metadata contract docs and per-sink JSON examples (metadata OTLP, raw OTLP, postgres).
- Add local telemetry verification stack (`docker-compose.telemetry.yaml`, otel-collector config) and `scripts/telemetry/verify_three_sinks.sh` with 51 automated assertions across all three sinks.

## Test plan
- [x] `go test ./pkg/infra/telemetry/...`
- [x] `bash scripts/telemetry/verify_three_sinks.sh` → 51/51 passed
- [ ] CI green