### PR TITLE
chore(k8s): scaffold config-sync signed auth mode in control-plane config.env

### DIFF
--- a/k8s/base/secrets.env.example
+++ b/k8s/base/secrets.env.example
@@ -32,6 +32,13 @@
 #   CONFIG_SYNC_LKG_KEY - AES-256 key that encrypts the on-disk last-known-good
 #                         snapshot on the data planes. Must be base64 that decodes to
 #                         exactly 32 bytes, e.g. `openssl rand -base64 32`.
+#   CONFIG_SYNC_JWT_PUBLIC_KEY - only for CONFIG_SYNC_AUTH_MODE=composite|signed. PKIX PEM
+#                         public key (EdDSA/ES256/RS256) that verifies the per-tenant config-sync
+#                         JWTs minted by DataCore for external (hybrid) data planes. Add it to the
+#                         agentgateway .env blob (newlines escaped so godotenv parses one line, or
+#                         base64-encoded PEM). Non-secret issuer/audience go in overlays/*/config.env
+#                         (CONFIG_SYNC_JWT_ISSUER/CONFIG_SYNC_JWT_AUDIENCE). Leave unset while
+#                         CONFIG_SYNC_AUTH_MODE=shared.
 #
 # DB-less config-sync gRPC TLS (prod only — the channel carries registry credentials,
 # so it must not be plaintext in a deployed environment). These are PEM files, mounted

--- a/k8s/overlays/dev/config.env
+++ b/k8s/overlays/dev/config.env
@@ -35,6 +35,19 @@ CONFIG_SYNC_LKG_PATH=/var/lib/trustgate/snapshot.lkg
 CONFIG_SYNC_RECOMPILE_DEBOUNCE=2s
 CONFIG_SYNC_RECOMPILE_BACKSTOP=5m
 CONFIG_SYNC_POLL_INTERVAL=5m
+# Config-sync data-plane authentication (admin control plane verifies incoming data planes).
+# "shared" (default): data planes present CONFIG_SYNC_TOKEN (shared bearer) and get the
+# global snapshot. "signed": data planes present a per-tenant signed JWT whose "scope"
+# claim selects the tenant partition (gateways filtered by metadata.tenant_id; token minted
+# by DataCore); the control plane serves only that tenant's snapshot. Signed mode fails
+# closed unless the three CONFIG_SYNC_JWT_* below are set. JWKS is not yet supported.
+# Left in "shared" until DataCore mints tokens.
+CONFIG_SYNC_AUTH_MODE=shared
+# Uncomment and populate to enable signed mode (issuer/audience must match DataCore's tokens;
+# the PEM public key is a secret and belongs in the GCP .env blob, not here):
+# CONFIG_SYNC_JWT_ISSUER=
+# CONFIG_SYNC_JWT_AUDIENCE=
+# CONFIG_SYNC_JWT_PUBLIC_KEY= (secret: GCP .env blob)
 # Telemetry: default exporters loaded from a YAML mounted via ConfigMap; both
 # metadata and raw classes ship to the ClickStack OTel Collector over OTLP/HTTP.
 # WithEndpointURL takes the path verbatim, so the endpoint must include /v1/logs.

--- a/k8s/overlays/dev/config.env
+++ b/k8s/overlays/dev/config.env
@@ -36,18 +36,23 @@ CONFIG_SYNC_RECOMPILE_DEBOUNCE=2s
 CONFIG_SYNC_RECOMPILE_BACKSTOP=5m
 CONFIG_SYNC_POLL_INTERVAL=5m
 # Config-sync data-plane authentication (admin control plane verifies incoming data planes).
-# "shared" (default): data planes present CONFIG_SYNC_TOKEN (shared bearer) and get the
-# global snapshot. "signed": data planes present a per-tenant signed JWT whose "scope"
-# claim selects the tenant partition (gateways filtered by metadata.tenant_id; token minted
-# by DataCore); the control plane serves only that tenant's snapshot. Signed mode fails
-# closed unless the three CONFIG_SYNC_JWT_* below are set. JWKS is not yet supported.
-# Left in "shared" until DataCore mints tokens.
+#   shared    (active): data planes present CONFIG_SYNC_TOKEN (shared bearer, in-cluster secret)
+#                       and receive the global snapshot. Correct while every data plane is ours.
+#   composite (target): the SAME control plane also accepts per-tenant signed JWTs from external
+#                       (hybrid, customer-hosted) data planes -- the JWT "scope" claim selects the
+#                       tenant partition (gateways filtered by metadata.tenant_id) -- while the
+#                       shared token keeps serving the global snapshot to the in-cluster fleet.
+#   signed             : JWT-only, no shared token (not used by the SaaS control plane).
+# composite/signed require the three CONFIG_SYNC_JWT_* below (asymmetric EdDSA/ES256/RS256; the
+# PEM public key is a secret in the GCP .env blob, issuer/audience are non-secret config). They
+# fail closed if unset. JWKS is not yet supported.
 CONFIG_SYNC_AUTH_MODE=shared
-# Uncomment and populate to enable signed mode (issuer/audience must match DataCore's tokens;
-# the PEM public key is a secret and belongs in the GCP .env blob, not here):
-# CONFIG_SYNC_JWT_ISSUER=
-# CONFIG_SYNC_JWT_AUDIENCE=
-# CONFIG_SYNC_JWT_PUBLIC_KEY= (secret: GCP .env blob)
+# Flip to composite once DataCore mints per-tenant signed JWTs: (1) add CONFIG_SYNC_JWT_PUBLIC_KEY
+# to the agentgateway secret blob, (2) uncomment the issuer/audience below to match DataCore's
+# tokens, (3) set CONFIG_SYNC_AUTH_MODE=composite.
+# CONFIG_SYNC_JWT_ISSUER=datacore
+# CONFIG_SYNC_JWT_AUDIENCE=trustgate-config-sync
+# CONFIG_SYNC_JWT_PUBLIC_KEY -> secret (agentgateway .env blob in GCP), never set here
 # Telemetry: default exporters loaded from a YAML mounted via ConfigMap; both
 # metadata and raw classes ship to the ClickStack OTel Collector over OTLP/HTTP.
 # WithEndpointURL takes the path verbatim, so the endpoint must include /v1/logs.

--- a/k8s/overlays/prod/config.env
+++ b/k8s/overlays/prod/config.env
@@ -34,18 +34,23 @@ CONFIG_SYNC_RECOMPILE_DEBOUNCE=2s
 CONFIG_SYNC_RECOMPILE_BACKSTOP=5m
 CONFIG_SYNC_POLL_INTERVAL=5m
 # Config-sync data-plane authentication (admin control plane verifies incoming data planes).
-# "shared" (default): data planes present CONFIG_SYNC_TOKEN (shared bearer) and get the
-# global snapshot. "signed": data planes present a per-tenant signed JWT whose "scope"
-# claim selects the tenant partition (gateways filtered by metadata.tenant_id; token minted
-# by DataCore); the control plane serves only that tenant's snapshot. Signed mode fails
-# closed unless the three CONFIG_SYNC_JWT_* below are set. JWKS is not yet supported.
-# Left in "shared" until DataCore mints tokens.
+#   shared    (active): data planes present CONFIG_SYNC_TOKEN (shared bearer, in-cluster secret)
+#                       and receive the global snapshot. Correct while every data plane is ours.
+#   composite (target): the SAME control plane also accepts per-tenant signed JWTs from external
+#                       (hybrid, customer-hosted) data planes -- the JWT "scope" claim selects the
+#                       tenant partition (gateways filtered by metadata.tenant_id) -- while the
+#                       shared token keeps serving the global snapshot to the in-cluster fleet.
+#   signed             : JWT-only, no shared token (not used by the SaaS control plane).
+# composite/signed require the three CONFIG_SYNC_JWT_* below (asymmetric EdDSA/ES256/RS256; the
+# PEM public key is a secret in the GCP .env blob, issuer/audience are non-secret config). They
+# fail closed if unset. JWKS is not yet supported.
 CONFIG_SYNC_AUTH_MODE=shared
-# Uncomment and populate to enable signed mode (issuer/audience must match DataCore's tokens;
-# the PEM public key is a secret and belongs in the GCP .env blob, not here):
-# CONFIG_SYNC_JWT_ISSUER=
-# CONFIG_SYNC_JWT_AUDIENCE=
-# CONFIG_SYNC_JWT_PUBLIC_KEY= (secret: GCP .env blob)
+# Flip to composite once DataCore mints per-tenant signed JWTs: (1) add CONFIG_SYNC_JWT_PUBLIC_KEY
+# to the agentgateway secret blob, (2) uncomment the issuer/audience below to match DataCore's
+# tokens, (3) set CONFIG_SYNC_AUTH_MODE=composite.
+# CONFIG_SYNC_JWT_ISSUER=datacore
+# CONFIG_SYNC_JWT_AUDIENCE=trustgate-config-sync
+# CONFIG_SYNC_JWT_PUBLIC_KEY -> secret (agentgateway .env blob in GCP), never set here
 # Telemetry: default exporters loaded from a YAML mounted via ConfigMap; both
 # metadata and raw classes ship to the ClickStack OTel Collector over OTLP/HTTP.
 # WithEndpointURL takes the path verbatim, so the endpoint must include /v1/logs.

--- a/k8s/overlays/prod/config.env
+++ b/k8s/overlays/prod/config.env
@@ -33,6 +33,19 @@ CONFIG_SYNC_LKG_PATH=/var/lib/trustgate/snapshot.lkg
 CONFIG_SYNC_RECOMPILE_DEBOUNCE=2s
 CONFIG_SYNC_RECOMPILE_BACKSTOP=5m
 CONFIG_SYNC_POLL_INTERVAL=5m
+# Config-sync data-plane authentication (admin control plane verifies incoming data planes).
+# "shared" (default): data planes present CONFIG_SYNC_TOKEN (shared bearer) and get the
+# global snapshot. "signed": data planes present a per-tenant signed JWT whose "scope"
+# claim selects the tenant partition (gateways filtered by metadata.tenant_id; token minted
+# by DataCore); the control plane serves only that tenant's snapshot. Signed mode fails
+# closed unless the three CONFIG_SYNC_JWT_* below are set. JWKS is not yet supported.
+# Left in "shared" until DataCore mints tokens.
+CONFIG_SYNC_AUTH_MODE=shared
+# Uncomment and populate to enable signed mode (issuer/audience must match DataCore's tokens;
+# the PEM public key is a secret and belongs in the GCP .env blob, not here):
+# CONFIG_SYNC_JWT_ISSUER=
+# CONFIG_SYNC_JWT_AUDIENCE=
+# CONFIG_SYNC_JWT_PUBLIC_KEY= (secret: GCP .env blob)
 # Telemetry: default exporters loaded from a YAML mounted via ConfigMap; both
 # metadata and raw classes ship to the ClickStack OTel Collector over OTLP/HTTP.
 # WithEndpointURL takes the path verbatim, so the endpoint must include /v1/logs.


### PR DESCRIPTION
## Summary
- Adds `CONFIG_SYNC_AUTH_MODE=shared` explicitly to both `dev` and `prod` control-plane `config.env` overlays (no behavior change — `shared` is the default).
- Adds a documented, commented block for signed-mode vars (`CONFIG_SYNC_JWT_ISSUER` / `CONFIG_SYNC_JWT_AUDIENCE` / `CONFIG_SYNC_JWT_PUBLIC_KEY`) so flipping the SaaS control plane to per-tenant signed config-sync is a one-line change once DataCore mints the scoped JWTs.
- Public key stays a GCP secret (documented as such), not committed.

Follow-up to the config-sync multi-tenant scope work merged in #182 (RUN-905). Mirrors the equivalent TrustGuard scaffold.

## Test plan
- [ ] Kustomize renders the `dev` and `prod` overlays without error.
- [ ] Existing deployments unaffected (`shared` mode default preserved).

RUN-905

Made with [Cursor](https://cursor.com)