### PR TITLE
Add RUN-915 TLS enrolment guidance

### DIFF
--- a/docs/hybrid-residency-gsm-secrets.md
+++ b/docs/hybrid-residency-gsm-secrets.md
@@ -1,0 +1,173 @@
+# Hybrid Data Residency — Google Secret Manager secrets
+
+Secretos que hay que crear en **Google Secret Manager (GSM)** para desplegar los
+tres componentes del subsistema de residencia (`DataCore`, `DataBridge`,
+`DataAgent`).
+
+Convencion: **un secret por app y por proyecto** —`neuraltrust-app-dev` y
+`neuraltrust-app-prod`— que contiene pares `KEY=VALUE`. En Kubernetes se
+materializa como el Secret nativo que referencian los deployments (`*-secrets`)
+via external-secrets / sealed-secrets.
+
+> Esto es aparte de los secrets de GitHub Actions (`DEV/PROD_WIF_PROVIDER`,
+> `DEV/PROD_WIF_SERVICE_ACCOUNT`, `GH_TOKEN`, `SLACK_WEBHOOK_URL`,
+> `OPENAI_API_KEY`), que viven en GitHub, no en GSM.
+
+---
+
+## DataCore — secret `datacore` -> Secret `datacore-secrets`
+
+Runtime namespace esperado: `datacore`.
+
+| Env var runtime | Valor esperado | Secret / key | Proposito | dev | prod |
+|---|---|---|---|:---:|:---:|
+| `AUTH_JWT_HS256_SECRET` | valor secreto | `datacore-secrets` / `AUTH_JWT_HS256_SECRET` | Firma/verificacion JWT del API REST | si | si |
+| `CLICKHOUSE_USER` | valor secreto | `datacore-secrets` / `CLICKHOUSE_USER` | Usuario ClickHouse | si | si |
+| `CLICKHOUSE_PASSWORD` | valor secreto | `datacore-secrets` / `CLICKHOUSE_PASSWORD` | Password ClickHouse | si | si |
+
+Notas:
+
+- Dev y prod usan `RESIDENCY_ALLOW_STUB=false`, asi que ambos necesitan
+  credenciales reales de ClickHouse.
+- `AUTH_JWT_ISSUER` y `AUTH_JWT_AUDIENCE` son configuracion no sensible; no
+  deben ir en el secret salvo que Infra use un unico mecanismo para inyectar
+  config.
+- `DATABRIDGE_TLS` es configuracion, no secreto. El cliente northbound
+  DataCore -> DataBridge no tiene mTLS propio hoy.
+
+---
+
+## DataBridge — secret `databridge` -> Secret `databridge-secrets`
+
+Runtime namespace esperado: `databridge`.
+
+`DataBridge` expone el endpoint southbound con TLS de servidor. El material TLS
+vive como ficheros montados desde el Secret `databridge-southbound-tls`; las env
+vars solo apuntan a esas rutas. La autenticacion de DataAgent es por
+`ENROLMENT_TOKEN` sobre el canal TLS.
+
+| Env var runtime | Valor esperado | Secret / key | Proposito | dev | prod |
+|---|---|---|---|:---:|:---:|
+| `ENROLMENT_TOKEN` | valor secreto | `databridge-secrets` / `ENROLMENT_TOKEN` | Token esperado antes de registrar DataAgent | si | si |
+| `SOUTHBOUND_TLS_CERT_FILE` | `/etc/southbound-tls/tls.crt` | `databridge-southbound-tls` / `tls.crt` | Certificado servidor para el endpoint southbound | cert-manager | Infra |
+| `SOUTHBOUND_TLS_KEY_FILE` | `/etc/southbound-tls/tls.key` | `databridge-southbound-tls` / `tls.key` | Clave privada del servidor southbound | cert-manager | Infra |
+| `SOUTHBOUND_CLIENT_CA_FILE` | ruta CA cliente | secret CA / `ca.crt` | Solo compatibilidad mTLS explicita | opcional | opcional |
+
+Notas:
+
+- `AUTH_MODE=token` es el default de despliegue; `AUTH_MODE=dev` queda solo para
+  desarrollo local inseguro.
+- `ENROLMENT_TOKEN` debe ser el mismo valor que presenta el DataAgent de ese
+  tenant y debe ser aleatorio, de al menos 32 caracteres.
+- Este modelo asume despliegue aislado 1:1 para tenant/DataAgent. No reutilizar
+  un mismo DataBridge como router multi-tenant con un unico token compartido.
+- En dev, cert-manager emite el cert de servidor con la CA `residency-ca-dev`; no
+  hay que crear un GSM secret para `tls.crt` / `tls.key`.
+- En prod, Infra debe proveer el Secret TLS equivalente y el montaje como volumen
+  con las mismas rutas.
+- `SOUTHBOUND_CLIENT_CA_FILE` queda vacio por defecto. Solo se configura para
+  despliegues internos o transicionales que mantengan mTLS cliente.
+
+---
+
+## DataAgent — secret `dataagent` -> Secret `dataagent-secrets`
+
+Runtime namespace esperado: `dataagent`. En produccion real puede correr dentro
+del entorno del cliente; en ese caso estos secretos viven en el secret manager
+del cliente o en el chart que use el cliente.
+
+`DataAgent` conecta outbound a DataBridge, valida el certificado de servidor con
+`DATABRIDGE_SERVER_NAME` y `TLS_CA_FILE` cuando usa CA privada, y presenta
+`ENROLMENT_TOKEN` como metadata gRPC solo sobre transporte seguro.
+
+| Env var runtime | Valor dev | Valor prod / cliente | Secret / key | Proposito | dev | prod |
+|---|---|---|---|---|:---:|:---:|
+| `ENROLMENT_TOKEN` | valor secreto | valor secreto | `dataagent-secrets` / `ENROLMENT_TOKEN` | Token presentado a DataBridge; debe coincidir con el esperado por DataBridge | si | si |
+| `DATABASE_URL` | no aplica (`STORE_BACKEND=memory`) | valor secreto | `dataagent-secrets` / `DATABASE_URL` | DSN read-only si `STORE_BACKEND=postgres` | no | si |
+| `RESIDENCY_REGISTRY_FILE` | no aplica (`STORE_BACKEND=memory`) | ruta runtime | config o `dataagent-secrets` / `RESIDENCY_REGISTRY_FILE` | Registro usado junto al backend Postgres | no | si, si postgres |
+| `TLS_CA_FILE` | `/etc/databridge-ca/ca.crt` | vacio si usa roots del sistema; ruta CA si PKI privada | CA bundle / `ca.crt`, si aplica | CA para validar el servidor DataBridge | cert-manager | si PKI privada |
+
+Notas:
+
+- El modo default es `TLS_MODE=tls` con `ENROLMENT_TOKEN`; no necesita
+  certificado ni clave cliente de DataAgent.
+- `DATABRIDGE_SERVER_NAME`, `TLS_MODE` y `STORE_BACKEND` son configuracion, no
+  secretos.
+- `TLS_CA_FILE` es ruta de fichero montado, no valor secreto en si mismo. Vacio
+  significa usar roots del sistema; si DataBridge usa una CA privada, montar el
+  bundle CA y apuntar esta env var.
+- `TLS_CLIENT_CERT_FILE` y `TLS_CLIENT_KEY_FILE` quedan solo para compatibilidad
+  mTLS explicita, no para el default.
+- En prod con Postgres, provisionar `DATABASE_URL` y `RESIDENCY_REGISTRY_FILE`
+  juntos; no arrancar con uno solo.
+
+---
+
+## Que crear ya
+
+| Entorno | Proyecto | Secrets necesarios |
+|---|---|---|
+| dev | `neuraltrust-app-dev` | `datacore` (`AUTH_JWT_HS256_SECRET`, `CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD`) · `databridge` (`ENROLMENT_TOKEN`) · `dataagent` (`ENROLMENT_TOKEN`) |
+| prod | `neuraltrust-app-prod` | `datacore` (JWT + ClickHouse), `databridge` (`ENROLMENT_TOKEN` + TLS servidor montado), `dataagent` (`ENROLMENT_TOKEN`; tambien `DATABASE_URL` + `RESIDENCY_REGISTRY_FILE` si postgres) |
+
+> En dev, la PKI TLS la genera cert-manager con la CA privada
+> `residency-ca-dev`. DataBridge recibe cert/key de servidor y DataAgent monta
+> solo el CA bundle para validar ese servidor.
+
+### Ejemplo de creacion (blob `KEY=VALUE`)
+
+```bash
+printf 'AUTH_JWT_HS256_SECRET=...\nCLICKHOUSE_USER=...\nCLICKHOUSE_PASSWORD=...\n' \
+  | gcloud secrets create datacore \
+      --project=neuraltrust-app-prod \
+      --data-file=-
+
+printf 'ENROLMENT_TOKEN=...\n' \
+  | gcloud secrets create databridge \
+      --project=neuraltrust-app-prod \
+      --data-file=-
+
+printf 'ENROLMENT_TOKEN=...\nDATABASE_URL=...\nRESIDENCY_REGISTRY_FILE=...\n' \
+  | gcloud secrets create dataagent \
+      --project=neuraltrust-app-prod \
+      --data-file=-
+```
+
+### Ejemplo material TLS servidor
+
+En dev no se crea a mano: cert-manager emite el Secret a partir de la CA privada.
+Basta con aplicar el bootstrap una vez y desplegar los overlays:
+
+```bash
+kubectl apply -k DataBridge/k8s/dev-pki
+```
+
+En prod, si Infra emite el material fuera del cluster:
+
+```bash
+kubectl create secret generic databridge-southbound-tls \
+  --type=kubernetes.io/tls \
+  --from-file=tls.crt=southbound.crt \
+  --from-file=tls.key=southbound.key \
+  -n databridge
+```
+
+Si el certificado de DataBridge usa una CA privada, DataAgent necesita el
+`ca.crt` de esa CA montado como bundle y `TLS_CA_FILE` apuntando al fichero.
+
+---
+
+## Rollout notes
+
+- Crear/provisionar `databridge-secrets` y `dataagent-secrets` antes de arrancar
+  pods: los `secretRef` fallan cerrado.
+- Confirmar antes del deploy el issuer del certificado DataBridge para prod o
+  cliente y decidir si DataAgent usara roots publicas del sistema o CA bundle.
+- Tras el rollout, borrar o ignorar recursos antiguos de certificado cliente de
+  DataAgent (`dataagent-client-tls`) que hayan quedado de la configuracion mTLS
+  anterior.
+
+## Referencias
+
+- Diseño del subsistema: `TrustGate/docs/hybrid-control-plane-agent.md`
+- Claves por repo documentadas en cada `k8s/base/secrets.env.example`

--- a/docs/sdd/run-915-tls-enrolment-auth/design.md
+++ b/docs/sdd/run-915-tls-enrolment-auth/design.md
@@ -1,0 +1,79 @@
+# Design: RUN-915 TLS Enrolment Auth
+
+## Technical Approach
+
+Keep the existing outbound DataAgent -> DataBridge bidi stream and registry flow. Change the default security boundary from client mTLS to server-side TLS plus application auth: DataAgent validates DataBridge TLS identity, sends `x-enrolment-token`, then DataBridge authenticates the first `Hello` before registration. No residency proto or `INSTANCE_ID` contract changes.
+
+## Architecture Decisions
+
+| Area | Choice | Rejected | Rationale |
+|---|---|---|---|
+| DataBridge auth | Add `AUTH_MODE=token` with singular `ENROLMENT_TOKEN`, loaded from `databridge-secrets`; compare the presented token in constant time and return `ErrUnauthenticated` on missing or invalid token. | mTLS default; DataBridge-side tenant token map; credential exchange now. | Fits the 1:1 DataAgent/tenant model: DataAgent owns one token and DataBridge validates the expected token for that deployment. |
+| DataAgent transport | Add `TLS_MODE=tls` and make it the default. Require `DATABRIDGE_SERVER_NAME` and `ENROLMENT_TOKEN`; use `TLS_CA_FILE` when set, otherwise system roots. | Reusing `mtls`; allowing empty server name; requiring private CA always. | Removes client cert/key from default path while preserving server identity validation. |
+| Compatibility | Keep `TLS_MODE=mtls` and `SOUTHBOUND_CLIENT_CA_FILE` as explicit internal compatibility only. | Deleting mTLS code now. | Lowers migration risk without documenting mTLS as the default. |
+| Dev trust | Replace `dataagent-client-tls` default with a CA-only trust bundle mounted at `/etc/databridge-ca/ca.crt`. | Mounting client cert just to get `ca.crt`; insecure dev stream. | Dev remains TLS with server validation and no client cert/key. |
+
+## Auth And TLS Flow
+
+```mermaid
+sequenceDiagram
+  participant DA as DataAgent
+  participant DB as DataBridge southbound
+  participant DC as DataCore
+  DA->>DB: TLS handshake, SNI DATABRIDGE_SERVER_NAME
+  DA->>DB: Connect metadata x-enrolment-token
+  DA->>DB: Hello{tenant_id, agent_version, supported_ops}
+  DB->>DB: load expected ENROLMENT_TOKEN
+  DB->>DB: constant-time token compare
+  DB->>DB: register tenant stream only after auth succeeds
+  DC->>DB: Execute(tenant_id, op)
+  DB->>DA: QueryRequest
+  DA->>DB: QueryResult frames
+```
+
+Failure handling is fail-closed: unauthenticated streams return gRPC `Unauthenticated`, log no token value, and never touch the registry.
+
+This singular-token design assumes an isolated 1:1 tenant/DataAgent deployment. A shared multi-tenant DataBridge would need tenant-bound credential storage before accepting multiple independent tenant tokens.
+
+## Config Contract
+
+DataBridge: `AUTH_MODE=token` outside local dev; `AUTH_MODE=dev` remains local-only. `ENROLMENT_TOKEN` is required in token mode and must match the token configured in the tenant's DataAgent. `SOUTHBOUND_TLS_CERT_FILE` and `SOUTHBOUND_TLS_KEY_FILE` are required outside dev. `SOUTHBOUND_CLIENT_CA_FILE` is unset by default; setting it intentionally enables client cert verification.
+
+DataAgent: `TLS_MODE=tls` default; `TLS_MODE=insecure` still requires `ALLOW_INSECURE_TRANSPORT=true` and never sends the token. `DATABRIDGE_SERVER_NAME` and `ENROLMENT_TOKEN` are required for `tls` and `mtls`. `TLS_CA_FILE` is optional in `tls`; `TLS_CLIENT_CERT_FILE` and `TLS_CLIENT_KEY_FILE` are only required in `mtls`.
+
+## File Changes
+
+| Repo | Files | Action |
+|---|---|---|
+| DataBridge | `internal/auth/auth.go`, `internal/auth/auth_test.go` | Modify: add token authenticator and table tests. |
+| DataBridge | `internal/config/config.go`, `internal/config/config_test.go`, `internal/container/modules/bridge.go` | Modify: parse/validate token auth config and wire provider. |
+| DataBridge | `internal/container/modules/servers.go`, `internal/container/modules/servers_test.go` | Modify/create: lock TLS-only default and explicit mTLS behavior. |
+| DataBridge | `internal/southbound/connect_test.go`, `internal/e2e/e2e_test.go` | Modify: cover TLS-only success, invalid token, missing token, and no registry registration. |
+| DataBridge | `.env.example`, `README.md`, `k8s/base/secrets.env.example`, `k8s/base/deployment.yaml`, `k8s/overlays/dev/config.env`, `k8s/overlays/prod/config.env`, `k8s/overlays/prod/kustomization.yaml`, `k8s/overlays/prod/patches/southbound-tls-patch.yaml` | Modify/create: token secret, TLS server mount/env, client CA unset by default. |
+| DataAgent | `internal/config/config.go`, `internal/config/config_test.go`, `internal/transport/credentials.go`, `internal/transport/credentials_test.go` | Modify: add `tls` mode, optional CA pool, token per-RPC credentials over TLS. |
+| DataAgent | `internal/supervisor/connector_test.go` | Modify: prove TLS-mode dial options carry token metadata through Connect. |
+| DataAgent | `.env.example`, `README.md`, `k8s/base/secrets.env.example`, `k8s/overlays/dev/config.env`, `k8s/overlays/dev/kustomization.yaml`, `k8s/overlays/dev/client-cert.yaml`, `k8s/overlays/dev/patches/client-tls-patch.yaml`, `k8s/overlays/dev/databridge-ca.yaml`, `k8s/overlays/dev/patches/ca-bundle-patch.yaml`, `k8s/overlays/prod/config.env` | Modify/delete/create: remove default client cert/key, add CA-only dev trust, set `TLS_MODE=tls`. |
+| DataCore | `docs/hybrid-residency-deploy-secrets-checklist.md` | Modify: docs-only removal of default DataAgent client cert rotation. |
+| TrustGate | `docs/hybrid-residency-gsm-secrets.md`, `docs/sdd/run-915-tls-enrolment-auth/design.md` | Create/modify: coordination docs and this design. |
+
+## Testing Strategy
+
+| Layer | Coverage |
+|---|---|
+| Unit | DataBridge token parsing/auth table tests; DataAgent config and credential provider tests for `tls`, `mtls`, `insecure`, CA file, system roots, and token security. |
+| Stream/e2e | In-process TLS-only Connect success, missing/invalid token rejection before registry registration, and Execute round trip after auth. |
+| Verification | `gofmt`, `go vet ./...`, `golangci-lint run`, `make test`, and `go test -race ./...` for DataBridge/DataAgent. Docs-only DataCore/TrustGate need markdown review. |
+
+## Rollout And Compatibility
+
+Deploy DataBridge first with TLS cert/key and `ENROLMENT_TOKEN`, leaving `SOUTHBOUND_CLIENT_CA_FILE` unset. Then deploy DataAgent with `TLS_MODE=tls`, `DATABRIDGE_SERVER_NAME`, optional CA file, and the same `ENROLMENT_TOKEN`. Rollback is explicit mTLS mode: restore client cert/key mounts, set DataAgent `TLS_MODE=mtls`, and set DataBridge `SOUTHBOUND_CLIENT_CA_FILE`.
+
+## Risks
+
+- Long-lived token remains weaker than per-agent credentials; track one-time exchange and credential lifecycle as follow-up.
+- `ENROLMENT_TOKEN` rotation needs a coordinated DataBridge/DataAgent rollout; document dual-token or grace-window rotation as follow-up if needed.
+- Dev CA bundle injection depends on cert-manager/cainjector availability in the cluster.
+
+## Open Questions
+
+None blocking.

--- a/docs/sdd/run-915-tls-enrolment-auth/explore.md
+++ b/docs/sdd/run-915-tls-enrolment-auth/explore.md
@@ -1,0 +1,64 @@
+# Exploration: RUN-915 TLS + enrolment auth
+
+## Current State
+
+DataAgent already has an `ENROLMENT_TOKEN` config field and sends it as gRPC per-RPC metadata key `x-enrolment-token`, but only when running the current `mtls` credential provider. `TLS_MODE` currently supports only `insecure` and `mtls`, defaults to `mtls`, and validation requires `TLS_CLIENT_CERT_FILE`, `TLS_CLIENT_KEY_FILE`, `TLS_CA_FILE`, and `DATABRIDGE_SERVER_NAME` for the default production path.
+
+DataBridge already reads `x-enrolment-token` from the incoming stream context before accepting the first `Hello`, but the only implemented authenticator is `DevAuthenticator`, which accepts any non-empty token plus the tenant claimed in `Hello`. Production auth is not implemented: `provideAuthenticator` fails unless `AUTH_MODE=dev`, with a placeholder pointing at the older production cert-to-tenant binding work.
+
+DataBridge southbound transport TLS already supports server-side TLS without client cert verification when `SOUTHBOUND_TLS_CERT_FILE` and `SOUTHBOUND_TLS_KEY_FILE` are set and `SOUTHBOUND_CLIENT_CA_FILE` is unset. If `SOUTHBOUND_CLIENT_CA_FILE` is set, the server requires and verifies a client certificate. Outside `AUTH_MODE=dev`, server TLS is required.
+
+Kubernetes and docs still describe the default hybrid path as mTLS. DataBridge dev config sets `SOUTHBOUND_CLIENT_CA_FILE`; DataAgent dev/prod config sets `TLS_MODE=mtls` plus client cert/key paths; DataAgent dev creates and mounts `dataagent-client-tls`. DataBridge prod currently does not set southbound TLS cert/key paths or mount `databridge-southbound-tls`, so prod deployment config is incomplete for the current non-dev server TLS requirement.
+
+DataCore is not part of the DataAgent southbound auth path. Its hybrid adapter calls DataBridge northbound with a separate `DATABRIDGE_TLS` boolean and no DataAgent credential coupling. The requested DataCore impact is documentation only.
+
+The primary TrustGate RUN worktree does not currently contain `docs/hybrid-residency-gsm-secrets.md`, though that document exists in the main TrustGate checkout and still states that DataBridge verifies DataAgent client certs and that DataAgent requires client mTLS material.
+
+## Affected Areas
+
+- `DataBridge/internal/config/config.go` - `SouthboundConfig.ClientCAFile` remains useful for optional mTLS compatibility, but default deployed flow should not depend on it. Production auth config for enrolment tokens is missing.
+- `DataBridge/internal/container/modules/servers.go` - southbound TLS behavior is already close to target: cert/key required outside dev, client verification only when client CA is configured. Needs tests locking the TLS-only default and optional mTLS compatibility.
+- `DataBridge/internal/container/modules/bridge.go` - production boot is currently blocked without `AUTH_MODE=dev`. This is the main auth implementation gap for RUN-915.
+- `DataBridge/internal/auth/auth.go` and `internal/auth/auth_test.go` - only permissive dev auth exists. Need a production authenticator that validates the singular enrolment token for the isolated 1:1 tenant/DataAgent deployment and leaves room for one-time bootstrap/per-agent credentials.
+- `DataBridge/internal/southbound/connect.go` and `internal/southbound/connect_test.go` - authentication happens before registry registration and missing-token rejection is tested. Need invalid-token rejection and credential identity/tenant binding tests.
+- `DataBridge/internal/e2e/e2e_test.go` - in-process flow uses insecure transport plus dev token. Add TLS-only plus valid/invalid enrolment coverage where feasible.
+- `DataBridge/.env.example`, `README.md`, `k8s/base/secrets.env.example`, `k8s/overlays/dev/config.env`, `k8s/overlays/dev/southbound-cert.yaml`, `k8s/overlays/prod/config.env`, prod deployment patches - update default docs/config to server TLS plus application auth; keep client CA only for optional compatibility.
+- `DataAgent/internal/config/config.go` and `internal/config/config_test.go` - add a server-TLS mode or rename the default mode so production no longer requires client cert/key. Require `ENROLMENT_TOKEN` outside insecure dev and continue requiring server identity validation.
+- `DataAgent/internal/transport/credentials.go` and `internal/transport/credentials_test.go` - add TLS-only credentials using CA/system roots policy, always attach token over secure transport, and keep the "never send token over insecure transport" invariant.
+- `DataAgent/internal/supervisor/connector.go` and tests - connection setup can stay mostly unchanged, but tests should prove token metadata reaches DataBridge under TLS-only. Current `INSTANCE_ID` is logged locally but not sent in `Hello`; DataBridge generates a new instance id server-side.
+- `DataAgent/.env.example`, `README.md`, `k8s/base/secrets.env.example`, `k8s/base/kustomization.yaml`, `k8s/overlays/dev/config.env`, `k8s/overlays/dev/kustomization.yaml`, `k8s/overlays/dev/client-cert.yaml`, `k8s/overlays/dev/patches/client-tls-patch.yaml`, `k8s/overlays/prod/config.env` - remove default `dataagent-client-tls` requirements and document `ENROLMENT_TOKEN`, optional `DATABASE_URL`, and server validation material.
+- `DataCore/docs/hybrid-residency-deploy-secrets-checklist.md` - update required secrets and rotation guidance to remove customer-side DataAgent client cert lifecycle from default production.
+- `TrustGate/docs/hybrid-residency-gsm-secrets.md` - update the coordination doc in the primary worktree or restore it if missing from this branch, then remove default DataAgent client mTLS guidance.
+
+## Approaches
+
+| Approach | Pros | Cons | Effort |
+|---|---|---|---|
+| Minimal shared enrolment token | Smallest code change; matches current `x-enrolment-token` metadata plumbing; easy to test valid/missing/invalid token. | Long-lived bearer token risk; weak revocation/audit identity; does not meet security note preference by itself. | Low |
+| Bootstrap token exchanged for agent credential | Aligns with issue security notes; enrolment token can be one-time/short-lived; later connections use per-agent credential with revocation and audit identity. | Needs credential persistence/lookup design in DataBridge; may require schema/store or external service not present in current code. | High |
+| Phased RUN-915 default: configured token validator now, credential lifecycle follow-up | Removes client mTLS immediately; enforces real token equality/hash and tenant binding; keeps optional mTLS compatibility; creates clear follow-up for one-time exchange/rotation if no store is available now. | Enrolment token may remain longer-lived for one release unless follow-up is prioritized; requires explicit documentation of residual risk. | Medium |
+
+## Recommendation
+
+Use the phased approach for RUN-915. Implement server-side TLS as the default transport, add DataAgent `tls` credentials that validate the DataBridge server and send `ENROLMENT_TOKEN`, and replace DataBridge's production-auth placeholder with a real configured token authenticator that rejects missing/invalid tokens and binds the credential to the claimed tenant. Keep `SOUTHBOUND_CLIENT_CA_FILE` and DataAgent mTLS mode as an explicit compatibility mode only, not the default deployment path.
+
+For the security notes, avoid treating the current token as an unbounded anonymous bearer. If the current repos do not have a durable credential store ready, scope RUN-915 to a hashed/configured bootstrap token with tenant binding, audit-safe credential id logging, and rate-limit hooks/tests where local structure allows. Track the stronger "bootstrap exchange to per-agent credential" as a follow-up if it needs storage or control-plane APIs outside this issue.
+
+## Risks
+
+- A simple static enrolment token is weaker than mTLS and can become a long-lived bearer unless the implementation scopes, hashes, rotates, and audits it.
+- DataBridge currently has no production authenticator, so this issue is not only deployment cleanup; it must add auth behavior before removing mTLS defaults.
+- Current event flow does not transmit DataAgent `INSTANCE_ID` to DataBridge; DataBridge generates an instance id per connection. Preserving audit fields may require a proto/schema change or a deliberate server-generated-id decision.
+- Prod DataBridge deployment config appears incomplete for server TLS today because prod config does not set cert/key paths or mount `databridge-southbound-tls`.
+- TrustGate hybrid docs are missing from the primary RUN worktree even though the issue names them; later phases should restore/update them in that worktree or confirm they intentionally moved.
+
+## Open Questions
+
+- Should RUN-915 implement one-time bootstrap exchange to a per-agent credential now, or is a configured tenant-bound token acceptable for this PR with a follow-up? Code investigation cannot fully answer this because there is no existing DataBridge credential store.
+- Should DataAgent server validation require a private CA file in production or allow system roots when `DATABRIDGE_SERVER_NAME` is set? Code can support either; product/security policy must choose.
+- Should `INSTANCE_ID` become part of the `Hello` contract so DataBridge can audit the customer-configured agent instance id? Code investigation shows it is not currently sent.
+- Should optional mTLS compatibility remain in the same `TLS_MODE=mtls` path? The current code already supports it and keeping it is low risk, but product can decide whether to document it.
+
+## Ready for Proposal
+
+Yes. Proposal should define the production token validation source and TLS server validation policy, then split implementation across DataBridge auth/TLS tests, DataAgent TLS-only credentials/config, k8s overlays, and docs.

--- a/docs/sdd/run-915-tls-enrolment-auth/proposal.md
+++ b/docs/sdd/run-915-tls-enrolment-auth/proposal.md
@@ -1,0 +1,67 @@
+# Proposal: RUN-915 TLS Enrolment Auth
+
+## Problem Statement
+
+Hybrid deployments still require DataAgent client mTLS material by default, creating customer-side certificate rotation and secret-mount burden. RUN-915 switches the southbound DataAgent -> DataBridge path to DataBridge server TLS plus application-level enrolment auth, while preserving server identity validation and rejection of unauthenticated agents.
+
+## Goals
+
+- DataAgent connects with server-side TLS and `ENROLMENT_TOKEN`, without default client cert/key mounts.
+- DataBridge rejects missing or invalid enrolment-token auth.
+- Deployed DataBridge still serves TLS; DataAgent validates `DATABRIDGE_SERVER_NAME`.
+- Dev/prod manifests and docs remove default `dataagent-client-tls` requirements.
+- Tests cover TLS-only success plus missing/invalid token rejection.
+
+## Non-Goals
+
+- No one-time token exchange or per-agent credential lifecycle in this PR.
+- No residency proto change for customer-configured `INSTANCE_ID`.
+- No DataCore product-code change; DataCore impact is docs only.
+- Optional mTLS compatibility may remain explicit, but not default.
+
+## Capabilities
+
+### New Capabilities
+
+- `southbound-enrolment-auth`: DataBridge validates the configured singular enrolment token for DataAgent streams.
+
+### Modified Capabilities
+
+- `hybrid-residency-deployment`: Default hybrid deployment uses server TLS plus enrolment token instead of client mTLS.
+
+## Chosen Approach
+
+Implement the phased RUN-915 approach: add/finish a configured token authenticator in DataBridge that validates a non-logged singular `ENROLMENT_TOKEN` and rejects the stream before registry registration. This assumes an isolated 1:1 tenant/DataAgent deployment; shared multi-tenant DataBridge deployments need tenant-bound credential storage first. Add DataAgent TLS-only credentials that require `DATABRIDGE_SERVER_NAME`, use `TLS_CA_FILE` when provided or system roots otherwise, and send `ENROLMENT_TOKEN` only on secure transport. Remove client cert/key env vars and secret mounts from default manifests/docs; keep `TLS_MODE=mtls` / `SOUTHBOUND_CLIENT_CA_FILE` only as explicit compatibility if low churn.
+
+## Alternatives Considered
+
+| Alternative | Decision | Reason |
+|---|---|---|
+| Keep mTLS default | Rejected | Fails RUN-915 customer secret-rotation goal. |
+| Static shared token only | Rejected | Too weak unless tenant-bound, validated, tested, and documented as transitional. |
+| One-time bootstrap exchange now | Deferred | Requires a DataBridge credential store/lifecycle not present today. |
+| Add `INSTANCE_ID` to proto | Deferred | Current contract omits it; server-generated instance id remains registry/audit identity. |
+
+## Cross-Repo Impact
+
+| Repo | Impact |
+|---|---|
+| DataBridge | Auth config/provider, southbound TLS tests, k8s/env/docs defaults. |
+| DataAgent | Config validation, TLS-only credentials, token metadata, k8s/env/docs defaults. |
+| DataCore | Update deployment secrets checklist only. |
+| TrustGate | Restore/add `docs/hybrid-residency-gsm-secrets.md` if required and remove default DataAgent client mTLS guidance. |
+
+## Risks And Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Long-lived bearer token leakage | Never log tokens; support rotation via configured secret; document residual risk and follow-up credential lifecycle. |
+| TLS misconfiguration weakens identity checks | Require `DATABRIDGE_SERVER_NAME`; use private CA when configured or system roots otherwise. |
+| Breaking mTLS users | Keep explicit compatibility mode if feasible, outside default docs/manifests. |
+| Prod DataBridge TLS incomplete | Ensure cert/key env and `databridge-southbound-tls` mount are present in deployed overlays. |
+
+## Rollout And Testing
+
+Roll out by updating DataBridge and DataAgent configs/manifests together, rotating in `ENROLMENT_TOKEN`, and removing `dataagent-client-tls` only after TLS server cert material is deployed. Rollback is to restore prior `TLS_MODE=mtls`, client cert/key mounts, and `SOUTHBOUND_CLIENT_CA_FILE` requirements.
+
+Verify with table-driven Go tests for token validator success/failure, DataAgent TLS config with private CA and system roots, TLS-only e2e happy path, and missing/invalid token rejection before registration. Run `gofmt`, `go vet`, `golangci-lint`, unit tests, and race tests for stream/supervisor paths.

--- a/docs/sdd/run-915-tls-enrolment-auth/spec.md
+++ b/docs/sdd/run-915-tls-enrolment-auth/spec.md
@@ -1,0 +1,136 @@
+# RUN-915 Behavioral Spec: TLS Enrolment Auth
+
+## Purpose
+
+RUN-915 SHALL switch the default DataAgent -> DataBridge southbound path from mandatory client mTLS to DataBridge server TLS plus application-level enrolment-token authentication, while preserving server identity validation and fail-closed authentication.
+
+## Requirements
+
+### Requirement R1: DataBridge Server TLS
+
+DataBridge MUST serve southbound gRPC with server-side TLS in deployed non-dev environments. It MUST fail startup when required server cert/key material is missing. It MAY request client certificates only when explicit compatibility mTLS is configured.
+
+#### Scenario: Deployed TLS server starts
+
+- GIVEN non-dev DataBridge config with server cert/key and no client CA
+- WHEN the southbound server starts
+- THEN it SHALL serve TLS
+- AND it SHALL NOT require a DataAgent client certificate
+
+#### Scenario: Missing deployed TLS material fails closed
+
+- GIVEN non-dev DataBridge config without server cert or key
+- WHEN DataBridge starts
+- THEN startup MUST fail before accepting southbound streams
+
+### Requirement R2: Enrolment Token Authentication
+
+DataBridge MUST authenticate each DataAgent `Connect` stream using the `x-enrolment-token` metadata before registry registration. Missing or invalid tokens MUST be rejected without registering an agent. The singular token model assumes an isolated 1:1 tenant/DataAgent deployment.
+
+#### Scenario: Valid token registers stream
+
+- GIVEN a configured `ENROLMENT_TOKEN`
+- WHEN a DataAgent connects with that token and claims tenant `T`
+- THEN DataBridge SHALL accept authentication
+- AND it MAY register the stream for tenant `T`
+
+#### Scenario: Missing or invalid token is rejected
+
+- GIVEN DataBridge requires enrolment authentication
+- WHEN a stream omits `x-enrolment-token` or sends an invalid token
+- THEN DataBridge MUST reject the stream
+- AND no registry entry SHALL be created
+
+#### Scenario: Token is not multi-tenant routing
+
+- GIVEN the singular token model
+- WHEN a deployment needs one DataBridge to accept independent tokens for multiple tenants
+- THEN that deployment MUST add tenant-bound credential storage before using the shared DataBridge as a multi-tenant router
+
+### Requirement R3: Token Safety And Error Behavior
+
+DataBridge and DataAgent MUST NOT log enrolment-token values. Authentication failures SHOULD return stable unauthenticated errors that do not reveal the expected token, configured token count, or tenant binding internals.
+
+#### Scenario: Token failure is audit-safe
+
+- GIVEN an invalid enrolment-token attempt
+- WHEN DataBridge records logs or returns an error
+- THEN the token value MUST NOT appear
+- AND the error MUST identify authentication failure without secret detail
+
+### Requirement R4: DataAgent TLS Credentials
+
+DataAgent MUST support a default deployed server-TLS credential mode that requires `ENROLMENT_TOKEN` and `DATABRIDGE_SERVER_NAME`, does not require client cert/key files, uses `TLS_CA_FILE` when set, and uses system roots when `TLS_CA_FILE` is empty.
+
+#### Scenario: TLS-only config is valid
+
+- GIVEN `ENROLMENT_TOKEN` and `DATABRIDGE_SERVER_NAME` are set
+- AND no client cert/key files are configured
+- WHEN DataAgent validates deployed TLS config
+- THEN validation SHALL succeed
+
+#### Scenario: Server identity is required
+
+- GIVEN deployed TLS mode without `DATABRIDGE_SERVER_NAME`
+- WHEN DataAgent validates config
+- THEN validation MUST fail before dialing DataBridge
+
+### Requirement R5: Secure Token Transmission
+
+DataAgent MUST send `ENROLMENT_TOKEN` metadata only on secure DataBridge transports. It MUST NOT send the token over insecure dev transport.
+
+#### Scenario: Token is sent over TLS
+
+- GIVEN DataAgent uses server TLS
+- WHEN it opens the southbound stream
+- THEN it SHALL attach `x-enrolment-token`
+
+#### Scenario: Token is withheld over insecure transport
+
+- GIVEN DataAgent uses explicit insecure dev transport
+- WHEN it opens the southbound stream
+- THEN it MUST NOT attach `x-enrolment-token`
+
+### Requirement R6: Default Kubernetes And Secrets Contract
+
+Default dev and production overlays MUST NOT mount or require `dataagent-client-tls` for DataAgent. DataBridge deployed overlays MUST provide server TLS cert/key material. Both sides MUST source `ENROLMENT_TOKEN` from secrets or equivalent deployment configuration.
+
+#### Scenario: Default overlays omit client mTLS
+
+- GIVEN default hybrid dev or production manifests
+- WHEN manifests are rendered
+- THEN DataAgent SHALL have no required client cert/key mount
+- AND DataBridge SHALL still have server TLS material in deployed environments
+
+### Requirement R7: Documentation And Rotation Guidance
+
+Production documentation MUST describe DataBridge server TLS, `DATABRIDGE_SERVER_NAME`, optional `TLS_CA_FILE`, and `ENROLMENT_TOKEN`. It MUST NOT require customer-side DataAgent client certificate rotation in the default path. DataCore changes SHALL be documentation-only.
+
+#### Scenario: Default docs match TLS enrolment flow
+
+- GIVEN an operator follows the production hybrid secrets docs
+- WHEN they provision default RUN-915 secrets
+- THEN they SHALL provision enrolment token and DataBridge server TLS material
+- AND they SHALL NOT be instructed to rotate DataAgent client cert/key material
+
+### Requirement R8: Compatibility And Non-Goals
+
+Explicit mTLS compatibility MAY remain for internal or transitional deployments, but it MUST NOT be the default documented or rendered path. RUN-915 SHALL NOT add one-time token exchange, per-agent credential lifecycle, or residency proto changes for `INSTANCE_ID`.
+
+#### Scenario: Compatibility is opt-in
+
+- GIVEN a deployment uses default RUN-915 config
+- WHEN DataAgent connects to DataBridge
+- THEN the connection SHALL use server TLS plus enrolment auth
+- AND mTLS SHALL require explicit non-default configuration
+
+### Requirement R9: Test Coverage
+
+Automated tests MUST cover TLS-only success, private-CA and system-root DataAgent TLS validation, missing/invalid enrolment-token rejection, no registration on auth failure, safe error/log behavior, and default manifest/docs expectations where repo tooling supports them.
+
+#### Scenario: Tests prove the behavioral contract
+
+- GIVEN the RUN-915 test suite is run
+- WHEN TLS-only and rejected-auth cases execute
+- THEN valid enrolment SHALL connect without client cert/key
+- AND invalid enrolment SHALL fail before registration

--- a/docs/sdd/run-915-tls-enrolment-auth/tasks.md
+++ b/docs/sdd/run-915-tls-enrolment-auth/tasks.md
@@ -1,0 +1,63 @@
+# Tasks: RUN-915 TLS Enrolment Auth
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | 1,000-1,500 across four repos |
+| 400-line budget risk | High |
+| Chained PRs recommended | Yes |
+| Suggested split | DataBridge code -> DataBridge deploy; DataAgent code -> DataAgent deploy; DataCore docs; TrustGate docs |
+| Delivery strategy | explicit user decision in tasks phase |
+| Chain strategy | stacked-to-main |
+
+Decision needed before apply: No
+Chained PRs recommended: Yes
+Chain strategy: stacked-to-main
+400-line budget risk: High
+
+### Suggested Work Units
+
+| Unit | Goal | Likely PR | Notes |
+|------|------|-----------|-------|
+| 1 | DataBridge token auth and TLS tests | DataBridge PR 1 | Base default branch; merge before deploy flip. |
+| 2 | DataBridge env/k8s deploy defaults | DataBridge PR 2 | Depends on Unit 1; still keep mTLS opt-in. |
+| 3 | DataAgent TLS mode and token credentials | DataAgent PR 1 | Can merge with compatibility preserved. |
+| 4 | DataAgent env/k8s deploy defaults | DataAgent PR 2 | Depends on Unit 3 and coordinated with DataBridge PR 2. |
+| 5 | DataCore docs-only update | DataCore PR | Independent docs PR. |
+| 6 | TrustGate coordination docs | TrustGate PR | Restores/updates SDD and GSM guidance. |
+
+## Phase 1: DataBridge Auth And TLS
+
+- [ ] 1.1 Modify `DataBridge/internal/auth/auth.go` and `internal/auth/auth_test.go`: add `AUTH_MODE=token` authenticator for singular `ENROLMENT_TOKEN`, constant-time compare, missing/invalid rejection, and token-safe errors.
+- [ ] 1.2 Modify `DataBridge/internal/config/config.go`, `internal/config/config_test.go`, and `internal/container/modules/bridge.go`: parse token mode, require token config outside dev, and wire the provider without changing proto or `INSTANCE_ID`.
+- [ ] 1.3 Modify/create `DataBridge/internal/container/modules/servers_test.go` around `servers.go`: prove non-dev server TLS starts without client CA and fails closed without cert/key; preserve explicit `SOUTHBOUND_CLIENT_CA_FILE` mTLS compatibility.
+- [ ] 1.4 Modify `DataBridge/internal/southbound/connect_test.go` and `internal/e2e/e2e_test.go`: cover TLS-only valid token, missing/invalid token, no registry registration on auth failure, and execute round trip after auth.
+- [ ] 1.5 Validate DataBridge PR 1 with `gofmt`, `go vet ./...`, `golangci-lint run`, `make test`, and focused `go test -race ./...`.
+
+## Phase 2: DataBridge Deployment Defaults
+
+- [ ] 2.1 Modify `DataBridge/.env.example`, `README.md`, `k8s/base/secrets.env.example`, `k8s/base/deployment.yaml`, `k8s/overlays/dev/config.env`, `k8s/overlays/prod/config.env`, `k8s/overlays/prod/kustomization.yaml`, and `k8s/overlays/prod/patches/southbound-tls-patch.yaml`: add token secret and server TLS mount/env, leave client CA unset by default.
+- [ ] 2.2 Validate DataBridge PR 2 with repo manifest rendering if available plus the Phase 1 Go gates.
+
+## Phase 3: DataAgent TLS Credentials
+
+- [ ] 3.1 Modify `DataAgent/internal/config/config.go` and `internal/config/config_test.go`: make `TLS_MODE=tls` default, require `DATABRIDGE_SERVER_NAME` and `ENROLMENT_TOKEN`, allow empty `TLS_CA_FILE` with system roots, and keep `mtls` explicit.
+- [ ] 3.2 Modify `DataAgent/internal/transport/credentials.go` and `internal/transport/credentials_test.go`: build TLS-only transport credentials, attach `x-enrolment-token` only over secure transport, withhold it for insecure dev, and test private CA plus system roots.
+- [ ] 3.3 Modify `DataAgent/internal/supervisor/connector_test.go`: prove TLS-mode dial/connect carries token metadata without client cert/key.
+- [ ] 3.4 Validate DataAgent PR 1 with `gofmt`, `go vet ./...`, `golangci-lint run`, `make test`, and focused `go test -race ./...`.
+
+## Phase 4: DataAgent Deployment Defaults
+
+- [ ] 4.1 Modify `DataAgent/.env.example`, `README.md`, `k8s/base/secrets.env.example`, `k8s/overlays/dev/config.env`, `k8s/overlays/dev/kustomization.yaml`, `k8s/overlays/dev/client-cert.yaml`, `k8s/overlays/dev/patches/client-tls-patch.yaml`, `k8s/overlays/dev/databridge-ca.yaml`, `k8s/overlays/dev/patches/ca-bundle-patch.yaml`, and `k8s/overlays/prod/config.env`: remove default `dataagent-client-tls`, add CA-only dev trust, set `TLS_MODE=tls`, and document optional mTLS.
+- [ ] 4.2 Validate DataAgent PR 2 with repo manifest rendering if available plus the Phase 3 Go gates.
+
+## Phase 5: Docs And Coordination
+
+- [ ] 5.1 Modify `DataCore/docs/hybrid-residency-deploy-secrets-checklist.md`: remove default DataAgent client cert/key rotation and describe server TLS, optional CA, `DATABRIDGE_SERVER_NAME`, and `ENROLMENT_TOKEN`.
+- [ ] 5.2 Create/modify `TrustGate/docs/hybrid-residency-gsm-secrets.md` and keep `TrustGate/docs/sdd/run-915-tls-enrolment-auth/design.md` aligned: remove default client mTLS guidance and note token lifecycle follow-up.
+- [ ] 5.3 Validate docs by searching for stale default `dataagent-client-tls`, `TLS_MODE=mtls`, `TLS_CLIENT_CERT_FILE`, and customer DataAgent cert rotation guidance.
+
+## Dependencies
+
+DataBridge auth must land before default deploy flips. DataAgent TLS credentials must land before removing client cert mounts. DataBridge and DataAgent deployment PRs should be released together; DataCore and TrustGate docs can merge after the contract is final.


### PR DESCRIPTION
## Summary
- Adds RUN-915 SDD artifacts for the server TLS plus singular enrolment-token direction.
- Adds `docs/hybrid-residency-gsm-secrets.md` with DataCore/DataBridge/DataAgent secret guidance.
- Documents that client mTLS is compatibility-only and that DataAgent validates DataBridge via server TLS.

## Linear
RUN-915: https://linear.app/neuraltrust/issue/RUN-915/switch-dataagent-southbound-auth-from-mtls-to-tls-enrolment-token

## Test plan
- [x] Docs-only review via reviewer subagent
- [x] Static search for stale `ENROLMENT_TOKENS` and tenant-map wording
- [x] Repository pre-commit hook passed successfully during commit

## Follow-up
- DataCore-issued bootstrap token and DataBridge introspection will be tracked in a new Linear issue.

Made with [Cursor](https://cursor.com)