### PR TITLE
feat(config-sync): data-plane connection registry + admin read API (RUN-909)

### DIFF
--- a/pkg/api/handler/http/configsync/list_connections_handler.go
+++ b/pkg/api/handler/http/configsync/list_connections_handler.go
@@ -1,0 +1,63 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configsync
+
+import (
+	"context"
+
+	"github.com/NeuralTrust/TrustGate/pkg/api/handler/http/configsync/response"
+	"github.com/NeuralTrust/TrustGate/pkg/api/handler/http/httpio"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/repository/configsyncconn"
+	"github.com/gofiber/fiber/v2"
+)
+
+// ConnectionLister reads persisted data-plane connection state, optionally
+// filtered by opaque scope.
+type ConnectionLister interface {
+	List(ctx context.Context, scope string) ([]configsyncconn.Connection, error)
+}
+
+type ListConnectionsHandler struct {
+	lister ConnectionLister
+}
+
+func NewListConnectionsHandler(lister ConnectionLister) *ListConnectionsHandler {
+	return &ListConnectionsHandler{lister: lister}
+}
+
+// Handle godoc
+// @Summary      List config-sync data-plane connections
+// @Description  Returns the observed data-plane Sync connections, optionally filtered by opaque scope. Answers "is this data plane online?".
+// @Tags         config-sync
+// @Produce      json
+// @Security     BearerAuth
+// @Param        scope  query     string  false  "Filter by opaque scope (exact match); omit for all"
+// @Success      200    {object}  response.ListConnectionsResponse
+// @Failure      401    {object}  httpio.ErrorBody
+// @Failure      500    {object}  httpio.ErrorBody
+// @Router       /v1/config-sync/connections [get]
+func (h *ListConnectionsHandler) Handle(c *fiber.Ctx) error {
+	conns, err := h.lister.List(c.UserContext(), c.Query("scope"))
+	if err != nil {
+		return httpio.WriteError(c, err)
+	}
+	out := response.ListConnectionsResponse{
+		Items: make([]response.ConnectionResponse, 0, len(conns)),
+	}
+	for _, conn := range conns {
+		out.Items = append(out.Items, response.FromConnection(conn))
+	}
+	return httpio.WriteOK(c, out)
+}

--- a/pkg/api/handler/http/configsync/list_connections_handler_test.go
+++ b/pkg/api/handler/http/configsync/list_connections_handler_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configsync_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+	"testing"
+
+	configsynchttp "github.com/NeuralTrust/TrustGate/pkg/api/handler/http/configsync"
+	"github.com/NeuralTrust/TrustGate/pkg/api/handler/http/configsync/response"
+	"github.com/NeuralTrust/TrustGate/pkg/api/middleware"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/repository/configsyncconn"
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeLister struct {
+	byScope map[string][]configsyncconn.Connection
+}
+
+func (f fakeLister) List(_ context.Context, scope string) ([]configsyncconn.Connection, error) {
+	return f.byScope[scope], nil
+}
+
+func newApp(lister configsynchttp.ConnectionLister) *fiber.App {
+	app := fiber.New()
+	h := configsynchttp.NewListConnectionsHandler(lister)
+	app.Get("/v1/config-sync/connections", h.Handle)
+	return app
+}
+
+func decode(t *testing.T, body io.Reader) response.ListConnectionsResponse {
+	t.Helper()
+	raw, _ := io.ReadAll(body)
+	var out response.ListConnectionsResponse
+	require.NoError(t, json.Unmarshal(raw, &out))
+	return out
+}
+
+func TestListConnectionsHandler_ScopeFilterReturnsMatching(t *testing.T) {
+	lister := fakeLister{byScope: map[string][]configsyncconn.Connection{
+		"tenant-a": {
+			{Scope: "tenant-a", InstanceID: "dp-1", State: "connected", AppliedVersion: "v3"},
+		},
+	}}
+	app := newApp(lister)
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/v1/config-sync/connections?scope=tenant-a", nil))
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	out := decode(t, resp.Body)
+	require.Len(t, out.Items, 1)
+	assert.Equal(t, "tenant-a", out.Items[0].Scope)
+	assert.Equal(t, "dp-1", out.Items[0].InstanceID)
+	assert.Equal(t, "v3", out.Items[0].AppliedVersion)
+}
+
+func TestListConnectionsHandler_UnknownScopeReturnsEmpty(t *testing.T) {
+	lister := fakeLister{byScope: map[string][]configsyncconn.Connection{}}
+	app := newApp(lister)
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/v1/config-sync/connections?scope=nope", nil))
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	out := decode(t, resp.Body)
+	assert.Empty(t, out.Items)
+	assert.NotNil(t, out.Items)
+}
+
+func TestListConnectionsHandler_AdminAuthEnforced(t *testing.T) {
+	app := fiber.New()
+	auth := middleware.NewAdminAuthMiddleware(nil, nil)
+	h := configsynchttp.NewListConnectionsHandler(fakeLister{})
+	app.Get("/v1/config-sync/connections", auth.Middleware(), h.Handle)
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/v1/config-sync/connections", nil))
+	require.NoError(t, err)
+	assert.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
+}

--- a/pkg/api/handler/http/configsync/response/connection_response.go
+++ b/pkg/api/handler/http/configsync/response/connection_response.go
@@ -1,0 +1,45 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package response
+
+import (
+	"time"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/repository/configsyncconn"
+)
+
+type ConnectionResponse struct {
+	Scope          string    `json:"scope"`
+	InstanceID     string    `json:"instance_id"`
+	State          string    `json:"state"`
+	AppliedVersion string    `json:"applied_version"`
+	FirstSeen      time.Time `json:"first_seen"`
+	LastSeen       time.Time `json:"last_seen"`
+}
+
+type ListConnectionsResponse struct {
+	Items []ConnectionResponse `json:"items"`
+}
+
+func FromConnection(c configsyncconn.Connection) ConnectionResponse {
+	return ConnectionResponse{
+		Scope:          c.Scope,
+		InstanceID:     c.InstanceID,
+		State:          c.State,
+		AppliedVersion: c.AppliedVersion,
+		FirstSeen:      c.FirstSeen,
+		LastSeen:       c.LastSeen,
+	}
+}

--- a/pkg/container/modules/control_config_sync.go
+++ b/pkg/container/modules/control_config_sync.go
@@ -33,6 +33,7 @@ import (
 	infrasnapshot "github.com/NeuralTrust/TrustGate/pkg/infra/configsnapshot"
 	snapshotpb "github.com/NeuralTrust/TrustGate/pkg/infra/configsnapshot/proto"
 	configsyncgrpc "github.com/NeuralTrust/TrustGate/pkg/infra/configsync/grpc"
+	configsyncconnrepo "github.com/NeuralTrust/TrustGate/pkg/infra/repository/configsyncconn"
 	outboxrepo "github.com/NeuralTrust/TrustGate/pkg/infra/repository/outbox"
 	"github.com/NeuralTrust/TrustGate/pkg/runtimeconfig/snapshot/readmodel"
 	configsync "github.com/NeuralTrust/TrustGate/pkg/runtimeconfig/sync"
@@ -77,8 +78,16 @@ func ControlConfigSync(c *container.Container) error {
 	}); err != nil {
 		return err
 	}
-	if err := c.Provide(func(logger *slog.Logger) *configsyncgrpc.Hub {
-		return configsyncgrpc.NewHub(logger)
+	if err := c.Provide(configsyncconnrepo.NewRepository); err != nil {
+		return err
+	}
+	if err := c.Provide(func(r *configsyncconnrepo.Repository) configsyncgrpc.ConnectionStore {
+		return r
+	}); err != nil {
+		return err
+	}
+	if err := c.Provide(func(logger *slog.Logger, store configsyncgrpc.ConnectionStore) *configsyncgrpc.Hub {
+		return configsyncgrpc.NewHub(logger, store)
 	}); err != nil {
 		return err
 	}

--- a/pkg/container/modules/server_admin.go
+++ b/pkg/container/modules/server_admin.go
@@ -21,6 +21,7 @@ import (
 	apihandler "github.com/NeuralTrust/TrustGate/pkg/api/handler/http"
 	authhttp "github.com/NeuralTrust/TrustGate/pkg/api/handler/http/auth"
 	cataloghttp "github.com/NeuralTrust/TrustGate/pkg/api/handler/http/catalog"
+	configsynchttp "github.com/NeuralTrust/TrustGate/pkg/api/handler/http/configsync"
 	consumerhttp "github.com/NeuralTrust/TrustGate/pkg/api/handler/http/consumer"
 	gatewayhttp "github.com/NeuralTrust/TrustGate/pkg/api/handler/http/gateway"
 	playgroundhttp "github.com/NeuralTrust/TrustGate/pkg/api/handler/http/playground"
@@ -30,6 +31,7 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/api/middleware"
 	"github.com/NeuralTrust/TrustGate/pkg/config"
 	"github.com/NeuralTrust/TrustGate/pkg/container"
+	configsyncconnrepo "github.com/NeuralTrust/TrustGate/pkg/infra/repository/configsyncconn"
 	"github.com/NeuralTrust/TrustGate/pkg/server"
 	"github.com/NeuralTrust/TrustGate/pkg/server/router"
 	"go.uber.org/dig"
@@ -109,6 +111,8 @@ type adminRouterParams struct {
 	ListMCPServersCatalog *cataloghttp.ListMCPServersHandler
 
 	GetTrace *playgroundhttp.GetTraceHandler
+
+	ListConfigSyncConnections *configsynchttp.ListConnectionsHandler
 }
 
 type adminServerParams struct {
@@ -120,6 +124,11 @@ type adminServerParams struct {
 
 func ServerAdmin(c *container.Container) error {
 	if err := c.Provide(adminTransport, dig.Name("admin")); err != nil {
+		return err
+	}
+	if err := c.Provide(func(repo *configsyncconnrepo.Repository) *configsynchttp.ListConnectionsHandler {
+		return configsynchttp.NewListConnectionsHandler(repo)
+	}); err != nil {
 		return err
 	}
 	if err := c.Provide(
@@ -172,6 +181,8 @@ func ServerAdmin(c *container.Container) error {
 				ListMCPServersCatalog: p.ListMCPServersCatalog,
 
 				GetTrace: p.GetTrace,
+
+				ListConfigSyncConnections: p.ListConfigSyncConnections,
 			})
 		},
 		dig.Name("admin"),

--- a/pkg/infra/configsync/grpc/client_test.go
+++ b/pkg/infra/configsync/grpc/client_test.go
@@ -107,7 +107,7 @@ func TestClient_FetchReassemblesMultipleChunks(t *testing.T) {
 	src := &fakeSource{}
 	raw := bytes.Repeat([]byte("abcd"), (3*snapshotChunkSize)/4+3)
 	src.set(raw, "v-big")
-	lis, _ := newBufServer(t, NewService(NewHub(discardLogger()), src, discardLogger()))
+	lis, _ := newBufServer(t, NewService(NewHub(discardLogger(), nil), src, discardLogger()))
 	client := dialClient(t, lis, "dp-1")
 
 	got, version, notModified, err := client.Fetch(context.Background(), "")
@@ -128,7 +128,7 @@ func TestClient_FetchReassemblesMultipleChunks(t *testing.T) {
 func TestClient_FetchNotModified(t *testing.T) {
 	src := &fakeSource{}
 	src.set([]byte("payload"), "v1")
-	lis, _ := newBufServer(t, NewService(NewHub(discardLogger()), src, discardLogger()))
+	lis, _ := newBufServer(t, NewService(NewHub(discardLogger(), nil), src, discardLogger()))
 	client := dialClient(t, lis, "dp-1")
 
 	_, _, notModified, err := client.Fetch(context.Background(), "v1")
@@ -171,7 +171,7 @@ func TestClient_FetchRejectsOversizeHeader(t *testing.T) {
 func TestClient_WatchAckRoundTrip(t *testing.T) {
 	src := &fakeSource{}
 	src.set([]byte("payload"), "v1")
-	hub := NewHub(discardLogger())
+	hub := NewHub(discardLogger(), nil)
 	lis, _ := newBufServer(t, NewService(hub, src, discardLogger()))
 	client := dialClient(t, lis, "dp-1")
 	ctx := context.Background()
@@ -205,7 +205,7 @@ func TestClient_WatchAckRoundTrip(t *testing.T) {
 func TestClient_WatchReconnectsOnStreamBreak(t *testing.T) {
 	src := &fakeSource{}
 	src.set([]byte("payload"), "v1")
-	hub := NewHub(discardLogger())
+	hub := NewHub(discardLogger(), nil)
 	lis, gsrv := newBufServer(t, NewService(hub, src, discardLogger()))
 	client := dialClient(t, lis, "dp-1")
 	ctx := context.Background()

--- a/pkg/infra/configsync/grpc/connstore.go
+++ b/pkg/infra/configsync/grpc/connstore.go
@@ -1,0 +1,27 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpc
+
+import "context"
+
+// ConnectionStore persists the observed lifecycle of data-plane Sync streams so
+// the control plane can answer "is this data plane online?". The Hub calls it
+// best-effort: a nil store or a returned error must never fail a stream or the
+// fail-closed verification path. scope is opaque to the store.
+type ConnectionStore interface {
+	MarkConnected(ctx context.Context, scope, instanceID string) error
+	MarkAck(ctx context.Context, scope, instanceID, appliedVersion string) error
+	MarkDisconnected(ctx context.Context, scope, instanceID string) error
+}

--- a/pkg/infra/configsync/grpc/hub.go
+++ b/pkg/infra/configsync/grpc/hub.go
@@ -15,24 +15,33 @@
 package grpc
 
 import (
+	"context"
 	"log/slog"
 	"sync"
+	"time"
 )
+
+// storeWriteTimeout bounds a best-effort connection-store write so a stalled
+// admin Postgres can never hang a Sync stream or its teardown.
+const storeWriteTimeout = 5 * time.Second
 
 // Hub is the registry of connected data-plane Sync streams. Broadcast fans a new
 // version out to every connection through a latest-only, size-1 drop-oldest
 // channel so a slow consumer never blocks the dispatcher and only the newest
-// version is ever delivered.
+// version is ever delivered. When a ConnectionStore is present the Hub also
+// records each stream's lifecycle best-effort for the admin read API.
 type Hub struct {
 	mu     sync.Mutex
 	conns  map[*connection]struct{}
 	logger *slog.Logger
+	store  ConnectionStore
 }
 
 // connection is one registered DP Sync stream. notices carries at most the
 // latest pending version; lastAcked tracks the last version the DP reported for
-// observability only.
+// observability only. scope is the verified, opaque tenant scope from the JWT.
 type connection struct {
+	scope      string
 	instanceID string
 	notices    chan string
 
@@ -40,19 +49,21 @@ type connection struct {
 	lastAcked string
 }
 
-// NewHub builds an empty Hub.
-func NewHub(logger *slog.Logger) *Hub {
+// NewHub builds an empty Hub. store may be nil, in which case connection
+// lifecycle is not persisted (in-memory-only self-host).
+func NewHub(logger *slog.Logger, store ConnectionStore) *Hub {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &Hub{conns: make(map[*connection]struct{}), logger: logger}
+	return &Hub{conns: make(map[*connection]struct{}), logger: logger, store: store}
 }
 
-func (h *Hub) register(instanceID string) *connection {
-	conn := &connection{instanceID: instanceID, notices: make(chan string, 1)}
+func (h *Hub) register(scope, instanceID string) *connection {
+	conn := &connection{scope: scope, instanceID: instanceID, notices: make(chan string, 1)}
 	h.mu.Lock()
 	h.conns[conn] = struct{}{}
 	h.mu.Unlock()
+	h.markConnected(conn)
 	return conn
 }
 
@@ -105,4 +116,54 @@ func (c *connection) acked() string {
 	c.ackMu.Lock()
 	defer c.ackMu.Unlock()
 	return c.lastAcked
+}
+
+// markConnected records the stream as connected. Best-effort: errors are logged
+// and swallowed so a store failure never blocks the data plane.
+func (h *Hub) markConnected(conn *connection) {
+	if h.store == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), storeWriteTimeout)
+	defer cancel()
+	if err := h.store.MarkConnected(ctx, conn.scope, conn.instanceID); err != nil {
+		h.logStoreErr("mark connected", conn, err)
+	}
+}
+
+// markAck records the DP's applied version for observability and persists it
+// best-effort.
+func (h *Hub) markAck(conn *connection, appliedVersion string) {
+	conn.recordAck(appliedVersion)
+	if h.store == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), storeWriteTimeout)
+	defer cancel()
+	if err := h.store.MarkAck(ctx, conn.scope, conn.instanceID, appliedVersion); err != nil {
+		h.logStoreErr("mark ack", conn, err)
+	}
+}
+
+// markDisconnected records the stream as disconnected. It runs from the stream's
+// teardown after the request context is already cancelled, so it uses its own
+// bounded context rather than the dead stream context.
+func (h *Hub) markDisconnected(conn *connection) {
+	if h.store == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), storeWriteTimeout)
+	defer cancel()
+	if err := h.store.MarkDisconnected(ctx, conn.scope, conn.instanceID); err != nil {
+		h.logStoreErr("mark disconnected", conn, err)
+	}
+}
+
+func (h *Hub) logStoreErr(op string, conn *connection, err error) {
+	h.logger.Warn("config-sync connection store write failed",
+		slog.String("component", "configsync-hub"),
+		slog.String("op", op),
+		slog.String("scope", conn.scope),
+		slog.String("instance_id", conn.instanceID),
+		slog.String("error", err.Error()))
 }

--- a/pkg/infra/configsync/grpc/hub_test.go
+++ b/pkg/infra/configsync/grpc/hub_test.go
@@ -15,6 +15,8 @@
 package grpc
 
 import (
+	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"sync"
@@ -26,9 +28,44 @@ func discardLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
+type recordingStore struct {
+	mu           sync.Mutex
+	connected    []string
+	acked        []string
+	disconnected []string
+	err          error
+}
+
+func (s *recordingStore) MarkConnected(_ context.Context, scope, instanceID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.connected = append(s.connected, scope+"/"+instanceID)
+	return s.err
+}
+
+func (s *recordingStore) MarkAck(_ context.Context, scope, instanceID, appliedVersion string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.acked = append(s.acked, scope+"/"+instanceID+"="+appliedVersion)
+	return s.err
+}
+
+func (s *recordingStore) MarkDisconnected(_ context.Context, scope, instanceID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.disconnected = append(s.disconnected, scope+"/"+instanceID)
+	return s.err
+}
+
+func (s *recordingStore) snapshot() ([]string, []string, []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.connected...), append([]string(nil), s.acked...), append([]string(nil), s.disconnected...)
+}
+
 func TestHub_BroadcastLatestOnlyDropsOldest(t *testing.T) {
-	h := NewHub(discardLogger())
-	conn := h.register("dp-1")
+	h := NewHub(discardLogger(), nil)
+	conn := h.register("", "dp-1")
 	defer h.unregister(conn)
 
 	h.Broadcast("v1")
@@ -51,8 +88,8 @@ func TestHub_BroadcastLatestOnlyDropsOldest(t *testing.T) {
 }
 
 func TestHub_BroadcastNeverBlocksSlowConsumer(t *testing.T) {
-	h := NewHub(discardLogger())
-	conn := h.register("dp-slow")
+	h := NewHub(discardLogger(), nil)
+	conn := h.register("", "dp-slow")
 	defer h.unregister(conn)
 
 	done := make(chan struct{})
@@ -70,7 +107,7 @@ func TestHub_BroadcastNeverBlocksSlowConsumer(t *testing.T) {
 }
 
 func TestHub_ConcurrentRegisterBroadcastAck(t *testing.T) {
-	h := NewHub(discardLogger())
+	h := NewHub(discardLogger(), nil)
 	stop := make(chan struct{})
 	var wg sync.WaitGroup
 
@@ -97,7 +134,7 @@ func TestHub_ConcurrentRegisterBroadcastAck(t *testing.T) {
 					return
 				default:
 				}
-				conn := h.register("dp")
+				conn := h.register("", "dp")
 				wg.Add(1)
 				go func() {
 					defer wg.Done()
@@ -119,4 +156,80 @@ func TestHub_ConcurrentRegisterBroadcastAck(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 	close(stop)
 	wg.Wait()
+}
+
+func TestHub_RegisterCarriesScopeAndMarksConnected(t *testing.T) {
+	store := &recordingStore{}
+	h := NewHub(discardLogger(), store)
+
+	conn := h.register("tenant-a", "dp-1")
+	defer h.unregister(conn)
+
+	if conn.scope != "tenant-a" {
+		t.Fatalf("connection.scope = %q, want tenant-a", conn.scope)
+	}
+	connected, _, _ := store.snapshot()
+	if len(connected) != 1 || connected[0] != "tenant-a/dp-1" {
+		t.Fatalf("MarkConnected = %v, want [tenant-a/dp-1]", connected)
+	}
+}
+
+func TestHub_MarkAckPersistsAppliedVersion(t *testing.T) {
+	store := &recordingStore{}
+	h := NewHub(discardLogger(), store)
+
+	conn := h.register("tenant-a", "dp-1")
+	defer h.unregister(conn)
+
+	h.markAck(conn, "v42")
+
+	if got := conn.acked(); got != "v42" {
+		t.Fatalf("conn.acked() = %q, want v42", got)
+	}
+	_, acked, _ := store.snapshot()
+	if len(acked) != 1 || acked[0] != "tenant-a/dp-1=v42" {
+		t.Fatalf("MarkAck = %v, want [tenant-a/dp-1=v42]", acked)
+	}
+}
+
+func TestHub_MarkDisconnected(t *testing.T) {
+	store := &recordingStore{}
+	h := NewHub(discardLogger(), store)
+
+	conn := h.register("tenant-a", "dp-1")
+	h.markDisconnected(conn)
+	h.unregister(conn)
+
+	_, _, disconnected := store.snapshot()
+	if len(disconnected) != 1 || disconnected[0] != "tenant-a/dp-1" {
+		t.Fatalf("MarkDisconnected = %v, want [tenant-a/dp-1]", disconnected)
+	}
+}
+
+func TestHub_StoreErrorsAreSwallowed(t *testing.T) {
+	store := &recordingStore{err: errors.New("db down")}
+	h := NewHub(discardLogger(), store)
+
+	conn := h.register("tenant-a", "dp-1")
+	h.markAck(conn, "v1")
+	h.markDisconnected(conn)
+	h.unregister(conn)
+
+	connected, acked, disconnected := store.snapshot()
+	if len(connected) != 1 || len(acked) != 1 || len(disconnected) != 1 {
+		t.Fatalf("store writes were attempted but errors must not abort: connected=%v acked=%v disconnected=%v", connected, acked, disconnected)
+	}
+}
+
+func TestHub_NilStoreIsNoOp(t *testing.T) {
+	h := NewHub(discardLogger(), nil)
+
+	conn := h.register("tenant-a", "dp-1")
+	h.markAck(conn, "v1")
+	h.markDisconnected(conn)
+	h.unregister(conn)
+
+	if got := conn.acked(); got != "v1" {
+		t.Fatalf("conn.acked() = %q, want v1 (ack recording must work without a store)", got)
+	}
 }

--- a/pkg/infra/configsync/grpc/server_test.go
+++ b/pkg/infra/configsync/grpc/server_test.go
@@ -39,7 +39,7 @@ func startServer(t *testing.T, token string, src SnapshotSource) *Server {
 	if err != nil {
 		t.Fatalf("NewAuthInterceptor: %v", err)
 	}
-	svc := NewService(NewHub(discardLogger()), src, discardLogger())
+	svc := NewService(NewHub(discardLogger(), nil), src, discardLogger())
 	srv, err := NewServer(cfg, svc, auth, discardLogger())
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)

--- a/pkg/infra/configsync/grpc/service.go
+++ b/pkg/infra/configsync/grpc/service.go
@@ -63,10 +63,11 @@ func (s *Service) Sync(stream snapshotpb.ConfigSync_SyncServer) error {
 	if hello == nil {
 		return status.Error(codes.InvalidArgument, "first Sync message must be Hello")
 	}
-	conn := s.hub.register(hello.GetInstanceId())
-	defer s.hub.unregister(conn)
-
 	scope := ScopeFromContext(ctx)
+	conn := s.hub.register(scope, hello.GetInstanceId())
+	defer s.hub.unregister(conn)
+	defer s.hub.markDisconnected(conn)
+
 	if _, version, ok := s.source.SnapshotFor(scope); ok && version != hello.GetLastAppliedVersion() {
 		conn.enqueue(version)
 	}
@@ -80,7 +81,7 @@ func (s *Service) Sync(stream snapshotpb.ConfigSync_SyncServer) error {
 				return
 			}
 			if ack := msg.GetAck(); ack != nil {
-				conn.recordAck(ack.GetAppliedVersion())
+				s.hub.markAck(conn, ack.GetAppliedVersion())
 			}
 		}
 	}()

--- a/pkg/infra/configsync/grpc/service_test.go
+++ b/pkg/infra/configsync/grpc/service_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestService_SyncUnregistersOnClose(t *testing.T) {
-	hub := NewHub(discardLogger())
+	hub := NewHub(discardLogger(), nil)
 	lis, _ := newBufServer(t, NewService(hub, &fakeSource{}, discardLogger()))
 	client := dialClient(t, lis, "dp-1")
 
@@ -42,7 +42,7 @@ func TestService_SyncUnregistersOnClose(t *testing.T) {
 func TestService_SyncNoInitialNoticeWhenUpToDate(t *testing.T) {
 	src := &fakeSource{}
 	src.set([]byte("payload"), "v1")
-	hub := NewHub(discardLogger())
+	hub := NewHub(discardLogger(), nil)
 	lis, _ := newBufServer(t, NewService(hub, src, discardLogger()))
 	client := dialClient(t, lis, "dp-1")
 	client.mu.Lock()
@@ -65,7 +65,7 @@ func TestService_SyncNoInitialNoticeWhenUpToDate(t *testing.T) {
 }
 
 func TestService_SyncRejectsNonHelloFirstMessage(t *testing.T) {
-	lis, _ := newBufServer(t, NewService(NewHub(discardLogger()), &fakeSource{}, discardLogger()))
+	lis, _ := newBufServer(t, NewService(NewHub(discardLogger(), nil), &fakeSource{}, discardLogger()))
 	conn, err := grpc.NewClient("passthrough:///bufnet",
 		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) { return lis.DialContext(ctx) }),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -91,7 +91,7 @@ func TestService_SyncRejectsNonHelloFirstMessage(t *testing.T) {
 func TestService_GetSnapshotStreamsHeaderThenChunks(t *testing.T) {
 	src := &fakeSource{}
 	src.set([]byte("hello-world"), "v1")
-	lis, _ := newBufServer(t, NewService(NewHub(discardLogger()), src, discardLogger()))
+	lis, _ := newBufServer(t, NewService(NewHub(discardLogger(), nil), src, discardLogger()))
 	conn, err := grpc.NewClient("passthrough:///bufnet",
 		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) { return lis.DialContext(ctx) }),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),

--- a/pkg/infra/database/migrations/20260708000000_config_sync_connections.go
+++ b/pkg/infra/database/migrations/20260708000000_config_sync_connections.go
@@ -1,0 +1,54 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrations
+
+import (
+	"context"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/database"
+	"github.com/jackc/pgx/v5"
+)
+
+func init() {
+	database.RegisterMigration(database.Migration{
+		ID:   "20260708000000_config_sync_connections",
+		Name: "config sync data-plane connection registry",
+		Up: func(ctx context.Context, tx pgx.Tx) error {
+			stmts := []string{
+				`CREATE TABLE IF NOT EXISTS config_sync_connections (
+					scope           TEXT NOT NULL,
+					instance_id     TEXT NOT NULL,
+					state           TEXT NOT NULL,
+					first_seen      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+					last_seen       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+					applied_version TEXT NOT NULL DEFAULT '',
+					PRIMARY KEY (scope, instance_id)
+				);`,
+				`CREATE INDEX IF NOT EXISTS idx_config_sync_connections_scope
+					ON config_sync_connections (scope);`,
+			}
+			for _, stmt := range stmts {
+				if _, err := tx.Exec(ctx, stmt); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		Down: func(ctx context.Context, tx pgx.Tx) error {
+			_, err := tx.Exec(ctx, `DROP TABLE IF EXISTS config_sync_connections;`)
+			return err
+		},
+	})
+}

--- a/pkg/infra/repository/configsyncconn/repository.go
+++ b/pkg/infra/repository/configsyncconn/repository.go
@@ -1,0 +1,122 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package configsyncconn provides the pgx-backed adapter over
+// config_sync_connections: the write side the config-sync Hub calls best-effort
+// to record data-plane stream lifecycle, and the read side the admin API lists.
+// scope is stored and matched opaquely.
+package configsyncconn
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/database"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// Connection is one persisted data-plane stream lifecycle row.
+type Connection struct {
+	Scope          string
+	InstanceID     string
+	State          string
+	AppliedVersion string
+	FirstSeen      time.Time
+	LastSeen       time.Time
+}
+
+// poolQuerier is the subset of pgxpool.Pool this repository uses, kept small to
+// fake in tests.
+type poolQuerier interface {
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+}
+
+// Repository is the pgx adapter over config_sync_connections.
+type Repository struct {
+	pool poolQuerier
+}
+
+// NewRepository builds the connection repository from the shared connection.
+func NewRepository(conn *database.Connection) *Repository {
+	return &Repository{pool: conn.Pool}
+}
+
+// MarkConnected upserts the stream as connected, preserving first_seen on an
+// existing row.
+func (r *Repository) MarkConnected(ctx context.Context, scope, instanceID string) error {
+	const stmt = `
+		INSERT INTO config_sync_connections (scope, instance_id, state)
+		VALUES ($1, $2, 'connected')
+		ON CONFLICT (scope, instance_id)
+		DO UPDATE SET state = 'connected', last_seen = NOW()`
+	if _, err := r.pool.Exec(ctx, stmt, scope, instanceID); err != nil {
+		return fmt.Errorf("configsyncconn: mark connected: %w", err)
+	}
+	return nil
+}
+
+// MarkAck records the data plane's applied version and refreshes last_seen.
+func (r *Repository) MarkAck(ctx context.Context, scope, instanceID, appliedVersion string) error {
+	const stmt = `
+		UPDATE config_sync_connections
+		SET applied_version = $3, last_seen = NOW(), state = 'connected'
+		WHERE scope = $1 AND instance_id = $2`
+	if _, err := r.pool.Exec(ctx, stmt, scope, instanceID, appliedVersion); err != nil {
+		return fmt.Errorf("configsyncconn: mark ack: %w", err)
+	}
+	return nil
+}
+
+// MarkDisconnected records the stream as disconnected and refreshes last_seen.
+func (r *Repository) MarkDisconnected(ctx context.Context, scope, instanceID string) error {
+	const stmt = `
+		UPDATE config_sync_connections
+		SET state = 'disconnected', last_seen = NOW()
+		WHERE scope = $1 AND instance_id = $2`
+	if _, err := r.pool.Exec(ctx, stmt, scope, instanceID); err != nil {
+		return fmt.Errorf("configsyncconn: mark disconnected: %w", err)
+	}
+	return nil
+}
+
+// List returns the connections for scope, or all connections when scope is
+// empty, ordered by (scope, instance_id).
+func (r *Repository) List(ctx context.Context, scope string) ([]Connection, error) {
+	const stmt = `
+		SELECT scope, instance_id, state, applied_version, first_seen, last_seen
+		FROM config_sync_connections
+		WHERE ($1 = '' OR scope = $1)
+		ORDER BY scope, instance_id`
+	rows, err := r.pool.Query(ctx, stmt, scope)
+	if err != nil {
+		return nil, fmt.Errorf("configsyncconn: list: %w", err)
+	}
+	defer rows.Close()
+
+	var conns []Connection
+	for rows.Next() {
+		var c Connection
+		if err := rows.Scan(&c.Scope, &c.InstanceID, &c.State, &c.AppliedVersion, &c.FirstSeen, &c.LastSeen); err != nil {
+			return nil, fmt.Errorf("configsyncconn: scan connection: %w", err)
+		}
+		conns = append(conns, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("configsyncconn: iterate connections: %w", err)
+	}
+	return conns, nil
+}

--- a/pkg/infra/repository/configsyncconn/repository_integration_test.go
+++ b/pkg/infra/repository/configsyncconn/repository_integration_test.go
@@ -1,0 +1,195 @@
+//go:build integration
+
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configsyncconn
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/NeuralTrust/TrustGate/pkg/config"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/database"
+	// Register the config_sync_connections migration (and the rest of the schema).
+	_ "github.com/NeuralTrust/TrustGate/pkg/infra/database/migrations"
+)
+
+// setupRepository builds a connection to a local Postgres and applies pending
+// migrations. It skips the test when no database is reachable so the integration
+// suite can run in environments without Postgres. Connection settings come from
+// the TEST_DB_* env vars, defaulting to the local functional database.
+func setupRepository(t *testing.T) (*database.Connection, *Repository) {
+	t.Helper()
+	ctx := context.Background()
+
+	port := 5432
+	if raw := os.Getenv("TEST_DB_PORT"); raw != "" {
+		if p, err := strconv.Atoi(raw); err == nil {
+			port = p
+		}
+	}
+	cfg := &config.DatabaseConfig{
+		Host:              envOr("TEST_DB_HOST", "localhost"),
+		Port:              port,
+		User:              envOr("TEST_DB_USER", "postgres"),
+		Password:          envOr("TEST_DB_PASSWORD", "postgres"),
+		Name:              envOr("TEST_DB_NAME", "trustgate_functional"),
+		SSLMode:           envOr("TEST_DB_SSLMODE", "disable"),
+		MinConns:          1,
+		MaxConns:          5,
+		MaxConnLifetime:   time.Hour,
+		MaxConnIdleTime:   30 * time.Minute,
+		HealthCheckPeriod: time.Minute,
+		ConnectTimeout:    5 * time.Second,
+	}
+
+	conn, err := database.NewConnection(ctx, cfg)
+	if err != nil {
+		t.Skipf("no reachable Postgres for the configsyncconn integration test: %v", err)
+	}
+	t.Cleanup(conn.Close)
+
+	// The migration is idempotent: applying twice must not fail.
+	if err := database.NewMigrationsManager(conn.Pool).ApplyPending(ctx); err != nil {
+		t.Fatalf("ApplyPending: %v", err)
+	}
+	if err := database.NewMigrationsManager(conn.Pool).ApplyPending(ctx); err != nil {
+		t.Fatalf("ApplyPending (re-run): %v", err)
+	}
+
+	if _, err := conn.Pool.Exec(ctx, `DELETE FROM config_sync_connections`); err != nil {
+		t.Fatalf("truncate config_sync_connections: %v", err)
+	}
+	return conn, NewRepository(conn)
+}
+
+func envOr(key, fallback string) string {
+	if v, ok := os.LookupEnv(key); ok && v != "" {
+		return v
+	}
+	return fallback
+}
+
+func find(conns []Connection, scope, instanceID string) (Connection, bool) {
+	for _, c := range conns {
+		if c.Scope == scope && c.InstanceID == instanceID {
+			return c, true
+		}
+	}
+	return Connection{}, false
+}
+
+func TestIntegration_ConnectAckDisconnectLifecycle(t *testing.T) {
+	_, repo := setupRepository(t)
+	ctx := context.Background()
+
+	if err := repo.MarkConnected(ctx, "tenant-a", "dp-1"); err != nil {
+		t.Fatalf("MarkConnected: %v", err)
+	}
+	connected, _ := mustGet(t, repo, "tenant-a", "dp-1")
+	if connected.State != "connected" {
+		t.Fatalf("state after connect = %q, want connected", connected.State)
+	}
+	firstSeen := connected.FirstSeen
+
+	if err := repo.MarkAck(ctx, "tenant-a", "dp-1", "v7"); err != nil {
+		t.Fatalf("MarkAck: %v", err)
+	}
+	acked, _ := mustGet(t, repo, "tenant-a", "dp-1")
+	if acked.AppliedVersion != "v7" || acked.State != "connected" {
+		t.Fatalf("after ack = %+v, want applied_version v7 / connected", acked)
+	}
+
+	if err := repo.MarkDisconnected(ctx, "tenant-a", "dp-1"); err != nil {
+		t.Fatalf("MarkDisconnected: %v", err)
+	}
+	gone, _ := mustGet(t, repo, "tenant-a", "dp-1")
+	if gone.State != "disconnected" {
+		t.Fatalf("state after disconnect = %q, want disconnected", gone.State)
+	}
+	if gone.AppliedVersion != "v7" {
+		t.Fatalf("applied_version must survive disconnect, got %q", gone.AppliedVersion)
+	}
+
+	// A reconnect must preserve first_seen (upsert, not insert).
+	if err := repo.MarkConnected(ctx, "tenant-a", "dp-1"); err != nil {
+		t.Fatalf("MarkConnected (reconnect): %v", err)
+	}
+	reconnected, _ := mustGet(t, repo, "tenant-a", "dp-1")
+	if !reconnected.FirstSeen.Equal(firstSeen) {
+		t.Fatalf("first_seen changed on reconnect: %v -> %v", firstSeen, reconnected.FirstSeen)
+	}
+	if reconnected.State != "connected" {
+		t.Fatalf("state after reconnect = %q, want connected", reconnected.State)
+	}
+}
+
+func TestIntegration_ListScopeIsolation(t *testing.T) {
+	_, repo := setupRepository(t)
+	ctx := context.Background()
+
+	if err := repo.MarkConnected(ctx, "tenant-a", "dp-1"); err != nil {
+		t.Fatalf("MarkConnected a/dp-1: %v", err)
+	}
+	if err := repo.MarkConnected(ctx, "tenant-a", "dp-2"); err != nil {
+		t.Fatalf("MarkConnected a/dp-2: %v", err)
+	}
+	if err := repo.MarkConnected(ctx, "tenant-b", "dp-9"); err != nil {
+		t.Fatalf("MarkConnected b/dp-9: %v", err)
+	}
+
+	scoped, err := repo.List(ctx, "tenant-a")
+	if err != nil {
+		t.Fatalf("List(tenant-a): %v", err)
+	}
+	if len(scoped) != 2 {
+		t.Fatalf("List(tenant-a) = %d rows, want 2", len(scoped))
+	}
+	if _, ok := find(scoped, "tenant-b", "dp-9"); ok {
+		t.Fatal("List(tenant-a) leaked a tenant-b connection")
+	}
+
+	unknown, err := repo.List(ctx, "tenant-missing")
+	if err != nil {
+		t.Fatalf("List(tenant-missing): %v", err)
+	}
+	if len(unknown) != 0 {
+		t.Fatalf("List(unknown scope) = %d rows, want 0", len(unknown))
+	}
+
+	all, err := repo.List(ctx, "")
+	if err != nil {
+		t.Fatalf("List(all): %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("List(empty scope) = %d rows, want all 3", len(all))
+	}
+}
+
+func mustGet(t *testing.T, repo *Repository, scope, instanceID string) (Connection, bool) {
+	t.Helper()
+	conns, err := repo.List(context.Background(), scope)
+	if err != nil {
+		t.Fatalf("List(%q): %v", scope, err)
+	}
+	c, ok := find(conns, scope, instanceID)
+	if !ok {
+		t.Fatalf("connection %s/%s not found", scope, instanceID)
+	}
+	return c, ok
+}

--- a/pkg/server/router/admin_router.go
+++ b/pkg/server/router/admin_router.go
@@ -18,6 +18,7 @@ import (
 	apihandler "github.com/NeuralTrust/TrustGate/pkg/api/handler/http"
 	authhttp "github.com/NeuralTrust/TrustGate/pkg/api/handler/http/auth"
 	cataloghttp "github.com/NeuralTrust/TrustGate/pkg/api/handler/http/catalog"
+	configsynchttp "github.com/NeuralTrust/TrustGate/pkg/api/handler/http/configsync"
 	consumerhttp "github.com/NeuralTrust/TrustGate/pkg/api/handler/http/consumer"
 	gatewayhttp "github.com/NeuralTrust/TrustGate/pkg/api/handler/http/gateway"
 	playgroundhttp "github.com/NeuralTrust/TrustGate/pkg/api/handler/http/playground"
@@ -40,6 +41,7 @@ const (
 	PoliciesCatalogPath   = "/v1/policies-catalog"
 	MCPServersCatalogPath = "/v1/mcp-servers-catalog"
 	PlaygroundTracePath   = "/v1/playground/traces/:trace_id"
+	ConfigSyncConnPath    = "/v1/config-sync/connections"
 )
 
 // AdminRouterDeps groups every handler mounted by the admin plane.
@@ -99,6 +101,8 @@ type AdminRouterDeps struct {
 	ListMCPServersCatalog *cataloghttp.ListMCPServersHandler
 
 	GetTrace *playgroundhttp.GetTraceHandler
+
+	ListConfigSyncConnections *configsynchttp.ListConnectionsHandler
 }
 
 type adminRouter struct {
@@ -184,6 +188,8 @@ func (r *adminRouter) BuildRoutes(app *fiber.App) error {
 	app.Get(MCPServersCatalogPath, r.deps.AdminAuth.Middleware(), r.deps.ListMCPServersCatalog.Handle)
 
 	app.Get(PlaygroundTracePath, r.deps.AdminAuth.Middleware(), r.deps.GetTrace.Handle)
+
+	app.Get(ConfigSyncConnPath, r.deps.AdminAuth.Middleware(), r.deps.ListConfigSyncConnections.Handle)
 
 	return nil
 }


### PR DESCRIPTION
## Summary

Implements the **RUN-909** connection-"online" registry in the OSS control plane. Builds on the already-shipped RUN-905/917 base (signed-JWT verify, scope injection, per-tenant snapshots, fail-closed) — this PR only adds **connection visibility**.

When a data plane connects over config-sync gRPC, the control plane already knows its identity from the verified JWT. This PR records that:
- The `Hub` threads the verified **`scope`** (from `ScopeFromContext`, previously dropped) into connection registration.
- Connections persist to the admin Postgres: `config_sync_connections (scope, instance_id, state, first_seen, last_seen, applied_version)` — updated on connect, on `Ack` (applied version), and on stream close (disconnected).
- Read API `GET /v1/config-sync/connections?scope=` behind `AdminAuth` so the control plane (and self-hosted OSS users) can answer *"is a data plane online for this scope?"*.

## Design guarantees
- **`scope` is opaque to the OSS** — no tenant / DataCore concept anywhere. No dependency on any proprietary service.
- **Best-effort persistence**: store is nil-safe and errors are logged-and-swallowed off the Hub mutex, with a bounded teardown context. A DB blip can **never** break fail-closed verification or drop a data plane.
- Per-tenant authz is left to the tenant-scoped app layer; the OSS only offers the generic `?scope=` filter.

## SDD artifacts
Cross-repo design lives in the DataCore RUN-911 PR (`openspec/changes/run-911-909-hybrid-credential-and-online/`).

## Test plan
- [x] `make build`
- [x] `make test` (hub: scope carried, ack updates version, disconnect on close, nil-store no-op; handler: `?scope=` isolation, unknown scope empty, AdminAuth enforced)
- [x] `make lint` (0 issues)
- [x] Repo integration test (`//go:build integration`, Postgres): connect/ack/disconnect upsert preserving `first_seen`, scope isolation

Linear: RUN-909 — https://linear.app/neuraltrust/issue/RUN-909
Part of RUN-905. Pairs with RUN-911 (DataCore credential) and mirrored in TrustGuard.

Made with [Cursor](https://cursor.com)