### PR TITLE
feat(metrics): dialect-agnostic column contract

### DIFF
--- a/pkg/metrics/column.go
+++ b/pkg/metrics/column.go
@@ -1,0 +1,49 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+// ColumnType is the dialect-agnostic logical type of a metrics column.
+// Consumers map it to their storage engine's concrete type.
+type ColumnType string
+
+const (
+	ColumnTypeString    ColumnType = "string"
+	ColumnTypeInt64     ColumnType = "int64"
+	ColumnTypeInt32     ColumnType = "int32"
+	ColumnTypeTimestamp ColumnType = "timestamp"
+)
+
+// Column describes one field of the metrics contract: its name, logical type,
+// and whether it is nullable. It is the shared source of truth consumers use to
+// derive or validate per-dialect DDL.
+type Column struct {
+	Name     string
+	Type     ColumnType
+	Nullable bool
+}
+
+// RawColumns returns the full raw-record column contract in write order.
+func RawColumns() []Column {
+	return []Column{
+		{Name: ColumnTraceID, Type: ColumnTypeString},
+		{Name: ColumnGatewayID, Type: ColumnTypeString},
+		{Name: ColumnTeamID, Type: ColumnTypeString, Nullable: true},
+		{Name: ColumnOccurredOn, Type: ColumnTypeInt64},
+		{Name: ColumnSchemaVersion, Type: ColumnTypeInt32},
+		{Name: ColumnRequestBody, Type: ColumnTypeString},
+		{Name: ColumnResponseBody, Type: ColumnTypeString, Nullable: true},
+		{Name: ColumnCreatedAt, Type: ColumnTypeTimestamp},
+	}
+}

--- a/pkg/metrics/column_test.go
+++ b/pkg/metrics/column_test.go
@@ -1,0 +1,32 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import "testing"
+
+func TestRawColumnsMatchReadColumns(t *testing.T) {
+	read := make(map[string]bool)
+	for _, c := range ReadColumns() {
+		read[c] = true
+	}
+	for _, c := range RawColumns() {
+		if !read[c.Name] {
+			t.Errorf("raw column %q not present in ReadColumns", c.Name)
+		}
+	}
+	if len(RawColumns()) != len(ReadColumns()) {
+		t.Errorf("RawColumns len = %d, ReadColumns len = %d", len(RawColumns()), len(ReadColumns()))
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a dialect-agnostic `Column` / `RawColumns()` contract to `pkg/metrics` so consumers (DataCore) can derive per-dialect DDL from a single source of truth and avoid schema drift.
- `pkg/metrics` stays **out of ClickHouse**: it owns only the raw (Postgres) contract plus `DataClass`/`SchemaVersion` (already used by the OTLP mapping).

## Context / scope correction
Original scope shipped ClickHouse `CREATE TABLE` migrations (`*_data` / `*_metadata`) here. That was misaligned with the real pipeline: producers emit OTLP `LogRecords` (`trustgate.N.metadata` / `.raw`) into a shared `otel_logs` landing table, and **materialized views** transform those into the rich `*_events` tables. Direct typed tables written from producers do not exist.

Correction: all ClickHouse DDL (otel_logs + `*_events` + `*_raw` + MVs) moves to DataCore (**RUN-897**), which imports this `Column` contract to keep the ClickHouse schema in sync with the producer raw schema.

## Changes
- `pkg/metrics/column.go` — `Column`, `ColumnType`, `RawColumns()`.
- `pkg/metrics/column_test.go` — validates `RawColumns` against existing `ReadColumns`.
- Reverted the ClickHouse migrations, the per-dialect registry split, and `MetadataColumns()`.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` green in `pkg/metrics`.

RUN-896