### PR TITLE
feat(config-sync): thread partition scope through snapshot source (RUN-906)

### DIFF
--- a/pkg/app/configsnapshot/holder.go
+++ b/pkg/app/configsnapshot/holder.go
@@ -41,6 +41,13 @@ func (h *Holder) Snapshot() (raw []byte, version string, ok bool) {
 	return state.raw, state.version, true
 }
 
+// SnapshotFor returns the compiled snapshot for the given partition scope. This
+// single-snapshot holder is scope-agnostic and returns the same snapshot for
+// every scope; per-scope compilation is layered on top separately.
+func (h *Holder) SnapshotFor(_ string) (raw []byte, version string, ok bool) {
+	return h.Snapshot()
+}
+
 func (h *Holder) Version() string {
 	state := h.current.Load()
 	if state == nil {

--- a/pkg/infra/configsync/grpc/client_test.go
+++ b/pkg/infra/configsync/grpc/client_test.go
@@ -46,7 +46,7 @@ type fakeSource struct {
 	ok      bool
 }
 
-func (f *fakeSource) Snapshot() ([]byte, string, bool) {
+func (f *fakeSource) SnapshotFor(string) ([]byte, string, bool) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.raw, f.version, f.ok

--- a/pkg/infra/configsync/grpc/interceptor.go
+++ b/pkg/infra/configsync/grpc/interceptor.go
@@ -65,35 +65,42 @@ func NewAuthInterceptor(cfg *config.Config, logger *slog.Logger) *AuthIntercepto
 	return interceptor
 }
 
-// UnaryServerInterceptor authenticates unary RPCs before the handler runs.
+// UnaryServerInterceptor authenticates unary RPCs before the handler runs and
+// propagates the resolved partition scope down the context.
 func (a *AuthInterceptor) UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
-		if err := a.authorize(ctx); err != nil {
+		scoped, err := a.authorize(ctx)
+		if err != nil {
 			return nil, err
 		}
-		return handler(ctx, req)
+		return handler(scoped, req)
 	}
 }
 
-// StreamServerInterceptor authenticates streaming RPCs before the handler runs.
+// StreamServerInterceptor authenticates streaming RPCs before the handler runs
+// and propagates the resolved partition scope down the stream context.
 func (a *AuthInterceptor) StreamServerInterceptor() grpc.StreamServerInterceptor {
 	return func(srv any, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-		if err := a.authorize(ss.Context()); err != nil {
+		scoped, err := a.authorize(ss.Context())
+		if err != nil {
 			return err
 		}
-		return handler(srv, ss)
+		return handler(srv, &scopedServerStream{ServerStream: ss, ctx: scoped})
 	}
 }
 
-func (a *AuthInterceptor) authorize(ctx context.Context) error {
+// authorize validates the bearer token and returns a context carrying the
+// resolved partition scope. In the shared-token mode the scope is empty, which
+// downstream resolves to the whole, unpartitioned config.
+func (a *AuthInterceptor) authorize(ctx context.Context) (context.Context, error) {
 	if len(a.tokenDigests) == 0 {
 		a.logger.Debug("config-sync token is not configured; rejecting RPC",
 			slog.String("component", component))
-		return status.Error(codes.Unauthenticated, "config-sync token is not configured")
+		return ctx, status.Error(codes.Unauthenticated, "config-sync token is not configured")
 	}
 	provided := bearerFromContext(ctx)
 	if provided == "" {
-		return status.Error(codes.Unauthenticated, "missing or invalid config-sync token")
+		return ctx, status.Error(codes.Unauthenticated, "missing or invalid config-sync token")
 	}
 	providedDigest := sha256.Sum256([]byte(provided))
 	matched := 0
@@ -101,10 +108,19 @@ func (a *AuthInterceptor) authorize(ctx context.Context) error {
 		matched |= subtle.ConstantTimeCompare(providedDigest[:], digest[:])
 	}
 	if matched != 1 {
-		return status.Error(codes.Unauthenticated, "missing or invalid config-sync token")
+		return ctx, status.Error(codes.Unauthenticated, "missing or invalid config-sync token")
 	}
-	return nil
+	return WithScope(ctx, ""), nil
 }
+
+// scopedServerStream overrides the stream context so handlers observe the scope
+// resolved by the interceptor.
+type scopedServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (s *scopedServerStream) Context() context.Context { return s.ctx }
 
 func bearerFromContext(ctx context.Context) string {
 	md, ok := metadata.FromIncomingContext(ctx)

--- a/pkg/infra/configsync/grpc/scope.go
+++ b/pkg/infra/configsync/grpc/scope.go
@@ -1,0 +1,35 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpc
+
+import "context"
+
+type scopeContextKeyType struct{}
+
+var scopeContextKey scopeContextKeyType
+
+// WithScope returns a context carrying the config-sync partition scope key. An
+// empty scope denotes the whole, unpartitioned config, which preserves the
+// single-tenant behavior.
+func WithScope(ctx context.Context, scope string) context.Context {
+	return context.WithValue(ctx, scopeContextKey, scope)
+}
+
+// ScopeFromContext returns the partition scope key set upstream by the auth
+// interceptor, or "" when none is present (unpartitioned / single-tenant).
+func ScopeFromContext(ctx context.Context) string {
+	scope, _ := ctx.Value(scopeContextKey).(string)
+	return scope
+}

--- a/pkg/infra/configsync/grpc/scope_test.go
+++ b/pkg/infra/configsync/grpc/scope_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/NeuralTrust/TrustGate/pkg/config"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestScopeContextRoundTrip(t *testing.T) {
+	ctx := WithScope(context.Background(), "org_42")
+	if got := ScopeFromContext(ctx); got != "org_42" {
+		t.Fatalf("scope = %q, want org_42", got)
+	}
+	if got := ScopeFromContext(context.Background()); got != "" {
+		t.Fatalf("missing scope = %q, want empty", got)
+	}
+}
+
+type recordingStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (s *recordingStream) Context() context.Context { return s.ctx }
+
+func TestStreamInterceptorInjectsScope(t *testing.T) {
+	auth := NewAuthInterceptor(&config.Config{ConfigSync: config.ConfigSyncConfig{Token: "tok"}}, discardLogger())
+	md := metadata.New(map[string]string{authMetadataKey: bearerPrefix + "tok"})
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+
+	var seen string
+	invoked := false
+	handler := func(_ any, ss grpc.ServerStream) error {
+		seen = ScopeFromContext(ss.Context())
+		invoked = true
+		return nil
+	}
+	if err := auth.StreamServerInterceptor()(nil, &recordingStream{ctx: ctx}, &grpc.StreamServerInfo{}, handler); err != nil {
+		t.Fatalf("interceptor: %v", err)
+	}
+	if !invoked {
+		t.Fatal("handler was not invoked")
+	}
+	if seen != "" {
+		t.Fatalf("shared-mode scope = %q, want empty", seen)
+	}
+}

--- a/pkg/infra/configsync/grpc/service.go
+++ b/pkg/infra/configsync/grpc/service.go
@@ -29,10 +29,11 @@ const (
 	snapshotChunkSize = 1 << 20
 )
 
-// SnapshotSource yields the current compiled snapshot bytes and version. The
+// SnapshotSource yields the compiled snapshot bytes and version for a given
+// partition scope. An empty scope means the whole, unpartitioned config. The
 // control-plane Holder satisfies it.
 type SnapshotSource interface {
-	Snapshot() (raw []byte, version string, ok bool)
+	SnapshotFor(scope string) (raw []byte, version string, ok bool)
 }
 
 // Service implements the ConfigSync gRPC server: the bidi Sync control channel
@@ -68,7 +69,8 @@ func (s *Service) Sync(stream snapshotpb.ConfigSync_SyncServer) error {
 	conn := s.hub.register(hello.GetInstanceId())
 	defer s.hub.unregister(conn)
 
-	if _, version, ok := s.source.Snapshot(); ok && version != hello.GetLastAppliedVersion() {
+	scope := ScopeFromContext(ctx)
+	if _, version, ok := s.source.SnapshotFor(scope); ok && version != hello.GetLastAppliedVersion() {
 		conn.enqueue(version)
 	}
 
@@ -107,7 +109,8 @@ func (s *Service) Sync(stream snapshotpb.ConfigSync_SyncServer) error {
 // GetSnapshot answers not_modified when the DP's applied_version matches current,
 // otherwise streams a SnapshotHeader followed by fixed-size data chunks.
 func (s *Service) GetSnapshot(req *snapshotpb.GetSnapshotRequest, stream snapshotpb.ConfigSync_GetSnapshotServer) error {
-	raw, version, ok := s.source.Snapshot()
+	scope := ScopeFromContext(stream.Context())
+	raw, version, ok := s.source.SnapshotFor(scope)
 	if !ok {
 		return status.Error(codes.Unavailable, "no snapshot available yet")
 	}


### PR DESCRIPTION
## Summary
Makes the OSS config-sync transport **scope-aware** without introducing any tenant concept in the open-source code:
- `SnapshotSource.Snapshot()` → **`SnapshotFor(scope string)`**. `Service.Sync`/`GetSnapshot` resolve the scope from the request context and ask the source for that scope.
- The auth interceptor now returns a **scope-carrying context** and wraps the server stream (`scopedServerStream`). In the shared-token mode the scope is **empty**, which resolves to the whole, unpartitioned config → **no behavior change** for existing single-tenant deployments.
- `Holder.SnapshotFor` ignores the scope (single global snapshot). Per-scope compilation is layered on top separately in RUN-908.
- Adds `WithScope`/`ScopeFromContext` helpers + tests (context round-trip, interceptor injects empty scope in shared mode).

The `scope` is an **opaque partition key**; the `scope → tenant_id` mapping lives in the proprietary layer (RUN-909). This is the OSS seam that RUN-907 (verification) and RUN-908 (per-scope compilation) build on.

## Context
Part of RUN-905 (config-sync multi-tenant). Base of the stack: RUN-907 and RUN-908 branch off this.

Linear: RUN-906 — https://linear.app/neuraltrust/issue/RUN-906

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/infra/configsync/... ./pkg/app/configsnapshot/...`
- [x] `go vet` + pre-commit (golangci-lint, gosec) pass
- [ ] Existing single-tenant data plane still converges (empty scope → global snapshot).

Made with [Cursor](https://cursor.com)