### PR TITLE
feat(provider): add Cerebras LLM provider (RUN-259)

### DIFF
--- a/openspec/changes/cerebras-llm-provider/proposal.md
+++ b/openspec/changes/cerebras-llm-provider/proposal.md
@@ -1,0 +1,26 @@
+---
+linear: RUN-259
+type: feat
+changelog: "Add Cerebras as an OpenAI-compatible LLM provider with catalog sync and connection probe."
+---
+
+# Proposal: Cerebras LLM provider (RUN-251 / RUN-259)
+
+## Why
+
+Cerebras Inference exposes an OpenAI-compatible Chat Completions API. TrustGate needs
+first-class routing, catalog seeding from models.dev, and connection testing so registries
+can target Cerebras like Groq or DeepSeek.
+
+## What
+
+- `provider: cerebras` client at `https://api.cerebras.ai/v1`
+- GET `/v1/models` connection probe
+- Catalog seed + models.dev mapping (`cerebras` key)
+- FormatOpenAI wire passthrough (no dedicated adapter format)
+- httptest smoke tests for sync, stream, and rate-limit handling
+
+## Out of scope
+
+- App v2 registry UI (RUN-920, separate PR)
+- multi-agent matrix tests (RUN-260 canceled)

--- a/pkg/app/catalog/provider_auth.go
+++ b/pkg/app/catalog/provider_auth.go
@@ -255,6 +255,7 @@ var providerAuthCatalog = map[string][]AuthTypeOption{
 	providers.ProviderMistral:          {apiKeyAuthOption},
 	providers.ProviderGroq:             {apiKeyAuthOption},
 	providers.ProviderDeepSeek:         {apiKeyAuthOption},
+	providers.ProviderCerebras:         {apiKeyAuthOption},
 }
 
 func ProviderAuthOptions(code string) []AuthTypeOption {

--- a/pkg/app/catalog/sync.go
+++ b/pkg/app/catalog/sync.go
@@ -44,6 +44,7 @@ var seedProviders = []seedProvider{
 	{providers.ProviderMistral, "Mistral", "openai"},
 	{providers.ProviderGroq, "Groq", "openai"},
 	{providers.ProviderDeepSeek, "DeepSeek", "openai"},
+	{providers.ProviderCerebras, "Cerebras", "openai"},
 }
 
 // modelsDevProviderToCode maps models.dev provider keys to the gateway provider
@@ -58,6 +59,7 @@ var modelsDevProviderToCode = map[string]string{
 	"mistral":        providers.ProviderMistral,
 	"groq":           providers.ProviderGroq,
 	"deepseek":       providers.ProviderDeepSeek,
+	"cerebras":       providers.ProviderCerebras,
 }
 
 //go:generate mockery --name=Syncer --dir=. --output=./mocks --filename=catalog_syncer_mock.go --case=underscore --with-expecter

--- a/pkg/domain/provider/provider.go
+++ b/pkg/domain/provider/provider.go
@@ -28,6 +28,7 @@ const (
 	Mistral          = "mistral"
 	Groq             = "groq"
 	DeepSeek         = "deepseek"
+	Cerebras         = "cerebras"
 )
 
 // Supported returns every provider name the gateway can route to.
@@ -43,6 +44,7 @@ func Supported() []string {
 		Mistral,
 		Groq,
 		DeepSeek,
+		Cerebras,
 	}
 }
 
@@ -58,7 +60,8 @@ func IsValid(name string) bool {
 		Azure,
 		Mistral,
 		Groq,
-		DeepSeek:
+		DeepSeek,
+		Cerebras:
 		return true
 	default:
 		return false

--- a/pkg/infra/providers/adapter/adapter_test.go
+++ b/pkg/infra/providers/adapter/adapter_test.go
@@ -168,6 +168,7 @@ func TestResolveAgentFormat_KnownProviders(t *testing.T) {
 		{"vertex", FormatVertex},
 		{"groq", FormatGroq},
 		{"deepseek", FormatDeepSeek},
+		{"cerebras", FormatOpenAI},
 	}
 	for _, tt := range tests {
 		t.Run(tt.provider, func(t *testing.T) {

--- a/pkg/infra/providers/adapter/format.go
+++ b/pkg/infra/providers/adapter/format.go
@@ -134,6 +134,8 @@ func resolveProviderWireFormat(providerName string) Format {
 		return FormatGroq
 	case provider.DeepSeek:
 		return FormatDeepSeek
+	case provider.Cerebras:
+		return FormatOpenAI
 	case provider.OpenAICompatible:
 		return FormatOpenAI
 	default:
@@ -161,7 +163,7 @@ func ResolveAgentFormat(providerName, sourceFormat string, providerOptions map[s
 		return Format(sourceFormat), nil
 	}
 	switch providerName {
-	case provider.OpenAI, provider.OpenAICompatible, provider.Azure, provider.Groq, provider.DeepSeek:
+	case provider.OpenAI, provider.OpenAICompatible, provider.Azure, provider.Groq, provider.DeepSeek, provider.Cerebras:
 		return ResolveTargetFormat(providerName, providerOptions), nil
 	case provider.Anthropic:
 		return FormatAnthropic, nil

--- a/pkg/infra/providers/cerebras/client.go
+++ b/pkg/infra/providers/cerebras/client.go
@@ -1,0 +1,51 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cerebras
+
+import (
+	"context"
+	"iter"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/openai"
+)
+
+const chatCompletionsURL = "https://api.cerebras.ai/v1/chat/completions"
+
+type client struct {
+	chat *openai.ChatCompletionsClient
+}
+
+func NewCerebrasClient() providers.Client {
+	return &client{
+		chat: openai.NewChatCompletionsClient(providers.ProviderCerebras, nil),
+	}
+}
+
+func (c *client) Completions(
+	ctx context.Context,
+	config *providers.Config,
+	reqBody []byte,
+) ([]byte, error) {
+	return c.chat.Completions(ctx, chatCompletionsURL, config, reqBody, nil)
+}
+
+func (c *client) CompletionsStream(
+	ctx context.Context,
+	config *providers.Config,
+	reqBody []byte,
+) (iter.Seq2[[]byte, error], error) {
+	return c.chat.CompletionsStream(ctx, chatCompletionsURL, config, reqBody, nil)
+}

--- a/pkg/infra/providers/cerebras/client_test.go
+++ b/pkg/infra/providers/cerebras/client_test.go
@@ -1,0 +1,145 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cerebras
+
+import (
+	"context"
+	"encoding/json"
+	"iter"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/openai"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// cerebrasClientAt is a test-only wrapper that targets a custom URL so the
+// OpenAI-compatible round trip can be exercised against an httptest server.
+type cerebrasClientAt struct {
+	chat *openai.ChatCompletionsClient
+	url  string
+}
+
+func newCerebrasClientAt(url string) providers.Client {
+	return &cerebrasClientAt{
+		chat: openai.NewChatCompletionsClient(providers.ProviderCerebras, nil),
+		url:  url,
+	}
+}
+
+func (c *cerebrasClientAt) Completions(ctx context.Context, config *providers.Config, reqBody []byte) ([]byte, error) {
+	return c.chat.Completions(ctx, c.url, config, reqBody, nil)
+}
+
+func (c *cerebrasClientAt) CompletionsStream(ctx context.Context, config *providers.Config, reqBody []byte) (iter.Seq2[[]byte, error], error) {
+	return c.chat.CompletionsStream(ctx, c.url, config, reqBody, nil)
+}
+
+func TestNewCerebrasClient(t *testing.T) {
+	assert.NotNil(t, NewCerebrasClient())
+}
+
+func TestCompletions_MissingAPIKey(t *testing.T) {
+	_, err := NewCerebrasClient().Completions(context.Background(), &providers.Config{}, []byte(`{}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "API key is required")
+}
+
+func TestCompletions_NonStreamingRoundTrip(t *testing.T) {
+	const wantModel = "llama-3.3-70b"
+	var gotAuth, gotModel string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		gotAuth = r.Header.Get("Authorization")
+
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		gotModel, _ = body["model"].(string)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"model": wantModel,
+			"usage": map[string]any{"total_tokens": 42},
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	resp, err := newCerebrasClientAt(srv.URL+"/chat/completions").Completions(
+		context.Background(),
+		&providers.Config{Credentials: providers.Credentials{ApiKey: "cerebras-test-key"}},
+		[]byte(`{"model":"`+wantModel+`","messages":[{"role":"user","content":"hello"}]}`),
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Bearer cerebras-test-key", gotAuth)
+	assert.Equal(t, wantModel, gotModel)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(resp, &parsed))
+	assert.Equal(t, wantModel, parsed["model"])
+	assert.NotNil(t, parsed["usage"], "usage must survive verbatim passthrough")
+}
+
+func TestCompletionsStream_RoundTrip(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer cerebras-key", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	t.Cleanup(srv.Close)
+
+	seq, err := newCerebrasClientAt(srv.URL+"/chat/completions").CompletionsStream(
+		context.Background(),
+		&providers.Config{Credentials: providers.Credentials{ApiKey: "cerebras-key"}},
+		[]byte(`{"model":"llama-3.3-70b","stream":true}`),
+	)
+	require.NoError(t, err)
+
+	var lines []string
+	for line, lerr := range seq {
+		require.NoError(t, lerr)
+		lines = append(lines, string(line))
+	}
+	require.NotEmpty(t, lines)
+	assert.Equal(t, `data: {"choices":[{"delta":{"content":"hi"}}]}`, lines[0])
+	assert.Equal(t, `data: [DONE]`, lines[len(lines)-1])
+}
+
+func TestCompletions_RateLimitRetryAfter(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "2")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"rate limit exceeded"}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := newCerebrasClientAt(srv.URL+"/chat/completions").Completions(
+		context.Background(),
+		&providers.Config{Credentials: providers.Credentials{ApiKey: "key"}},
+		[]byte(`{"model":"llama-3.3-70b","messages":[{"role":"user","content":"hi"}]}`),
+	)
+	require.Error(t, err)
+
+	be, ok := registry.IsBackendError(err)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusTooManyRequests, be.StatusCode)
+	assert.Equal(t, "2", be.RetryAfter)
+}

--- a/pkg/infra/providers/cerebras/connection.go
+++ b/pkg/infra/providers/cerebras/connection.go
@@ -1,0 +1,27 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cerebras
+
+import (
+	"context"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+)
+
+const modelsURL = "https://api.cerebras.ai/v1/models"
+
+func (c *client) TestConnection(ctx context.Context, config *providers.Config) providers.ProbeResult {
+	return providers.RunBearerGETProbe(ctx, providers.ProviderCerebras, modelsURL, config.Credentials.ApiKey)
+}

--- a/pkg/infra/providers/client.go
+++ b/pkg/infra/providers/client.go
@@ -35,6 +35,7 @@ const (
 	ProviderMistral          = provider.Mistral
 	ProviderGroq             = provider.Groq
 	ProviderDeepSeek         = provider.DeepSeek
+	ProviderCerebras         = provider.Cerebras
 )
 
 type Config struct {

--- a/pkg/infra/providers/factory/locator.go
+++ b/pkg/infra/providers/factory/locator.go
@@ -21,6 +21,7 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/anthropic"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/azure"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/bedrock"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/cerebras"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/deepseek"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/google"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/groq"
@@ -43,6 +44,7 @@ const (
 	ProviderMistral          = providers.ProviderMistral
 	ProviderGroq             = providers.ProviderGroq
 	ProviderDeepSeek         = providers.ProviderDeepSeek
+	ProviderCerebras         = providers.ProviderCerebras
 )
 
 //go:generate mockery --name=ProviderLocator --dir=. --output=./mocks --filename=provider_locator_mock.go --case=underscore --with-expecter
@@ -73,6 +75,7 @@ func NewProviderLocator() ProviderLocator {
 			ProviderMistral:          mistral.NewMistralClient(),
 			ProviderGroq:             groq.NewGroqClient(),
 			ProviderDeepSeek:         deepseek.NewDeepSeekClient(),
+			ProviderCerebras:         cerebras.NewCerebrasClient(),
 			ProviderVertex:           vertex.NewVertexClient(),
 		},
 	}

--- a/pkg/infra/providers/factory/locator_test.go
+++ b/pkg/infra/providers/factory/locator_test.go
@@ -35,6 +35,7 @@ func TestProviderLocator_Get(t *testing.T) {
 		ProviderMistral,
 		ProviderGroq,
 		ProviderDeepSeek,
+		ProviderCerebras,
 	} {
 		t.Run(provider, func(t *testing.T) {
 			client, err := locator.Get(provider)


### PR DESCRIPTION
## Summary
- Add `provider: cerebras` OpenAI-compatible client (`https://api.cerebras.ai/v1`)
- Connection probe via GET `/v1/models`
- Catalog seed + models.dev `cerebras` mapping
- FormatOpenAI wire passthrough + httptest smoke tests

## Linear
RUN-251 — https://linear.app/neuraltrust/issue/RUN-251/featprovider-cerebras-llm-provider
RUN-259 — https://linear.app/neuraltrust/issue/RUN-259/featcerebras-trustgate-core-integration
RUN-921 — https://linear.app/neuraltrust/issue/RUN-921/testcerebras-functional-provider-smoke-tests

## Test plan
- [x] `go test ./pkg/infra/providers/cerebras/...`
- [x] `go test ./pkg/infra/providers/factory/...`
- [x] `go test ./pkg/app/catalog/...`
- [x] `go test ./pkg/infra/providers/adapter/...`