### PR TITLE
feat(xai): add xAI Grok provider to TrustGate (RUN-253)

### DIFF
--- a/pkg/app/catalog/provider_auth.go
+++ b/pkg/app/catalog/provider_auth.go
@@ -255,6 +255,7 @@ var providerAuthCatalog = map[string][]AuthTypeOption{
 	providers.ProviderMistral:          {apiKeyAuthOption},
 	providers.ProviderGroq:             {apiKeyAuthOption},
 	providers.ProviderDeepSeek:         {apiKeyAuthOption},
+	providers.ProviderXAI:              {apiKeyAuthOption},
 }
 
 func ProviderAuthOptions(code string) []AuthTypeOption {

--- a/pkg/app/catalog/sync.go
+++ b/pkg/app/catalog/sync.go
@@ -44,6 +44,7 @@ var seedProviders = []seedProvider{
 	{providers.ProviderMistral, "Mistral", "openai"},
 	{providers.ProviderGroq, "Groq", "openai"},
 	{providers.ProviderDeepSeek, "DeepSeek", "openai"},
+	{providers.ProviderXAI, "xAI", "openai"},
 }
 
 // modelsDevProviderToCode maps models.dev provider keys to the gateway provider
@@ -58,6 +59,7 @@ var modelsDevProviderToCode = map[string]string{
 	"mistral":        providers.ProviderMistral,
 	"groq":           providers.ProviderGroq,
 	"deepseek":       providers.ProviderDeepSeek,
+	"xai":            providers.ProviderXAI,
 }
 
 //go:generate mockery --name=Syncer --dir=. --output=./mocks --filename=catalog_syncer_mock.go --case=underscore --with-expecter

--- a/pkg/domain/provider/provider.go
+++ b/pkg/domain/provider/provider.go
@@ -28,6 +28,7 @@ const (
 	Mistral          = "mistral"
 	Groq             = "groq"
 	DeepSeek         = "deepseek"
+	XAI              = "xai"
 )
 
 // Supported returns every provider name the gateway can route to.
@@ -43,6 +44,7 @@ func Supported() []string {
 		Mistral,
 		Groq,
 		DeepSeek,
+		XAI,
 	}
 }
 
@@ -58,7 +60,8 @@ func IsValid(name string) bool {
 		Azure,
 		Mistral,
 		Groq,
-		DeepSeek:
+		DeepSeek,
+		XAI:
 		return true
 	default:
 		return false

--- a/pkg/infra/providers/adapter/format.go
+++ b/pkg/infra/providers/adapter/format.go
@@ -35,6 +35,7 @@ const (
 	FormatVertex          Format = "vertex"
 	FormatMistral         Format = "mistral"
 	FormatDeepSeek        Format = "deepseek" // wire-compatible with OpenAI Chat Completions
+	FormatXAI             Format = "xai"      // wire-compatible with OpenAI Chat Completions
 )
 
 // GeminiModelsRoutePrefix is the fixed Gemini route segment that carries the
@@ -111,7 +112,7 @@ func (f Format) IsOpenAIFamily() bool {
 func SupportedSourceFormat(f Format) bool {
 	switch f {
 	case FormatOpenAI, FormatOpenAIResponses, FormatAnthropic, FormatGemini,
-		FormatAzure, FormatGroq, FormatVertex, FormatMistral, FormatDeepSeek:
+		FormatAzure, FormatGroq, FormatVertex, FormatMistral, FormatDeepSeek, FormatXAI:
 		return true
 	default:
 		return false
@@ -134,6 +135,8 @@ func resolveProviderWireFormat(providerName string) Format {
 		return FormatGroq
 	case provider.DeepSeek:
 		return FormatDeepSeek
+	case provider.XAI:
+		return FormatXAI
 	case provider.OpenAICompatible:
 		return FormatOpenAI
 	default:
@@ -161,7 +164,7 @@ func ResolveAgentFormat(providerName, sourceFormat string, providerOptions map[s
 		return Format(sourceFormat), nil
 	}
 	switch providerName {
-	case provider.OpenAI, provider.OpenAICompatible, provider.Azure, provider.Groq, provider.DeepSeek:
+	case provider.OpenAI, provider.OpenAICompatible, provider.Azure, provider.Groq, provider.DeepSeek, provider.XAI:
 		return ResolveTargetFormat(providerName, providerOptions), nil
 	case provider.Anthropic:
 		return FormatAnthropic, nil
@@ -186,7 +189,7 @@ func IsSameWireFormat(a, b Format) bool {
 
 func normalizeFormat(f Format) Format {
 	switch f {
-	case FormatAzure, FormatGroq, FormatDeepSeek:
+	case FormatAzure, FormatGroq, FormatDeepSeek, FormatXAI:
 		return FormatOpenAI
 	case FormatVertex:
 		return FormatGemini

--- a/pkg/infra/providers/client.go
+++ b/pkg/infra/providers/client.go
@@ -35,6 +35,7 @@ const (
 	ProviderMistral          = provider.Mistral
 	ProviderGroq             = provider.Groq
 	ProviderDeepSeek         = provider.DeepSeek
+	ProviderXAI              = provider.XAI
 )
 
 type Config struct {

--- a/pkg/infra/providers/factory/locator.go
+++ b/pkg/infra/providers/factory/locator.go
@@ -28,6 +28,7 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/openai"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/openaicompat"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/vertex"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/xai"
 )
 
 // Provider name constants — aliased from the providers package so callers that
@@ -43,6 +44,7 @@ const (
 	ProviderMistral          = providers.ProviderMistral
 	ProviderGroq             = providers.ProviderGroq
 	ProviderDeepSeek         = providers.ProviderDeepSeek
+	ProviderXAI              = providers.ProviderXAI
 )
 
 //go:generate mockery --name=ProviderLocator --dir=. --output=./mocks --filename=provider_locator_mock.go --case=underscore --with-expecter
@@ -73,6 +75,7 @@ func NewProviderLocator() ProviderLocator {
 			ProviderMistral:          mistral.NewMistralClient(),
 			ProviderGroq:             groq.NewGroqClient(),
 			ProviderDeepSeek:         deepseek.NewDeepSeekClient(),
+			ProviderXAI:              xai.NewXAIClient(),
 			ProviderVertex:           vertex.NewVertexClient(),
 		},
 	}

--- a/pkg/infra/providers/factory/locator_test.go
+++ b/pkg/infra/providers/factory/locator_test.go
@@ -35,6 +35,7 @@ func TestProviderLocator_Get(t *testing.T) {
 		ProviderMistral,
 		ProviderGroq,
 		ProviderDeepSeek,
+		ProviderXAI,
 	} {
 		t.Run(provider, func(t *testing.T) {
 			client, err := locator.Get(provider)

--- a/pkg/infra/providers/xai/client.go
+++ b/pkg/infra/providers/xai/client.go
@@ -1,0 +1,51 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xai
+
+import (
+	"context"
+	"iter"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/openai"
+)
+
+const chatCompletionsURL = "https://api.x.ai/v1/chat/completions"
+
+type client struct {
+	chat *openai.ChatCompletionsClient
+}
+
+func NewXAIClient() providers.Client {
+	return &client{
+		chat: openai.NewChatCompletionsClient(providers.ProviderXAI, nil),
+	}
+}
+
+func (c *client) Completions(
+	ctx context.Context,
+	config *providers.Config,
+	reqBody []byte,
+) ([]byte, error) {
+	return c.chat.Completions(ctx, chatCompletionsURL, config, reqBody, nil)
+}
+
+func (c *client) CompletionsStream(
+	ctx context.Context,
+	config *providers.Config,
+	reqBody []byte,
+) (iter.Seq2[[]byte, error], error) {
+	return c.chat.CompletionsStream(ctx, chatCompletionsURL, config, reqBody, nil)
+}

--- a/pkg/infra/providers/xai/client_test.go
+++ b/pkg/infra/providers/xai/client_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xai
+
+import (
+	"context"
+	"encoding/json"
+	"iter"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/openai"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type xaiClientAt struct {
+	chat *openai.ChatCompletionsClient
+	url  string
+}
+
+func newXAIClientAt(url string) providers.Client {
+	return &xaiClientAt{
+		chat: openai.NewChatCompletionsClient(providers.ProviderXAI, nil),
+		url:  url,
+	}
+}
+
+func (c *xaiClientAt) Completions(ctx context.Context, config *providers.Config, reqBody []byte) ([]byte, error) {
+	return c.chat.Completions(ctx, c.url, config, reqBody, nil)
+}
+
+func (c *xaiClientAt) CompletionsStream(ctx context.Context, config *providers.Config, reqBody []byte) (iter.Seq2[[]byte, error], error) {
+	return c.chat.CompletionsStream(ctx, c.url, config, reqBody, nil)
+}
+
+func TestNewXAIClient(t *testing.T) {
+	assert.NotNil(t, NewXAIClient())
+}
+
+func TestCompletions_MissingAPIKey(t *testing.T) {
+	_, err := NewXAIClient().Completions(context.Background(), &providers.Config{}, []byte(`{}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "API key is required")
+}
+
+func TestCompletions_NonStreamingRoundTrip(t *testing.T) {
+	const wantModel = "grok-3"
+	var gotAuth, gotModel string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		gotAuth = r.Header.Get("Authorization")
+
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		gotModel, _ = body["model"].(string)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"model": wantModel,
+			"id":    "chatcmpl-xai-1",
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	resp, err := newXAIClientAt(srv.URL+"/chat/completions").Completions(
+		context.Background(),
+		&providers.Config{Credentials: providers.Credentials{ApiKey: "xai-test-key"}},
+		[]byte(`{"model":"`+wantModel+`","messages":[{"role":"user","content":"hello"}]}`),
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Bearer xai-test-key", gotAuth)
+	assert.Equal(t, wantModel, gotModel)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(resp, &parsed))
+	assert.Equal(t, wantModel, parsed["model"])
+}
+
+func TestCompletionsStream_RoundTrip(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer xai-key", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	t.Cleanup(srv.Close)
+
+	seq, err := newXAIClientAt(srv.URL+"/chat/completions").CompletionsStream(
+		context.Background(),
+		&providers.Config{Credentials: providers.Credentials{ApiKey: "xai-key"}},
+		[]byte(`{"model":"grok-3","stream":true}`),
+	)
+	require.NoError(t, err)
+
+	var lines []string
+	for line, lerr := range seq {
+		require.NoError(t, lerr)
+		lines = append(lines, string(line))
+	}
+	require.NotEmpty(t, lines)
+	assert.Equal(t, `data: {"choices":[{"delta":{"content":"hi"}}]}`, lines[0])
+	assert.Equal(t, `data: [DONE]`, lines[len(lines)-1])
+}
+
+func TestCompletions_RateLimitRetryAfter(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "2")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"rate limit exceeded"}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := newXAIClientAt(srv.URL+"/chat/completions").Completions(
+		context.Background(),
+		&providers.Config{Credentials: providers.Credentials{ApiKey: "key"}},
+		[]byte(`{"model":"grok-3","messages":[{"role":"user","content":"hi"}]}`),
+	)
+	require.Error(t, err)
+
+	be, ok := registry.IsBackendError(err)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusTooManyRequests, be.StatusCode)
+	assert.Equal(t, "2", be.RetryAfter)
+}

--- a/pkg/infra/providers/xai/connection.go
+++ b/pkg/infra/providers/xai/connection.go
@@ -1,0 +1,27 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xai
+
+import (
+	"context"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+)
+
+const modelsURL = "https://api.x.ai/v1/models"
+
+func (c *client) TestConnection(ctx context.Context, config *providers.Config) providers.ProbeResult {
+	return providers.RunBearerGETProbe(ctx, providers.ProviderXAI, modelsURL, config.Credentials.ApiKey)
+}


### PR DESCRIPTION
## Summary
- Add `xai` as a first-class OpenAI-wire-compatible provider (`https://api.x.ai/v1`)
- Register client, connection probe, catalog seed, models.dev mapping, and format passthrough
- Add httptest coverage for sync/stream chat completions and rate-limit handling

## Linear
RUN-248 — https://linear.app/neuraltrust/issue/RUN-248/featprovider-xai-grok-llm-provider
RUN-253 — https://linear.app/neuraltrust/issue/RUN-253/featxai-trustgate-core-integration

## Test plan
- [x] `go test ./pkg/infra/providers/xai/... ./pkg/infra/providers/factory/... ./pkg/infra/providers/adapter/... -race`
- [ ] CI green
- [ ] Manual test-connection with valid xAI API key (post-merge QA)