### PR TITLE
feat(config-sync): composite auth mode (shared token + signed JWT) [RUN-917]

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -147,6 +147,10 @@ type Config struct {
 const (
 	ConfigSyncAuthModeShared = "shared"
 	ConfigSyncAuthModeSigned = "signed"
+	// ConfigSyncAuthModeComposite accepts both a signed per-tenant JWT (external
+	// data planes → scoped snapshot) and the shared bearer token (in-cluster data
+	// plane → global snapshot) on a single control plane.
+	ConfigSyncAuthModeComposite = "composite"
 )
 
 type ConfigSyncConfig struct {
@@ -733,19 +737,28 @@ func (cs ConfigSyncConfig) validateAuthMode() error {
 	case "", ConfigSyncAuthModeShared:
 		return nil
 	case ConfigSyncAuthModeSigned:
-		if cs.JWTPublicKey == "" {
-			if cs.JWTJWKSURL != "" {
-				return fmt.Errorf("%w: CONFIG_SYNC_AUTH_MODE=signed with JWKS is not yet supported; set CONFIG_SYNC_JWT_PUBLIC_KEY", errors.ErrInvalidConfig)
-			}
-			return fmt.Errorf("%w: CONFIG_SYNC_AUTH_MODE=signed requires CONFIG_SYNC_JWT_PUBLIC_KEY", errors.ErrInvalidConfig)
+		return cs.validateSignedJWTParams()
+	case ConfigSyncAuthModeComposite:
+		if cs.Token == "" {
+			return fmt.Errorf("%w: CONFIG_SYNC_AUTH_MODE=composite requires CONFIG_SYNC_TOKEN for the in-cluster data plane that pulls the global snapshot", errors.ErrInvalidConfig)
 		}
-		if cs.JWTIssuer == "" || cs.JWTAudience == "" {
-			return fmt.Errorf("%w: CONFIG_SYNC_AUTH_MODE=signed requires CONFIG_SYNC_JWT_ISSUER and CONFIG_SYNC_JWT_AUDIENCE", errors.ErrInvalidConfig)
-		}
-		return nil
+		return cs.validateSignedJWTParams()
 	default:
-		return fmt.Errorf("%w: CONFIG_SYNC_AUTH_MODE must be %q or %q", errors.ErrInvalidConfig, ConfigSyncAuthModeShared, ConfigSyncAuthModeSigned)
+		return fmt.Errorf("%w: CONFIG_SYNC_AUTH_MODE must be %q, %q or %q", errors.ErrInvalidConfig, ConfigSyncAuthModeShared, ConfigSyncAuthModeSigned, ConfigSyncAuthModeComposite)
 	}
+}
+
+func (cs ConfigSyncConfig) validateSignedJWTParams() error {
+	if cs.JWTPublicKey == "" {
+		if cs.JWTJWKSURL != "" {
+			return fmt.Errorf("%w: CONFIG_SYNC_AUTH_MODE=%s with JWKS is not yet supported; set CONFIG_SYNC_JWT_PUBLIC_KEY", errors.ErrInvalidConfig, cs.AuthMode)
+		}
+		return fmt.Errorf("%w: CONFIG_SYNC_AUTH_MODE=%s requires CONFIG_SYNC_JWT_PUBLIC_KEY", errors.ErrInvalidConfig, cs.AuthMode)
+	}
+	if cs.JWTIssuer == "" || cs.JWTAudience == "" {
+		return fmt.Errorf("%w: CONFIG_SYNC_AUTH_MODE=%s requires CONFIG_SYNC_JWT_ISSUER and CONFIG_SYNC_JWT_AUDIENCE", errors.ErrInvalidConfig, cs.AuthMode)
+	}
+	return nil
 }
 
 // IsDeployed reports whether APP_ENV marks a non-local deployment (staging or

--- a/pkg/config/configsync_auth_test.go
+++ b/pkg/config/configsync_auth_test.go
@@ -33,6 +33,9 @@ func TestConfigSyncValidateAuthMode(t *testing.T) {
 		{name: "signed jwks only", cfg: ConfigSyncConfig{AuthMode: ConfigSyncAuthModeSigned, JWTJWKSURL: "https://x/jwks", JWTIssuer: "i", JWTAudience: "a"}, wantErr: true},
 		{name: "signed without iss/aud", cfg: ConfigSyncConfig{AuthMode: ConfigSyncAuthModeSigned, JWTPublicKey: "pem"}, wantErr: true},
 		{name: "signed complete", cfg: ConfigSyncConfig{AuthMode: ConfigSyncAuthModeSigned, JWTPublicKey: "pem", JWTIssuer: "i", JWTAudience: "a"}, wantErr: false},
+		{name: "composite complete", cfg: ConfigSyncConfig{AuthMode: ConfigSyncAuthModeComposite, Token: "t", JWTPublicKey: "pem", JWTIssuer: "i", JWTAudience: "a"}, wantErr: false},
+		{name: "composite without token", cfg: ConfigSyncConfig{AuthMode: ConfigSyncAuthModeComposite, JWTPublicKey: "pem", JWTIssuer: "i", JWTAudience: "a"}, wantErr: true},
+		{name: "composite without jwt", cfg: ConfigSyncConfig{AuthMode: ConfigSyncAuthModeComposite, Token: "t"}, wantErr: true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/infra/configsync/grpc/authenticator.go
+++ b/pkg/infra/configsync/grpc/authenticator.go
@@ -116,6 +116,32 @@ func (j *jwtAuthenticator) authenticate(bearer string) (string, error) {
 	return scope, nil
 }
 
+// compositeAuthenticator accepts either a signed per-tenant JWT (external data
+// planes → scoped snapshot) or the shared bearer token (in-cluster data plane →
+// global snapshot). The JWT is verified first; only a bearer that fails JWT
+// verification is compared against the shared token in constant time. This lets a
+// single control plane serve an internal shared fleet and external per-tenant
+// data planes at once, without the shared secret ever leaving the cluster.
+type compositeAuthenticator struct {
+	jwt    *jwtAuthenticator
+	shared *sharedAuthenticator
+}
+
+func newCompositeAuthenticator(cfg config.ConfigSyncConfig) (*compositeAuthenticator, error) {
+	jwtAuth, err := newJWTAuthenticator(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &compositeAuthenticator{jwt: jwtAuth, shared: newSharedAuthenticator(cfg)}, nil
+}
+
+func (c *compositeAuthenticator) authenticate(bearer string) (string, error) {
+	if scope, err := c.jwt.authenticate(bearer); err == nil {
+		return scope, nil
+	}
+	return c.shared.authenticate(bearer)
+}
+
 func parsePKIXPublicKeyPEM(pemStr string) (any, error) {
 	block, _ := pem.Decode([]byte(pemStr))
 	if block == nil {

--- a/pkg/infra/configsync/grpc/authenticator_test.go
+++ b/pkg/infra/configsync/grpc/authenticator_test.go
@@ -154,6 +154,66 @@ func TestSharedAuthenticator(t *testing.T) {
 	}
 }
 
+func TestCompositeAuthenticator(t *testing.T) {
+	cfg, priv := newSignedTestConfig(t)
+	cfg.AuthMode = config.ConfigSyncAuthModeComposite
+	cfg.Token = "shared-tok"
+	cfg.TokenPrevious = "old-tok"
+	auth, err := newCompositeAuthenticator(cfg)
+	if err != nil {
+		t.Fatalf("newCompositeAuthenticator: %v", err)
+	}
+
+	scope, err := auth.authenticate(mint(t, priv, jwt.SigningMethodEdDSA, validClaims()))
+	if err != nil {
+		t.Fatalf("jwt authenticate: %v", err)
+	}
+	if scope != "org_1" {
+		t.Fatalf("jwt scope = %q, want org_1", scope)
+	}
+
+	for _, tok := range []string{"shared-tok", "old-tok"} {
+		scope, err := auth.authenticate(tok)
+		if err != nil {
+			t.Fatalf("shared authenticate(%q): %v", tok, err)
+		}
+		if scope != "" {
+			t.Fatalf("shared scope = %q, want empty (global)", scope)
+		}
+	}
+
+	_, otherPriv, _ := ed25519.GenerateKey(nil)
+	for name, bearer := range map[string]string{
+		"empty":         "",
+		"garbage":       "not-a-jwt",
+		"wrong_token":   "nope",
+		"bad_signature": mint(t, otherPriv, jwt.SigningMethodEdDSA, validClaims()),
+		"expired": mint(t, priv, jwt.SigningMethodEdDSA, jwt.MapClaims{
+			"iss": testIssuer, "aud": testAudience, "scope": "org_1",
+			"exp": time.Now().Add(-time.Hour).Unix(),
+		}),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := auth.authenticate(bearer); err == nil {
+				t.Fatalf("expected rejection for %s", name)
+			}
+		})
+	}
+}
+
+func TestNewAuthInterceptor_Composite(t *testing.T) {
+	cfg, _ := newSignedTestConfig(t)
+	cfg.AuthMode = config.ConfigSyncAuthModeComposite
+	cfg.Token = "shared-tok"
+	interceptor, err := NewAuthInterceptor(&config.Config{ConfigSync: cfg}, discardLogger())
+	if err != nil {
+		t.Fatalf("NewAuthInterceptor composite: %v", err)
+	}
+	if _, ok := interceptor.authenticator.(*compositeAuthenticator); !ok {
+		t.Fatalf("authenticator = %T, want *compositeAuthenticator", interceptor.authenticator)
+	}
+}
+
 func TestNewAuthInterceptor_SignedRequiresValidKey(t *testing.T) {
 	_, err := NewAuthInterceptor(&config.Config{ConfigSync: config.ConfigSyncConfig{
 		AuthMode:     config.ConfigSyncAuthModeSigned,

--- a/pkg/infra/configsync/grpc/interceptor.go
+++ b/pkg/infra/configsync/grpc/interceptor.go
@@ -54,6 +54,13 @@ func NewAuthInterceptor(cfg *config.Config, logger *slog.Logger) (*AuthIntercept
 		}
 		interceptor.authenticator = authenticator
 		logger.Info("config-sync auth: signed JWT mode enabled", slog.String("component", component))
+	case config.ConfigSyncAuthModeComposite:
+		authenticator, err := newCompositeAuthenticator(cfg.ConfigSync)
+		if err != nil {
+			return nil, err
+		}
+		interceptor.authenticator = authenticator
+		logger.Info("config-sync auth: composite mode enabled (shared token + signed JWT)", slog.String("component", component))
 	default:
 		shared := newSharedAuthenticator(cfg.ConfigSync)
 		if !shared.configured() {


### PR DESCRIPTION
## Summary
Adds `CONFIG_SYNC_AUTH_MODE=composite` so a **single** SaaS control plane can serve both consumer types at once:

| Consumer | Credential | scope | Snapshot |
|---|---|---|---|
| In-cluster data plane (SaaS) | `CONFIG_SYNC_TOKEN` (in-cluster secret) | `""` | global |
| External hybrid data planes | signed JWT (`scope=tenant_id`) | `tenant_id` | that tenant only |

`shared` and `signed` are mutually exclusive per instance, so neither covers the real topology (one control plane, internal shared fleet + external per-tenant data planes). `composite` verifies the JWT first (external → scoped); a bearer that is not a valid JWT is compared against the shared token in constant time (internal → global). Reuses existing `Holder.SnapshotFor` semantics — no compiler/holder changes. Fails closed when neither credential matches.

## Changes
- `pkg/config`: `ConfigSyncAuthModeComposite` constant + validation (requires shared token **and** JWT params). Refactored signed-JWT validation into a shared helper.
- `pkg/infra/configsync/grpc`: `compositeAuthenticator` (JWT-first, shared-token fallback) + wiring in `NewAuthInterceptor`.
- Tests: composite authenticator (JWT→scoped, token→global, cross-tenant/invalid→rejected), interceptor wiring, config validation.

## Security
- `CONFIG_SYNC_TOKEN` = full access; stays an in-cluster secret, never committed, never handed to a customer. External DPs only ever get a per-tenant JWT.
- No forged JWT (no private key) and no shared-token guess pass. Only risk is theft of the in-cluster secret = global, same as today's `shared`.

## Test plan
- [ ] `go test ./pkg/config/... ./pkg/infra/configsync/grpc/...`
- [ ] `shared` / `signed` unchanged (no regression).

Follow-up to RUN-905 (#182). Mirror in TrustGuard tracked in the same issue.

RUN-917

Made with [Cursor](https://cursor.com)