### PR TITLE
feat(config-sync): per-scope snapshot compilation & holder (RUN-908)

### DIFF
--- a/pkg/app/configsnapshot/compiler.go
+++ b/pkg/app/configsnapshot/compiler.go
@@ -67,15 +67,29 @@ func NewCompiler(
 	}
 }
 
+// Compile builds the whole, unpartitioned snapshot (every gateway). It is the
+// scope-agnostic path used by shared-token deployments.
 func (c *Compiler) Compile(ctx context.Context) (*readmodel.Snapshot, error) {
+	return c.CompileFor(ctx, "")
+}
+
+// CompileFor builds a snapshot restricted to a partition scope: only gateways
+// whose metadata.team_id equals scope (and all their associated config) are
+// included. An empty scope includes every gateway (the whole config). Shared
+// catalog data (providers/models) is included in every scope.
+func (c *Compiler) CompileFor(ctx context.Context, scope string) (*readmodel.Snapshot, error) {
 	gateways, err := c.listGateways(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	data := readmodel.Data{}
-	var skipped int
+	var skipped, considered int
 	for i := range gateways {
+		if scope != "" && gateways[i].TeamID() != scope {
+			continue
+		}
+		considered++
 		var gwData readmodel.Data
 		if err := c.collectGateway(ctx, gateways[i].ID, &gwData); err != nil {
 			if errors.Is(err, commonerrors.ErrCorruptData) {
@@ -88,24 +102,101 @@ func (c *Compiler) Compile(ctx context.Context) (*readmodel.Snapshot, error) {
 			}
 			return nil, err
 		}
-		data.Gateways = append(data.Gateways, gateways[i])
-		data.Consumers = append(data.Consumers, gwData.Consumers...)
-		data.Registries = append(data.Registries, gwData.Registries...)
-		data.Policies = append(data.Policies, gwData.Policies...)
-		data.Auths = append(data.Auths, gwData.Auths...)
-		data.Roles = append(data.Roles, gwData.Roles...)
+		appendGatewayData(&data, gateways[i], gwData)
 	}
 
-	if skipped > 0 && len(data.Gateways) == 0 {
+	if skipped > 0 && skipped == considered {
 		return nil, fmt.Errorf("configsnapshot: every gateway (%d) skipped due to corrupt persisted config; refusing to publish empty snapshot: %w", skipped, commonerrors.ErrCorruptData)
 	}
 
-	if err := c.collectCatalog(ctx, &data); err != nil {
+	cat, err := c.collectCatalogData(ctx)
+	if err != nil {
 		return nil, err
 	}
+	mergeCatalog(&data, cat)
 
 	sortData(&data)
 	return readmodel.Build(data), nil
+}
+
+// CompileAll builds the whole snapshot plus one snapshot per non-empty scope in a
+// single pass over the gateways, so serving partitioned data planes does not cost
+// one full gateway listing per scope. The returned map is keyed by scope
+// (metadata.team_id) and each per-scope snapshot carries the shared catalog.
+func (c *Compiler) CompileAll(ctx context.Context) (*readmodel.Snapshot, map[string]*readmodel.Snapshot, error) {
+	gateways, err := c.listGateways(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	global := readmodel.Data{}
+	buckets := map[string]*readmodel.Data{}
+	var skipped int
+	for i := range gateways {
+		var gwData readmodel.Data
+		if err := c.collectGateway(ctx, gateways[i].ID, &gwData); err != nil {
+			if errors.Is(err, commonerrors.ErrCorruptData) {
+				c.logger.Warn("skipping gateway with corrupt persisted config from snapshot",
+					slog.String("component", component),
+					slog.String("gateway_id", gateways[i].ID.String()),
+					slog.String("error", err.Error()))
+				skipped++
+				continue
+			}
+			return nil, nil, err
+		}
+		appendGatewayData(&global, gateways[i], gwData)
+		if scope := gateways[i].TeamID(); scope != "" {
+			bucket, ok := buckets[scope]
+			if !ok {
+				bucket = &readmodel.Data{}
+				buckets[scope] = bucket
+			}
+			appendGatewayData(bucket, gateways[i], gwData)
+		}
+	}
+
+	if skipped > 0 && len(global.Gateways) == 0 {
+		return nil, nil, fmt.Errorf("configsnapshot: every gateway (%d) skipped due to corrupt persisted config; refusing to publish empty snapshot: %w", skipped, commonerrors.ErrCorruptData)
+	}
+
+	cat, err := c.collectCatalogData(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	mergeCatalog(&global, cat)
+	sortData(&global)
+
+	scoped := make(map[string]*readmodel.Snapshot, len(buckets))
+	for scope, bucket := range buckets {
+		mergeCatalog(bucket, cat)
+		sortData(bucket)
+		scoped[scope] = readmodel.Build(*bucket)
+	}
+	return readmodel.Build(global), scoped, nil
+}
+
+func appendGatewayData(dst *readmodel.Data, gateway gatewaydomain.Gateway, gwData readmodel.Data) {
+	dst.Gateways = append(dst.Gateways, gateway)
+	dst.Consumers = append(dst.Consumers, gwData.Consumers...)
+	dst.Registries = append(dst.Registries, gwData.Registries...)
+	dst.Policies = append(dst.Policies, gwData.Policies...)
+	dst.Auths = append(dst.Auths, gwData.Auths...)
+	dst.Roles = append(dst.Roles, gwData.Roles...)
+}
+
+func mergeCatalog(dst *readmodel.Data, catalog readmodel.Data) {
+	dst.Providers = append(dst.Providers, catalog.Providers...)
+	dst.CatalogModels = append(dst.CatalogModels, catalog.CatalogModels...)
+}
+
+func (c *Compiler) collectCatalogData(ctx context.Context) (readmodel.Data, error) {
+	var data readmodel.Data
+	if err := c.collectCatalog(ctx, &data); err != nil {
+		return readmodel.Data{}, err
+	}
+	return data, nil
 }
 
 func (c *Compiler) listGateways(ctx context.Context) ([]gatewaydomain.Gateway, error) {

--- a/pkg/app/configsnapshot/dispatcher.go
+++ b/pkg/app/configsnapshot/dispatcher.go
@@ -40,6 +40,13 @@ type SnapshotCompiler interface {
 	Compile(ctx context.Context) (*readmodel.Snapshot, error)
 }
 
+// PartitionedCompiler additionally compiles one snapshot per partition scope in a
+// single pass. A compiler that implements it makes the dispatcher publish
+// per-scope snapshots alongside the whole snapshot.
+type PartitionedCompiler interface {
+	CompileAll(ctx context.Context) (*readmodel.Snapshot, map[string]*readmodel.Snapshot, error)
+}
+
 // DispatcherConfig tunes the debounce/backstop cadence and the outbox safety bound.
 type DispatcherConfig struct {
 	Debounce  time.Duration
@@ -200,19 +207,18 @@ func (d *Dispatcher) dispatch(ctx context.Context) error {
 		pending = nil
 	}
 
-	snapshot, err := d.compiler.Compile(ctx)
+	raw, version, scoped, err := d.compile(ctx)
 	if err != nil {
-		return fmt.Errorf("configsnapshot: compile: %w", err)
+		return err
 	}
-	raw, err := d.codec.Encode(snapshot)
-	if err != nil {
-		return fmt.Errorf("configsnapshot: encode: %w", err)
-	}
-	version := d.codec.Version(raw)
 
 	d.mu.Lock()
 	if version != d.published {
-		d.holder.Set(raw, version)
+		if scoped != nil {
+			d.holder.SetPartitioned(raw, version, scoped)
+		} else {
+			d.holder.Set(raw, version)
+		}
 		d.broadcaster.Broadcast(version)
 		d.published = version
 	}
@@ -225,4 +231,46 @@ func (d *Dispatcher) dispatch(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+// compile encodes the whole snapshot and, when the compiler is partitioned, the
+// per-scope snapshots. A nil scoped map means the whole-snapshot-only path.
+func (d *Dispatcher) compile(ctx context.Context) (raw []byte, version string, scoped map[string]ScopedSnapshot, err error) {
+	if partitioned, ok := d.compiler.(PartitionedCompiler); ok {
+		global, scopedSnaps, cerr := partitioned.CompileAll(ctx)
+		if cerr != nil {
+			return nil, "", nil, fmt.Errorf("configsnapshot: compile: %w", cerr)
+		}
+		raw, version, err = d.encode(global)
+		if err != nil {
+			return nil, "", nil, err
+		}
+		scoped = make(map[string]ScopedSnapshot, len(scopedSnaps))
+		for scope, snap := range scopedSnaps {
+			scopedRaw, scopedVersion, eerr := d.encode(snap)
+			if eerr != nil {
+				return nil, "", nil, eerr
+			}
+			scoped[scope] = ScopedSnapshot{Raw: scopedRaw, Version: scopedVersion}
+		}
+		return raw, version, scoped, nil
+	}
+
+	snapshot, cerr := d.compiler.Compile(ctx)
+	if cerr != nil {
+		return nil, "", nil, fmt.Errorf("configsnapshot: compile: %w", cerr)
+	}
+	raw, version, err = d.encode(snapshot)
+	if err != nil {
+		return nil, "", nil, err
+	}
+	return raw, version, nil, nil
+}
+
+func (d *Dispatcher) encode(snapshot *readmodel.Snapshot) ([]byte, string, error) {
+	raw, err := d.codec.Encode(snapshot)
+	if err != nil {
+		return nil, "", fmt.Errorf("configsnapshot: encode: %w", err)
+	}
+	return raw, d.codec.Version(raw), nil
 }

--- a/pkg/app/configsnapshot/holder.go
+++ b/pkg/app/configsnapshot/holder.go
@@ -21,16 +21,40 @@ type snapshotState struct {
 	version string
 }
 
+// ScopedSnapshot is a compiled snapshot for a single partition scope.
+type ScopedSnapshot struct {
+	Raw     []byte
+	Version string
+}
+
+// Holder stores the current compiled snapshot(s) for the gRPC server to serve.
+// It always holds the whole, unpartitioned snapshot (scope "") and, when
+// partitioned compilation is active, a per-scope map. Reads are lock-free.
 type Holder struct {
 	current atomic.Pointer[snapshotState]
+	scoped  atomic.Pointer[map[string]snapshotState]
 }
 
 func NewHolder() *Holder {
 	return &Holder{}
 }
 
+// Set replaces the whole, unpartitioned snapshot and leaves the per-scope map
+// untouched.
 func (h *Holder) Set(raw []byte, version string) {
 	h.current.Store(&snapshotState{raw: raw, version: version})
+}
+
+// SetPartitioned atomically replaces the whole snapshot and the entire per-scope
+// map, so scopes that no longer exist stop being served (fail-closed) on the next
+// dispatch.
+func (h *Holder) SetPartitioned(raw []byte, version string, scoped map[string]ScopedSnapshot) {
+	next := make(map[string]snapshotState, len(scoped))
+	for scope, snap := range scoped {
+		next[scope] = snapshotState{raw: snap.Raw, version: snap.Version}
+	}
+	h.current.Store(&snapshotState{raw: raw, version: version})
+	h.scoped.Store(&next)
 }
 
 func (h *Holder) Snapshot() (raw []byte, version string, ok bool) {
@@ -41,11 +65,23 @@ func (h *Holder) Snapshot() (raw []byte, version string, ok bool) {
 	return state.raw, state.version, true
 }
 
-// SnapshotFor returns the compiled snapshot for the given partition scope. This
-// single-snapshot holder is scope-agnostic and returns the same snapshot for
-// every scope; per-scope compilation is layered on top separately.
-func (h *Holder) SnapshotFor(_ string) (raw []byte, version string, ok bool) {
-	return h.Snapshot()
+// SnapshotFor returns the compiled snapshot for a partition scope. An empty scope
+// returns the whole, unpartitioned snapshot. A non-empty scope returns only that
+// scope's snapshot and never falls back to the whole snapshot: an unknown scope
+// yields ok=false so the transport denies it rather than leaking global config.
+func (h *Holder) SnapshotFor(scope string) (raw []byte, version string, ok bool) {
+	if scope == "" {
+		return h.Snapshot()
+	}
+	m := h.scoped.Load()
+	if m == nil {
+		return nil, "", false
+	}
+	state, present := (*m)[scope]
+	if !present {
+		return nil, "", false
+	}
+	return state.raw, state.version, true
 }
 
 func (h *Holder) Version() string {

--- a/pkg/app/configsnapshot/holder.go
+++ b/pkg/app/configsnapshot/holder.go
@@ -41,6 +41,13 @@ func (h *Holder) Snapshot() (raw []byte, version string, ok bool) {
 	return state.raw, state.version, true
 }
 
+// SnapshotFor returns the compiled snapshot for the given partition scope. This
+// single-snapshot holder is scope-agnostic and returns the same snapshot for
+// every scope; per-scope compilation is layered on top separately.
+func (h *Holder) SnapshotFor(_ string) (raw []byte, version string, ok bool) {
+	return h.Snapshot()
+}
+
 func (h *Holder) Version() string {
 	state := h.current.Load()
 	if state == nil {

--- a/pkg/app/configsnapshot/scope_test.go
+++ b/pkg/app/configsnapshot/scope_test.go
@@ -1,0 +1,134 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configsnapshot_test
+
+import (
+	"context"
+	"testing"
+
+	appsnapshot "github.com/NeuralTrust/TrustGate/pkg/app/configsnapshot"
+	authdomain "github.com/NeuralTrust/TrustGate/pkg/domain/auth"
+	catalogdomain "github.com/NeuralTrust/TrustGate/pkg/domain/catalog"
+	consumerdomain "github.com/NeuralTrust/TrustGate/pkg/domain/consumer"
+	gatewaydomain "github.com/NeuralTrust/TrustGate/pkg/domain/gateway"
+	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
+	policydomain "github.com/NeuralTrust/TrustGate/pkg/domain/policy"
+	registrydomain "github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	roledomain "github.com/NeuralTrust/TrustGate/pkg/domain/role"
+)
+
+func gatewayWithTeam(id ids.GatewayID, team string) *gatewaydomain.Gateway {
+	return &gatewaydomain.Gateway{ID: id, Metadata: map[string]string{gatewaydomain.MetadataTeamIDKey: team}}
+}
+
+func twoTenantCompiler(t *testing.T, acme, globex ids.GatewayID, acmeConsumer, globexConsumer ids.ConsumerID) *appsnapshot.Compiler {
+	t.Helper()
+	return appsnapshot.NewCompiler(
+		fakeGateways{items: []*gatewaydomain.Gateway{
+			gatewayWithTeam(acme, "acme"),
+			gatewayWithTeam(globex, "globex"),
+		}},
+		fakeConsumers{byGateway: map[string][]*consumerdomain.Consumer{
+			acme.String():   {{ID: acmeConsumer, GatewayID: acme}},
+			globex.String(): {{ID: globexConsumer, GatewayID: globex}},
+		}},
+		fakeRegistries{byGateway: map[string][]*registrydomain.Registry{}},
+		fakePolicies{byGateway: map[string][]*policydomain.Policy{}},
+		fakeAuths{byGateway: map[string][]*authdomain.Auth{}},
+		fakeRoles{byGateway: map[string][]*roledomain.Role{}},
+		fakeCatalog{providers: []catalogdomain.Provider{{Code: "openai"}}},
+		nil,
+	)
+}
+
+func TestCompilerCompileForIsolatesScope(t *testing.T) {
+	acme := mustGatewayID(t, "11111111-1111-1111-1111-111111111111")
+	globex := mustGatewayID(t, "22222222-2222-2222-2222-222222222222")
+	acmeConsumer := mustConsumerID(t, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+	globexConsumer := mustConsumerID(t, "cccccccc-cccc-cccc-cccc-cccccccccccc")
+
+	compiler := twoTenantCompiler(t, acme, globex, acmeConsumer, globexConsumer)
+
+	snap, err := compiler.CompileFor(context.Background(), "acme")
+	if err != nil {
+		t.Fatalf("compile for acme: %v", err)
+	}
+	data := snap.Data()
+	if len(data.Gateways) != 1 || data.Gateways[0].ID != acme {
+		t.Fatalf("expected only the acme gateway, got %+v", data.Gateways)
+	}
+	if len(data.Consumers) != 1 || data.Consumers[0].ID != acmeConsumer {
+		t.Fatalf("expected only the acme consumer, got %+v", data.Consumers)
+	}
+	if len(data.Providers) != 1 {
+		t.Fatalf("expected shared catalog in scope snapshot, got %d providers", len(data.Providers))
+	}
+}
+
+func TestCompilerCompileAllPartitionsAndIsolates(t *testing.T) {
+	acme := mustGatewayID(t, "11111111-1111-1111-1111-111111111111")
+	globex := mustGatewayID(t, "22222222-2222-2222-2222-222222222222")
+	acmeConsumer := mustConsumerID(t, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+	globexConsumer := mustConsumerID(t, "cccccccc-cccc-cccc-cccc-cccccccccccc")
+
+	compiler := twoTenantCompiler(t, acme, globex, acmeConsumer, globexConsumer)
+
+	global, scoped, err := compiler.CompileAll(context.Background())
+	if err != nil {
+		t.Fatalf("compile all: %v", err)
+	}
+	if len(global.Data().Gateways) != 2 {
+		t.Fatalf("expected both gateways in the whole snapshot, got %d", len(global.Data().Gateways))
+	}
+	if len(scoped) != 2 {
+		t.Fatalf("expected 2 scopes, got %d", len(scoped))
+	}
+	acmeSnap, ok := scoped["acme"]
+	if !ok {
+		t.Fatal("missing acme scope")
+	}
+	if gws := acmeSnap.Data().Gateways; len(gws) != 1 || gws[0].ID != acme {
+		t.Fatalf("acme scope leaked other gateways: %+v", gws)
+	}
+	for _, cs := range acmeSnap.Data().Consumers {
+		if cs.ID == globexConsumer {
+			t.Fatal("globex consumer leaked into acme scope")
+		}
+	}
+	if len(acmeSnap.Data().Providers) != 1 {
+		t.Fatalf("expected shared catalog in acme scope, got %d", len(acmeSnap.Data().Providers))
+	}
+	globexSnap := scoped["globex"]
+	if gws := globexSnap.Data().Gateways; len(gws) != 1 || gws[0].ID != globex {
+		t.Fatalf("globex scope leaked other gateways: %+v", gws)
+	}
+}
+
+func TestHolderPartitionedFailsClosed(t *testing.T) {
+	h := appsnapshot.NewHolder()
+	h.SetPartitioned([]byte("global"), "vg", map[string]appsnapshot.ScopedSnapshot{
+		"acme": {Raw: []byte("acme-cfg"), Version: "va"},
+	})
+
+	if raw, version, ok := h.SnapshotFor(""); !ok || string(raw) != "global" || version != "vg" {
+		t.Fatalf("empty scope = (%q,%q,%v), want the whole snapshot", raw, version, ok)
+	}
+	if raw, version, ok := h.SnapshotFor("acme"); !ok || string(raw) != "acme-cfg" || version != "va" {
+		t.Fatalf("acme scope = (%q,%q,%v), want the acme snapshot", raw, version, ok)
+	}
+	if _, _, ok := h.SnapshotFor("globex"); ok {
+		t.Fatal("unknown scope must fail closed, not fall back to the whole snapshot")
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -144,12 +144,34 @@ type Config struct {
 	ConfigSync       ConfigSyncConfig
 }
 
+// Config-sync control-plane auth modes. shared keeps the historical
+// constant-time shared-token compare; signed verifies a signed JWT and extracts
+// its opaque scope claim.
+const (
+	ConfigSyncAuthModeShared = "shared"
+	ConfigSyncAuthModeSigned = "signed"
+)
+
 type ConfigSyncConfig struct {
 	DataPlaneEnabled bool
 	Token            string // #nosec G117 -- config struct field, not a hardcoded credential
 	// TokenPrevious is the prior bearer accepted alongside Token so a token can be
 	// rotated without a window where in-flight data planes fail to authenticate.
-	TokenPrevious     string // #nosec G117 -- config struct field, not a hardcoded credential
+	TokenPrevious string // #nosec G117 -- config struct field, not a hardcoded credential
+	// AuthMode selects how the control plane verifies the data-plane bearer:
+	// ConfigSyncAuthModeShared (constant-time compare against the shared token)
+	// or ConfigSyncAuthModeSigned (verify a signed JWT and extract its opaque
+	// scope claim). It is chosen explicitly; there is no auto-detection and no
+	// fallback from signed to shared.
+	AuthMode string
+	// JWTPublicKey is the PEM-encoded PKIX public key that verifies signed
+	// tokens. Required when AuthMode is signed.
+	JWTPublicKey string // #nosec G117 -- config struct field, not a hardcoded credential
+	// JWTJWKSURL is reserved for JWKS-based verification (not yet wired).
+	JWTJWKSURL string
+	// JWTIssuer and JWTAudience are the expected iss/aud claims in signed mode.
+	JWTIssuer         string
+	JWTAudience       string
 	LKGPath           string
 	LKGKey            string // #nosec G117 -- config struct field, not a hardcoded credential
 	PollInterval      time.Duration
@@ -592,6 +614,11 @@ func getConfigSyncConfig() ConfigSyncConfig {
 		DataPlaneEnabled:     getEnvBool("CONFIG_SYNC_DATA_PLANE_ENABLED", defaultConfigSyncDataPlaneEnabled),
 		Token:                getEnv("CONFIG_SYNC_TOKEN", ""),
 		TokenPrevious:        getEnv("CONFIG_SYNC_TOKEN_PREVIOUS", ""),
+		AuthMode:             normalizeConfigSyncAuthMode(getEnv("CONFIG_SYNC_AUTH_MODE", ConfigSyncAuthModeShared)),
+		JWTPublicKey:         getEnv("CONFIG_SYNC_JWT_PUBLIC_KEY", ""),
+		JWTJWKSURL:           getEnv("CONFIG_SYNC_JWT_JWKS_URL", ""),
+		JWTIssuer:            getEnv("CONFIG_SYNC_JWT_ISSUER", ""),
+		JWTAudience:          getEnv("CONFIG_SYNC_JWT_AUDIENCE", ""),
 		LKGPath:              getEnv("CONFIG_SYNC_LKG_PATH", defaultConfigSyncLKGPath),
 		LKGKey:               getEnv("CONFIG_SYNC_LKG_KEY", ""),
 		PollInterval:         getEnvDuration("CONFIG_SYNC_POLL_INTERVAL", defaultConfigSyncPollInterval),
@@ -612,6 +639,10 @@ func getConfigSyncConfig() ConfigSyncConfig {
 		OutboxRetention:      getEnvDuration("CONFIG_SYNC_OUTBOX_RETENTION", defaultConfigSyncOutboxRetention),
 		OutboxMaxRows:        getEnvInt64("CONFIG_SYNC_OUTBOX_MAX_ROWS", defaultConfigSyncOutboxMaxRows),
 	}
+}
+
+func normalizeConfigSyncAuthMode(mode string) string {
+	return strings.ToLower(strings.TrimSpace(mode))
 }
 
 func resolveConfigSyncInstanceID() string {
@@ -700,10 +731,36 @@ func (c *Config) Validate() error {
 	if c.isDeployed() && c.ConfigSync.DataPlaneEnabled && c.ConfigSync.TLSInsecure {
 		return fmt.Errorf("%w: CONFIG_SYNC_TLS_INSECURE must not be true in deployed environments so the config-sync channel is not sent in cleartext", errors.ErrInvalidConfig)
 	}
+	if err := c.ConfigSync.validateAuthMode(); err != nil {
+		return err
+	}
 	if err := c.ConfigSync.Validate(); err != nil {
 		return err
 	}
 	return nil
+}
+
+// validateAuthMode checks the control-plane config-sync auth strategy. signed
+// mode fails closed at boot when its verification key or expected claims are
+// missing; an unknown mode is rejected outright.
+func (cs ConfigSyncConfig) validateAuthMode() error {
+	switch cs.AuthMode {
+	case "", ConfigSyncAuthModeShared:
+		return nil
+	case ConfigSyncAuthModeSigned:
+		if cs.JWTPublicKey == "" {
+			if cs.JWTJWKSURL != "" {
+				return fmt.Errorf("%w: CONFIG_SYNC_AUTH_MODE=signed with JWKS is not yet supported; set CONFIG_SYNC_JWT_PUBLIC_KEY", errors.ErrInvalidConfig)
+			}
+			return fmt.Errorf("%w: CONFIG_SYNC_AUTH_MODE=signed requires CONFIG_SYNC_JWT_PUBLIC_KEY", errors.ErrInvalidConfig)
+		}
+		if cs.JWTIssuer == "" || cs.JWTAudience == "" {
+			return fmt.Errorf("%w: CONFIG_SYNC_AUTH_MODE=signed requires CONFIG_SYNC_JWT_ISSUER and CONFIG_SYNC_JWT_AUDIENCE", errors.ErrInvalidConfig)
+		}
+		return nil
+	default:
+		return fmt.Errorf("%w: CONFIG_SYNC_AUTH_MODE must be %q or %q", errors.ErrInvalidConfig, ConfigSyncAuthModeShared, ConfigSyncAuthModeSigned)
+	}
 }
 
 // IsDeployed reports whether APP_ENV marks a non-local deployment (staging or

--- a/pkg/config/configsync_auth_test.go
+++ b/pkg/config/configsync_auth_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	stderrors "errors"
+	"testing"
+
+	"github.com/NeuralTrust/TrustGate/pkg/common/errors"
+)
+
+func TestConfigSyncValidateAuthMode(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     ConfigSyncConfig
+		wantErr bool
+	}{
+		{name: "shared default", cfg: ConfigSyncConfig{AuthMode: ConfigSyncAuthModeShared}, wantErr: false},
+		{name: "unknown mode", cfg: ConfigSyncConfig{AuthMode: "magic"}, wantErr: true},
+		{name: "signed without key", cfg: ConfigSyncConfig{AuthMode: ConfigSyncAuthModeSigned, JWTIssuer: "i", JWTAudience: "a"}, wantErr: true},
+		{name: "signed jwks only", cfg: ConfigSyncConfig{AuthMode: ConfigSyncAuthModeSigned, JWTJWKSURL: "https://x/jwks", JWTIssuer: "i", JWTAudience: "a"}, wantErr: true},
+		{name: "signed without iss/aud", cfg: ConfigSyncConfig{AuthMode: ConfigSyncAuthModeSigned, JWTPublicKey: "pem"}, wantErr: true},
+		{name: "signed complete", cfg: ConfigSyncConfig{AuthMode: ConfigSyncAuthModeSigned, JWTPublicKey: "pem", JWTIssuer: "i", JWTAudience: "a"}, wantErr: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.validateAuthMode()
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantErr && err != nil && !stderrors.Is(err, errors.ErrInvalidConfig) {
+				t.Fatalf("error = %v, want ErrInvalidConfig", err)
+			}
+		})
+	}
+}
+
+func TestNormalizeConfigSyncAuthMode(t *testing.T) {
+	for in, want := range map[string]string{
+		"  Shared ": ConfigSyncAuthModeShared,
+		"SIGNED":    ConfigSyncAuthModeSigned,
+		"":          "",
+	} {
+		if got := normalizeConfigSyncAuthMode(in); got != want {
+			t.Fatalf("normalize(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/pkg/infra/configsync/grpc/authenticator.go
+++ b/pkg/infra/configsync/grpc/authenticator.go
@@ -1,0 +1,140 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpc
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+
+	"github.com/NeuralTrust/TrustGate/pkg/config"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// signedTokenAlgorithms is the allowlist of JWT signing algorithms accepted in
+// signed mode. "none" is deliberately excluded so an unsigned token is rejected.
+var signedTokenAlgorithms = []string{"EdDSA", "ES256", "RS256"}
+
+var (
+	errAuthNotConfigured = errors.New("config-sync auth is not configured")
+	errUnauthenticated   = errors.New("missing or invalid config-sync token")
+)
+
+// scopeAuthenticator validates a presented bearer and returns the partition
+// scope it authorizes. An empty scope denotes the whole, unpartitioned config.
+type scopeAuthenticator interface {
+	authenticate(bearer string) (scope string, err error)
+}
+
+// sharedAuthenticator compares the presented bearer, in constant time, against
+// the configured current and previous shared-token digests. It never grants a
+// scope: the shared token identifies no partition, so the scope is always empty.
+type sharedAuthenticator struct {
+	tokenDigests [][32]byte
+}
+
+func newSharedAuthenticator(cfg config.ConfigSyncConfig) *sharedAuthenticator {
+	auth := &sharedAuthenticator{}
+	if cfg.Token != "" {
+		auth.tokenDigests = append(auth.tokenDigests, sha256.Sum256([]byte(cfg.Token)))
+		if cfg.TokenPrevious != "" {
+			auth.tokenDigests = append(auth.tokenDigests, sha256.Sum256([]byte(cfg.TokenPrevious)))
+		}
+	}
+	return auth
+}
+
+func (s *sharedAuthenticator) configured() bool { return len(s.tokenDigests) > 0 }
+
+func (s *sharedAuthenticator) authenticate(bearer string) (string, error) {
+	if !s.configured() {
+		return "", errAuthNotConfigured
+	}
+	if bearer == "" {
+		return "", errUnauthenticated
+	}
+	providedDigest := sha256.Sum256([]byte(bearer))
+	matched := 0
+	for _, digest := range s.tokenDigests {
+		matched |= subtle.ConstantTimeCompare(providedDigest[:], digest[:])
+	}
+	if matched != 1 {
+		return "", errUnauthenticated
+	}
+	return "", nil
+}
+
+// jwtAuthenticator verifies a signed JWT (allowlisted algorithm, expected
+// issuer/audience, required expiry) and extracts its opaque scope claim. It
+// fails closed: any verification failure or a missing scope yields an
+// unauthenticated error and never falls back to shared-token behavior.
+type jwtAuthenticator struct {
+	parser  *jwt.Parser
+	keyfunc jwt.Keyfunc
+}
+
+func newJWTAuthenticator(cfg config.ConfigSyncConfig) (*jwtAuthenticator, error) {
+	if cfg.JWTPublicKey == "" {
+		return nil, errors.New("config-sync signed mode requires a JWT public key")
+	}
+	key, err := parsePKIXPublicKeyPEM(cfg.JWTPublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("parse config-sync JWT public key: %w", err)
+	}
+	opts := []jwt.ParserOption{
+		jwt.WithValidMethods(signedTokenAlgorithms),
+		jwt.WithExpirationRequired(),
+	}
+	if cfg.JWTIssuer != "" {
+		opts = append(opts, jwt.WithIssuer(cfg.JWTIssuer))
+	}
+	if cfg.JWTAudience != "" {
+		opts = append(opts, jwt.WithAudience(cfg.JWTAudience))
+	}
+	return &jwtAuthenticator{
+		parser:  jwt.NewParser(opts...),
+		keyfunc: func(*jwt.Token) (any, error) { return key, nil },
+	}, nil
+}
+
+func (j *jwtAuthenticator) authenticate(bearer string) (string, error) {
+	if bearer == "" {
+		return "", errUnauthenticated
+	}
+	claims := jwt.MapClaims{}
+	if _, err := j.parser.ParseWithClaims(bearer, claims, j.keyfunc); err != nil {
+		return "", errUnauthenticated
+	}
+	scope, ok := claims["scope"].(string)
+	if !ok || scope == "" {
+		return "", errUnauthenticated
+	}
+	return scope, nil
+}
+
+func parsePKIXPublicKeyPEM(pemStr string) (any, error) {
+	block, _ := pem.Decode([]byte(pemStr))
+	if block == nil {
+		return nil, errors.New("no PEM block found")
+	}
+	key, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	return key, nil
+}

--- a/pkg/infra/configsync/grpc/authenticator_test.go
+++ b/pkg/infra/configsync/grpc/authenticator_test.go
@@ -1,0 +1,167 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpc
+
+import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+	"time"
+
+	"github.com/NeuralTrust/TrustGate/pkg/config"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+const (
+	testIssuer   = "datacore"
+	testAudience = "trustgate-config-sync"
+)
+
+func newSignedTestConfig(t *testing.T) (config.ConfigSyncConfig, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		t.Fatalf("marshal public key: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})
+	cfg := config.ConfigSyncConfig{
+		AuthMode:     config.ConfigSyncAuthModeSigned,
+		JWTPublicKey: string(pemBytes),
+		JWTIssuer:    testIssuer,
+		JWTAudience:  testAudience,
+	}
+	return cfg, priv
+}
+
+func mint(t *testing.T, priv ed25519.PrivateKey, method jwt.SigningMethod, claims jwt.MapClaims) string {
+	t.Helper()
+	token := jwt.NewWithClaims(method, claims)
+	var (
+		signed string
+		err    error
+	)
+	if method == jwt.SigningMethodNone {
+		signed, err = token.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	} else {
+		signed, err = token.SignedString(priv)
+	}
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+	return signed
+}
+
+func validClaims() jwt.MapClaims {
+	return jwt.MapClaims{
+		"iss":   testIssuer,
+		"aud":   testAudience,
+		"scope": "org_1",
+		"exp":   time.Now().Add(time.Hour).Unix(),
+	}
+}
+
+func TestJWTAuthenticator_ValidTokenExtractsScope(t *testing.T) {
+	cfg, priv := newSignedTestConfig(t)
+	auth, err := newJWTAuthenticator(cfg)
+	if err != nil {
+		t.Fatalf("newJWTAuthenticator: %v", err)
+	}
+	scope, err := auth.authenticate(mint(t, priv, jwt.SigningMethodEdDSA, validClaims()))
+	if err != nil {
+		t.Fatalf("authenticate: %v", err)
+	}
+	if scope != "org_1" {
+		t.Fatalf("scope = %q, want org_1", scope)
+	}
+}
+
+func TestJWTAuthenticator_Rejects(t *testing.T) {
+	cfg, priv := newSignedTestConfig(t)
+	auth, err := newJWTAuthenticator(cfg)
+	if err != nil {
+		t.Fatalf("newJWTAuthenticator: %v", err)
+	}
+	_, otherPriv, _ := ed25519.GenerateKey(nil)
+
+	cases := map[string]string{
+		"empty":         "",
+		"garbage":       "not-a-jwt",
+		"alg_none":      mint(t, priv, jwt.SigningMethodNone, validClaims()),
+		"bad_signature": mint(t, otherPriv, jwt.SigningMethodEdDSA, validClaims()),
+		"expired": mint(t, priv, jwt.SigningMethodEdDSA, jwt.MapClaims{
+			"iss": testIssuer, "aud": testAudience, "scope": "org_1",
+			"exp": time.Now().Add(-time.Hour).Unix(),
+		}),
+		"no_exp": mint(t, priv, jwt.SigningMethodEdDSA, jwt.MapClaims{
+			"iss": testIssuer, "aud": testAudience, "scope": "org_1",
+		}),
+		"wrong_issuer": mint(t, priv, jwt.SigningMethodEdDSA, jwt.MapClaims{
+			"iss": "evil", "aud": testAudience, "scope": "org_1",
+			"exp": time.Now().Add(time.Hour).Unix(),
+		}),
+		"wrong_audience": mint(t, priv, jwt.SigningMethodEdDSA, jwt.MapClaims{
+			"iss": testIssuer, "aud": "other", "scope": "org_1",
+			"exp": time.Now().Add(time.Hour).Unix(),
+		}),
+		"missing_scope": mint(t, priv, jwt.SigningMethodEdDSA, jwt.MapClaims{
+			"iss": testIssuer, "aud": testAudience,
+			"exp": time.Now().Add(time.Hour).Unix(),
+		}),
+	}
+	for name, token := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := auth.authenticate(token); err == nil {
+				t.Fatalf("expected rejection for %s", name)
+			}
+		})
+	}
+}
+
+func TestSharedAuthenticator(t *testing.T) {
+	auth := newSharedAuthenticator(config.ConfigSyncConfig{Token: "tok", TokenPrevious: "old"})
+	for _, tok := range []string{"tok", "old"} {
+		scope, err := auth.authenticate(tok)
+		if err != nil {
+			t.Fatalf("authenticate(%q): %v", tok, err)
+		}
+		if scope != "" {
+			t.Fatalf("shared scope = %q, want empty", scope)
+		}
+	}
+	if _, err := auth.authenticate("wrong"); err == nil {
+		t.Fatal("expected rejection for wrong token")
+	}
+	unconfigured := newSharedAuthenticator(config.ConfigSyncConfig{})
+	if _, err := unconfigured.authenticate("anything"); err == nil {
+		t.Fatal("expected rejection when no token configured")
+	}
+}
+
+func TestNewAuthInterceptor_SignedRequiresValidKey(t *testing.T) {
+	_, err := NewAuthInterceptor(&config.Config{ConfigSync: config.ConfigSyncConfig{
+		AuthMode:     config.ConfigSyncAuthModeSigned,
+		JWTPublicKey: "-----BEGIN PUBLIC KEY-----\nnot-base64\n-----END PUBLIC KEY-----",
+		JWTIssuer:    testIssuer,
+		JWTAudience:  testAudience,
+	}}, discardLogger())
+	if err == nil {
+		t.Fatal("expected error for malformed public key")
+	}
+}

--- a/pkg/infra/configsync/grpc/client_test.go
+++ b/pkg/infra/configsync/grpc/client_test.go
@@ -46,7 +46,7 @@ type fakeSource struct {
 	ok      bool
 }
 
-func (f *fakeSource) Snapshot() ([]byte, string, bool) {
+func (f *fakeSource) SnapshotFor(string) ([]byte, string, bool) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.raw, f.version, f.ok

--- a/pkg/infra/configsync/grpc/interceptor.go
+++ b/pkg/infra/configsync/grpc/interceptor.go
@@ -19,8 +19,7 @@ package grpc
 
 import (
 	"context"
-	"crypto/sha256"
-	"crypto/subtle"
+	"errors"
 	"log/slog"
 	"strings"
 
@@ -37,32 +36,40 @@ const (
 	component       = "configsync-grpc"
 )
 
-// AuthInterceptor authenticates config-sync RPCs by comparing the presented
-// bearer token digest against the configured current and previous token digests
-// with a constant-time compare. It fails closed when no token is configured.
+// AuthInterceptor authenticates config-sync RPCs with the configured strategy
+// (shared token or signed JWT) and propagates the resolved partition scope down
+// the request context. It fails closed when auth is not configured.
 type AuthInterceptor struct {
-	tokenDigests [][32]byte
-	logger       *slog.Logger
+	authenticator scopeAuthenticator
+	logger        *slog.Logger
 }
 
-// NewAuthInterceptor builds an AuthInterceptor from the config-sync tokens,
-// warning once when no token is configured so the operator learns the transport
-// will reject every RPC.
-func NewAuthInterceptor(cfg *config.Config, logger *slog.Logger) *AuthInterceptor {
+// NewAuthInterceptor builds an AuthInterceptor for the configured auth mode.
+// signed mode returns an error when the JWT verification key cannot be loaded so
+// the process fails at boot rather than silently rejecting every RPC. shared
+// mode warns once when no token is configured.
+func NewAuthInterceptor(cfg *config.Config, logger *slog.Logger) (*AuthInterceptor, error) {
 	if logger == nil {
 		logger = slog.Default()
 	}
 	interceptor := &AuthInterceptor{logger: logger}
-	if cfg.ConfigSync.Token != "" {
-		interceptor.tokenDigests = append(interceptor.tokenDigests, sha256.Sum256([]byte(cfg.ConfigSync.Token)))
-		if cfg.ConfigSync.TokenPrevious != "" {
-			interceptor.tokenDigests = append(interceptor.tokenDigests, sha256.Sum256([]byte(cfg.ConfigSync.TokenPrevious)))
+	switch cfg.ConfigSync.AuthMode {
+	case config.ConfigSyncAuthModeSigned:
+		authenticator, err := newJWTAuthenticator(cfg.ConfigSync)
+		if err != nil {
+			return nil, err
 		}
-	} else {
-		logger.Warn("config-sync token is not configured; the gRPC transport will reject every RPC and no data plane can converge",
-			slog.String("component", component))
+		interceptor.authenticator = authenticator
+		logger.Info("config-sync auth: signed JWT mode enabled", slog.String("component", component))
+	default:
+		shared := newSharedAuthenticator(cfg.ConfigSync)
+		if !shared.configured() {
+			logger.Warn("config-sync token is not configured; the gRPC transport will reject every RPC and no data plane can converge",
+				slog.String("component", component))
+		}
+		interceptor.authenticator = shared
 	}
-	return interceptor
+	return interceptor, nil
 }
 
 // UnaryServerInterceptor authenticates unary RPCs before the handler runs and
@@ -90,27 +97,20 @@ func (a *AuthInterceptor) StreamServerInterceptor() grpc.StreamServerInterceptor
 }
 
 // authorize validates the bearer token and returns a context carrying the
-// resolved partition scope. In the shared-token mode the scope is empty, which
-// downstream resolves to the whole, unpartitioned config.
+// resolved partition scope. In shared mode the scope is empty, which downstream
+// resolves to the whole, unpartitioned config; in signed mode the scope is the
+// opaque claim extracted from the verified JWT.
 func (a *AuthInterceptor) authorize(ctx context.Context) (context.Context, error) {
-	if len(a.tokenDigests) == 0 {
-		a.logger.Debug("config-sync token is not configured; rejecting RPC",
-			slog.String("component", component))
-		return ctx, status.Error(codes.Unauthenticated, "config-sync token is not configured")
-	}
-	provided := bearerFromContext(ctx)
-	if provided == "" {
+	scope, err := a.authenticator.authenticate(bearerFromContext(ctx))
+	if err != nil {
+		if errors.Is(err, errAuthNotConfigured) {
+			a.logger.Debug("config-sync auth is not configured; rejecting RPC",
+				slog.String("component", component))
+			return ctx, status.Error(codes.Unauthenticated, "config-sync auth is not configured")
+		}
 		return ctx, status.Error(codes.Unauthenticated, "missing or invalid config-sync token")
 	}
-	providedDigest := sha256.Sum256([]byte(provided))
-	matched := 0
-	for _, digest := range a.tokenDigests {
-		matched |= subtle.ConstantTimeCompare(providedDigest[:], digest[:])
-	}
-	if matched != 1 {
-		return ctx, status.Error(codes.Unauthenticated, "missing or invalid config-sync token")
-	}
-	return WithScope(ctx, ""), nil
+	return WithScope(ctx, scope), nil
 }
 
 // scopedServerStream overrides the stream context so handlers observe the scope

--- a/pkg/infra/configsync/grpc/interceptor.go
+++ b/pkg/infra/configsync/grpc/interceptor.go
@@ -65,35 +65,42 @@ func NewAuthInterceptor(cfg *config.Config, logger *slog.Logger) *AuthIntercepto
 	return interceptor
 }
 
-// UnaryServerInterceptor authenticates unary RPCs before the handler runs.
+// UnaryServerInterceptor authenticates unary RPCs before the handler runs and
+// propagates the resolved partition scope down the context.
 func (a *AuthInterceptor) UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
-		if err := a.authorize(ctx); err != nil {
+		scoped, err := a.authorize(ctx)
+		if err != nil {
 			return nil, err
 		}
-		return handler(ctx, req)
+		return handler(scoped, req)
 	}
 }
 
-// StreamServerInterceptor authenticates streaming RPCs before the handler runs.
+// StreamServerInterceptor authenticates streaming RPCs before the handler runs
+// and propagates the resolved partition scope down the stream context.
 func (a *AuthInterceptor) StreamServerInterceptor() grpc.StreamServerInterceptor {
 	return func(srv any, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-		if err := a.authorize(ss.Context()); err != nil {
+		scoped, err := a.authorize(ss.Context())
+		if err != nil {
 			return err
 		}
-		return handler(srv, ss)
+		return handler(srv, &scopedServerStream{ServerStream: ss, ctx: scoped})
 	}
 }
 
-func (a *AuthInterceptor) authorize(ctx context.Context) error {
+// authorize validates the bearer token and returns a context carrying the
+// resolved partition scope. In the shared-token mode the scope is empty, which
+// downstream resolves to the whole, unpartitioned config.
+func (a *AuthInterceptor) authorize(ctx context.Context) (context.Context, error) {
 	if len(a.tokenDigests) == 0 {
 		a.logger.Debug("config-sync token is not configured; rejecting RPC",
 			slog.String("component", component))
-		return status.Error(codes.Unauthenticated, "config-sync token is not configured")
+		return ctx, status.Error(codes.Unauthenticated, "config-sync token is not configured")
 	}
 	provided := bearerFromContext(ctx)
 	if provided == "" {
-		return status.Error(codes.Unauthenticated, "missing or invalid config-sync token")
+		return ctx, status.Error(codes.Unauthenticated, "missing or invalid config-sync token")
 	}
 	providedDigest := sha256.Sum256([]byte(provided))
 	matched := 0
@@ -101,10 +108,19 @@ func (a *AuthInterceptor) authorize(ctx context.Context) error {
 		matched |= subtle.ConstantTimeCompare(providedDigest[:], digest[:])
 	}
 	if matched != 1 {
-		return status.Error(codes.Unauthenticated, "missing or invalid config-sync token")
+		return ctx, status.Error(codes.Unauthenticated, "missing or invalid config-sync token")
 	}
-	return nil
+	return WithScope(ctx, ""), nil
 }
+
+// scopedServerStream overrides the stream context so handlers observe the scope
+// resolved by the interceptor.
+type scopedServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (s *scopedServerStream) Context() context.Context { return s.ctx }
 
 func bearerFromContext(ctx context.Context) string {
 	md, ok := metadata.FromIncomingContext(ctx)

--- a/pkg/infra/configsync/grpc/interceptor_test.go
+++ b/pkg/infra/configsync/grpc/interceptor_test.go
@@ -27,10 +27,15 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func testInterceptor(token, previous string) *AuthInterceptor {
+func testInterceptor(t *testing.T, token, previous string) *AuthInterceptor {
+	t.Helper()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	cfg := &config.Config{ConfigSync: config.ConfigSyncConfig{Token: token, TokenPrevious: previous}}
-	return NewAuthInterceptor(cfg, logger)
+	interceptor, err := NewAuthInterceptor(cfg, logger)
+	if err != nil {
+		t.Fatalf("NewAuthInterceptor: %v", err)
+	}
+	return interceptor
 }
 
 func contextWithAuth(header string, set bool) context.Context {
@@ -83,7 +88,7 @@ func TestAuthInterceptor_Unary(t *testing.T) {
 	for _, tc := range authCases() {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			interceptor := testInterceptor(tc.token, tc.previous)
+			interceptor := testInterceptor(t, tc.token, tc.previous)
 			ctx := contextWithAuth(tc.header, tc.setMeta)
 			called := false
 			handler := func(context.Context, any) (any, error) {
@@ -105,7 +110,7 @@ func TestAuthInterceptor_Stream(t *testing.T) {
 	for _, tc := range authCases() {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			interceptor := testInterceptor(tc.token, tc.previous)
+			interceptor := testInterceptor(t, tc.token, tc.previous)
 			ctx := contextWithAuth(tc.header, tc.setMeta)
 			called := false
 			handler := func(any, grpc.ServerStream) error {

--- a/pkg/infra/configsync/grpc/scope.go
+++ b/pkg/infra/configsync/grpc/scope.go
@@ -1,0 +1,35 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpc
+
+import "context"
+
+type scopeContextKeyType struct{}
+
+var scopeContextKey scopeContextKeyType
+
+// WithScope returns a context carrying the config-sync partition scope key. An
+// empty scope denotes the whole, unpartitioned config, which preserves the
+// single-tenant behavior.
+func WithScope(ctx context.Context, scope string) context.Context {
+	return context.WithValue(ctx, scopeContextKey, scope)
+}
+
+// ScopeFromContext returns the partition scope key set upstream by the auth
+// interceptor, or "" when none is present (unpartitioned / single-tenant).
+func ScopeFromContext(ctx context.Context) string {
+	scope, _ := ctx.Value(scopeContextKey).(string)
+	return scope
+}

--- a/pkg/infra/configsync/grpc/scope_test.go
+++ b/pkg/infra/configsync/grpc/scope_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/NeuralTrust/TrustGate/pkg/config"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestScopeContextRoundTrip(t *testing.T) {
+	ctx := WithScope(context.Background(), "org_42")
+	if got := ScopeFromContext(ctx); got != "org_42" {
+		t.Fatalf("scope = %q, want org_42", got)
+	}
+	if got := ScopeFromContext(context.Background()); got != "" {
+		t.Fatalf("missing scope = %q, want empty", got)
+	}
+}
+
+type recordingStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (s *recordingStream) Context() context.Context { return s.ctx }
+
+func TestStreamInterceptorInjectsScope(t *testing.T) {
+	auth := NewAuthInterceptor(&config.Config{ConfigSync: config.ConfigSyncConfig{Token: "tok"}}, discardLogger())
+	md := metadata.New(map[string]string{authMetadataKey: bearerPrefix + "tok"})
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+
+	var seen string
+	invoked := false
+	handler := func(_ any, ss grpc.ServerStream) error {
+		seen = ScopeFromContext(ss.Context())
+		invoked = true
+		return nil
+	}
+	if err := auth.StreamServerInterceptor()(nil, &recordingStream{ctx: ctx}, &grpc.StreamServerInfo{}, handler); err != nil {
+		t.Fatalf("interceptor: %v", err)
+	}
+	if !invoked {
+		t.Fatal("handler was not invoked")
+	}
+	if seen != "" {
+		t.Fatalf("shared-mode scope = %q, want empty", seen)
+	}
+}

--- a/pkg/infra/configsync/grpc/scope_test.go
+++ b/pkg/infra/configsync/grpc/scope_test.go
@@ -41,7 +41,10 @@ type recordingStream struct {
 func (s *recordingStream) Context() context.Context { return s.ctx }
 
 func TestStreamInterceptorInjectsScope(t *testing.T) {
-	auth := NewAuthInterceptor(&config.Config{ConfigSync: config.ConfigSyncConfig{Token: "tok"}}, discardLogger())
+	auth, err := NewAuthInterceptor(&config.Config{ConfigSync: config.ConfigSyncConfig{Token: "tok"}}, discardLogger())
+	if err != nil {
+		t.Fatalf("NewAuthInterceptor: %v", err)
+	}
 	md := metadata.New(map[string]string{authMetadataKey: bearerPrefix + "tok"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 

--- a/pkg/infra/configsync/grpc/server_test.go
+++ b/pkg/infra/configsync/grpc/server_test.go
@@ -35,7 +35,10 @@ func startServer(t *testing.T, token string, src SnapshotSource) *Server {
 		GRPCKeepaliveTime:    30 * time.Second,
 		GRPCKeepaliveTimeout: 10 * time.Second,
 	}
-	auth := NewAuthInterceptor(&config.Config{ConfigSync: config.ConfigSyncConfig{Token: token}}, discardLogger())
+	auth, err := NewAuthInterceptor(&config.Config{ConfigSync: config.ConfigSyncConfig{Token: token}}, discardLogger())
+	if err != nil {
+		t.Fatalf("NewAuthInterceptor: %v", err)
+	}
 	svc := NewService(NewHub(discardLogger()), src, discardLogger())
 	srv, err := NewServer(cfg, svc, auth, discardLogger())
 	if err != nil {

--- a/pkg/infra/configsync/grpc/service.go
+++ b/pkg/infra/configsync/grpc/service.go
@@ -29,10 +29,11 @@ const (
 	snapshotChunkSize = 1 << 20
 )
 
-// SnapshotSource yields the current compiled snapshot bytes and version. The
+// SnapshotSource yields the compiled snapshot bytes and version for a given
+// partition scope. An empty scope means the whole, unpartitioned config. The
 // control-plane Holder satisfies it.
 type SnapshotSource interface {
-	Snapshot() (raw []byte, version string, ok bool)
+	SnapshotFor(scope string) (raw []byte, version string, ok bool)
 }
 
 // Service implements the ConfigSync gRPC server: the bidi Sync control channel
@@ -68,7 +69,8 @@ func (s *Service) Sync(stream snapshotpb.ConfigSync_SyncServer) error {
 	conn := s.hub.register(hello.GetInstanceId())
 	defer s.hub.unregister(conn)
 
-	if _, version, ok := s.source.Snapshot(); ok && version != hello.GetLastAppliedVersion() {
+	scope := ScopeFromContext(ctx)
+	if _, version, ok := s.source.SnapshotFor(scope); ok && version != hello.GetLastAppliedVersion() {
 		conn.enqueue(version)
 	}
 
@@ -107,7 +109,8 @@ func (s *Service) Sync(stream snapshotpb.ConfigSync_SyncServer) error {
 // GetSnapshot answers not_modified when the DP's applied_version matches current,
 // otherwise streams a SnapshotHeader followed by fixed-size data chunks.
 func (s *Service) GetSnapshot(req *snapshotpb.GetSnapshotRequest, stream snapshotpb.ConfigSync_GetSnapshotServer) error {
-	raw, version, ok := s.source.Snapshot()
+	scope := ScopeFromContext(stream.Context())
+	raw, version, ok := s.source.SnapshotFor(scope)
 	if !ok {
 		return status.Error(codes.Unavailable, "no snapshot available yet")
 	}


### PR DESCRIPTION
> Stacked on #180 (RUN-907) → #179 (RUN-906). Review/merge the stack in order; diff is against develop.

## Summary
Lets the control plane serve a data plane **only its partition's config**, keyed by the opaque scope (`metadata.team_id`):
- **`Compiler.CompileFor(ctx, scope)`** filters gateways — and their consumers, registries, policies, auths, roles — by `metadata.team_id`. Empty scope = the whole config (unchanged).
- **`Compiler.CompileAll(ctx)`** builds the whole snapshot **plus one snapshot per non-empty scope in a single pass**, sharing catalog (providers/models) across scopes (one gateway listing, not N).
- **`Holder`** is multi-scope: `SetPartitioned` atomically replaces the whole snapshot and the entire per-scope map (removed scopes stop being served). **`SnapshotFor(scope)` fails closed** for an unknown scope and never falls back to the whole snapshot.
- **`Dispatcher`** publishes per-scope snapshots when its compiler implements the optional `PartitionedCompiler`; otherwise the whole-snapshot path is byte-for-byte unchanged.

## Isolation (acceptance criteria)
- `CompileFor("acme")` includes only `team_id=acme` gateways + all their associated config; excludes `globex`. ✔ tested
- `CompileAll` partitions both tenants and carries shared catalog into each scope. ✔ tested
- Unknown scope → `SnapshotFor` denies (no global leak). ✔ tested

## Notes / follow-ups
- Cost: `CompileAll` recompiles every scope each dispatch. Lazy per-scope cache + outbox-marker-driven invalidation is a deliberate follow-up (called out in RUN-908).
- Broadcast stays global (any change bumps the version); each DP re-pulls and `GetSnapshot` returns its scope's snapshot with its own version (RUN-906), so `not_modified` is per scope. Scope-targeted broadcast is optional per the issue.
- A DB index on `metadata.team_id` is coordinated with the security sub-issue (RUN-912).

Linear: RUN-908 — https://linear.app/neuraltrust/issue/RUN-908

## Test plan
- [x] `go build ./...`, `go vet`, pre-commit
- [x] `go test ./pkg/app/configsnapshot/... ./pkg/infra/configsync/...`
- [ ] With partitioned compiler live, a scoped DP converges to only its gateways.

Made with [Cursor](https://cursor.com)