### PR TITLE
feat(config-sync): multi-tenant scope for hybrid pull-config (RUN-905)

### DIFF
--- a/docs/config-sync-enrolment-credential.md
+++ b/docs/config-sync-enrolment-credential.md
@@ -1,0 +1,156 @@
+# Config-sync — credencial de enrolamiento del data plane
+
+Spec del **contrato de la credencial** que el data plane presenta al control plane
+en el transporte config-sync (gRPC). Es la fuente de verdad para la verificación
+(control plane OSS) y la emisión (DataCore / script de instalación).
+
+> Linear: RUN-910 (sub-issue de RUN-905). Afecta por igual a **TrustGate** y
+> **TrustGuard** (mismo mecanismo de pull config).
+
+## Contexto
+
+Hoy el data plane se autentica con un **bearer token compartido**
+(`CONFIG_SYNC_TOKEN`) que el control plane compara en tiempo constante contra el
+digest del token actual/anterior. Ese token **no lleva identidad**: el control
+plane sirve un único snapshot global a cualquier data plane autenticado.
+
+Para el modo **híbrido** (control plane = SaaS de NeuralTrust, data plane alojado
+por el cliente) la credencial debe **portar identidad de forma no falsificable**,
+de modo que el control plane sepa a qué partición (`scope`, que en la capa
+propietaria mapea a `tenant_id`) pertenece el data plane y le devuelva **solo su
+configuración**.
+
+Principio rector: **el `scope`/`tenant_id` efectivo nunca lo declara el cliente**;
+sale de algo que solo el emisor puede producir (una firma) o de una fila del
+emisor (lookup). La seguridad **no** depende de que el `scope` sea secreto.
+
+## El data plane no cambia
+
+El data plane manda un bearer opaco: copia `CONFIG_SYNC_TOKEN` en
+`authorization: Bearer <token>` sin interpretarlo. Le da igual si es un JWT firmado
+o un secreto aleatorio. **El método de validación lo decide el control plane**
+(`CONFIG_SYNC_AUTH_MODE`, ver RUN-907). Esta spec define el formato del token que
+el emisor produce y el verificador acepta.
+
+## Modo recomendado: JWT firmado
+
+### Algoritmo de firma
+
+- **EdDSA (Ed25519)** como opción por defecto (claves cortas, firma rápida,
+  sin parámetros ambiguos). Alternativas aceptables: `ES256` o `RS256`.
+- El verificador mantiene una **allowlist de `alg`** y **rechaza `none`** y
+  cualquier `alg` fuera de la lista (defensa frente a *algorithm confusion*).
+- La clave se identifica por **`kid`** en la cabecera JWT para permitir rotación.
+
+### Claims
+
+| Claim | Obligatorio | Descripción |
+|---|:---:|---|
+| `iss` | ✅ | Emisor. DataCore/CP en híbrido. Verificado contra `CONFIG_SYNC_JWT_ISSUER`. |
+| `aud` | ✅ | Audiencia fija del transporte config-sync. Verificado contra `CONFIG_SYNC_JWT_AUDIENCE`. |
+| `scope` | ✅ | Clave de partición **opaca** para el OSS. La capa propietaria la interpreta como `tenant_id`. Nombre único y estable. |
+| `exp` | ✅ | Expiración. Obliga a renovación/rotación. |
+| `iat` | ✅ | Emisión. |
+| `nbf` | ⬜ | *Not before* (si aplica). |
+| `jti` | ✅ | Identificador único del token, para revocación / anti-replay. |
+| `gateway_scope` | ⬜ | Restringe a un subconjunto de gateways dentro del `scope` (lista de gateway IDs). Vacío/ausente = todos los del `scope`. |
+| `sub` / `instance` | ⬜ | Identificador del deployment/DP (informativo; no es control de acceso). |
+
+> El OSS extrae únicamente `scope` (string opaca) y valida `iss`/`aud`/`exp`/`nbf`
+> + firma. **La palabra "tenant" no aparece en el OSS**; el mapeo
+> `scope → tenant_id` vive en la capa propietaria (RUN-909).
+
+### Ejemplo (payload)
+
+```json
+{
+  "iss": "datacore",
+  "aud": "trustgate-config-sync",
+  "scope": "org_7f3a9c2e-1b4d-4e8a-9c11-2d5f6a7b8c90",
+  "gateway_scope": [],
+  "iat": 1751980800,
+  "nbf": 1751980800,
+  "exp": 1752585600,
+  "jti": "b0f1c2d3-e4a5-6789-90ab-cdef01234567"
+}
+```
+
+## Alternativa: token opaco con lookup
+
+Cuando se prefiere no depender de verificación de firma en el hot path (o para el
+modo `shared` sin identidad), el token puede ser opaco:
+
+- Formato `"<key_id>.<secret>"`.
+- El verificador busca `key_id` en su almacén → `{ hash(secret), scope, estado }`.
+- Compara `secret` en **tiempo constante** contra el hash almacenado.
+- El `scope` **no viaja en el token**; se deriva de la fila del emisor.
+
+Ventaja: revocación inmediata (marcar `estado=revocado`). Coste: un lookup por
+conexión (mitigable con caché corta). El `scope` sigue siendo server-authoritative.
+
+## Rotación de claves
+
+- Cada credencial firmada indica su `kid`. El verificador mantiene un **conjunto
+  de claves activas** (`kid → public key`).
+- Al rotar, se publica la nueva pública **antes** de emitir con ella y se retira la
+  vieja **después** de que caduquen los tokens que la usaban (solapamiento sin
+  ventana de fallo). Es el equivalente firmado de
+  `CONFIG_SYNC_TOKEN` + `CONFIG_SYNC_TOKEN_PREVIOUS`.
+- Para el modo opaco, rotación = emitir nuevo `key_id` y marcar el viejo como
+  `deprecado` hasta expirar.
+
+## Revocación
+
+- **Por `jti`/`kid`**: lista de revocados consultada por el verificador (o TTL
+  corto que fuerza refresco). Necesario para *offboarding* de un cliente.
+- **Kill-switch** por `scope`: invalidar todas las credenciales de un `scope`.
+- Para el modo opaco, revocar = `estado=revocado` en el almacén.
+
+## Bootstrap vs long-lived
+
+Patrón alineado con `ENROLMENT_TOKEN` del subsistema de residencia
+(DataAgent/DataBridge):
+
+1. En el alta del gateway self-hosted, el emisor entrega un **token de
+   enrolamiento** (vida corta, de un solo uso).
+2. En el primer dial, el data plane **canjea** ese token por una **credencial de
+   larga duración** (JWT con `exp` razonable + rotación).
+3. El token de enrolamiento se **invalida** tras el canje, para no dejar vivo el
+   secreto de alta.
+
+> Nota: el canje requiere un endpoint de emisión en el control plane/DataCore
+> (fuera del alcance OSS; ver RUN-911). Para self-hosted 100% no aplica: el
+> `CONFIG_SYNC_TOKEN` es un secreto compartido sin identidad generado por el script
+> de instalación, y el control plane corre en modo `shared` (`scope` vacío →
+> snapshot global).
+
+## Variables de entorno relacionadas (verificación, RUN-907)
+
+```
+CONFIG_SYNC_AUTH_MODE      = shared | signed     # default: shared
+CONFIG_SYNC_JWT_PUBLIC_KEY = <PEM>               # o CONFIG_SYNC_JWT_JWKS_URL
+CONFIG_SYNC_JWT_ISSUER     = <iss esperado>
+CONFIG_SYNC_JWT_AUDIENCE   = <aud esperado>
+```
+
+En modo `signed`, un token no-JWT, con firma inválida, `alg:none`, `exp` vencido o
+`iss`/`aud` incorrectos se **rechaza sin fallback** a `shared` (fail-closed).
+
+## Requisitos de seguridad
+
+- El `scope`/`tenant_id` **nunca** se toma de un campo auto-declarado no firmado.
+- `alg` en allowlist; `none` prohibido.
+- `exp` obligatorio; `jti` para revocación/anti-replay.
+- Un token por deployment (radio de explosión = una partición).
+- No loguear tokens.
+- El control primario es la firma/lookup, no el secreto del `scope`
+  (asúmelo conocido por el atacante).
+
+## Referencias
+
+- `RUN-905` — diseño general (config-sync multi-tenant).
+- `RUN-907` — `CONFIG_SYNC_AUTH_MODE` + verificación JWT (consumidor de esta spec).
+- `RUN-909` — capa propietaria (`scope → tenant_id`).
+- `RUN-911` — emisión de credencial + evento data-plane-online (DataCore).
+- `pkg/infra/configsync/grpc/{interceptor,credentials}.go` — auth actual.
+- `pkg/config/config.go` — `ConfigSyncConfig`, `STS_ISSUER`/`STS_SIGNING_KEY`.

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -5917,6 +5917,14 @@ const docTemplate = `{
         "github_com_NeuralTrust_TrustGate_pkg_domain_telemetry.ExporterConfig": {
             "type": "object",
             "properties": {
+                "class": {
+                    "description": "Class binds the exporter to a data class, set from the group it is declared\nunder in the defaults file. Empty for per-gateway configs.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_metrics.DataClass"
+                        }
+                    ]
+                },
                 "name": {
                     "type": "string"
                 },
@@ -6084,7 +6092,7 @@ const docTemplate = `{
                 "status": {
                     "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_infra_metrics_events.Status"
                 },
-                "team_id": {
+                "tenant_id": {
                     "type": "string"
                 },
                 "timestamp": {
@@ -6322,6 +6330,17 @@ const docTemplate = `{
                     "type": "integer"
                 }
             }
+        },
+        "github_com_NeuralTrust_TrustGate_pkg_metrics.DataClass": {
+            "type": "string",
+            "enum": [
+                "metadata",
+                "raw"
+            ],
+            "x-enum-varnames": [
+                "Metadata",
+                "Raw"
+            ]
         },
         "github_com_NeuralTrust_TrustGate_pkg_version.Info": {
             "type": "object",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -76,6 +76,19 @@
                                 }
                             }
                         }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -94,8 +107,8 @@
                 "summary": "List gateways",
                 "parameters": [
                     {
-                        "description": "Filter by name (substring match)",
-                        "name": "name",
+                        "description": "Filter by slug (substring match)",
+                        "name": "slug",
                         "in": "query",
                         "schema": {
                             "type": "string"
@@ -134,7 +147,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -144,7 +157,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -189,7 +202,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -199,7 +212,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -209,7 +222,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -281,7 +294,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -291,7 +304,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -348,7 +361,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -358,7 +371,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -368,7 +381,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -378,7 +391,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -436,7 +449,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -446,7 +459,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -456,7 +469,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -523,7 +536,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -533,7 +546,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -543,7 +556,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -553,7 +566,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -602,7 +615,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -612,7 +625,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -622,7 +635,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -632,7 +645,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -704,7 +717,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -714,7 +727,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -771,7 +784,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -781,7 +794,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -791,7 +804,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -801,7 +814,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -859,7 +872,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -869,7 +882,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -879,7 +892,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -946,7 +959,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -956,7 +969,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -966,7 +979,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -976,7 +989,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1025,7 +1038,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1035,7 +1048,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1045,7 +1058,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1055,7 +1068,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1116,7 +1129,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1126,7 +1139,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1136,7 +1149,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1195,7 +1208,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1205,7 +1218,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1215,7 +1228,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1276,7 +1289,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1286,7 +1299,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1296,7 +1309,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1355,7 +1368,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1365,7 +1378,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1375,7 +1388,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1446,7 +1459,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1456,7 +1469,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1466,7 +1479,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1525,7 +1538,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1535,7 +1548,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1545,7 +1558,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1606,7 +1619,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1616,7 +1629,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1626,7 +1639,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1636,7 +1649,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1695,7 +1708,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1705,7 +1718,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1715,7 +1728,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1787,7 +1800,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1797,7 +1810,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1854,7 +1867,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1864,7 +1877,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1874,7 +1887,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1884,7 +1897,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1942,7 +1955,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1952,7 +1965,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -1962,7 +1975,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2029,7 +2042,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2039,7 +2052,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2049,7 +2062,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2059,7 +2072,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2108,7 +2121,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2118,7 +2131,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2128,7 +2141,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2138,7 +2151,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2196,7 +2209,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2206,7 +2219,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2216,7 +2229,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2226,7 +2239,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2284,7 +2297,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2294,7 +2307,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2304,7 +2317,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2360,7 +2373,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2370,7 +2383,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2380,7 +2393,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2452,7 +2465,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2462,7 +2475,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2519,7 +2532,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2529,7 +2542,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2539,7 +2552,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2549,7 +2562,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2608,7 +2621,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2618,7 +2631,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2628,7 +2641,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2638,7 +2651,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2696,7 +2709,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2706,7 +2719,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2716,7 +2729,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2783,7 +2796,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2793,7 +2806,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2803,7 +2816,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2813,7 +2826,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2862,7 +2875,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2872,7 +2885,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2882,7 +2895,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2892,7 +2905,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2964,7 +2977,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -2974,7 +2987,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3031,7 +3044,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3041,7 +3054,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3051,7 +3064,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3061,7 +3074,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3119,7 +3132,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3129,7 +3142,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3139,7 +3152,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3206,7 +3219,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3216,7 +3229,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3226,7 +3239,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3236,7 +3249,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3285,7 +3298,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3295,7 +3308,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3305,7 +3318,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3315,7 +3328,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3376,7 +3389,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3386,7 +3399,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3396,7 +3409,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3455,7 +3468,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3465,7 +3478,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3475,7 +3488,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3485,7 +3498,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3533,7 +3546,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3543,7 +3556,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3553,7 +3566,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3610,7 +3623,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3620,7 +3633,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3630,7 +3643,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3640,7 +3653,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3679,7 +3692,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3689,7 +3702,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3699,7 +3712,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3735,7 +3748,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3787,7 +3800,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3834,7 +3847,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3844,7 +3857,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3854,7 +3867,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3890,7 +3903,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -3932,7 +3945,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -4010,7 +4023,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -4020,7 +4033,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -4030,7 +4043,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -4040,7 +4053,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -4050,7 +4063,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                                 }
                             }
                         }
@@ -4145,6 +4158,9 @@
                             "type": "string"
                         }
                     },
+                    "authorize_url": {
+                        "type": "string"
+                    },
                     "client_id": {
                         "type": "string"
                     },
@@ -4170,6 +4186,9 @@
                         "type": "boolean"
                     },
                     "subject_claim": {
+                        "type": "string"
+                    },
+                    "token_url": {
                         "type": "string"
                     },
                     "userinfo_url": {
@@ -4340,6 +4359,9 @@
                             "type": "string"
                         }
                     },
+                    "authorize_url": {
+                        "type": "string"
+                    },
                     "client_id": {
                         "type": "string"
                     },
@@ -4365,6 +4387,9 @@
                         "type": "boolean"
                     },
                     "subject_claim": {
+                        "type": "string"
+                    },
+                    "token_url": {
                         "type": "string"
                     },
                     "userinfo_url": {
@@ -5053,9 +5078,6 @@
                             "type": "string"
                         }
                     },
-                    "name": {
-                        "type": "string"
-                    },
                     "session_config": {
                         "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_domain_gateway.SessionConfig"
                     },
@@ -5081,9 +5103,6 @@
                         "additionalProperties": {
                             "type": "string"
                         }
-                    },
-                    "name": {
-                        "type": "string"
                     },
                     "session_config": {
                         "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_domain_gateway.SessionConfig"
@@ -5134,9 +5153,6 @@
                             "type": "string"
                         }
                     },
-                    "name": {
-                        "type": "string"
-                    },
                     "session_config": {
                         "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_domain_gateway.SessionConfig"
                     },
@@ -5177,7 +5193,7 @@
                     }
                 }
             },
-            "github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody": {
+            "github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody": {
                 "type": "object",
                 "properties": {
                     "error": {
@@ -6722,6 +6738,14 @@
             "github_com_NeuralTrust_TrustGate_pkg_domain_telemetry.ExporterConfig": {
                 "type": "object",
                 "properties": {
+                    "class": {
+                        "description": "Class binds the exporter to a data class, set from the group it is declared\nunder in the defaults file. Empty for per-gateway configs.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_metrics.DataClass"
+                            }
+                        ]
+                    },
                     "name": {
                         "type": "string"
                     },
@@ -6889,7 +6913,7 @@
                     "status": {
                         "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_infra_metrics_events.Status"
                     },
-                    "team_id": {
+                    "tenant_id": {
                         "type": "string"
                     },
                     "timestamp": {
@@ -7127,6 +7151,17 @@
                         "type": "integer"
                     }
                 }
+            },
+            "github_com_NeuralTrust_TrustGate_pkg_metrics.DataClass": {
+                "type": "string",
+                "enum": [
+                    "metadata",
+                    "raw"
+                ],
+                "x-enum-varnames": [
+                    "Metadata",
+                    "Raw"
+                ]
             },
             "github_com_NeuralTrust_TrustGate_pkg_version.Info": {
                 "type": "object",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -5910,6 +5910,14 @@
         "github_com_NeuralTrust_TrustGate_pkg_domain_telemetry.ExporterConfig": {
             "type": "object",
             "properties": {
+                "class": {
+                    "description": "Class binds the exporter to a data class, set from the group it is declared\nunder in the defaults file. Empty for per-gateway configs.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_metrics.DataClass"
+                        }
+                    ]
+                },
                 "name": {
                     "type": "string"
                 },
@@ -6077,7 +6085,7 @@
                 "status": {
                     "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_infra_metrics_events.Status"
                 },
-                "team_id": {
+                "tenant_id": {
                     "type": "string"
                 },
                 "timestamp": {
@@ -6315,6 +6323,17 @@
                     "type": "integer"
                 }
             }
+        },
+        "github_com_NeuralTrust_TrustGate_pkg_metrics.DataClass": {
+            "type": "string",
+            "enum": [
+                "metadata",
+                "raw"
+            ],
+            "x-enum-varnames": [
+                "Metadata",
+                "Raw"
+            ]
         },
         "github_com_NeuralTrust_TrustGate_pkg_version.Info": {
             "type": "object",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1801,6 +1801,12 @@ definitions:
     type: object
   github_com_NeuralTrust_TrustGate_pkg_domain_telemetry.ExporterConfig:
     properties:
+      class:
+        allOf:
+        - $ref: '#/definitions/github_com_NeuralTrust_TrustGate_pkg_metrics.DataClass'
+        description: |-
+          Class binds the exporter to a data class, set from the group it is declared
+          under in the defaults file. Empty for per-gateway configs.
       name:
         type: string
       settings:
@@ -1911,7 +1917,7 @@ definitions:
         type: string
       status:
         $ref: '#/definitions/github_com_NeuralTrust_TrustGate_pkg_infra_metrics_events.Status'
-      team_id:
+      tenant_id:
         type: string
       timestamp:
         type: string
@@ -2068,6 +2074,14 @@ definitions:
       total_tokens:
         type: integer
     type: object
+  github_com_NeuralTrust_TrustGate_pkg_metrics.DataClass:
+    enum:
+    - metadata
+    - raw
+    type: string
+    x-enum-varnames:
+    - Metadata
+    - Raw
   github_com_NeuralTrust_TrustGate_pkg_version.Info:
     properties:
       app_name:

--- a/docs/telemetry-exporter-split.md
+++ b/docs/telemetry-exporter-split.md
@@ -57,7 +57,7 @@ are duplicated into **both** views so the sensible row can be joined back to the
 **Decision (narrowed): sensible data is ONLY the request input and the response output — i.e. the two
 payload bodies.** Everything else is metadata.
 
-**Correlation keys (in both views):** `SchemaVersion`, `TraceID`, `GatewayID`, `TeamID`, `OccurredOn`
+**Correlation keys (in both views):** `SchemaVersion`, `TraceID`, `GatewayID`, `TenantID`, `OccurredOn`
 (+ `Timestamp`).
 
 **Sensible (→ Postgres):** `Request.Body` (input) and `Response.Body` (output). Nothing else.
@@ -220,7 +220,7 @@ type Migration struct { ID, Name, UpSQL, DownSQL string }
 CREATE TABLE IF NOT EXISTS trustgate_data (
     trace_id         TEXT        NOT NULL,
     gateway_id       TEXT        NOT NULL,
-    team_id          TEXT,
+    tenant_id          TEXT,
     occurred_on      BIGINT      NOT NULL,          -- epoch millis, from Event.OccurredOn
     schema_version   INT         NOT NULL,
     request_body     TEXT,                          -- input

--- a/docs/telemetry/examples/sink-1-metadata-otlp.json
+++ b/docs/telemetry/examples/sink-1-metadata-otlp.json
@@ -26,7 +26,7 @@
       "trustgate.kind": "llm",
       "trustgate.trace_id": "b1c8a71f-35d8-4aff-a8da-dcb78d05cac9",
       "trustgate.gateway_id": "gw-support-chat",
-      "trustgate.team_id": "00000000-0000-0000-0000-000000000001",
+      "trustgate.tenant_id": "00000000-0000-0000-0000-000000000001",
       "trustgate.consumer.id": "consumer-42",
       "trustgate.consumer.name": "acme-web",
       "trustgate.session_id": "sess-7c9c",

--- a/docs/telemetry/examples/sink-2-raw-otlp.json
+++ b/docs/telemetry/examples/sink-2-raw-otlp.json
@@ -14,7 +14,7 @@
       "trustgate.schema_version": 3,
       "trustgate.trace_id": "b1c8a71f-35d8-4aff-a8da-dcb78d05cac9",
       "trustgate.gateway_id": "gw-support-chat",
-      "trustgate.team_id": "00000000-0000-0000-0000-000000000001",
+      "trustgate.tenant_id": "00000000-0000-0000-0000-000000000001",
       "trustgate.request.body": {
         "model": "gpt-4o",
         "messages": [

--- a/docs/telemetry/examples/sink-3-postgres.json
+++ b/docs/telemetry/examples/sink-3-postgres.json
@@ -4,7 +4,7 @@
   "_table": "trustgate_data",
   "trace_id": "b1c8a71f-35d8-4aff-a8da-dcb78d05cac9",
   "gateway_id": "gw-support-chat",
-  "team_id": "00000000-0000-0000-0000-000000000001",
+  "tenant_id": "00000000-0000-0000-0000-000000000001",
   "occurred_on": 1783420474000,
   "schema_version": 1,
   "created_at": "2026-07-07T10:34:34.504770+00:00",

--- a/docs/telemetry/otlp-metadata-contract.md
+++ b/docs/telemetry/otlp-metadata-contract.md
@@ -46,7 +46,7 @@ and — when an `otlp` exporter is declared under `exporters.raw[]` — also emi
 | `trustgate.kind` | `kind` |
 | `trustgate.trace_id` | `trace_id` |
 | `trustgate.gateway_id` | `gateway_id` |
-| `trustgate.team_id` | `team_id` |
+| `trustgate.tenant_id` | `tenant_id` |
 | `trustgate.consumer.id` | `consumer.id` |
 | `trustgate.consumer.name` | `consumer.name` |
 | `trustgate.session_id` | `session_id` |
@@ -85,10 +85,10 @@ exporter declared under `exporters.raw[]`:
 |------|---------|
 | PostgreSQL `trustgate_data` | `request_body` + `response_body` only |
 | OTLP (`otlp` under `raw`) | `trustgate.request.body` / `trustgate.response.body` + join keys |
-| Join keys | `trace_id`, `gateway_id`, `team_id`, `occurred_on` |
+| Join keys | `trace_id`, `gateway_id`, `tenant_id`, `occurred_on` |
 
 The raw OTLP record emits `trustgate.schema_version`, `trustgate.trace_id`,
-`trustgate.gateway_id`, `trustgate.team_id`, `trustgate.request.body`, and
+`trustgate.gateway_id`, `trustgate.tenant_id`, `trustgate.request.body`, and
 `trustgate.response.body` — no metadata attributes, no policy chain.
 
 ## Severity

--- a/pkg/api/middleware/admin_auth.go
+++ b/pkg/api/middleware/admin_auth.go
@@ -68,8 +68,8 @@ func (m *AdminAuthMiddleware) Middleware() fiber.Handler {
 			return m.unauthorized(c, "Token not valid for admin API", nil)
 		}
 
-		if claims.TeamID != "" {
-			c.Locals(string(infracontext.TeamIDContextKey), claims.TeamID)
+		if claims.TenantID != "" {
+			c.Locals(string(infracontext.TenantIDContextKey), claims.TenantID)
 		}
 		if claims.UserID != "" {
 			c.Locals(string(infracontext.UserIDContextKey), claims.UserID)

--- a/pkg/api/middleware/mcp_metrics.go
+++ b/pkg/api/middleware/mcp_metrics.go
@@ -94,7 +94,7 @@ func (m *MCPMetricsMiddleware) buildTraceMetadata(c *fiber.Ctx, gatewayID string
 		Kind:      events.KindMCP,
 	}
 	if gw != nil {
-		meta.TeamID = gw.TeamID()
+		meta.TenantID = gw.TenantID()
 	}
 	return meta
 }

--- a/pkg/api/middleware/metrics.go
+++ b/pkg/api/middleware/metrics.go
@@ -134,7 +134,7 @@ func (m *MetricsMiddleware) attachTrace(c *fiber.Ctx, requestTrace *trace.Reques
 func (m *MetricsMiddleware) buildTraceMetadata(c *fiber.Ctx, gatewayID string, gw *gatewaydomain.Gateway) trace.Metadata {
 	meta := trace.Metadata{
 		GatewayID: gatewayID,
-		TeamID:    gw.TeamID(),
+		TenantID:    gw.TenantID(),
 		Path:      c.Path(),
 		Method:    c.Method(),
 		IP:        c.IP(),

--- a/pkg/api/middleware/metrics_functional_test.go
+++ b/pkg/api/middleware/metrics_functional_test.go
@@ -168,11 +168,11 @@ func postChat(t *testing.T, app *fiber.App) {
 	require.Equal(t, fiber.StatusOK, resp.StatusCode)
 }
 
-func TestMetricsFunctional_DefaultPlusExtraAndTeamID(t *testing.T) {
+func TestMetricsFunctional_DefaultPlusExtraAndTenantID(t *testing.T) {
 	rec := newEventRecorder()
 	gw := &gatewaydomain.Gateway{
 		ID:       ids.New[ids.GatewayKind](),
-		Metadata: map[string]string{gatewaydomain.MetadataTeamIDKey: "team-9"},
+		Metadata: map[string]string{gatewaydomain.MetadataTenantIDKey: "team-9"},
 		Telemetry: &telemetrydomain.Telemetry{
 			Exporters: []telemetrydomain.ExporterConfig{
 				{Name: "memory", Settings: map[string]interface{}{"topic": "team-metrics"}},
@@ -186,8 +186,8 @@ func TestMetricsFunctional_DefaultPlusExtraAndTeamID(t *testing.T) {
 		return rec.count("kafka/"+defaultTopic) == 1 && rec.count("memory/team-metrics") == 1
 	}, 2*time.Second, 10*time.Millisecond)
 
-	assert.Equal(t, "team-9", rec.first("kafka/"+defaultTopic).TeamID)
-	assert.Equal(t, "team-9", rec.first("memory/team-metrics").TeamID)
+	assert.Equal(t, "team-9", rec.first("kafka/"+defaultTopic).TenantID)
+	assert.Equal(t, "team-9", rec.first("memory/team-metrics").TenantID)
 }
 
 func TestMetricsFunctional_OverrideByNameRedirectsDefault(t *testing.T) {

--- a/pkg/app/configsnapshot/compiler.go
+++ b/pkg/app/configsnapshot/compiler.go
@@ -67,16 +67,10 @@ func NewCompiler(
 	}
 }
 
-// Compile builds the whole, unpartitioned snapshot (every gateway). It is the
-// scope-agnostic path used by shared-token deployments.
 func (c *Compiler) Compile(ctx context.Context) (*readmodel.Snapshot, error) {
 	return c.CompileFor(ctx, "")
 }
 
-// CompileFor builds a snapshot restricted to a partition scope: only gateways
-// whose metadata.team_id equals scope (and all their associated config) are
-// included. An empty scope includes every gateway (the whole config). Shared
-// catalog data (providers/models) is included in every scope.
 func (c *Compiler) CompileFor(ctx context.Context, scope string) (*readmodel.Snapshot, error) {
 	gateways, err := c.listGateways(ctx)
 	if err != nil {
@@ -119,10 +113,6 @@ func (c *Compiler) CompileFor(ctx context.Context, scope string) (*readmodel.Sna
 	return readmodel.Build(data), nil
 }
 
-// CompileAll builds the whole snapshot plus one snapshot per non-empty scope in a
-// single pass over the gateways, so serving partitioned data planes does not cost
-// one full gateway listing per scope. The returned map is keyed by scope
-// (metadata.team_id) and each per-scope snapshot carries the shared catalog.
 func (c *Compiler) CompileAll(ctx context.Context) (*readmodel.Snapshot, map[string]*readmodel.Snapshot, error) {
 	gateways, err := c.listGateways(ctx)
 	if err != nil {

--- a/pkg/app/configsnapshot/compiler.go
+++ b/pkg/app/configsnapshot/compiler.go
@@ -80,7 +80,7 @@ func (c *Compiler) CompileFor(ctx context.Context, scope string) (*readmodel.Sna
 	data := readmodel.Data{}
 	var skipped, considered int
 	for i := range gateways {
-		if scope != "" && gateways[i].TeamID() != scope {
+		if scope != "" && gateways[i].TenantID() != scope {
 			continue
 		}
 		considered++
@@ -136,7 +136,7 @@ func (c *Compiler) CompileAll(ctx context.Context) (*readmodel.Snapshot, map[str
 			return nil, nil, err
 		}
 		appendGatewayData(&global, gateways[i], gwData)
-		if scope := gateways[i].TeamID(); scope != "" {
+		if scope := gateways[i].TenantID(); scope != "" {
 			bucket, ok := buckets[scope]
 			if !ok {
 				bucket = &readmodel.Data{}

--- a/pkg/app/configsnapshot/compiler.go
+++ b/pkg/app/configsnapshot/compiler.go
@@ -67,15 +67,29 @@ func NewCompiler(
 	}
 }
 
+// Compile builds the whole, unpartitioned snapshot (every gateway). It is the
+// scope-agnostic path used by shared-token deployments.
 func (c *Compiler) Compile(ctx context.Context) (*readmodel.Snapshot, error) {
+	return c.CompileFor(ctx, "")
+}
+
+// CompileFor builds a snapshot restricted to a partition scope: only gateways
+// whose metadata.team_id equals scope (and all their associated config) are
+// included. An empty scope includes every gateway (the whole config). Shared
+// catalog data (providers/models) is included in every scope.
+func (c *Compiler) CompileFor(ctx context.Context, scope string) (*readmodel.Snapshot, error) {
 	gateways, err := c.listGateways(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	data := readmodel.Data{}
-	var skipped int
+	var skipped, considered int
 	for i := range gateways {
+		if scope != "" && gateways[i].TeamID() != scope {
+			continue
+		}
+		considered++
 		var gwData readmodel.Data
 		if err := c.collectGateway(ctx, gateways[i].ID, &gwData); err != nil {
 			if errors.Is(err, commonerrors.ErrCorruptData) {
@@ -88,24 +102,101 @@ func (c *Compiler) Compile(ctx context.Context) (*readmodel.Snapshot, error) {
 			}
 			return nil, err
 		}
-		data.Gateways = append(data.Gateways, gateways[i])
-		data.Consumers = append(data.Consumers, gwData.Consumers...)
-		data.Registries = append(data.Registries, gwData.Registries...)
-		data.Policies = append(data.Policies, gwData.Policies...)
-		data.Auths = append(data.Auths, gwData.Auths...)
-		data.Roles = append(data.Roles, gwData.Roles...)
+		appendGatewayData(&data, gateways[i], gwData)
 	}
 
-	if skipped > 0 && len(data.Gateways) == 0 {
+	if skipped > 0 && skipped == considered {
 		return nil, fmt.Errorf("configsnapshot: every gateway (%d) skipped due to corrupt persisted config; refusing to publish empty snapshot: %w", skipped, commonerrors.ErrCorruptData)
 	}
 
-	if err := c.collectCatalog(ctx, &data); err != nil {
+	cat, err := c.collectCatalogData(ctx)
+	if err != nil {
 		return nil, err
 	}
+	mergeCatalog(&data, cat)
 
 	sortData(&data)
 	return readmodel.Build(data), nil
+}
+
+// CompileAll builds the whole snapshot plus one snapshot per non-empty scope in a
+// single pass over the gateways, so serving partitioned data planes does not cost
+// one full gateway listing per scope. The returned map is keyed by scope
+// (metadata.team_id) and each per-scope snapshot carries the shared catalog.
+func (c *Compiler) CompileAll(ctx context.Context) (*readmodel.Snapshot, map[string]*readmodel.Snapshot, error) {
+	gateways, err := c.listGateways(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	global := readmodel.Data{}
+	buckets := map[string]*readmodel.Data{}
+	var skipped int
+	for i := range gateways {
+		var gwData readmodel.Data
+		if err := c.collectGateway(ctx, gateways[i].ID, &gwData); err != nil {
+			if errors.Is(err, commonerrors.ErrCorruptData) {
+				c.logger.Warn("skipping gateway with corrupt persisted config from snapshot",
+					slog.String("component", component),
+					slog.String("gateway_id", gateways[i].ID.String()),
+					slog.String("error", err.Error()))
+				skipped++
+				continue
+			}
+			return nil, nil, err
+		}
+		appendGatewayData(&global, gateways[i], gwData)
+		if scope := gateways[i].TeamID(); scope != "" {
+			bucket, ok := buckets[scope]
+			if !ok {
+				bucket = &readmodel.Data{}
+				buckets[scope] = bucket
+			}
+			appendGatewayData(bucket, gateways[i], gwData)
+		}
+	}
+
+	if skipped > 0 && len(global.Gateways) == 0 {
+		return nil, nil, fmt.Errorf("configsnapshot: every gateway (%d) skipped due to corrupt persisted config; refusing to publish empty snapshot: %w", skipped, commonerrors.ErrCorruptData)
+	}
+
+	cat, err := c.collectCatalogData(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	mergeCatalog(&global, cat)
+	sortData(&global)
+
+	scoped := make(map[string]*readmodel.Snapshot, len(buckets))
+	for scope, bucket := range buckets {
+		mergeCatalog(bucket, cat)
+		sortData(bucket)
+		scoped[scope] = readmodel.Build(*bucket)
+	}
+	return readmodel.Build(global), scoped, nil
+}
+
+func appendGatewayData(dst *readmodel.Data, gateway gatewaydomain.Gateway, gwData readmodel.Data) {
+	dst.Gateways = append(dst.Gateways, gateway)
+	dst.Consumers = append(dst.Consumers, gwData.Consumers...)
+	dst.Registries = append(dst.Registries, gwData.Registries...)
+	dst.Policies = append(dst.Policies, gwData.Policies...)
+	dst.Auths = append(dst.Auths, gwData.Auths...)
+	dst.Roles = append(dst.Roles, gwData.Roles...)
+}
+
+func mergeCatalog(dst *readmodel.Data, catalog readmodel.Data) {
+	dst.Providers = append(dst.Providers, catalog.Providers...)
+	dst.CatalogModels = append(dst.CatalogModels, catalog.CatalogModels...)
+}
+
+func (c *Compiler) collectCatalogData(ctx context.Context) (readmodel.Data, error) {
+	var data readmodel.Data
+	if err := c.collectCatalog(ctx, &data); err != nil {
+		return readmodel.Data{}, err
+	}
+	return data, nil
 }
 
 func (c *Compiler) listGateways(ctx context.Context) ([]gatewaydomain.Gateway, error) {

--- a/pkg/app/configsnapshot/dispatcher.go
+++ b/pkg/app/configsnapshot/dispatcher.go
@@ -40,6 +40,13 @@ type SnapshotCompiler interface {
 	Compile(ctx context.Context) (*readmodel.Snapshot, error)
 }
 
+// PartitionedCompiler additionally compiles one snapshot per partition scope in a
+// single pass. A compiler that implements it makes the dispatcher publish
+// per-scope snapshots alongside the whole snapshot.
+type PartitionedCompiler interface {
+	CompileAll(ctx context.Context) (*readmodel.Snapshot, map[string]*readmodel.Snapshot, error)
+}
+
 // DispatcherConfig tunes the debounce/backstop cadence and the outbox safety bound.
 type DispatcherConfig struct {
 	Debounce  time.Duration
@@ -200,19 +207,18 @@ func (d *Dispatcher) dispatch(ctx context.Context) error {
 		pending = nil
 	}
 
-	snapshot, err := d.compiler.Compile(ctx)
+	raw, version, scoped, err := d.compile(ctx)
 	if err != nil {
-		return fmt.Errorf("configsnapshot: compile: %w", err)
+		return err
 	}
-	raw, err := d.codec.Encode(snapshot)
-	if err != nil {
-		return fmt.Errorf("configsnapshot: encode: %w", err)
-	}
-	version := d.codec.Version(raw)
 
 	d.mu.Lock()
 	if version != d.published {
-		d.holder.Set(raw, version)
+		if scoped != nil {
+			d.holder.SetPartitioned(raw, version, scoped)
+		} else {
+			d.holder.Set(raw, version)
+		}
 		d.broadcaster.Broadcast(version)
 		d.published = version
 	}
@@ -225,4 +231,46 @@ func (d *Dispatcher) dispatch(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+// compile encodes the whole snapshot and, when the compiler is partitioned, the
+// per-scope snapshots. A nil scoped map means the whole-snapshot-only path.
+func (d *Dispatcher) compile(ctx context.Context) (raw []byte, version string, scoped map[string]ScopedSnapshot, err error) {
+	if partitioned, ok := d.compiler.(PartitionedCompiler); ok {
+		global, scopedSnaps, cerr := partitioned.CompileAll(ctx)
+		if cerr != nil {
+			return nil, "", nil, fmt.Errorf("configsnapshot: compile: %w", cerr)
+		}
+		raw, version, err = d.encode(global)
+		if err != nil {
+			return nil, "", nil, err
+		}
+		scoped = make(map[string]ScopedSnapshot, len(scopedSnaps))
+		for scope, snap := range scopedSnaps {
+			scopedRaw, scopedVersion, eerr := d.encode(snap)
+			if eerr != nil {
+				return nil, "", nil, eerr
+			}
+			scoped[scope] = ScopedSnapshot{Raw: scopedRaw, Version: scopedVersion}
+		}
+		return raw, version, scoped, nil
+	}
+
+	snapshot, cerr := d.compiler.Compile(ctx)
+	if cerr != nil {
+		return nil, "", nil, fmt.Errorf("configsnapshot: compile: %w", cerr)
+	}
+	raw, version, err = d.encode(snapshot)
+	if err != nil {
+		return nil, "", nil, err
+	}
+	return raw, version, nil, nil
+}
+
+func (d *Dispatcher) encode(snapshot *readmodel.Snapshot) ([]byte, string, error) {
+	raw, err := d.codec.Encode(snapshot)
+	if err != nil {
+		return nil, "", fmt.Errorf("configsnapshot: encode: %w", err)
+	}
+	return raw, d.codec.Version(raw), nil
 }

--- a/pkg/app/configsnapshot/dispatcher.go
+++ b/pkg/app/configsnapshot/dispatcher.go
@@ -40,9 +40,6 @@ type SnapshotCompiler interface {
 	Compile(ctx context.Context) (*readmodel.Snapshot, error)
 }
 
-// PartitionedCompiler additionally compiles one snapshot per partition scope in a
-// single pass. A compiler that implements it makes the dispatcher publish
-// per-scope snapshots alongside the whole snapshot.
 type PartitionedCompiler interface {
 	CompileAll(ctx context.Context) (*readmodel.Snapshot, map[string]*readmodel.Snapshot, error)
 }
@@ -233,8 +230,6 @@ func (d *Dispatcher) dispatch(ctx context.Context) error {
 	return nil
 }
 
-// compile encodes the whole snapshot and, when the compiler is partitioned, the
-// per-scope snapshots. A nil scoped map means the whole-snapshot-only path.
 func (d *Dispatcher) compile(ctx context.Context) (raw []byte, version string, scoped map[string]ScopedSnapshot, err error) {
 	if partitioned, ok := d.compiler.(PartitionedCompiler); ok {
 		global, scopedSnaps, cerr := partitioned.CompileAll(ctx)

--- a/pkg/app/configsnapshot/holder.go
+++ b/pkg/app/configsnapshot/holder.go
@@ -21,16 +21,40 @@ type snapshotState struct {
 	version string
 }
 
+// ScopedSnapshot is a compiled snapshot for a single partition scope.
+type ScopedSnapshot struct {
+	Raw     []byte
+	Version string
+}
+
+// Holder stores the current compiled snapshot(s) for the gRPC server to serve.
+// It always holds the whole, unpartitioned snapshot (scope "") and, when
+// partitioned compilation is active, a per-scope map. Reads are lock-free.
 type Holder struct {
 	current atomic.Pointer[snapshotState]
+	scoped  atomic.Pointer[map[string]snapshotState]
 }
 
 func NewHolder() *Holder {
 	return &Holder{}
 }
 
+// Set replaces the whole, unpartitioned snapshot and leaves the per-scope map
+// untouched.
 func (h *Holder) Set(raw []byte, version string) {
 	h.current.Store(&snapshotState{raw: raw, version: version})
+}
+
+// SetPartitioned atomically replaces the whole snapshot and the entire per-scope
+// map, so scopes that no longer exist stop being served (fail-closed) on the next
+// dispatch.
+func (h *Holder) SetPartitioned(raw []byte, version string, scoped map[string]ScopedSnapshot) {
+	next := make(map[string]snapshotState, len(scoped))
+	for scope, snap := range scoped {
+		next[scope] = snapshotState{raw: snap.Raw, version: snap.Version}
+	}
+	h.current.Store(&snapshotState{raw: raw, version: version})
+	h.scoped.Store(&next)
 }
 
 func (h *Holder) Snapshot() (raw []byte, version string, ok bool) {
@@ -41,11 +65,23 @@ func (h *Holder) Snapshot() (raw []byte, version string, ok bool) {
 	return state.raw, state.version, true
 }
 
-// SnapshotFor returns the compiled snapshot for the given partition scope. This
-// single-snapshot holder is scope-agnostic and returns the same snapshot for
-// every scope; per-scope compilation is layered on top separately.
-func (h *Holder) SnapshotFor(_ string) (raw []byte, version string, ok bool) {
-	return h.Snapshot()
+// SnapshotFor returns the compiled snapshot for a partition scope. An empty scope
+// returns the whole, unpartitioned snapshot. A non-empty scope returns only that
+// scope's snapshot and never falls back to the whole snapshot: an unknown scope
+// yields ok=false so the transport denies it rather than leaking global config.
+func (h *Holder) SnapshotFor(scope string) (raw []byte, version string, ok bool) {
+	if scope == "" {
+		return h.Snapshot()
+	}
+	m := h.scoped.Load()
+	if m == nil {
+		return nil, "", false
+	}
+	state, present := (*m)[scope]
+	if !present {
+		return nil, "", false
+	}
+	return state.raw, state.version, true
 }
 
 func (h *Holder) Version() string {

--- a/pkg/app/configsnapshot/holder.go
+++ b/pkg/app/configsnapshot/holder.go
@@ -41,6 +41,13 @@ func (h *Holder) Snapshot() (raw []byte, version string, ok bool) {
 	return state.raw, state.version, true
 }
 
+// SnapshotFor returns the compiled snapshot for the given partition scope. This
+// single-snapshot holder is scope-agnostic and returns the same snapshot for
+// every scope; per-scope compilation is layered on top separately.
+func (h *Holder) SnapshotFor(_ string) (raw []byte, version string, ok bool) {
+	return h.Snapshot()
+}
+
 func (h *Holder) Version() string {
 	state := h.current.Load()
 	if state == nil {

--- a/pkg/app/configsnapshot/holder.go
+++ b/pkg/app/configsnapshot/holder.go
@@ -21,15 +21,11 @@ type snapshotState struct {
 	version string
 }
 
-// ScopedSnapshot is a compiled snapshot for a single partition scope.
 type ScopedSnapshot struct {
 	Raw     []byte
 	Version string
 }
 
-// Holder stores the current compiled snapshot(s) for the gRPC server to serve.
-// It always holds the whole, unpartitioned snapshot (scope "") and, when
-// partitioned compilation is active, a per-scope map. Reads are lock-free.
 type Holder struct {
 	current atomic.Pointer[snapshotState]
 	scoped  atomic.Pointer[map[string]snapshotState]
@@ -39,15 +35,10 @@ func NewHolder() *Holder {
 	return &Holder{}
 }
 
-// Set replaces the whole, unpartitioned snapshot and leaves the per-scope map
-// untouched.
 func (h *Holder) Set(raw []byte, version string) {
 	h.current.Store(&snapshotState{raw: raw, version: version})
 }
 
-// SetPartitioned atomically replaces the whole snapshot and the entire per-scope
-// map, so scopes that no longer exist stop being served (fail-closed) on the next
-// dispatch.
 func (h *Holder) SetPartitioned(raw []byte, version string, scoped map[string]ScopedSnapshot) {
 	next := make(map[string]snapshotState, len(scoped))
 	for scope, snap := range scoped {
@@ -65,10 +56,6 @@ func (h *Holder) Snapshot() (raw []byte, version string, ok bool) {
 	return state.raw, state.version, true
 }
 
-// SnapshotFor returns the compiled snapshot for a partition scope. An empty scope
-// returns the whole, unpartitioned snapshot. A non-empty scope returns only that
-// scope's snapshot and never falls back to the whole snapshot: an unknown scope
-// yields ok=false so the transport denies it rather than leaking global config.
 func (h *Holder) SnapshotFor(scope string) (raw []byte, version string, ok bool) {
 	if scope == "" {
 		return h.Snapshot()

--- a/pkg/app/configsnapshot/scope_test.go
+++ b/pkg/app/configsnapshot/scope_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func gatewayWithTeam(id ids.GatewayID, team string) *gatewaydomain.Gateway {
-	return &gatewaydomain.Gateway{ID: id, Metadata: map[string]string{gatewaydomain.MetadataTeamIDKey: team}}
+	return &gatewaydomain.Gateway{ID: id, Metadata: map[string]string{gatewaydomain.MetadataTenantIDKey: team}}
 }
 
 func mustID[K ids.Kind](t *testing.T, s string) ids.ID[K] {

--- a/pkg/app/configsnapshot/scope_test.go
+++ b/pkg/app/configsnapshot/scope_test.go
@@ -1,0 +1,134 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configsnapshot_test
+
+import (
+	"context"
+	"testing"
+
+	appsnapshot "github.com/NeuralTrust/TrustGate/pkg/app/configsnapshot"
+	authdomain "github.com/NeuralTrust/TrustGate/pkg/domain/auth"
+	catalogdomain "github.com/NeuralTrust/TrustGate/pkg/domain/catalog"
+	consumerdomain "github.com/NeuralTrust/TrustGate/pkg/domain/consumer"
+	gatewaydomain "github.com/NeuralTrust/TrustGate/pkg/domain/gateway"
+	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
+	policydomain "github.com/NeuralTrust/TrustGate/pkg/domain/policy"
+	registrydomain "github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	roledomain "github.com/NeuralTrust/TrustGate/pkg/domain/role"
+)
+
+func gatewayWithTeam(id ids.GatewayID, team string) *gatewaydomain.Gateway {
+	return &gatewaydomain.Gateway{ID: id, Metadata: map[string]string{gatewaydomain.MetadataTeamIDKey: team}}
+}
+
+func twoTenantCompiler(t *testing.T, acme, globex ids.GatewayID, acmeConsumer, globexConsumer ids.ConsumerID) *appsnapshot.Compiler {
+	t.Helper()
+	return appsnapshot.NewCompiler(
+		fakeGateways{items: []*gatewaydomain.Gateway{
+			gatewayWithTeam(acme, "acme"),
+			gatewayWithTeam(globex, "globex"),
+		}},
+		fakeConsumers{byGateway: map[string][]*consumerdomain.Consumer{
+			acme.String():   {{ID: acmeConsumer, GatewayID: acme}},
+			globex.String(): {{ID: globexConsumer, GatewayID: globex}},
+		}},
+		fakeRegistries{byGateway: map[string][]*registrydomain.Registry{}},
+		fakePolicies{byGateway: map[string][]*policydomain.Policy{}},
+		fakeAuths{byGateway: map[string][]*authdomain.Auth{}},
+		fakeRoles{byGateway: map[string][]*roledomain.Role{}},
+		fakeCatalog{providers: []catalogdomain.Provider{{Code: "openai"}}},
+		nil,
+	)
+}
+
+func TestCompilerCompileForIsolatesScope(t *testing.T) {
+	acme := mustGatewayID(t, "11111111-1111-1111-1111-111111111111")
+	globex := mustGatewayID(t, "22222222-2222-2222-2222-222222222222")
+	acmeConsumer := mustConsumerID(t, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+	globexConsumer := mustConsumerID(t, "cccccccc-cccc-cccc-cccc-cccccccccccc")
+
+	compiler := twoTenantCompiler(t, acme, globex, acmeConsumer, globexConsumer)
+
+	snap, err := compiler.CompileFor(context.Background(), "acme")
+	if err != nil {
+		t.Fatalf("compile for acme: %v", err)
+	}
+	data := snap.Data()
+	if len(data.Gateways) != 1 || data.Gateways[0].ID != acme {
+		t.Fatalf("expected only the acme gateway, got %+v", data.Gateways)
+	}
+	if len(data.Consumers) != 1 || data.Consumers[0].ID != acmeConsumer {
+		t.Fatalf("expected only the acme consumer, got %+v", data.Consumers)
+	}
+	if len(data.Providers) != 1 {
+		t.Fatalf("expected shared catalog in scope snapshot, got %d providers", len(data.Providers))
+	}
+}
+
+func TestCompilerCompileAllPartitionsAndIsolates(t *testing.T) {
+	acme := mustGatewayID(t, "11111111-1111-1111-1111-111111111111")
+	globex := mustGatewayID(t, "22222222-2222-2222-2222-222222222222")
+	acmeConsumer := mustConsumerID(t, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+	globexConsumer := mustConsumerID(t, "cccccccc-cccc-cccc-cccc-cccccccccccc")
+
+	compiler := twoTenantCompiler(t, acme, globex, acmeConsumer, globexConsumer)
+
+	global, scoped, err := compiler.CompileAll(context.Background())
+	if err != nil {
+		t.Fatalf("compile all: %v", err)
+	}
+	if len(global.Data().Gateways) != 2 {
+		t.Fatalf("expected both gateways in the whole snapshot, got %d", len(global.Data().Gateways))
+	}
+	if len(scoped) != 2 {
+		t.Fatalf("expected 2 scopes, got %d", len(scoped))
+	}
+	acmeSnap, ok := scoped["acme"]
+	if !ok {
+		t.Fatal("missing acme scope")
+	}
+	if gws := acmeSnap.Data().Gateways; len(gws) != 1 || gws[0].ID != acme {
+		t.Fatalf("acme scope leaked other gateways: %+v", gws)
+	}
+	for _, cs := range acmeSnap.Data().Consumers {
+		if cs.ID == globexConsumer {
+			t.Fatal("globex consumer leaked into acme scope")
+		}
+	}
+	if len(acmeSnap.Data().Providers) != 1 {
+		t.Fatalf("expected shared catalog in acme scope, got %d", len(acmeSnap.Data().Providers))
+	}
+	globexSnap := scoped["globex"]
+	if gws := globexSnap.Data().Gateways; len(gws) != 1 || gws[0].ID != globex {
+		t.Fatalf("globex scope leaked other gateways: %+v", gws)
+	}
+}
+
+func TestHolderPartitionedFailsClosed(t *testing.T) {
+	h := appsnapshot.NewHolder()
+	h.SetPartitioned([]byte("global"), "vg", map[string]appsnapshot.ScopedSnapshot{
+		"acme": {Raw: []byte("acme-cfg"), Version: "va"},
+	})
+
+	if raw, version, ok := h.SnapshotFor(""); !ok || string(raw) != "global" || version != "vg" {
+		t.Fatalf("empty scope = (%q,%q,%v), want the whole snapshot", raw, version, ok)
+	}
+	if raw, version, ok := h.SnapshotFor("acme"); !ok || string(raw) != "acme-cfg" || version != "va" {
+		t.Fatalf("acme scope = (%q,%q,%v), want the acme snapshot", raw, version, ok)
+	}
+	if _, _, ok := h.SnapshotFor("globex"); ok {
+		t.Fatal("unknown scope must fail closed, not fall back to the whole snapshot")
+	}
+}

--- a/pkg/app/configsnapshot/scope_test.go
+++ b/pkg/app/configsnapshot/scope_test.go
@@ -33,6 +33,15 @@ func gatewayWithTeam(id ids.GatewayID, team string) *gatewaydomain.Gateway {
 	return &gatewaydomain.Gateway{ID: id, Metadata: map[string]string{gatewaydomain.MetadataTeamIDKey: team}}
 }
 
+func mustID[K ids.Kind](t *testing.T, s string) ids.ID[K] {
+	t.Helper()
+	id, err := ids.Parse[K](s)
+	if err != nil {
+		t.Fatalf("parse id %q: %v", s, err)
+	}
+	return id
+}
+
 func twoTenantCompiler(t *testing.T, acme, globex ids.GatewayID, acmeConsumer, globexConsumer ids.ConsumerID) *appsnapshot.Compiler {
 	t.Helper()
 	return appsnapshot.NewCompiler(
@@ -113,6 +122,70 @@ func TestCompilerCompileAllPartitionsAndIsolates(t *testing.T) {
 	globexSnap := scoped["globex"]
 	if gws := globexSnap.Data().Gateways; len(gws) != 1 || gws[0].ID != globex {
 		t.Fatalf("globex scope leaked other gateways: %+v", gws)
+	}
+}
+
+func TestCompileForIsolatesEveryChildObjectType(t *testing.T) {
+	acme := mustGatewayID(t, "11111111-1111-1111-1111-111111111111")
+	globex := mustGatewayID(t, "22222222-2222-2222-2222-222222222222")
+
+	acmeRegistry := mustID[ids.RegistryKind](t, "aaaa1111-1111-1111-1111-111111111111")
+	globexRegistry := mustID[ids.RegistryKind](t, "bbbb2222-2222-2222-2222-222222222222")
+	acmePolicy := mustID[ids.PolicyKind](t, "aaaa3333-3333-3333-3333-333333333333")
+	globexPolicy := mustID[ids.PolicyKind](t, "bbbb4444-4444-4444-4444-444444444444")
+	acmeAuth := mustID[ids.AuthKind](t, "aaaa5555-5555-5555-5555-555555555555")
+	globexAuth := mustID[ids.AuthKind](t, "bbbb6666-6666-6666-6666-666666666666")
+	acmeRole := mustID[ids.RoleKind](t, "aaaa7777-7777-7777-7777-777777777777")
+	globexRole := mustID[ids.RoleKind](t, "bbbb8888-8888-8888-8888-888888888888")
+
+	compiler := appsnapshot.NewCompiler(
+		fakeGateways{items: []*gatewaydomain.Gateway{
+			gatewayWithTeam(acme, "acme"),
+			gatewayWithTeam(globex, "globex"),
+		}},
+		fakeConsumers{byGateway: map[string][]*consumerdomain.Consumer{}},
+		fakeRegistries{byGateway: map[string][]*registrydomain.Registry{
+			acme.String():   {{ID: acmeRegistry, GatewayID: acme}},
+			globex.String(): {{ID: globexRegistry, GatewayID: globex}},
+		}},
+		fakePolicies{byGateway: map[string][]*policydomain.Policy{
+			acme.String():   {{ID: acmePolicy, GatewayID: acme}},
+			globex.String(): {{ID: globexPolicy, GatewayID: globex}},
+		}},
+		fakeAuths{byGateway: map[string][]*authdomain.Auth{
+			acme.String():   {{ID: acmeAuth, GatewayID: acme}},
+			globex.String(): {{ID: globexAuth, GatewayID: globex}},
+		}},
+		fakeRoles{byGateway: map[string][]*roledomain.Role{
+			acme.String():   {{ID: acmeRole, GatewayID: acme}},
+			globex.String(): {{ID: globexRole, GatewayID: globex}},
+		}},
+		fakeCatalog{},
+		nil,
+	)
+
+	snap, err := compiler.CompileFor(context.Background(), "acme")
+	if err != nil {
+		t.Fatalf("compile for acme: %v", err)
+	}
+	data := snap.Data()
+
+	if len(data.Registries) != 1 || data.Registries[0].ID != acmeRegistry {
+		t.Fatalf("registries leaked across scope: %+v", data.Registries)
+	}
+	if len(data.Policies) != 1 || data.Policies[0].ID != acmePolicy {
+		t.Fatalf("policies leaked across scope: %+v", data.Policies)
+	}
+	if len(data.Auths) != 1 || data.Auths[0].ID != acmeAuth {
+		t.Fatalf("auths leaked across scope: %+v", data.Auths)
+	}
+	if len(data.Roles) != 1 || data.Roles[0].ID != acmeRole {
+		t.Fatalf("roles leaked across scope: %+v", data.Roles)
+	}
+	for _, r := range data.Registries {
+		if r.GatewayID == globex {
+			t.Fatal("globex registry surfaced in the acme scope")
+		}
 	}
 }
 

--- a/pkg/app/gateway/creator.go
+++ b/pkg/app/gateway/creator.go
@@ -74,7 +74,7 @@ func (c *creator) Create(ctx context.Context, in CreateInput) (*domain.Gateway, 
 		return nil, err
 	}
 	g.Domain = in.Domain
-	g.Metadata = in.Metadata
+	g.Metadata = domain.SanitizeClientMetadata(in.Metadata)
 	g.Telemetry = in.Telemetry
 	g.ClientTLSConfig = in.ClientTLSConfig
 	g.SessionConfig = in.SessionConfig

--- a/pkg/app/gateway/creator_test.go
+++ b/pkg/app/gateway/creator_test.go
@@ -160,12 +160,12 @@ func TestCreator_Create_RejectsDuplicateExporter(t *testing.T) {
 	}
 }
 
-func TestCreator_Create_StripsClientProvidedTeamID(t *testing.T) {
+func TestCreator_Create_StripsClientProvidedTenantID(t *testing.T) {
 	t.Parallel()
 	repo := repomocks.NewRepository(t)
 	repo.EXPECT().
 		Save(mock.Anything, mock.MatchedBy(func(g *domain.Gateway) bool {
-			return g.TeamID() == "" && g.Metadata["env"] == "prod"
+			return g.TenantID() == "" && g.Metadata["env"] == "prod"
 		})).
 		Return(nil).
 		Once()
@@ -174,13 +174,13 @@ func TestCreator_Create_StripsClientProvidedTeamID(t *testing.T) {
 
 	g, err := creator.Create(context.Background(), appgateway.CreateInput{
 		Slug:     "prod",
-		Metadata: map[string]string{domain.MetadataTeamIDKey: "attacker-team", "env": "prod"},
+		Metadata: map[string]string{domain.MetadataTenantIDKey: "attacker-team", "env": "prod"},
 	})
 	if err != nil {
 		t.Fatalf("Create error: %v", err)
 	}
-	if g.TeamID() != "" {
-		t.Fatalf("client-provided team_id was not stripped: %q", g.TeamID())
+	if g.TenantID() != "" {
+		t.Fatalf("client-provided tenant_id was not stripped: %q", g.TenantID())
 	}
 }
 

--- a/pkg/app/gateway/creator_test.go
+++ b/pkg/app/gateway/creator_test.go
@@ -160,6 +160,30 @@ func TestCreator_Create_RejectsDuplicateExporter(t *testing.T) {
 	}
 }
 
+func TestCreator_Create_StripsClientProvidedTeamID(t *testing.T) {
+	t.Parallel()
+	repo := repomocks.NewRepository(t)
+	repo.EXPECT().
+		Save(mock.Anything, mock.MatchedBy(func(g *domain.Gateway) bool {
+			return g.TeamID() == "" && g.Metadata["env"] == "prod"
+		})).
+		Return(nil).
+		Once()
+
+	creator := appgateway.NewCreator(repo, newCacheManager(), nil, newTestLogger(), nil)
+
+	g, err := creator.Create(context.Background(), appgateway.CreateInput{
+		Slug:     "prod",
+		Metadata: map[string]string{domain.MetadataTeamIDKey: "attacker-team", "env": "prod"},
+	})
+	if err != nil {
+		t.Fatalf("Create error: %v", err)
+	}
+	if g.TeamID() != "" {
+		t.Fatalf("client-provided team_id was not stripped: %q", g.TeamID())
+	}
+}
+
 func TestCreator_Create_PropagatesRepoError(t *testing.T) {
 	t.Parallel()
 	repo := repomocks.NewRepository(t)

--- a/pkg/app/gateway/updater.go
+++ b/pkg/app/gateway/updater.go
@@ -91,7 +91,7 @@ func (u *updater) Update(ctx context.Context, in UpdateInput) (*domain.Gateway, 
 		g.Domain = *in.Domain
 	}
 	if in.Metadata != nil {
-		g.Metadata = in.Metadata
+		g.Metadata = domain.WithTeamID(domain.SanitizeClientMetadata(in.Metadata), old.TeamID())
 	}
 	if in.Telemetry != nil {
 		g.Telemetry = in.Telemetry

--- a/pkg/app/gateway/updater.go
+++ b/pkg/app/gateway/updater.go
@@ -91,7 +91,7 @@ func (u *updater) Update(ctx context.Context, in UpdateInput) (*domain.Gateway, 
 		g.Domain = *in.Domain
 	}
 	if in.Metadata != nil {
-		g.Metadata = domain.WithTeamID(domain.SanitizeClientMetadata(in.Metadata), old.TeamID())
+		g.Metadata = domain.WithTenantID(domain.SanitizeClientMetadata(in.Metadata), old.TenantID())
 	}
 	if in.Telemetry != nil {
 		g.Telemetry = in.Telemetry

--- a/pkg/app/gateway/updater_test.go
+++ b/pkg/app/gateway/updater_test.go
@@ -152,18 +152,18 @@ func TestUpdater_Update_Partial_PreservesStatus(t *testing.T) {
 	}
 }
 
-func TestUpdater_Update_TeamIDIsServerOnlyAndImmutable(t *testing.T) {
+func TestUpdater_Update_TenantIDIsServerOnlyAndImmutable(t *testing.T) {
 	t.Parallel()
 	repo := repomocks.NewRepository(t)
 	id := ids.New[ids.GatewayKind]()
 	now := time.Now().UTC()
 	existing := domain.Rehydrate(id, "old", "active", "", nil, nil, nil, now, now)
-	existing.Metadata = map[string]string{domain.MetadataTeamIDKey: "acme", "env": "prod"}
+	existing.Metadata = map[string]string{domain.MetadataTenantIDKey: "acme", "env": "prod"}
 
 	repo.EXPECT().FindByID(mock.Anything, id).Return(existing, nil).Once()
 	repo.EXPECT().
 		Update(mock.Anything, mock.MatchedBy(func(g *domain.Gateway) bool {
-			return g.TeamID() == "acme" && g.Metadata["env"] == "staging"
+			return g.TenantID() == "acme" && g.Metadata["env"] == "staging"
 		})).
 		Return(nil).
 		Once()
@@ -171,13 +171,13 @@ func TestUpdater_Update_TeamIDIsServerOnlyAndImmutable(t *testing.T) {
 	updater := appgateway.NewUpdater(repo, newCacheManager(), cachetest.NoopPublisher(), nil, newTestLogger(), nil)
 	got, err := updater.Update(context.Background(), appgateway.UpdateInput{
 		ID:       id,
-		Metadata: map[string]string{domain.MetadataTeamIDKey: "globex", "env": "staging"},
+		Metadata: map[string]string{domain.MetadataTenantIDKey: "globex", "env": "staging"},
 	})
 	if err != nil {
 		t.Fatalf("Update error: %v", err)
 	}
-	if got.TeamID() != "acme" {
-		t.Fatalf("team_id mutated by client: got %q, want the immutable acme", got.TeamID())
+	if got.TenantID() != "acme" {
+		t.Fatalf("tenant_id mutated by client: got %q, want the immutable acme", got.TenantID())
 	}
 	if got.Metadata["env"] != "staging" {
 		t.Fatalf("non-reserved metadata was not updated: %+v", got.Metadata)

--- a/pkg/app/gateway/updater_test.go
+++ b/pkg/app/gateway/updater_test.go
@@ -152,6 +152,38 @@ func TestUpdater_Update_Partial_PreservesStatus(t *testing.T) {
 	}
 }
 
+func TestUpdater_Update_TeamIDIsServerOnlyAndImmutable(t *testing.T) {
+	t.Parallel()
+	repo := repomocks.NewRepository(t)
+	id := ids.New[ids.GatewayKind]()
+	now := time.Now().UTC()
+	existing := domain.Rehydrate(id, "old", "active", "", nil, nil, nil, now, now)
+	existing.Metadata = map[string]string{domain.MetadataTeamIDKey: "acme", "env": "prod"}
+
+	repo.EXPECT().FindByID(mock.Anything, id).Return(existing, nil).Once()
+	repo.EXPECT().
+		Update(mock.Anything, mock.MatchedBy(func(g *domain.Gateway) bool {
+			return g.TeamID() == "acme" && g.Metadata["env"] == "staging"
+		})).
+		Return(nil).
+		Once()
+
+	updater := appgateway.NewUpdater(repo, newCacheManager(), cachetest.NoopPublisher(), nil, newTestLogger(), nil)
+	got, err := updater.Update(context.Background(), appgateway.UpdateInput{
+		ID:       id,
+		Metadata: map[string]string{domain.MetadataTeamIDKey: "globex", "env": "staging"},
+	})
+	if err != nil {
+		t.Fatalf("Update error: %v", err)
+	}
+	if got.TeamID() != "acme" {
+		t.Fatalf("team_id mutated by client: got %q, want the immutable acme", got.TeamID())
+	}
+	if got.Metadata["env"] != "staging" {
+		t.Fatalf("non-reserved metadata was not updated: %+v", got.Metadata)
+	}
+}
+
 func TestUpdater_Update_RejectsEmptySlug(t *testing.T) {
 	t.Parallel()
 	repo := repomocks.NewRepository(t)

--- a/pkg/app/metrics/builder.go
+++ b/pkg/app/metrics/builder.go
@@ -65,7 +65,7 @@ func (b *Builder) Build(
 		Kind:          events.KindLLM,
 		TraceID:       traceID,
 		GatewayID:     meta.GatewayID,
-		TeamID:        meta.TeamID,
+		TenantID:        meta.TenantID,
 		Timestamp:     startTime.UTC().Format(time.RFC3339),
 		OccurredOn:    startTime.UnixMilli(),
 		EndTimestamp:  endTime.UnixMilli(),

--- a/pkg/app/metrics/builder_mcp_test.go
+++ b/pkg/app/metrics/builder_mcp_test.go
@@ -36,7 +36,7 @@ func mcpSpan(name string, attrs *trace.MCPAttrs, latency time.Duration) *trace.S
 func TestBuilder_MCPFoldsUpstreamAndLatency(t *testing.T) {
 	rt := trace.New("trace-mcp", trace.Metadata{
 		GatewayID:    "gw-1",
-		TeamID:       "team-9",
+		TenantID:       "team-9",
 		ConsumerID:   "c-1",
 		ConsumerName: "agent",
 		Kind:         events.KindMCP,
@@ -62,7 +62,7 @@ func TestBuilder_MCPFoldsUpstreamAndLatency(t *testing.T) {
 	evt := newBuilder(appcatalog.Pricing{}).Build(context.Background(), rt, req, resp, start, end)
 
 	assert.Equal(t, events.KindMCP, evt.Kind)
-	assert.Equal(t, "team-9", evt.TeamID)
+	assert.Equal(t, "team-9", evt.TenantID)
 	assert.Equal(t, "c-1", evt.Consumer.ID)
 	require.NotNil(t, evt.MCP)
 	assert.Equal(t, "tools/call", evt.MCP.Method)

--- a/pkg/app/metrics/builder_test.go
+++ b/pkg/app/metrics/builder_test.go
@@ -72,8 +72,8 @@ func pluginSpan(name string, attrs *trace.PluginAttrs, statusCode int, latency t
 const openAIRequestBody = `{"model":"gpt-4o","temperature":0.7,"max_tokens":100,"stream":false,` +
 	`"messages":[{"role":"user","content":"hello"}]}`
 
-func TestBuilder_SetsTeamIDFromMetadata(t *testing.T) {
-	rt := trace.New("trace-team", trace.Metadata{GatewayID: "gw-1", TeamID: "team-123"})
+func TestBuilder_SetsTenantIDFromMetadata(t *testing.T) {
+	rt := trace.New("trace-team", trace.Metadata{GatewayID: "gw-1", TenantID: "team-123"})
 
 	req := &infracontext.RequestContext{GatewayID: "gw-1", Method: "POST", Path: "/v1/chat/completions"}
 	resp := &infracontext.ResponseContext{StatusCode: 200}
@@ -81,7 +81,7 @@ func TestBuilder_SetsTeamIDFromMetadata(t *testing.T) {
 	start := time.UnixMilli(1_000_000)
 	evt := newBuilder(appcatalog.Pricing{}).Build(context.Background(), rt, req, resp, start, start.Add(time.Millisecond))
 
-	assert.Equal(t, "team-123", evt.TeamID)
+	assert.Equal(t, "team-123", evt.TenantID)
 }
 
 func TestBuilder_SyncSuccessFoldsCostAndLatency(t *testing.T) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -144,12 +144,34 @@ type Config struct {
 	ConfigSync       ConfigSyncConfig
 }
 
+// Config-sync control-plane auth modes. shared keeps the historical
+// constant-time shared-token compare; signed verifies a signed JWT and extracts
+// its opaque scope claim.
+const (
+	ConfigSyncAuthModeShared = "shared"
+	ConfigSyncAuthModeSigned = "signed"
+)
+
 type ConfigSyncConfig struct {
 	DataPlaneEnabled bool
 	Token            string // #nosec G117 -- config struct field, not a hardcoded credential
 	// TokenPrevious is the prior bearer accepted alongside Token so a token can be
 	// rotated without a window where in-flight data planes fail to authenticate.
-	TokenPrevious     string // #nosec G117 -- config struct field, not a hardcoded credential
+	TokenPrevious string // #nosec G117 -- config struct field, not a hardcoded credential
+	// AuthMode selects how the control plane verifies the data-plane bearer:
+	// ConfigSyncAuthModeShared (constant-time compare against the shared token)
+	// or ConfigSyncAuthModeSigned (verify a signed JWT and extract its opaque
+	// scope claim). It is chosen explicitly; there is no auto-detection and no
+	// fallback from signed to shared.
+	AuthMode string
+	// JWTPublicKey is the PEM-encoded PKIX public key that verifies signed
+	// tokens. Required when AuthMode is signed.
+	JWTPublicKey string // #nosec G117 -- config struct field, not a hardcoded credential
+	// JWTJWKSURL is reserved for JWKS-based verification (not yet wired).
+	JWTJWKSURL string
+	// JWTIssuer and JWTAudience are the expected iss/aud claims in signed mode.
+	JWTIssuer         string
+	JWTAudience       string
 	LKGPath           string
 	LKGKey            string // #nosec G117 -- config struct field, not a hardcoded credential
 	PollInterval      time.Duration
@@ -592,6 +614,11 @@ func getConfigSyncConfig() ConfigSyncConfig {
 		DataPlaneEnabled:     getEnvBool("CONFIG_SYNC_DATA_PLANE_ENABLED", defaultConfigSyncDataPlaneEnabled),
 		Token:                getEnv("CONFIG_SYNC_TOKEN", ""),
 		TokenPrevious:        getEnv("CONFIG_SYNC_TOKEN_PREVIOUS", ""),
+		AuthMode:             normalizeConfigSyncAuthMode(getEnv("CONFIG_SYNC_AUTH_MODE", ConfigSyncAuthModeShared)),
+		JWTPublicKey:         getEnv("CONFIG_SYNC_JWT_PUBLIC_KEY", ""),
+		JWTJWKSURL:           getEnv("CONFIG_SYNC_JWT_JWKS_URL", ""),
+		JWTIssuer:            getEnv("CONFIG_SYNC_JWT_ISSUER", ""),
+		JWTAudience:          getEnv("CONFIG_SYNC_JWT_AUDIENCE", ""),
 		LKGPath:              getEnv("CONFIG_SYNC_LKG_PATH", defaultConfigSyncLKGPath),
 		LKGKey:               getEnv("CONFIG_SYNC_LKG_KEY", ""),
 		PollInterval:         getEnvDuration("CONFIG_SYNC_POLL_INTERVAL", defaultConfigSyncPollInterval),
@@ -612,6 +639,10 @@ func getConfigSyncConfig() ConfigSyncConfig {
 		OutboxRetention:      getEnvDuration("CONFIG_SYNC_OUTBOX_RETENTION", defaultConfigSyncOutboxRetention),
 		OutboxMaxRows:        getEnvInt64("CONFIG_SYNC_OUTBOX_MAX_ROWS", defaultConfigSyncOutboxMaxRows),
 	}
+}
+
+func normalizeConfigSyncAuthMode(mode string) string {
+	return strings.ToLower(strings.TrimSpace(mode))
 }
 
 func resolveConfigSyncInstanceID() string {
@@ -700,10 +731,36 @@ func (c *Config) Validate() error {
 	if c.isDeployed() && c.ConfigSync.DataPlaneEnabled && c.ConfigSync.TLSInsecure {
 		return fmt.Errorf("%w: CONFIG_SYNC_TLS_INSECURE must not be true in deployed environments so the config-sync channel is not sent in cleartext", errors.ErrInvalidConfig)
 	}
+	if err := c.ConfigSync.validateAuthMode(); err != nil {
+		return err
+	}
 	if err := c.ConfigSync.Validate(); err != nil {
 		return err
 	}
 	return nil
+}
+
+// validateAuthMode checks the control-plane config-sync auth strategy. signed
+// mode fails closed at boot when its verification key or expected claims are
+// missing; an unknown mode is rejected outright.
+func (cs ConfigSyncConfig) validateAuthMode() error {
+	switch cs.AuthMode {
+	case "", ConfigSyncAuthModeShared:
+		return nil
+	case ConfigSyncAuthModeSigned:
+		if cs.JWTPublicKey == "" {
+			if cs.JWTJWKSURL != "" {
+				return fmt.Errorf("%w: CONFIG_SYNC_AUTH_MODE=signed with JWKS is not yet supported; set CONFIG_SYNC_JWT_PUBLIC_KEY", errors.ErrInvalidConfig)
+			}
+			return fmt.Errorf("%w: CONFIG_SYNC_AUTH_MODE=signed requires CONFIG_SYNC_JWT_PUBLIC_KEY", errors.ErrInvalidConfig)
+		}
+		if cs.JWTIssuer == "" || cs.JWTAudience == "" {
+			return fmt.Errorf("%w: CONFIG_SYNC_AUTH_MODE=signed requires CONFIG_SYNC_JWT_ISSUER and CONFIG_SYNC_JWT_AUDIENCE", errors.ErrInvalidConfig)
+		}
+		return nil
+	default:
+		return fmt.Errorf("%w: CONFIG_SYNC_AUTH_MODE must be %q or %q", errors.ErrInvalidConfig, ConfigSyncAuthModeShared, ConfigSyncAuthModeSigned)
+	}
 }
 
 // IsDeployed reports whether APP_ENV marks a non-local deployment (staging or

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -144,9 +144,6 @@ type Config struct {
 	ConfigSync       ConfigSyncConfig
 }
 
-// Config-sync control-plane auth modes. shared keeps the historical
-// constant-time shared-token compare; signed verifies a signed JWT and extracts
-// its opaque scope claim.
 const (
 	ConfigSyncAuthModeShared = "shared"
 	ConfigSyncAuthModeSigned = "signed"
@@ -157,19 +154,10 @@ type ConfigSyncConfig struct {
 	Token            string // #nosec G117 -- config struct field, not a hardcoded credential
 	// TokenPrevious is the prior bearer accepted alongside Token so a token can be
 	// rotated without a window where in-flight data planes fail to authenticate.
-	TokenPrevious string // #nosec G117 -- config struct field, not a hardcoded credential
-	// AuthMode selects how the control plane verifies the data-plane bearer:
-	// ConfigSyncAuthModeShared (constant-time compare against the shared token)
-	// or ConfigSyncAuthModeSigned (verify a signed JWT and extract its opaque
-	// scope claim). It is chosen explicitly; there is no auto-detection and no
-	// fallback from signed to shared.
-	AuthMode string
-	// JWTPublicKey is the PEM-encoded PKIX public key that verifies signed
-	// tokens. Required when AuthMode is signed.
-	JWTPublicKey string // #nosec G117 -- config struct field, not a hardcoded credential
-	// JWTJWKSURL is reserved for JWKS-based verification (not yet wired).
-	JWTJWKSURL string
-	// JWTIssuer and JWTAudience are the expected iss/aud claims in signed mode.
+	TokenPrevious     string // #nosec G117 -- config struct field, not a hardcoded credential
+	AuthMode          string
+	JWTPublicKey      string // #nosec G117 -- config struct field, not a hardcoded credential
+	JWTJWKSURL        string
 	JWTIssuer         string
 	JWTAudience       string
 	LKGPath           string
@@ -740,9 +728,6 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-// validateAuthMode checks the control-plane config-sync auth strategy. signed
-// mode fails closed at boot when its verification key or expected claims are
-// missing; an unknown mode is rejected outright.
 func (cs ConfigSyncConfig) validateAuthMode() error {
 	switch cs.AuthMode {
 	case "", ConfigSyncAuthModeShared:

--- a/pkg/config/configsync_auth_test.go
+++ b/pkg/config/configsync_auth_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	stderrors "errors"
+	"testing"
+
+	"github.com/NeuralTrust/TrustGate/pkg/common/errors"
+)
+
+func TestConfigSyncValidateAuthMode(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     ConfigSyncConfig
+		wantErr bool
+	}{
+		{name: "shared default", cfg: ConfigSyncConfig{AuthMode: ConfigSyncAuthModeShared}, wantErr: false},
+		{name: "unknown mode", cfg: ConfigSyncConfig{AuthMode: "magic"}, wantErr: true},
+		{name: "signed without key", cfg: ConfigSyncConfig{AuthMode: ConfigSyncAuthModeSigned, JWTIssuer: "i", JWTAudience: "a"}, wantErr: true},
+		{name: "signed jwks only", cfg: ConfigSyncConfig{AuthMode: ConfigSyncAuthModeSigned, JWTJWKSURL: "https://x/jwks", JWTIssuer: "i", JWTAudience: "a"}, wantErr: true},
+		{name: "signed without iss/aud", cfg: ConfigSyncConfig{AuthMode: ConfigSyncAuthModeSigned, JWTPublicKey: "pem"}, wantErr: true},
+		{name: "signed complete", cfg: ConfigSyncConfig{AuthMode: ConfigSyncAuthModeSigned, JWTPublicKey: "pem", JWTIssuer: "i", JWTAudience: "a"}, wantErr: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.validateAuthMode()
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantErr && err != nil && !stderrors.Is(err, errors.ErrInvalidConfig) {
+				t.Fatalf("error = %v, want ErrInvalidConfig", err)
+			}
+		})
+	}
+}
+
+func TestNormalizeConfigSyncAuthMode(t *testing.T) {
+	for in, want := range map[string]string{
+		"  Shared ": ConfigSyncAuthModeShared,
+		"SIGNED":    ConfigSyncAuthModeSigned,
+		"":          "",
+	} {
+		if got := normalizeConfigSyncAuthMode(in); got != want {
+			t.Fatalf("normalize(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/pkg/domain/gateway/gateway.go
+++ b/pkg/domain/gateway/gateway.go
@@ -26,7 +26,7 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/domain/telemetry"
 )
 
-const MetadataTeamIDKey = "team_id"
+const MetadataTenantIDKey = "tenant_id"
 
 type Gateway struct {
 	ID              ids.GatewayID        `json:"id"`
@@ -41,15 +41,15 @@ type Gateway struct {
 	UpdatedAt       time.Time            `json:"updated_at"`
 }
 
-func (g *Gateway) TeamID() string {
+func (g *Gateway) TenantID() string {
 	if g == nil || g.Metadata == nil {
 		return ""
 	}
-	return g.Metadata[MetadataTeamIDKey]
+	return g.Metadata[MetadataTenantIDKey]
 }
 
 func isReservedMetadataKey(key string) bool {
-	return key == MetadataTeamIDKey
+	return key == MetadataTenantIDKey
 }
 
 func SanitizeClientMetadata(metadata map[string]string) map[string]string {
@@ -69,14 +69,14 @@ func SanitizeClientMetadata(metadata map[string]string) map[string]string {
 	return out
 }
 
-func WithTeamID(metadata map[string]string, teamID string) map[string]string {
-	if teamID == "" {
+func WithTenantID(metadata map[string]string, tenantID string) map[string]string {
+	if tenantID == "" {
 		return metadata
 	}
 	if metadata == nil {
 		metadata = make(map[string]string, 1)
 	}
-	metadata[MetadataTeamIDKey] = teamID
+	metadata[MetadataTenantIDKey] = tenantID
 	return metadata
 }
 

--- a/pkg/domain/gateway/gateway.go
+++ b/pkg/domain/gateway/gateway.go
@@ -48,6 +48,38 @@ func (g *Gateway) TeamID() string {
 	return g.Metadata[MetadataTeamIDKey]
 }
 
+func isReservedMetadataKey(key string) bool {
+	return key == MetadataTeamIDKey
+}
+
+func SanitizeClientMetadata(metadata map[string]string) map[string]string {
+	if metadata == nil {
+		return nil
+	}
+	out := make(map[string]string, len(metadata))
+	for key, value := range metadata {
+		if isReservedMetadataKey(key) {
+			continue
+		}
+		out[key] = value
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func WithTeamID(metadata map[string]string, teamID string) map[string]string {
+	if teamID == "" {
+		return metadata
+	}
+	if metadata == nil {
+		metadata = make(map[string]string, 1)
+	}
+	metadata[MetadataTeamIDKey] = teamID
+	return metadata
+}
+
 type SessionConfig struct {
 	Enabled       *bool  `json:"enabled,omitempty"`
 	HeaderName    string `json:"header_name,omitempty"`

--- a/pkg/domain/gateway/gateway_test.go
+++ b/pkg/domain/gateway/gateway_test.go
@@ -179,3 +179,68 @@ func TestClientTLSConfig_NilRoundTrip(t *testing.T) {
 		t.Fatalf("Value = %v, want nil for nil ClientTLSConfig", v)
 	}
 }
+
+func TestSanitizeClientMetadata(t *testing.T) {
+	t.Parallel()
+
+	t.Run("strips server-only team_id", func(t *testing.T) {
+		t.Parallel()
+		in := map[string]string{MetadataTeamIDKey: "attacker-team", "env": "prod"}
+		out := SanitizeClientMetadata(in)
+		if _, ok := out[MetadataTeamIDKey]; ok {
+			t.Fatalf("team_id survived sanitization: %v", out)
+		}
+		if out["env"] != "prod" {
+			t.Fatalf("non-reserved key dropped: %v", out)
+		}
+		if _, ok := in[MetadataTeamIDKey]; !ok {
+			t.Fatal("input map mutated; sanitize must copy")
+		}
+	})
+
+	t.Run("nil input stays nil", func(t *testing.T) {
+		t.Parallel()
+		if out := SanitizeClientMetadata(nil); out != nil {
+			t.Fatalf("nil input produced %v, want nil", out)
+		}
+	})
+
+	t.Run("only reserved keys collapse to nil", func(t *testing.T) {
+		t.Parallel()
+		if out := SanitizeClientMetadata(map[string]string{MetadataTeamIDKey: "x"}); out != nil {
+			t.Fatalf("expected nil after removing sole reserved key, got %v", out)
+		}
+	})
+}
+
+func TestWithTeamID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty team leaves metadata untouched", func(t *testing.T) {
+		t.Parallel()
+		in := map[string]string{"env": "prod"}
+		out := WithTeamID(in, "")
+		if _, ok := out[MetadataTeamIDKey]; ok {
+			t.Fatalf("empty teamID injected a key: %v", out)
+		}
+	})
+
+	t.Run("sets team_id while preserving other keys", func(t *testing.T) {
+		t.Parallel()
+		out := WithTeamID(map[string]string{"env": "prod"}, "team-1")
+		if out[MetadataTeamIDKey] != "team-1" {
+			t.Fatalf("team_id = %q, want team-1", out[MetadataTeamIDKey])
+		}
+		if out["env"] != "prod" {
+			t.Fatalf("existing key lost: %v", out)
+		}
+	})
+
+	t.Run("initializes nil metadata", func(t *testing.T) {
+		t.Parallel()
+		out := WithTeamID(nil, "team-1")
+		if out[MetadataTeamIDKey] != "team-1" {
+			t.Fatalf("team_id = %q, want team-1", out[MetadataTeamIDKey])
+		}
+	})
+}

--- a/pkg/domain/gateway/gateway_test.go
+++ b/pkg/domain/gateway/gateway_test.go
@@ -183,17 +183,17 @@ func TestClientTLSConfig_NilRoundTrip(t *testing.T) {
 func TestSanitizeClientMetadata(t *testing.T) {
 	t.Parallel()
 
-	t.Run("strips server-only team_id", func(t *testing.T) {
+	t.Run("strips server-only tenant_id", func(t *testing.T) {
 		t.Parallel()
-		in := map[string]string{MetadataTeamIDKey: "attacker-team", "env": "prod"}
+		in := map[string]string{MetadataTenantIDKey: "attacker-team", "env": "prod"}
 		out := SanitizeClientMetadata(in)
-		if _, ok := out[MetadataTeamIDKey]; ok {
-			t.Fatalf("team_id survived sanitization: %v", out)
+		if _, ok := out[MetadataTenantIDKey]; ok {
+			t.Fatalf("tenant_id survived sanitization: %v", out)
 		}
 		if out["env"] != "prod" {
 			t.Fatalf("non-reserved key dropped: %v", out)
 		}
-		if _, ok := in[MetadataTeamIDKey]; !ok {
+		if _, ok := in[MetadataTenantIDKey]; !ok {
 			t.Fatal("input map mutated; sanitize must copy")
 		}
 	})
@@ -207,29 +207,29 @@ func TestSanitizeClientMetadata(t *testing.T) {
 
 	t.Run("only reserved keys collapse to nil", func(t *testing.T) {
 		t.Parallel()
-		if out := SanitizeClientMetadata(map[string]string{MetadataTeamIDKey: "x"}); out != nil {
+		if out := SanitizeClientMetadata(map[string]string{MetadataTenantIDKey: "x"}); out != nil {
 			t.Fatalf("expected nil after removing sole reserved key, got %v", out)
 		}
 	})
 }
 
-func TestWithTeamID(t *testing.T) {
+func TestWithTenantID(t *testing.T) {
 	t.Parallel()
 
 	t.Run("empty team leaves metadata untouched", func(t *testing.T) {
 		t.Parallel()
 		in := map[string]string{"env": "prod"}
-		out := WithTeamID(in, "")
-		if _, ok := out[MetadataTeamIDKey]; ok {
+		out := WithTenantID(in, "")
+		if _, ok := out[MetadataTenantIDKey]; ok {
 			t.Fatalf("empty teamID injected a key: %v", out)
 		}
 	})
 
-	t.Run("sets team_id while preserving other keys", func(t *testing.T) {
+	t.Run("sets tenant_id while preserving other keys", func(t *testing.T) {
 		t.Parallel()
-		out := WithTeamID(map[string]string{"env": "prod"}, "team-1")
-		if out[MetadataTeamIDKey] != "team-1" {
-			t.Fatalf("team_id = %q, want team-1", out[MetadataTeamIDKey])
+		out := WithTenantID(map[string]string{"env": "prod"}, "team-1")
+		if out[MetadataTenantIDKey] != "team-1" {
+			t.Fatalf("tenant_id = %q, want team-1", out[MetadataTenantIDKey])
 		}
 		if out["env"] != "prod" {
 			t.Fatalf("existing key lost: %v", out)
@@ -238,9 +238,9 @@ func TestWithTeamID(t *testing.T) {
 
 	t.Run("initializes nil metadata", func(t *testing.T) {
 		t.Parallel()
-		out := WithTeamID(nil, "team-1")
-		if out[MetadataTeamIDKey] != "team-1" {
-			t.Fatalf("team_id = %q, want team-1", out[MetadataTeamIDKey])
+		out := WithTenantID(nil, "team-1")
+		if out[MetadataTenantIDKey] != "team-1" {
+			t.Fatalf("tenant_id = %q, want team-1", out[MetadataTenantIDKey])
 		}
 	})
 }

--- a/pkg/infra/auth/jwt/jwt_manager.go
+++ b/pkg/infra/auth/jwt/jwt_manager.go
@@ -57,7 +57,7 @@ func NewJwtManager(config *config.ServerConfig) Manager {
 const PurposePlayground = "playground"
 
 type Claims struct {
-	TeamID    string `json:"team_id,omitempty"`
+	TenantID    string `json:"tenant_id,omitempty"`
 	UserID    string `json:"user_id,omitempty"`
 	UserEmail string `json:"user_email,omitempty"`
 	// Purpose restricts where a token is accepted. Empty means a regular

--- a/pkg/infra/configsync/grpc/authenticator.go
+++ b/pkg/infra/configsync/grpc/authenticator.go
@@ -1,0 +1,140 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpc
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+
+	"github.com/NeuralTrust/TrustGate/pkg/config"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// signedTokenAlgorithms is the allowlist of JWT signing algorithms accepted in
+// signed mode. "none" is deliberately excluded so an unsigned token is rejected.
+var signedTokenAlgorithms = []string{"EdDSA", "ES256", "RS256"}
+
+var (
+	errAuthNotConfigured = errors.New("config-sync auth is not configured")
+	errUnauthenticated   = errors.New("missing or invalid config-sync token")
+)
+
+// scopeAuthenticator validates a presented bearer and returns the partition
+// scope it authorizes. An empty scope denotes the whole, unpartitioned config.
+type scopeAuthenticator interface {
+	authenticate(bearer string) (scope string, err error)
+}
+
+// sharedAuthenticator compares the presented bearer, in constant time, against
+// the configured current and previous shared-token digests. It never grants a
+// scope: the shared token identifies no partition, so the scope is always empty.
+type sharedAuthenticator struct {
+	tokenDigests [][32]byte
+}
+
+func newSharedAuthenticator(cfg config.ConfigSyncConfig) *sharedAuthenticator {
+	auth := &sharedAuthenticator{}
+	if cfg.Token != "" {
+		auth.tokenDigests = append(auth.tokenDigests, sha256.Sum256([]byte(cfg.Token)))
+		if cfg.TokenPrevious != "" {
+			auth.tokenDigests = append(auth.tokenDigests, sha256.Sum256([]byte(cfg.TokenPrevious)))
+		}
+	}
+	return auth
+}
+
+func (s *sharedAuthenticator) configured() bool { return len(s.tokenDigests) > 0 }
+
+func (s *sharedAuthenticator) authenticate(bearer string) (string, error) {
+	if !s.configured() {
+		return "", errAuthNotConfigured
+	}
+	if bearer == "" {
+		return "", errUnauthenticated
+	}
+	providedDigest := sha256.Sum256([]byte(bearer))
+	matched := 0
+	for _, digest := range s.tokenDigests {
+		matched |= subtle.ConstantTimeCompare(providedDigest[:], digest[:])
+	}
+	if matched != 1 {
+		return "", errUnauthenticated
+	}
+	return "", nil
+}
+
+// jwtAuthenticator verifies a signed JWT (allowlisted algorithm, expected
+// issuer/audience, required expiry) and extracts its opaque scope claim. It
+// fails closed: any verification failure or a missing scope yields an
+// unauthenticated error and never falls back to shared-token behavior.
+type jwtAuthenticator struct {
+	parser  *jwt.Parser
+	keyfunc jwt.Keyfunc
+}
+
+func newJWTAuthenticator(cfg config.ConfigSyncConfig) (*jwtAuthenticator, error) {
+	if cfg.JWTPublicKey == "" {
+		return nil, errors.New("config-sync signed mode requires a JWT public key")
+	}
+	key, err := parsePKIXPublicKeyPEM(cfg.JWTPublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("parse config-sync JWT public key: %w", err)
+	}
+	opts := []jwt.ParserOption{
+		jwt.WithValidMethods(signedTokenAlgorithms),
+		jwt.WithExpirationRequired(),
+	}
+	if cfg.JWTIssuer != "" {
+		opts = append(opts, jwt.WithIssuer(cfg.JWTIssuer))
+	}
+	if cfg.JWTAudience != "" {
+		opts = append(opts, jwt.WithAudience(cfg.JWTAudience))
+	}
+	return &jwtAuthenticator{
+		parser:  jwt.NewParser(opts...),
+		keyfunc: func(*jwt.Token) (any, error) { return key, nil },
+	}, nil
+}
+
+func (j *jwtAuthenticator) authenticate(bearer string) (string, error) {
+	if bearer == "" {
+		return "", errUnauthenticated
+	}
+	claims := jwt.MapClaims{}
+	if _, err := j.parser.ParseWithClaims(bearer, claims, j.keyfunc); err != nil {
+		return "", errUnauthenticated
+	}
+	scope, ok := claims["scope"].(string)
+	if !ok || scope == "" {
+		return "", errUnauthenticated
+	}
+	return scope, nil
+}
+
+func parsePKIXPublicKeyPEM(pemStr string) (any, error) {
+	block, _ := pem.Decode([]byte(pemStr))
+	if block == nil {
+		return nil, errors.New("no PEM block found")
+	}
+	key, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	return key, nil
+}

--- a/pkg/infra/configsync/grpc/authenticator.go
+++ b/pkg/infra/configsync/grpc/authenticator.go
@@ -26,8 +26,6 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 )
 
-// signedTokenAlgorithms is the allowlist of JWT signing algorithms accepted in
-// signed mode. "none" is deliberately excluded so an unsigned token is rejected.
 var signedTokenAlgorithms = []string{"EdDSA", "ES256", "RS256"}
 
 var (
@@ -35,15 +33,10 @@ var (
 	errUnauthenticated   = errors.New("missing or invalid config-sync token")
 )
 
-// scopeAuthenticator validates a presented bearer and returns the partition
-// scope it authorizes. An empty scope denotes the whole, unpartitioned config.
 type scopeAuthenticator interface {
 	authenticate(bearer string) (scope string, err error)
 }
 
-// sharedAuthenticator compares the presented bearer, in constant time, against
-// the configured current and previous shared-token digests. It never grants a
-// scope: the shared token identifies no partition, so the scope is always empty.
 type sharedAuthenticator struct {
 	tokenDigests [][32]byte
 }
@@ -79,10 +72,6 @@ func (s *sharedAuthenticator) authenticate(bearer string) (string, error) {
 	return "", nil
 }
 
-// jwtAuthenticator verifies a signed JWT (allowlisted algorithm, expected
-// issuer/audience, required expiry) and extracts its opaque scope claim. It
-// fails closed: any verification failure or a missing scope yields an
-// unauthenticated error and never falls back to shared-token behavior.
 type jwtAuthenticator struct {
 	parser  *jwt.Parser
 	keyfunc jwt.Keyfunc

--- a/pkg/infra/configsync/grpc/authenticator_test.go
+++ b/pkg/infra/configsync/grpc/authenticator_test.go
@@ -1,0 +1,167 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpc
+
+import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+	"time"
+
+	"github.com/NeuralTrust/TrustGate/pkg/config"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+const (
+	testIssuer   = "datacore"
+	testAudience = "trustgate-config-sync"
+)
+
+func newSignedTestConfig(t *testing.T) (config.ConfigSyncConfig, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		t.Fatalf("marshal public key: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})
+	cfg := config.ConfigSyncConfig{
+		AuthMode:     config.ConfigSyncAuthModeSigned,
+		JWTPublicKey: string(pemBytes),
+		JWTIssuer:    testIssuer,
+		JWTAudience:  testAudience,
+	}
+	return cfg, priv
+}
+
+func mint(t *testing.T, priv ed25519.PrivateKey, method jwt.SigningMethod, claims jwt.MapClaims) string {
+	t.Helper()
+	token := jwt.NewWithClaims(method, claims)
+	var (
+		signed string
+		err    error
+	)
+	if method == jwt.SigningMethodNone {
+		signed, err = token.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	} else {
+		signed, err = token.SignedString(priv)
+	}
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+	return signed
+}
+
+func validClaims() jwt.MapClaims {
+	return jwt.MapClaims{
+		"iss":   testIssuer,
+		"aud":   testAudience,
+		"scope": "org_1",
+		"exp":   time.Now().Add(time.Hour).Unix(),
+	}
+}
+
+func TestJWTAuthenticator_ValidTokenExtractsScope(t *testing.T) {
+	cfg, priv := newSignedTestConfig(t)
+	auth, err := newJWTAuthenticator(cfg)
+	if err != nil {
+		t.Fatalf("newJWTAuthenticator: %v", err)
+	}
+	scope, err := auth.authenticate(mint(t, priv, jwt.SigningMethodEdDSA, validClaims()))
+	if err != nil {
+		t.Fatalf("authenticate: %v", err)
+	}
+	if scope != "org_1" {
+		t.Fatalf("scope = %q, want org_1", scope)
+	}
+}
+
+func TestJWTAuthenticator_Rejects(t *testing.T) {
+	cfg, priv := newSignedTestConfig(t)
+	auth, err := newJWTAuthenticator(cfg)
+	if err != nil {
+		t.Fatalf("newJWTAuthenticator: %v", err)
+	}
+	_, otherPriv, _ := ed25519.GenerateKey(nil)
+
+	cases := map[string]string{
+		"empty":         "",
+		"garbage":       "not-a-jwt",
+		"alg_none":      mint(t, priv, jwt.SigningMethodNone, validClaims()),
+		"bad_signature": mint(t, otherPriv, jwt.SigningMethodEdDSA, validClaims()),
+		"expired": mint(t, priv, jwt.SigningMethodEdDSA, jwt.MapClaims{
+			"iss": testIssuer, "aud": testAudience, "scope": "org_1",
+			"exp": time.Now().Add(-time.Hour).Unix(),
+		}),
+		"no_exp": mint(t, priv, jwt.SigningMethodEdDSA, jwt.MapClaims{
+			"iss": testIssuer, "aud": testAudience, "scope": "org_1",
+		}),
+		"wrong_issuer": mint(t, priv, jwt.SigningMethodEdDSA, jwt.MapClaims{
+			"iss": "evil", "aud": testAudience, "scope": "org_1",
+			"exp": time.Now().Add(time.Hour).Unix(),
+		}),
+		"wrong_audience": mint(t, priv, jwt.SigningMethodEdDSA, jwt.MapClaims{
+			"iss": testIssuer, "aud": "other", "scope": "org_1",
+			"exp": time.Now().Add(time.Hour).Unix(),
+		}),
+		"missing_scope": mint(t, priv, jwt.SigningMethodEdDSA, jwt.MapClaims{
+			"iss": testIssuer, "aud": testAudience,
+			"exp": time.Now().Add(time.Hour).Unix(),
+		}),
+	}
+	for name, token := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := auth.authenticate(token); err == nil {
+				t.Fatalf("expected rejection for %s", name)
+			}
+		})
+	}
+}
+
+func TestSharedAuthenticator(t *testing.T) {
+	auth := newSharedAuthenticator(config.ConfigSyncConfig{Token: "tok", TokenPrevious: "old"})
+	for _, tok := range []string{"tok", "old"} {
+		scope, err := auth.authenticate(tok)
+		if err != nil {
+			t.Fatalf("authenticate(%q): %v", tok, err)
+		}
+		if scope != "" {
+			t.Fatalf("shared scope = %q, want empty", scope)
+		}
+	}
+	if _, err := auth.authenticate("wrong"); err == nil {
+		t.Fatal("expected rejection for wrong token")
+	}
+	unconfigured := newSharedAuthenticator(config.ConfigSyncConfig{})
+	if _, err := unconfigured.authenticate("anything"); err == nil {
+		t.Fatal("expected rejection when no token configured")
+	}
+}
+
+func TestNewAuthInterceptor_SignedRequiresValidKey(t *testing.T) {
+	_, err := NewAuthInterceptor(&config.Config{ConfigSync: config.ConfigSyncConfig{
+		AuthMode:     config.ConfigSyncAuthModeSigned,
+		JWTPublicKey: "-----BEGIN PUBLIC KEY-----\nnot-base64\n-----END PUBLIC KEY-----",
+		JWTIssuer:    testIssuer,
+		JWTAudience:  testAudience,
+	}}, discardLogger())
+	if err == nil {
+		t.Fatal("expected error for malformed public key")
+	}
+}

--- a/pkg/infra/configsync/grpc/client_test.go
+++ b/pkg/infra/configsync/grpc/client_test.go
@@ -46,7 +46,7 @@ type fakeSource struct {
 	ok      bool
 }
 
-func (f *fakeSource) Snapshot() ([]byte, string, bool) {
+func (f *fakeSource) SnapshotFor(string) ([]byte, string, bool) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.raw, f.version, f.ok

--- a/pkg/infra/configsync/grpc/interceptor.go
+++ b/pkg/infra/configsync/grpc/interceptor.go
@@ -19,8 +19,7 @@ package grpc
 
 import (
 	"context"
-	"crypto/sha256"
-	"crypto/subtle"
+	"errors"
 	"log/slog"
 	"strings"
 
@@ -37,32 +36,40 @@ const (
 	component       = "configsync-grpc"
 )
 
-// AuthInterceptor authenticates config-sync RPCs by comparing the presented
-// bearer token digest against the configured current and previous token digests
-// with a constant-time compare. It fails closed when no token is configured.
+// AuthInterceptor authenticates config-sync RPCs with the configured strategy
+// (shared token or signed JWT) and propagates the resolved partition scope down
+// the request context. It fails closed when auth is not configured.
 type AuthInterceptor struct {
-	tokenDigests [][32]byte
-	logger       *slog.Logger
+	authenticator scopeAuthenticator
+	logger        *slog.Logger
 }
 
-// NewAuthInterceptor builds an AuthInterceptor from the config-sync tokens,
-// warning once when no token is configured so the operator learns the transport
-// will reject every RPC.
-func NewAuthInterceptor(cfg *config.Config, logger *slog.Logger) *AuthInterceptor {
+// NewAuthInterceptor builds an AuthInterceptor for the configured auth mode.
+// signed mode returns an error when the JWT verification key cannot be loaded so
+// the process fails at boot rather than silently rejecting every RPC. shared
+// mode warns once when no token is configured.
+func NewAuthInterceptor(cfg *config.Config, logger *slog.Logger) (*AuthInterceptor, error) {
 	if logger == nil {
 		logger = slog.Default()
 	}
 	interceptor := &AuthInterceptor{logger: logger}
-	if cfg.ConfigSync.Token != "" {
-		interceptor.tokenDigests = append(interceptor.tokenDigests, sha256.Sum256([]byte(cfg.ConfigSync.Token)))
-		if cfg.ConfigSync.TokenPrevious != "" {
-			interceptor.tokenDigests = append(interceptor.tokenDigests, sha256.Sum256([]byte(cfg.ConfigSync.TokenPrevious)))
+	switch cfg.ConfigSync.AuthMode {
+	case config.ConfigSyncAuthModeSigned:
+		authenticator, err := newJWTAuthenticator(cfg.ConfigSync)
+		if err != nil {
+			return nil, err
 		}
-	} else {
-		logger.Warn("config-sync token is not configured; the gRPC transport will reject every RPC and no data plane can converge",
-			slog.String("component", component))
+		interceptor.authenticator = authenticator
+		logger.Info("config-sync auth: signed JWT mode enabled", slog.String("component", component))
+	default:
+		shared := newSharedAuthenticator(cfg.ConfigSync)
+		if !shared.configured() {
+			logger.Warn("config-sync token is not configured; the gRPC transport will reject every RPC and no data plane can converge",
+				slog.String("component", component))
+		}
+		interceptor.authenticator = shared
 	}
-	return interceptor
+	return interceptor, nil
 }
 
 // UnaryServerInterceptor authenticates unary RPCs before the handler runs and
@@ -90,27 +97,20 @@ func (a *AuthInterceptor) StreamServerInterceptor() grpc.StreamServerInterceptor
 }
 
 // authorize validates the bearer token and returns a context carrying the
-// resolved partition scope. In the shared-token mode the scope is empty, which
-// downstream resolves to the whole, unpartitioned config.
+// resolved partition scope. In shared mode the scope is empty, which downstream
+// resolves to the whole, unpartitioned config; in signed mode the scope is the
+// opaque claim extracted from the verified JWT.
 func (a *AuthInterceptor) authorize(ctx context.Context) (context.Context, error) {
-	if len(a.tokenDigests) == 0 {
-		a.logger.Debug("config-sync token is not configured; rejecting RPC",
-			slog.String("component", component))
-		return ctx, status.Error(codes.Unauthenticated, "config-sync token is not configured")
-	}
-	provided := bearerFromContext(ctx)
-	if provided == "" {
+	scope, err := a.authenticator.authenticate(bearerFromContext(ctx))
+	if err != nil {
+		if errors.Is(err, errAuthNotConfigured) {
+			a.logger.Debug("config-sync auth is not configured; rejecting RPC",
+				slog.String("component", component))
+			return ctx, status.Error(codes.Unauthenticated, "config-sync auth is not configured")
+		}
 		return ctx, status.Error(codes.Unauthenticated, "missing or invalid config-sync token")
 	}
-	providedDigest := sha256.Sum256([]byte(provided))
-	matched := 0
-	for _, digest := range a.tokenDigests {
-		matched |= subtle.ConstantTimeCompare(providedDigest[:], digest[:])
-	}
-	if matched != 1 {
-		return ctx, status.Error(codes.Unauthenticated, "missing or invalid config-sync token")
-	}
-	return WithScope(ctx, ""), nil
+	return WithScope(ctx, scope), nil
 }
 
 // scopedServerStream overrides the stream context so handlers observe the scope

--- a/pkg/infra/configsync/grpc/interceptor.go
+++ b/pkg/infra/configsync/grpc/interceptor.go
@@ -36,18 +36,11 @@ const (
 	component       = "configsync-grpc"
 )
 
-// AuthInterceptor authenticates config-sync RPCs with the configured strategy
-// (shared token or signed JWT) and propagates the resolved partition scope down
-// the request context. It fails closed when auth is not configured.
 type AuthInterceptor struct {
 	authenticator scopeAuthenticator
 	logger        *slog.Logger
 }
 
-// NewAuthInterceptor builds an AuthInterceptor for the configured auth mode.
-// signed mode returns an error when the JWT verification key cannot be loaded so
-// the process fails at boot rather than silently rejecting every RPC. shared
-// mode warns once when no token is configured.
 func NewAuthInterceptor(cfg *config.Config, logger *slog.Logger) (*AuthInterceptor, error) {
 	if logger == nil {
 		logger = slog.Default()
@@ -72,8 +65,6 @@ func NewAuthInterceptor(cfg *config.Config, logger *slog.Logger) (*AuthIntercept
 	return interceptor, nil
 }
 
-// UnaryServerInterceptor authenticates unary RPCs before the handler runs and
-// propagates the resolved partition scope down the context.
 func (a *AuthInterceptor) UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		scoped, err := a.authorize(ctx)
@@ -84,8 +75,6 @@ func (a *AuthInterceptor) UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 	}
 }
 
-// StreamServerInterceptor authenticates streaming RPCs before the handler runs
-// and propagates the resolved partition scope down the stream context.
 func (a *AuthInterceptor) StreamServerInterceptor() grpc.StreamServerInterceptor {
 	return func(srv any, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		scoped, err := a.authorize(ss.Context())
@@ -96,10 +85,6 @@ func (a *AuthInterceptor) StreamServerInterceptor() grpc.StreamServerInterceptor
 	}
 }
 
-// authorize validates the bearer token and returns a context carrying the
-// resolved partition scope. In shared mode the scope is empty, which downstream
-// resolves to the whole, unpartitioned config; in signed mode the scope is the
-// opaque claim extracted from the verified JWT.
 func (a *AuthInterceptor) authorize(ctx context.Context) (context.Context, error) {
 	scope, err := a.authenticator.authenticate(bearerFromContext(ctx))
 	if err != nil {
@@ -113,8 +98,6 @@ func (a *AuthInterceptor) authorize(ctx context.Context) (context.Context, error
 	return WithScope(ctx, scope), nil
 }
 
-// scopedServerStream overrides the stream context so handlers observe the scope
-// resolved by the interceptor.
 type scopedServerStream struct {
 	grpc.ServerStream
 	ctx context.Context

--- a/pkg/infra/configsync/grpc/interceptor.go
+++ b/pkg/infra/configsync/grpc/interceptor.go
@@ -65,35 +65,42 @@ func NewAuthInterceptor(cfg *config.Config, logger *slog.Logger) *AuthIntercepto
 	return interceptor
 }
 
-// UnaryServerInterceptor authenticates unary RPCs before the handler runs.
+// UnaryServerInterceptor authenticates unary RPCs before the handler runs and
+// propagates the resolved partition scope down the context.
 func (a *AuthInterceptor) UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
-		if err := a.authorize(ctx); err != nil {
+		scoped, err := a.authorize(ctx)
+		if err != nil {
 			return nil, err
 		}
-		return handler(ctx, req)
+		return handler(scoped, req)
 	}
 }
 
-// StreamServerInterceptor authenticates streaming RPCs before the handler runs.
+// StreamServerInterceptor authenticates streaming RPCs before the handler runs
+// and propagates the resolved partition scope down the stream context.
 func (a *AuthInterceptor) StreamServerInterceptor() grpc.StreamServerInterceptor {
 	return func(srv any, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-		if err := a.authorize(ss.Context()); err != nil {
+		scoped, err := a.authorize(ss.Context())
+		if err != nil {
 			return err
 		}
-		return handler(srv, ss)
+		return handler(srv, &scopedServerStream{ServerStream: ss, ctx: scoped})
 	}
 }
 
-func (a *AuthInterceptor) authorize(ctx context.Context) error {
+// authorize validates the bearer token and returns a context carrying the
+// resolved partition scope. In the shared-token mode the scope is empty, which
+// downstream resolves to the whole, unpartitioned config.
+func (a *AuthInterceptor) authorize(ctx context.Context) (context.Context, error) {
 	if len(a.tokenDigests) == 0 {
 		a.logger.Debug("config-sync token is not configured; rejecting RPC",
 			slog.String("component", component))
-		return status.Error(codes.Unauthenticated, "config-sync token is not configured")
+		return ctx, status.Error(codes.Unauthenticated, "config-sync token is not configured")
 	}
 	provided := bearerFromContext(ctx)
 	if provided == "" {
-		return status.Error(codes.Unauthenticated, "missing or invalid config-sync token")
+		return ctx, status.Error(codes.Unauthenticated, "missing or invalid config-sync token")
 	}
 	providedDigest := sha256.Sum256([]byte(provided))
 	matched := 0
@@ -101,10 +108,19 @@ func (a *AuthInterceptor) authorize(ctx context.Context) error {
 		matched |= subtle.ConstantTimeCompare(providedDigest[:], digest[:])
 	}
 	if matched != 1 {
-		return status.Error(codes.Unauthenticated, "missing or invalid config-sync token")
+		return ctx, status.Error(codes.Unauthenticated, "missing or invalid config-sync token")
 	}
-	return nil
+	return WithScope(ctx, ""), nil
 }
+
+// scopedServerStream overrides the stream context so handlers observe the scope
+// resolved by the interceptor.
+type scopedServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (s *scopedServerStream) Context() context.Context { return s.ctx }
 
 func bearerFromContext(ctx context.Context) string {
 	md, ok := metadata.FromIncomingContext(ctx)

--- a/pkg/infra/configsync/grpc/interceptor_test.go
+++ b/pkg/infra/configsync/grpc/interceptor_test.go
@@ -27,10 +27,15 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func testInterceptor(token, previous string) *AuthInterceptor {
+func testInterceptor(t *testing.T, token, previous string) *AuthInterceptor {
+	t.Helper()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	cfg := &config.Config{ConfigSync: config.ConfigSyncConfig{Token: token, TokenPrevious: previous}}
-	return NewAuthInterceptor(cfg, logger)
+	interceptor, err := NewAuthInterceptor(cfg, logger)
+	if err != nil {
+		t.Fatalf("NewAuthInterceptor: %v", err)
+	}
+	return interceptor
 }
 
 func contextWithAuth(header string, set bool) context.Context {
@@ -83,7 +88,7 @@ func TestAuthInterceptor_Unary(t *testing.T) {
 	for _, tc := range authCases() {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			interceptor := testInterceptor(tc.token, tc.previous)
+			interceptor := testInterceptor(t, tc.token, tc.previous)
 			ctx := contextWithAuth(tc.header, tc.setMeta)
 			called := false
 			handler := func(context.Context, any) (any, error) {
@@ -105,7 +110,7 @@ func TestAuthInterceptor_Stream(t *testing.T) {
 	for _, tc := range authCases() {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			interceptor := testInterceptor(tc.token, tc.previous)
+			interceptor := testInterceptor(t, tc.token, tc.previous)
 			ctx := contextWithAuth(tc.header, tc.setMeta)
 			called := false
 			handler := func(any, grpc.ServerStream) error {

--- a/pkg/infra/configsync/grpc/scope.go
+++ b/pkg/infra/configsync/grpc/scope.go
@@ -1,0 +1,35 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpc
+
+import "context"
+
+type scopeContextKeyType struct{}
+
+var scopeContextKey scopeContextKeyType
+
+// WithScope returns a context carrying the config-sync partition scope key. An
+// empty scope denotes the whole, unpartitioned config, which preserves the
+// single-tenant behavior.
+func WithScope(ctx context.Context, scope string) context.Context {
+	return context.WithValue(ctx, scopeContextKey, scope)
+}
+
+// ScopeFromContext returns the partition scope key set upstream by the auth
+// interceptor, or "" when none is present (unpartitioned / single-tenant).
+func ScopeFromContext(ctx context.Context) string {
+	scope, _ := ctx.Value(scopeContextKey).(string)
+	return scope
+}

--- a/pkg/infra/configsync/grpc/scope.go
+++ b/pkg/infra/configsync/grpc/scope.go
@@ -20,15 +20,10 @@ type scopeContextKeyType struct{}
 
 var scopeContextKey scopeContextKeyType
 
-// WithScope returns a context carrying the config-sync partition scope key. An
-// empty scope denotes the whole, unpartitioned config, which preserves the
-// single-tenant behavior.
 func WithScope(ctx context.Context, scope string) context.Context {
 	return context.WithValue(ctx, scopeContextKey, scope)
 }
 
-// ScopeFromContext returns the partition scope key set upstream by the auth
-// interceptor, or "" when none is present (unpartitioned / single-tenant).
 func ScopeFromContext(ctx context.Context) string {
 	scope, _ := ctx.Value(scopeContextKey).(string)
 	return scope

--- a/pkg/infra/configsync/grpc/scope_test.go
+++ b/pkg/infra/configsync/grpc/scope_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/NeuralTrust/TrustGate/pkg/config"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestScopeContextRoundTrip(t *testing.T) {
+	ctx := WithScope(context.Background(), "org_42")
+	if got := ScopeFromContext(ctx); got != "org_42" {
+		t.Fatalf("scope = %q, want org_42", got)
+	}
+	if got := ScopeFromContext(context.Background()); got != "" {
+		t.Fatalf("missing scope = %q, want empty", got)
+	}
+}
+
+type recordingStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (s *recordingStream) Context() context.Context { return s.ctx }
+
+func TestStreamInterceptorInjectsScope(t *testing.T) {
+	auth := NewAuthInterceptor(&config.Config{ConfigSync: config.ConfigSyncConfig{Token: "tok"}}, discardLogger())
+	md := metadata.New(map[string]string{authMetadataKey: bearerPrefix + "tok"})
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+
+	var seen string
+	invoked := false
+	handler := func(_ any, ss grpc.ServerStream) error {
+		seen = ScopeFromContext(ss.Context())
+		invoked = true
+		return nil
+	}
+	if err := auth.StreamServerInterceptor()(nil, &recordingStream{ctx: ctx}, &grpc.StreamServerInfo{}, handler); err != nil {
+		t.Fatalf("interceptor: %v", err)
+	}
+	if !invoked {
+		t.Fatal("handler was not invoked")
+	}
+	if seen != "" {
+		t.Fatalf("shared-mode scope = %q, want empty", seen)
+	}
+}

--- a/pkg/infra/configsync/grpc/scope_test.go
+++ b/pkg/infra/configsync/grpc/scope_test.go
@@ -41,7 +41,10 @@ type recordingStream struct {
 func (s *recordingStream) Context() context.Context { return s.ctx }
 
 func TestStreamInterceptorInjectsScope(t *testing.T) {
-	auth := NewAuthInterceptor(&config.Config{ConfigSync: config.ConfigSyncConfig{Token: "tok"}}, discardLogger())
+	auth, err := NewAuthInterceptor(&config.Config{ConfigSync: config.ConfigSyncConfig{Token: "tok"}}, discardLogger())
+	if err != nil {
+		t.Fatalf("NewAuthInterceptor: %v", err)
+	}
 	md := metadata.New(map[string]string{authMetadataKey: bearerPrefix + "tok"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 

--- a/pkg/infra/configsync/grpc/server_test.go
+++ b/pkg/infra/configsync/grpc/server_test.go
@@ -35,7 +35,10 @@ func startServer(t *testing.T, token string, src SnapshotSource) *Server {
 		GRPCKeepaliveTime:    30 * time.Second,
 		GRPCKeepaliveTimeout: 10 * time.Second,
 	}
-	auth := NewAuthInterceptor(&config.Config{ConfigSync: config.ConfigSyncConfig{Token: token}}, discardLogger())
+	auth, err := NewAuthInterceptor(&config.Config{ConfigSync: config.ConfigSyncConfig{Token: token}}, discardLogger())
+	if err != nil {
+		t.Fatalf("NewAuthInterceptor: %v", err)
+	}
 	svc := NewService(NewHub(discardLogger()), src, discardLogger())
 	srv, err := NewServer(cfg, svc, auth, discardLogger())
 	if err != nil {

--- a/pkg/infra/configsync/grpc/service.go
+++ b/pkg/infra/configsync/grpc/service.go
@@ -29,10 +29,11 @@ const (
 	snapshotChunkSize = 1 << 20
 )
 
-// SnapshotSource yields the current compiled snapshot bytes and version. The
+// SnapshotSource yields the compiled snapshot bytes and version for a given
+// partition scope. An empty scope means the whole, unpartitioned config. The
 // control-plane Holder satisfies it.
 type SnapshotSource interface {
-	Snapshot() (raw []byte, version string, ok bool)
+	SnapshotFor(scope string) (raw []byte, version string, ok bool)
 }
 
 // Service implements the ConfigSync gRPC server: the bidi Sync control channel
@@ -68,7 +69,8 @@ func (s *Service) Sync(stream snapshotpb.ConfigSync_SyncServer) error {
 	conn := s.hub.register(hello.GetInstanceId())
 	defer s.hub.unregister(conn)
 
-	if _, version, ok := s.source.Snapshot(); ok && version != hello.GetLastAppliedVersion() {
+	scope := ScopeFromContext(ctx)
+	if _, version, ok := s.source.SnapshotFor(scope); ok && version != hello.GetLastAppliedVersion() {
 		conn.enqueue(version)
 	}
 
@@ -107,7 +109,8 @@ func (s *Service) Sync(stream snapshotpb.ConfigSync_SyncServer) error {
 // GetSnapshot answers not_modified when the DP's applied_version matches current,
 // otherwise streams a SnapshotHeader followed by fixed-size data chunks.
 func (s *Service) GetSnapshot(req *snapshotpb.GetSnapshotRequest, stream snapshotpb.ConfigSync_GetSnapshotServer) error {
-	raw, version, ok := s.source.Snapshot()
+	scope := ScopeFromContext(stream.Context())
+	raw, version, ok := s.source.SnapshotFor(scope)
 	if !ok {
 		return status.Error(codes.Unavailable, "no snapshot available yet")
 	}

--- a/pkg/infra/configsync/grpc/service.go
+++ b/pkg/infra/configsync/grpc/service.go
@@ -29,9 +29,6 @@ const (
 	snapshotChunkSize = 1 << 20
 )
 
-// SnapshotSource yields the compiled snapshot bytes and version for a given
-// partition scope. An empty scope means the whole, unpartitioned config. The
-// control-plane Holder satisfies it.
 type SnapshotSource interface {
 	SnapshotFor(scope string) (raw []byte, version string, ok bool)
 }

--- a/pkg/infra/context/context_keys.go
+++ b/pkg/infra/context/context_keys.go
@@ -24,8 +24,8 @@ const (
 	// middleware from the per-gateway session configuration.
 	SessionContextKey          ContextKey = "session_id"
 	SessionGeneratedContextKey ContextKey = "session_id_generated"
-	// TeamIDContextKey holds the team identifier decoded from an admin JWT.
-	TeamIDContextKey ContextKey = "team_id"
+	// TenantIDContextKey holds the tenant identifier decoded from an admin JWT.
+	TenantIDContextKey ContextKey = "tenant_id"
 	// UserIDContextKey holds the user identifier decoded from an admin JWT.
 	UserIDContextKey ContextKey = "user_id"
 	// UserEmailContextKey holds the user email decoded from an admin JWT.

--- a/pkg/infra/metrics/events/event.go
+++ b/pkg/infra/metrics/events/event.go
@@ -26,7 +26,7 @@ type Event struct {
 	Kind          string `json:"kind"`
 	TraceID       string `json:"trace_id"`
 	GatewayID     string `json:"gateway_id"`
-	TeamID        string `json:"team_id,omitempty"`
+	TenantID        string `json:"tenant_id,omitempty"`
 
 	Timestamp    string `json:"timestamp"`
 	OccurredOn   int64  `json:"occurred_on"`

--- a/pkg/infra/metrics/events/views.go
+++ b/pkg/infra/metrics/events/views.go
@@ -25,7 +25,7 @@ func (e Event) SensibleView() Event {
 		SchemaVersion: e.SchemaVersion,
 		TraceID:       e.TraceID,
 		GatewayID:     e.GatewayID,
-		TeamID:        e.TeamID,
+		TenantID:        e.TenantID,
 		OccurredOn:    e.OccurredOn,
 		Request:       Request{Body: e.Request.Body},
 		Response:      Response{Body: e.Response.Body},

--- a/pkg/infra/metrics/events/views_test.go
+++ b/pkg/infra/metrics/events/views_test.go
@@ -29,7 +29,7 @@ func fullEvent() events.Event {
 		Kind:          events.KindLLM,
 		TraceID:       "trace-1",
 		GatewayID:     "gw-1",
-		TeamID:        "team-1",
+		TenantID:        "team-1",
 		Timestamp:     "2026-07-06T00:00:00Z",
 		OccurredOn:    1751760000,
 		EndTimestamp:  1751760001,
@@ -74,7 +74,7 @@ func TestEvent_MetadataView_ExcludesBodies(t *testing.T) {
 	assert.Equal(t, evt.Kind, meta.Kind)
 	assert.Equal(t, evt.TraceID, meta.TraceID)
 	assert.Equal(t, evt.GatewayID, meta.GatewayID)
-	assert.Equal(t, evt.TeamID, meta.TeamID)
+	assert.Equal(t, evt.TenantID, meta.TenantID)
 	assert.Equal(t, evt.IP, meta.IP)
 	assert.Equal(t, evt.Consumer, meta.Consumer)
 	assert.Equal(t, evt.Status, meta.Status)
@@ -101,7 +101,7 @@ func TestEvent_SensibleView_OnlyBodiesAndCorrelationKeys(t *testing.T) {
 	assert.Equal(t, evt.SchemaVersion, sensible.SchemaVersion)
 	assert.Equal(t, evt.TraceID, sensible.TraceID)
 	assert.Equal(t, evt.GatewayID, sensible.GatewayID)
-	assert.Equal(t, evt.TeamID, sensible.TeamID)
+	assert.Equal(t, evt.TenantID, sensible.TenantID)
 	assert.Equal(t, evt.OccurredOn, sensible.OccurredOn)
 
 	assert.Empty(t, sensible.Kind)

--- a/pkg/infra/telemetry/otlp/mapping.go
+++ b/pkg/infra/telemetry/otlp/mapping.go
@@ -63,7 +63,7 @@ const (
 	attrStatusIsTimeout      = "trustgate.status.is_timeout"
 	attrTraceID              = "trustgate.trace_id"
 	attrGatewayID            = "trustgate.gateway_id"
-	attrTeamID               = "trustgate.team_id"
+	attrTenantID               = "trustgate.tenant_id"
 	attrConsumerID           = "trustgate.consumer.id"
 	attrConsumerName         = "trustgate.consumer.name"
 	attrSessionID            = "trustgate.session_id"
@@ -168,7 +168,7 @@ func eventToRecord(evt *events.Event) otellog.Record {
 	}
 	appendStr(attrTraceID, evt.TraceID)
 	appendStr(attrGatewayID, evt.GatewayID)
-	appendStr(attrTeamID, evt.TeamID)
+	appendStr(attrTenantID, evt.TenantID)
 	appendStr(attrConsumerID, evt.Consumer.ID)
 	appendStr(attrConsumerName, evt.Consumer.Name)
 	appendStr(attrSessionID, evt.SessionID)
@@ -238,7 +238,7 @@ func rawEventToRecord(evt *events.Event) otellog.Record {
 	attrs = append(attrs, otellog.Int(attrSchemaVersion, evt.SchemaVersion))
 	appendStr(attrTraceID, evt.TraceID)
 	appendStr(attrGatewayID, evt.GatewayID)
-	appendStr(attrTeamID, evt.TeamID)
+	appendStr(attrTenantID, evt.TenantID)
 	appendStr(attrRequestBody, evt.Request.Body)
 	if evt.Response.Body != nil {
 		appendStr(attrResponseBody, *evt.Response.Body)

--- a/pkg/infra/telemetry/otlp/mapping_mcp_test.go
+++ b/pkg/infra/telemetry/otlp/mapping_mcp_test.go
@@ -28,7 +28,7 @@ func TestEventToRecord_MCPAttributes(t *testing.T) {
 		Kind:          events.KindMCP,
 		TraceID:       "trace-mcp",
 		GatewayID:     "gw-1",
-		TeamID:        "team-1",
+		TenantID:        "team-1",
 		Consumer:      events.Consumer{ID: "c-1", Name: "agent"},
 		Status:        events.Status{Code: 200},
 		Request:       events.Request{Method: "POST", Path: "/mcp"},

--- a/pkg/infra/telemetry/otlp/mapping_test.go
+++ b/pkg/infra/telemetry/otlp/mapping_test.go
@@ -39,7 +39,7 @@ func fullEvent() *events.Event {
 		SchemaVersion: events.SchemaVersion,
 		TraceID:       "trace-123",
 		GatewayID:     "gw-1",
-		TeamID:        "team-1",
+		TenantID:        "team-1",
 		OccurredOn:    1_700_000_000_000,
 		Consumer:      events.Consumer{ID: "c-1", Name: "alice"},
 		SessionID:     "sess-1",
@@ -101,7 +101,7 @@ func TestEventToRecord_StandardAndProprietaryCoexist(t *testing.T) {
 	assert.Equal(t, int64(events.SchemaVersion), attrs["trustgate.schema_version"].AsInt64())
 	assert.Equal(t, "trace-123", attrs["trustgate.trace_id"].AsString())
 	assert.Equal(t, "gw-1", attrs["trustgate.gateway_id"].AsString())
-	assert.Equal(t, "team-1", attrs["trustgate.team_id"].AsString())
+	assert.Equal(t, "team-1", attrs["trustgate.tenant_id"].AsString())
 	assert.Equal(t, "c-1", attrs["trustgate.consumer.id"].AsString())
 	assert.Equal(t, "alice", attrs["trustgate.consumer.name"].AsString())
 	assert.InDelta(t, 0.01, attrs["trustgate.cost.total_usd"].AsFloat64(), 1e-9)

--- a/pkg/infra/telemetry/postgres/exporter.go
+++ b/pkg/infra/telemetry/postgres/exporter.go
@@ -85,7 +85,7 @@ func (e *Exporter) Publish(ctx context.Context, evt *events.Event) error {
 	if _, err := e.pool.Exec(ctx, e.insertSQL,
 		rec.TraceID,
 		rec.GatewayID,
-		rec.TeamID,
+		rec.TenantID,
 		rec.OccurredOn,
 		rec.SchemaVersion,
 		rec.RequestBody,
@@ -115,8 +115,8 @@ func toRecord(view events.Event) metrics.SensibleRecord {
 		RequestBody:   view.Request.Body,
 		ResponseBody:  view.Response.Body,
 	}
-	if team := strings.TrimSpace(view.TeamID); team != "" {
-		rec.TeamID = &team
+	if team := strings.TrimSpace(view.TenantID); team != "" {
+		rec.TenantID = &team
 	}
 	return rec
 }

--- a/pkg/infra/telemetry/postgres/exporter_test.go
+++ b/pkg/infra/telemetry/postgres/exporter_test.go
@@ -31,7 +31,7 @@ func TestDataClassIsRaw(t *testing.T) {
 
 func TestBuildInsertSQL(t *testing.T) {
 	t.Parallel()
-	want := "INSERT INTO " + metrics.TableName + " (trace_id, gateway_id, team_id, occurred_on, schema_version, request_body, response_body) " +
+	want := "INSERT INTO " + metrics.TableName + " (trace_id, gateway_id, tenant_id, occurred_on, schema_version, request_body, response_body) " +
 		"VALUES ($1, $2, $3, $4, $5, $6, $7) ON CONFLICT (trace_id) DO NOTHING"
 	assert.Equal(t, want, buildInsertSQL(metrics.TableName))
 }
@@ -44,7 +44,7 @@ func TestToRecordMapsSensibleViewAndStampsSchemaVersion(t *testing.T) {
 		SchemaVersion: events.SchemaVersion,
 		TraceID:       "t1",
 		GatewayID:     "g1",
-		TeamID:        "team1",
+		TenantID:        "team1",
 		OccurredOn:    42,
 		IP:            "1.2.3.4",
 		Request:       events.Request{Body: "req-body", Headers: map[string][]string{"h": {"v"}}},
@@ -55,8 +55,8 @@ func TestToRecordMapsSensibleViewAndStampsSchemaVersion(t *testing.T) {
 
 	assert.Equal(t, "t1", rec.TraceID)
 	assert.Equal(t, "g1", rec.GatewayID)
-	require.NotNil(t, rec.TeamID)
-	assert.Equal(t, "team1", *rec.TeamID)
+	require.NotNil(t, rec.TenantID)
+	assert.Equal(t, "team1", *rec.TenantID)
 	assert.Equal(t, int64(42), rec.OccurredOn)
 	assert.Equal(t, metrics.SchemaVersion, rec.SchemaVersion)
 	assert.Equal(t, "req-body", rec.RequestBody)
@@ -71,7 +71,7 @@ func TestToRecordNilTeamAndResponse(t *testing.T) {
 
 	rec := toRecord(evt.SensibleView())
 
-	assert.Nil(t, rec.TeamID)
+	assert.Nil(t, rec.TenantID)
 	assert.Nil(t, rec.ResponseBody)
 	assert.Empty(t, rec.RequestBody)
 }

--- a/pkg/infra/telemetry/postgres/migrate_integration_test.go
+++ b/pkg/infra/telemetry/postgres/migrate_integration_test.go
@@ -73,7 +73,7 @@ func TestExporterInsertsSensibleRowIdempotently(t *testing.T) {
 	evt := &events.Event{
 		TraceID:    trace,
 		GatewayID:  "g",
-		TeamID:     "tm",
+		TenantID:     "tm",
 		OccurredOn: time.Now().UnixMilli(),
 		Request:    events.Request{Body: "hello-req"},
 		Response:   events.Response{Body: &resp},

--- a/pkg/infra/telemetry/publishlog.go
+++ b/pkg/infra/telemetry/publishlog.go
@@ -34,6 +34,6 @@ func LogPublish(logger *slog.Logger, exporter string, class metrics.DataClass, e
 		slog.Int("schema_version", evt.SchemaVersion),
 		slog.String("trace_id", evt.TraceID),
 		slog.String("gateway_id", evt.GatewayID),
-		slog.String("team_id", evt.TeamID),
+		slog.String("tenant_id", evt.TenantID),
 	)
 }

--- a/pkg/infra/trace/trace.go
+++ b/pkg/infra/trace/trace.go
@@ -25,7 +25,7 @@ import (
 
 type Metadata struct {
 	GatewayID    string
-	TeamID       string
+	TenantID       string
 	ConsumerID   string
 	ConsumerName string
 	Path         string

--- a/pkg/metrics/allowlist.go
+++ b/pkg/metrics/allowlist.go
@@ -18,7 +18,7 @@ func ReadColumns() []string {
 	return []string{
 		ColumnTraceID,
 		ColumnGatewayID,
-		ColumnTeamID,
+		ColumnTenantID,
 		ColumnOccurredOn,
 		ColumnSchemaVersion,
 		ColumnRequestBody,

--- a/pkg/metrics/column.go
+++ b/pkg/metrics/column.go
@@ -39,7 +39,7 @@ func RawColumns() []Column {
 	return []Column{
 		{Name: ColumnTraceID, Type: ColumnTypeString},
 		{Name: ColumnGatewayID, Type: ColumnTypeString},
-		{Name: ColumnTeamID, Type: ColumnTypeString, Nullable: true},
+		{Name: ColumnTenantID, Type: ColumnTypeString, Nullable: true},
 		{Name: ColumnOccurredOn, Type: ColumnTypeInt64},
 		{Name: ColumnSchemaVersion, Type: ColumnTypeInt32},
 		{Name: ColumnRequestBody, Type: ColumnTypeString},

--- a/pkg/metrics/migrations/migration_0001_create_trustgate_data.go
+++ b/pkg/metrics/migrations/migration_0001_create_trustgate_data.go
@@ -21,7 +21,7 @@ func init() {
 		UpSQL: `CREATE TABLE IF NOT EXISTS trustgate_data (
     trace_id         TEXT        NOT NULL,
     gateway_id       TEXT        NOT NULL,
-    team_id          TEXT,
+    tenant_id          TEXT,
     occurred_on      BIGINT      NOT NULL,
     schema_version   INT         NOT NULL,
     request_body     TEXT,

--- a/pkg/metrics/record.go
+++ b/pkg/metrics/record.go
@@ -17,7 +17,7 @@ package metrics
 type SensibleRecord struct {
 	TraceID       string  `db:"trace_id" json:"trace_id"`
 	GatewayID     string  `db:"gateway_id" json:"gateway_id"`
-	TeamID        *string `db:"team_id" json:"team_id,omitempty"`
+	TenantID        *string `db:"tenant_id" json:"tenant_id,omitempty"`
 	OccurredOn    int64   `db:"occurred_on" json:"occurred_on"`
 	SchemaVersion int     `db:"schema_version" json:"schema_version"`
 	RequestBody   string  `db:"request_body" json:"request_body"`

--- a/pkg/metrics/schema.go
+++ b/pkg/metrics/schema.go
@@ -21,7 +21,7 @@ const TableName = "trustgate_data"
 const (
 	ColumnTraceID       = "trace_id"
 	ColumnGatewayID     = "gateway_id"
-	ColumnTeamID        = "team_id"
+	ColumnTenantID        = "tenant_id"
 	ColumnOccurredOn    = "occurred_on"
 	ColumnSchemaVersion = "schema_version"
 	ColumnRequestBody   = "request_body"
@@ -43,7 +43,7 @@ func InsertColumns() []string {
 	return []string{
 		ColumnTraceID,
 		ColumnGatewayID,
-		ColumnTeamID,
+		ColumnTenantID,
 		ColumnOccurredOn,
 		ColumnSchemaVersion,
 		ColumnRequestBody,

--- a/pkg/metrics/version.go
+++ b/pkg/metrics/version.go
@@ -14,7 +14,7 @@
 
 package metrics
 
-const SchemaVersion = 1
+const SchemaVersion = 2
 
 type DataClass string
 

--- a/pkg/runtimeconfig/snapshot/adapters/adapters_test.go
+++ b/pkg/runtimeconfig/snapshot/adapters/adapters_test.go
@@ -55,7 +55,7 @@ func newFixture() fixture {
 		Slug:      "gw-one",
 		Status:    "active",
 		Domain:    "one.example.com",
-		Metadata:  map[string]string{"team_id": "team-1"},
+		Metadata:  map[string]string{"tenant_id": "team-1"},
 		CreatedAt: baseTime,
 	}
 	reg := registrydomain.Registry{
@@ -117,10 +117,10 @@ func TestGatewayAdapterReads(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, f.gateway.ID, got.ID)
 
-	got.Metadata["team_id"] = "mutated"
+	got.Metadata["tenant_id"] = "mutated"
 	fresh, err := repo.FindByID(ctx, f.gateway.ID)
 	require.NoError(t, err)
-	assert.Equal(t, "team-1", fresh.Metadata["team_id"], "returned gateway must be a deep clone")
+	assert.Equal(t, "team-1", fresh.Metadata["tenant_id"], "returned gateway must be a deep clone")
 
 	_, err = repo.FindByDomain(ctx, "unknown.example.com")
 	assert.ErrorIs(t, err, gatewaydomain.ErrNotFound)

--- a/postman/TrustGate-TrustGuard-E2E.postman_collection.json
+++ b/postman/TrustGate-TrustGuard-E2E.postman_collection.json
@@ -2,7 +2,7 @@
 	"info": {
 		"_postman_id": "e2e00000-tg-tguard-0000-collection-0001",
 		"name": "TrustGate + TrustGuard E2E",
-		"description": "End-to-end flows wiring TrustGate to TrustGuard through the `trustguard` plugin.\n\nTwo self-contained scenarios (run one folder with Collection Runner):\n- **Flow - injection_protection (SQLi)**: `injection_protection` detector, SQL-injection KO, optional direct `/v1/guard` via `collector_key`.\n- **Flow - prompt_guard (jailbreak)**: `prompt_guard` detector via NeuralTrust Firewall; requires `firewall_base_url` + `firewall_token`.\n\nShared setup per flow: TrustGate gateway/registry/consumer, TrustGuard platform tenant + collector (`metadata.gateway_id`), TrustGate `trustguard` plugin policy with `collector_id`.\n\nAuth:\n- TrustGate admin: `Authorization: Bearer {{tg_admin_token}}`.\n- TrustGuard admin: `Authorization: Bearer {{admin_jwt}}` (auto-minted from `admin_jwt_secret` + `team_id`).\n- Runtime TrustGate\u2194TrustGuard: server-side platform OAuth2 (`TRUSTGUARD_CLIENT_ID`/`SECRET` on TrustGate = `TRUSTGUARD_PLATFORM_CLIENT_ID`/`SECRET` on TrustGuard).\n\nVariables: tg_base_url, tg_proxy_url, tg_admin_token, guard_base_url, admin_jwt_secret, team_id, openai_api_key; prompt_guard also needs firewall_base_url, firewall_token.",
+		"description": "End-to-end flows wiring TrustGate to TrustGuard through the `trustguard` plugin.\n\nTwo self-contained scenarios (run one folder with Collection Runner):\n- **Flow - injection_protection (SQLi)**: `injection_protection` detector, SQL-injection KO, optional direct `/v1/guard` via `collector_key`.\n- **Flow - prompt_guard (jailbreak)**: `prompt_guard` detector via NeuralTrust Firewall; requires `firewall_base_url` + `firewall_token`.\n\nShared setup per flow: TrustGate gateway/registry/consumer, TrustGuard platform tenant + collector (`metadata.gateway_id`), TrustGate `trustguard` plugin policy with `collector_id`.\n\nAuth:\n- TrustGate admin: `Authorization: Bearer {{tg_admin_token}}`.\n- TrustGuard admin: `Authorization: Bearer {{admin_jwt}}` (auto-minted from `admin_jwt_secret` + `tenant_id`).\n- Runtime TrustGate\u2194TrustGuard: server-side platform OAuth2 (`TRUSTGUARD_CLIENT_ID`/`SECRET` on TrustGate = `TRUSTGUARD_PLATFORM_CLIENT_ID`/`SECRET` on TrustGuard).\n\nVariables: tg_base_url, tg_proxy_url, tg_admin_token, guard_base_url, admin_jwt_secret, tenant_id, openai_api_key; prompt_guard also needs firewall_base_url, firewall_token.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"event": [
@@ -11,7 +11,7 @@
 			"script": {
 				"type": "text/javascript",
 				"exec": [
-					"// Auto-mint admin_jwt (HS256) from team_id + user_id + admin_jwt_secret for the TrustGuard admin API.",
+					"// Auto-mint admin_jwt (HS256) from tenant_id + user_id + admin_jwt_secret for the TrustGuard admin API.",
 					"// If admin_jwt_secret is empty, the admin_jwt you set manually is used as-is.",
 					"var CryptoJS = require('crypto-js');",
 					"var secret = pm.environment.get('admin_jwt_secret') || pm.collectionVariables.get('admin_jwt_secret');",
@@ -19,7 +19,7 @@
 					"    var b64 = function (wa) { return CryptoJS.enc.Base64.stringify(wa).replace(/=+$/, '').replace(/\\+/g, '-').replace(/\\//g, '_'); };",
 					"    var b64s = function (s) { return b64(CryptoJS.enc.Utf8.parse(s)); };",
 					"    var header = b64s(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));",
-					"    var claims = { team_id: pm.environment.get('team_id') || pm.collectionVariables.get('team_id') || '' };",
+					"    var claims = { tenant_id: pm.environment.get('tenant_id') || pm.collectionVariables.get('tenant_id') || '' };",
 					"    var uid = pm.environment.get('user_id') || pm.collectionVariables.get('user_id'); if (uid) { claims.user_id = uid; }",
 					"    claims.exp = Math.floor(Date.now() / 1000) + 3600;",
 					"    var payload = b64s(JSON.stringify(claims));",
@@ -373,7 +373,7 @@
 										"tenants"
 									]
 								},
-								"description": "The team is taken from the admin JWT (team_id), never the body. One team owns one tenant, so this may 409 on a seeded environment; the rest of the folder still works against the team's existing tenant. scope=platform issues no service_client credentials."
+								"description": "The team is taken from the admin JWT (tenant_id), never the body. One team owns one tenant, so this may 409 on a seeded environment; the rest of the folder still works against the team's existing tenant. scope=platform issues no service_client credentials."
 							}
 						},
 						{
@@ -1342,7 +1342,7 @@
 										"tenants"
 									]
 								},
-								"description": "The team is taken from the admin JWT (team_id), never the body. One team owns one tenant, so this may 409 on a seeded environment; the rest of the folder still works against the team's existing tenant. scope=platform issues no service_client credentials."
+								"description": "The team is taken from the admin JWT (tenant_id), never the body. One team owns one tenant, so this may 409 on a seeded environment; the rest of the folder still works against the team's existing tenant. scope=platform issues no service_client credentials."
 							}
 						},
 						{
@@ -1857,7 +1857,7 @@
 			"type": "string"
 		},
 		{
-			"key": "team_id",
+			"key": "tenant_id",
 			"value": "11111111-1111-1111-1111-111111111111",
 			"type": "string"
 		},

--- a/scripts/generate_jwt_token.sh
+++ b/scripts/generate_jwt_token.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
-team_id=${TEAM_ID:-""}
+tenant_id=${TENANT_ID:-""}
 user_id=${USER_ID:-""}
 secret=${SERVER_SECRET_KEY}
 
 header=$(echo -n '{"alg":"HS256","typ":"JWT"}' | openssl base64 -A | tr '+/' '-_' | tr -d '=')
 
 if [ -n "$user_id" ]; then
-    payload=$(echo -n "{\"team_id\":\"$team_id\",\"user_id\":\"$user_id\"}" | openssl base64 -A | tr '+/' '-_' | tr -d '=')
+    payload=$(echo -n "{\"tenant_id\":\"$tenant_id\",\"user_id\":\"$user_id\"}" | openssl base64 -A | tr '+/' '-_' | tr -d '=')
 else
-    payload=$(echo -n "{\"team_id\":\"$team_id\"}" | openssl base64 -A | tr '+/' '-_' | tr -d '=')
+    payload=$(echo -n "{\"tenant_id\":\"$tenant_id\"}" | openssl base64 -A | tr '+/' '-_' | tr -d '=')
 fi
 signature=$(echo -n "$header.$payload" | openssl dgst -binary -sha256 -hmac "$secret" | openssl base64 -A | tr '+/' '-_' | tr -d '=')
 


### PR DESCRIPTION
## Summary

Consolidated PR for the config-sync multi-tenant scope work in TrustGate (parent **RUN-905**). Replaces the previously stacked PRs #178, #179, #180, #181, #182 with a single change against `develop`.

OSS-only: TrustGate stays tenant-agnostic and deals with an opaque `scope` key; the `scope → tenant_id` mapping lives in the proprietary layer (out of scope here). No behavior change for single-tenant / shared-token deployments (empty scope = whole config).

### What's included

- **RUN-910 — enrolment credential spec** (`docs/config-sync-enrolment-credential.md`): JWT claims, signing, rotation, revocation for the data-plane credential.
- **RUN-906 — scope-aware transport**: `SnapshotSource.Snapshot()` → `SnapshotFor(scope)`; the auth interceptor returns a scope-carrying context and wraps the server stream; `WithScope`/`ScopeFromContext` helpers.
- **RUN-907 — `CONFIG_SYNC_AUTH_MODE`**: explicit `shared|signed` (no auto-detection, no `signed → shared` fallback). `signed` verifies a signed JWT (PKIX key) and extracts the opaque `scope` claim, failing closed at boot when key/issuer/audience are missing.
- **RUN-908 — per-scope compilation & holder**: `CompileFor(scope)` filters gateways by `metadata.team_id`; `CompileAll` builds the whole snapshot plus one per scope in a single pass; `Holder.SetPartitioned`/`SnapshotFor` fail closed for unknown scopes.
- **RUN-912 — security & isolation**: `metadata.team_id` server-only (stripped from client input on create) and immutable on update; cross-tenant isolation tests over every snapshot object type + fail-closed tests.

### Deferred (not in this PR)

- Proprietary `scope → tenant_id` wiring and DataCore token issuance (RUN-909 / RUN-911).
- TrustGuard mirror: deferred until the `tenant → Guard` rename lands.

## Test plan

- [x] `go build ./...`, `go vet` on changed packages
- [x] `go test ./pkg/app/gateway/... ./pkg/domain/gateway/... ./pkg/app/configsnapshot/... ./pkg/infra/configsync/... ./pkg/config/...`

## Linear

Parent: RUN-905 — https://linear.app/neuraltrust/issue/RUN-905
Sub-issues: RUN-910, RUN-906, RUN-907, RUN-908, RUN-912