### PR TITLE
feat(provider): add OpenRouter LLM provider (RUN-252)

### DIFF
--- a/openspec/changes/openrouter-llm-provider/design.md
+++ b/openspec/changes/openrouter-llm-provider/design.md
@@ -1,0 +1,113 @@
+# Design: OpenRouter LLM provider (RUN-252)
+
+## Technical Approach
+
+Add a first-class `openrouter` provider by mirroring the **groq** infra pattern: thin `pkg/infra/providers/openrouter/` client over `openai.ChatCompletionsClient`, factory locator wiring, `FormatOpenRouter` in the adapter layer, and catalog **seed-only** registration (no models.dev import). `@openrouter/vendor/model` routing already exists in `pkg/domain/routing/intent.go` and `pkg/app/proxy/routing.go`; this change completes registry CRUD, connection probe, proxy forwarding, and extension-aware adaptation.
+
+Hexagonal binding: **infra** owns HTTP client + format adapters; **app/catalog** owns provider seed + auth catalog; **domain** gains no new types (validates via `IsValidProvider`); wiring stays in `pkg/infra/providers/factory/locator.go`.
+
+## Architecture Decisions
+
+| Decision | Choice | Rejected | Rationale |
+|----------|--------|----------|-----------|
+| Client shape | Dedicated `openrouter` package (groq clone) | `openai_compatible` + `base_url` | Registry needs `provider: "openrouter"`; intent `@openrouter/...` must match; separate telemetry pool |
+| Adapter shape | `OpenRouterAdapter` wraps `OpenAIAdapter` (Mistral pattern) | Register bare `OpenAIAdapter` like groq | OpenRouter has request fields (`provider`, `models`, `transforms`, `route`), response metadata, and SSE comment keep-alives groq does not |
+| Request extensions | `RequestExtensions map[string]json.RawMessage` on `CanonicalRequest` | Typed fields only in `openaiRequest` | Four optional keys; map matches existing `ProviderExtensions` response pattern |
+| Wire passthrough | `normalizeFormat` → `openai`; `ShouldPassthroughSameWireFormat` forces adapter for openrouter↔openai | Always passthrough | Same lesson as groq/`x_groq`: wire-similar ≠ byte-identical |
+| Catalog models | Seed row only (`wire_format: openai`) | models.dev mapping | Prior OpenRouter catalog purged; free-form `vendor/model` slugs are runtime-only |
+| Optional headers | Defer `HTTP-Referer` / `X-Title` | v1 attribution headers | Not in codebase; `ChatCompletionsClient` custom headers can follow later |
+| Delivery | Three chained PRs: core → adapter → tests | Single PR | ~400-line review budget; slices align RUN-922 / RUN-261 / RUN-924 |
+
+## Data Flow
+
+### Sync completion
+
+```
+Client ──► Proxy forwarder ──► ResolveAgentFormat("openrouter") → FormatOpenRouter
+                │                        │
+                │              Registry.AdaptRequest(source → openrouter)
+                ▼                        ▼
+         applyIntentToBody          OpenRouterAdapter.EncodeRequest
+         (model = vendor/slug)              │
+                │                           ▼
+                └──────────► factory.Get("openrouter") ──► openrouter.client
+                                              │
+                                              ▼
+                              POST https://openrouter.ai/api/v1/chat/completions
+                                              │
+                ◄─────────────────────────────┘
+         Registry.AdaptResponse(openrouter → source) ──► Client
+```
+
+### Connection probe
+
+```
+Admin API ──► GetTester("openrouter") ──► RunBearerGETProbe
+                              GET https://openrouter.ai/api/v1/models
+```
+
+### Streaming (adapter slice)
+
+```
+openrouter SSE line ──► OpenRouterAdapter.DecodeStreamChunk
+         │                      │ skip lines starting with ":" (ping / processing)
+         │                      ▼
+         └────► OpenAIAdapter decode/encode ──► Registry.AdaptStreamChunk → client
+```
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `pkg/infra/providers/openrouter/client.go` | Create | `NewOpenRouterClient()`; `ChatCompletionsClient` → `https://openrouter.ai/api/v1/chat/completions` |
+| `pkg/infra/providers/openrouter/connection.go` | Create | `TestConnection` via `GET …/api/v1/models` + `RunBearerGETProbe` |
+| `pkg/infra/providers/openrouter/client_test.go` | Create | httptest sync/stream (copy `groq/client_test.go` + `openRouterClientAt`) |
+| `pkg/infra/providers/openrouter/connection_test.go` | Create | httptest probe success/failure |
+| `pkg/infra/providers/client.go` | Modify | `ProviderOpenRouter`; extend `SupportedProviders` / `IsValidProvider` |
+| `pkg/infra/providers/factory/locator.go` | Modify | Map `ProviderOpenRouter` → `openrouter.NewOpenRouterClient()` |
+| `pkg/infra/providers/factory/locator_test.go` | Modify | Assert openrouter in locator table |
+| `pkg/infra/providers/adapter/format.go` | Modify | `FormatOpenRouter`; `resolveProviderWireFormat`, `ResolveAgentFormat`, `SupportedSourceFormat`, `normalizeFormat` |
+| `pkg/infra/providers/adapter/openrouter_adapter.go` | Create | Wrap `OpenAIAdapter`; peel/merge request + response extensions; filter SSE comments |
+| `pkg/infra/providers/adapter/openrouter_adapter_test.go` | Create | Round-trip extensions; cross-format strip (mirror `groq_adapter_test.go`) |
+| `pkg/infra/providers/adapter/registry.go` | Modify | `Register(FormatOpenRouter, &OpenRouterAdapter{})`; extend `ShouldPassthroughSameWireFormat` |
+| `pkg/infra/providers/adapter/canonical.go` | Modify | Add `RequestExtensions` on `CanonicalRequest` |
+| `pkg/app/catalog/sync.go` | Modify | Seed `{ProviderOpenRouter, "OpenRouter", "openai"}`; **no** `modelsDevProviderToCode` entry |
+| `pkg/app/catalog/provider_auth.go` | Modify | `providerAuthCatalog[ProviderOpenRouter] = {apiKeyAuthOption}` |
+| `pkg/app/catalog/sync_test.go` | Modify | Seed count follows `len(seedProviders)` automatically |
+
+**Out of scope:** `pkg/domain/routing/intent.go`, models.dev sync, OpenRouter catalog API, attribution headers.
+
+## Interfaces / Contracts
+
+```go
+// pkg/infra/providers/client.go
+const ProviderOpenRouter = "openrouter"
+
+// pkg/infra/providers/adapter/format.go
+const FormatOpenRouter Format = "openrouter"
+
+// pkg/infra/providers/adapter/canonical.go
+type CanonicalRequest struct {
+    // ...existing fields...
+    RequestExtensions map[string]json.RawMessage `json:"request_extensions,omitempty"`
+}
+```
+
+OpenRouter request extension keys (preserve on openrouter round-trip, strip on cross-format): `provider`, `models`, `transforms`, `route`. Response keys land in `ProviderExtensions` (e.g. OpenRouter usage/provider metadata).
+
+## Testing Strategy
+
+| Layer | What | Approach |
+|-------|------|----------|
+| Unit | Client, probe, adapter | httptest; table-driven; `-race` |
+| Adapter | Extension round-trip + cross-format strip | Copy `groq_adapter_test.go` patterns |
+| Functional | `@openrouter/vendor/model` routing | Fake upstream; existing intent tests + new smoke |
+
+## Migration / Rollout
+
+No migration required. Catalog sync adds one provider row on next sync. Existing purged `source='openrouter'` model rows stay absent.
+
+## Open Questions
+
+- [ ] Exact OpenRouter response extension keys to preserve beyond usage (confirm against live API during RUN-261)
+- [ ] Whether SSE comment filtering belongs only in `OpenRouterAdapter.DecodeStreamChunk` or also in shared stream reader (default: adapter-only)

--- a/openspec/changes/openrouter-llm-provider/exploration.md
+++ b/openspec/changes/openrouter-llm-provider/exploration.md
@@ -1,0 +1,105 @@
+## Exploration: OpenRouter LLM provider (RUN-252)
+
+### Current State
+
+TrustGate routes LLM traffic through provider packages under `pkg/infra/providers/`, a factory locator, and format adapters. OpenAI-compatible providers (**groq**, **deepseek**) are the closest siblings: thin wrappers over `openai.ChatCompletionsClient` with a fixed endpoint, `RunBearerGETProbe` connection test, and a dedicated `Format*` in `adapter/format.go` registered in `adapter/registry.go`.
+
+**OpenRouter does not exist yet** — no `pkg/infra/providers/openrouter/`, no `ProviderOpenRouter` constant, no catalog seed row.
+
+**Routing intent for `@openrouter` is already implemented** in `pkg/domain/routing/intent.go`:
+- `@openrouter/anthropic/claude-sonnet-4` → `{Provider: "openrouter", Model: "anthropic/claude-sonnet-4"}`
+- Nested slashes preserved (test at `intent_test.go:36`)
+- `applyIntentToBody` in `pkg/app/proxy/routing.go` rewrites qualified intents to native `vendor/model` before upstream call
+- `CandidateSet.resolveQualified` filters by registry provider + allowlist
+
+**Catalog policy:** models sync from **models.dev only** (`pkg/app/catalog/sync.go`). A prior OpenRouter catalog was purged (`migrations/20260617000000_purge_openrouter_catalog.go`). OpenRouter gets a **provider seed row only** — no `modelsDevProviderToCode` entry.
+
+**Extension pattern (groq):** `x_groq` preserved via typed fields + `ProviderExtensions` in `openai_completions_adapter.go`; `ShouldPassthroughSameWireFormat` forces openai↔groq through adapter; cross-format strips extensions in `registry.go`.
+
+### Affected Areas
+
+#### RUN-922 — Core integration
+
+| File | Why |
+|------|-----|
+| `pkg/infra/providers/client.go` | Add `ProviderOpenRouter`, `SupportedProviders()`, `IsValidProvider()` |
+| `pkg/infra/providers/openrouter/client.go` | **New** — groq pattern: `ChatCompletionsClient` → `https://openrouter.ai/api/v1/chat/completions` |
+| `pkg/infra/providers/openrouter/connection.go` | **New** — `GET https://openrouter.ai/api/v1/models` probe |
+| `pkg/infra/providers/factory/locator.go` | Wire `openrouter.NewOpenRouterClient()` |
+| `pkg/infra/providers/factory/locator_test.go` | Assert openrouter in locator map |
+| `pkg/infra/providers/adapter/format.go` | `FormatOpenRouter`, `ResolveAgentFormat`, `SupportedSourceFormat`, `normalizeFormat` |
+| `pkg/app/catalog/sync.go` | Add to `seedProviders` (wire_format `openai`); **do not** add to `modelsDevProviderToCode` |
+| `pkg/app/catalog/provider_auth.go` | `providerAuthCatalog[ProviderOpenRouter] = {apiKeyAuthOption}` |
+| `pkg/app/catalog/sync_test.go` | Update expected seed count |
+| `pkg/domain/registry/llm_target.go` | Auto-validates via `IsValidProvider` (no direct edit if constant added) |
+
+**Not needed for RUN-922:** changes to `pkg/domain/routing/intent.go` (already supports `@openrouter/vendor/model`).
+
+#### RUN-261 — Adapter extensions
+
+| File | Why |
+|------|-----|
+| `pkg/infra/providers/adapter/openrouter_adapter.go` | **New** — wrap `OpenAIAdapter`; preserve OpenRouter request fields (`provider`, `models`, `transforms`, `route`) and response metadata |
+| `pkg/infra/providers/adapter/openrouter_adapter_test.go` | **New** — round-trip + cross-format strip (mirror `groq_adapter_test.go`) |
+| `pkg/infra/providers/adapter/registry.go` | `Register(FormatOpenRouter, &OpenRouterAdapter{})`; extend `ShouldPassthroughSameWireFormat` for openrouter↔openai |
+| `pkg/infra/providers/adapter/openai_completions_adapter.go` | Likely extend decode/encode for OpenRouter extension fields OR handle in dedicated adapter |
+| `pkg/infra/providers/adapter/canonical.go` | Possibly `RequestExtensions map[string]json.RawMessage` on `CanonicalRequest` if passthrough cannot use typed fields |
+| `pkg/infra/providers/stream.go` or adapter | Filter SSE comment lines (`: ping`, `: OPENROUTER PROCESSING`) before JSON decode |
+
+#### RUN-924 — Functional smoke tests
+
+| File | Why |
+|------|-----|
+| `pkg/infra/providers/openrouter/client_test.go` | httptest sync+stream (copy `groq/client_test.go` + `groqClientAt` pattern) |
+| `pkg/infra/providers/openrouter/connection_test.go` | httptest `TestConnection` |
+| `pkg/infra/providers/adapter/openrouter_adapter_test.go` | Extension round-trip, cross-format strip |
+| `tests/functional/routing_intent_test.go` or new `openrouter_*_test.go` | E2E `@openrouter/vendor/model` with fake upstream |
+
+#### Cross-cutting (verify after each slice)
+
+| File | Why |
+|------|-----|
+| `pkg/infra/providers/validate.go` | No options validation needed (like groq/mistral) unless optional headers added later |
+| `pkg/api/handler/http/catalog/response/catalog_response.go` | Picks up auth via `ProviderAuthOptions` automatically |
+
+### Approaches
+
+| Approach | Pros | Cons | Effort |
+|----------|------|------|--------|
+| **A. Dedicated `openrouter` package + `FormatOpenRouter` adapter (groq model)** | First-class provider; extension preservation; matches epic + sub-issue split; catalog seed without models.dev pollution | More files than alias | **Medium** |
+| **B. Reuse `openai_compatible` with `base_url: https://openrouter.ai/api/v1`** | Zero new client code | No `provider:openrouter` in catalog/API; no extension adapter; routing intent `@openrouter/...` won't match registry provider; fails acceptance | Low |
+| **C. Extend `openai` client with OpenRouter endpoint flag** | Single client | Conflates providers; breaks locator/factory pattern; poor telemetry separation | Medium–High |
+
+### Recommendation
+
+**Approach A** — mirror **groq** for the HTTP client (`ChatCompletionsClient` + fixed URL) and **groq adapter tests** for extension round-trip / cross-format stripping. Use a dedicated `OpenRouterAdapter` (like `MistralAdapter` wraps `OpenAIAdapter`) for OpenRouter-specific request/response fields and SSE keep-alive filtering.
+
+**Implementation order:**
+1. **RUN-922** — unblocks registry creation, catalog listing, connection probe, basic sync/stream to OpenRouter
+2. **RUN-261** — required for extension field preservation and SSE keep-alive (acceptance criteria)
+3. **RUN-924** — httptest + functional smoke; can start unit tests in parallel with 261
+
+**PR strategy:** Three chained PRs aligned to RUN-922 → RUN-261 → RUN-924 (~400-line budget each). Total forecast **Medium–High** risk of exceeding single-PR budget.
+
+### Open Questions
+
+| Question | Resolution from code |
+|----------|---------------------|
+| Is `@openrouter/vendor/model` routing implemented? | **Yes** — `ParseModelRef` + `applyIntentToBody`; only missing `IsValidProvider("openrouter")` for registry CRUD |
+| Catalog models for OpenRouter? | **No** — seed provider only; no `modelsDevProviderToCode`; migration already purged old `source='openrouter'` rows |
+| Free-form `vendor/model` strings (app v2)? | Works when consumer has **no allowlist** (`Candidate.Allowed == nil` → `AllowsModel` returns true); qualified intent passes full slug via `OverrideModel` |
+| OpenRouter optional headers (`HTTP-Referer`, `X-Title`)? | **Not in codebase** — defer unless epic requires; could add via `ChatCompletionsClient` `customHeaders` later |
+| SSE `: ping` keep-alives? | **Not filtered today** — `StreamSSE` yields all lines; implement skip in `OpenRouterAdapter.DecodeStreamChunk` or proxy stream handler |
+| Request fields `provider`/`models`/`transforms`/`route`? | **Not in codebase** — RUN-261 must add (groq's `x_groq` / `ProviderExtensions` is the response-side pattern) |
+| Closest sibling? | **groq** (client) + **groq_adapter_test** (extensions); mistral only if tool-call ID normalization needed (unlikely for OpenRouter) |
+
+### Risks
+
+- OpenRouter response extensions may differ from groq's `x_groq` — adapter design must use flexible `ProviderExtensions` / `RequestExtensions` maps
+- SSE comment lines may break stream JSON parsing if not filtered before `DecodeStreamChunk`
+- Allowlisted consumers will reject unknown `vendor/model` slugs unless UI uses free-form (nil allowlist) or catalog picks models.dev slugs only
+- No openspec change folder existed before this explore artifact — proposal/spec phases should create full SDD tree
+
+### Ready for Proposal
+
+**Yes** — recommend `sdd-propose` with Approach A, three PR slices (RUN-922 / RUN-261 / RUN-924), and explicit out-of-scope: models.dev sync, OpenRouter catalog API, optional attribution headers (unless product requires in v1).

--- a/openspec/changes/openrouter-llm-provider/proposal.md
+++ b/openspec/changes/openrouter-llm-provider/proposal.md
@@ -1,0 +1,76 @@
+---
+linear: RUN-252
+type: feat
+changelog: "Add OpenRouter as a first-class LLM provider with groq-style client, extension adapter, and smoke tests."
+---
+
+# Proposal: OpenRouter LLM provider (RUN-252)
+
+## Intent
+
+TrustGate must route LLM traffic to OpenRouter as a first-class provider. Routing intent (`@openrouter/vendor/model`) and body rewrite already exist in `pkg/domain/routing/intent.go`, but registry CRUD, catalog listing, connection probe, and proxy upstream calls fail because `openrouter` is not registered — no client, factory entry, format adapter, or catalog seed.
+
+## Scope
+
+### In Scope
+- **RUN-922 (core):** `ProviderOpenRouter`; `pkg/infra/providers/openrouter/` client + connection probe; factory locator; `FormatOpenRouter` in `format.go`; catalog seed row + API-key auth; sync/stream to `https://openrouter.ai/api/v1/chat/completions`
+- **RUN-261 (adapter):** `OpenRouterAdapter` preserving request fields (`provider`, `models`, `transforms`, `route`) and response metadata; SSE comment-line filtering; registry passthrough for openrouter↔openai
+- **RUN-924 (tests):** httptest client/connection tests; adapter round-trip; functional smoke for `@openrouter/vendor/model`
+
+### Out of Scope
+- models.dev catalog sync (seed provider only; prior OpenRouter catalog purged)
+- OpenRouter catalog API; optional `HTTP-Referer` / `X-Title` headers
+- `openai_compatible` base-URL alias (no registry provider match, no extensions)
+
+## Capabilities
+
+### New Capabilities
+- `openrouter-llm-provider`: first-class OpenRouter integration — registry validation, proxy sync/stream, extension preservation, qualified routing intent
+
+### Modified Capabilities
+- None (routing intent already implemented; no existing provider spec in `openspec/specs/`)
+
+## Approach
+
+**Approach A** — dedicated `openrouter` package + `FormatOpenRouter`, mirroring **groq**: thin wrapper over `openai.ChatCompletionsClient` with fixed endpoint; `RunBearerGETProbe` on `GET /api/v1/models`; dedicated adapter wrapping `OpenAIAdapter` (Mistral/groq pattern) for OpenRouter-specific fields and `ProviderExtensions` / request extension maps.
+
+**Delivery:** three chained PRs aligned to Linear sub-issues, ~400-line budget each: **RUN-922 → RUN-261 → RUN-924**.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `pkg/infra/providers/openrouter/` | New | Client, connection, tests |
+| `pkg/infra/providers/client.go` | Modified | Constant, `SupportedProviders`, `IsValidProvider` |
+| `pkg/infra/providers/factory/locator.go` | Modified | Wire `NewOpenRouterClient()` |
+| `pkg/infra/providers/adapter/` | Modified/New | `FormatOpenRouter`, `OpenRouterAdapter`, registry |
+| `pkg/app/catalog/sync.go` | Modified | Seed row; no `modelsDevProviderToCode` entry |
+| `pkg/app/catalog/provider_auth.go` | Modified | API key auth catalog entry |
+| `tests/functional/` | New | Routing smoke with fake upstream |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| OpenRouter extensions differ from groq `x_groq` | Med | Flexible extension maps on canonical model |
+| SSE `: ping` lines break stream JSON decode | Med | Filter comment lines before `DecodeStreamChunk` (RUN-261) |
+| Allowlisted consumers reject free-form `vendor/model` | Med | Document nil-allowlist behavior; no models.dev rows |
+| Single PR exceeds 400-line budget | High | Three chained PRs per sub-issue |
+
+## Rollback Plan
+
+Additive change. Revert by removing the `openrouter` package, factory locator entry, adapter registration, `FormatOpenRouter`, catalog seed, and provider constant. No migrations or schema changes. Existing providers unaffected.
+
+## Dependencies
+
+- OpenRouter Chat Completions API (OpenAI-compatible wire format)
+- Existing `openai.ChatCompletionsClient` and HTTP client pool
+
+## Success Criteria
+
+- [ ] Registry CRUD and connection probe accept `provider=openrouter`
+- [ ] `@openrouter/vendor/model` proxies sync + stream to OpenRouter
+- [ ] OpenRouter request/response extensions round-trip same-wire; stripped cross-format
+- [ ] SSE keep-alive comments do not break streaming
+- [ ] Catalog lists OpenRouter with API key auth; no models.dev sync rows
+- [ ] `-race`-clean unit and functional tests per RUN-922 / RUN-261 / RUN-924

--- a/openspec/changes/openrouter-llm-provider/spec.md
+++ b/openspec/changes/openrouter-llm-provider/spec.md
@@ -1,0 +1,79 @@
+# OpenRouter LLM Provider Specification
+
+**Linear:** RUN-252 · RUN-922 · RUN-261 · RUN-924 · **Change:** `openrouter-llm-provider`
+
+## Purpose
+
+Add OpenRouter as a first-class OpenAI-wire-compatible LLM provider. Catalog seeds the provider only (no models.dev import). `@openrouter/vendor/model` routing intent already exists and MUST remain unchanged.
+
+## ADDED Requirements
+
+### Requirement: Provider registration
+
+TrustGate MUST register `openrouter` in `SupportedProviders`, `IsValidProvider`, the factory locator, `FormatOpenRouter`, and catalog auth (`api_key`). Completions MUST use `https://openrouter.ai/api/v1/chat/completions`. Connection test MUST probe `GET https://openrouter.ai/api/v1/models` with Bearer auth.
+
+#### Scenario: Registry and locator accept openrouter
+
+- GIVEN `provider: openrouter` with valid API key
+- WHEN an operator creates a registry target or runs test-connection
+- THEN validation succeeds, the locator returns an OpenRouter client, and the models probe succeeds
+
+### Requirement: Sync and stream completions
+
+The client MUST proxy sync and stream chat completions with `vendor/model` slugs (e.g. `anthropic/claude-sonnet-4`) unchanged, using `Bearer {api_key}`. Missing credentials MUST fail before upstream call.
+
+#### Scenario: Sync and stream with vendor/model slug
+
+- GIVEN an openrouter target and model `anthropic/claude-sonnet-4`
+- WHEN sync or streaming completion is proxied
+- THEN the upstream body retains the model slug and responses complete (sync body or SSE chunks)
+
+### Requirement: Catalog provider seed without models.dev models
+
+Catalog sync MUST seed an `openrouter` provider row (wire format `openai`). OpenRouter MUST NOT appear in `modelsDevProviderToCode`; no OpenRouter model rows MAY be imported from models.dev.
+
+#### Scenario: Provider seeded, models not imported
+
+- GIVEN catalog sync runs
+- WHEN providers seed and models.dev import complete
+- THEN an `openrouter` provider with `api_key` auth exists and zero catalog models reference `openrouter`
+
+### Requirement: Routing intent compatibility (unchanged)
+
+`ParseModelRef` / `applyIntentToBody` for `@openrouter/...` MUST NOT change. Nested slashes MUST be preserved. This change only enables `IsValidProvider("openrouter")` for registry CRUD and candidate resolution.
+
+#### Scenario: Intent parses and rewrites model
+
+- GIVEN ref `@openrouter/meta-llama/llama-3-70b` or `@openrouter/anthropic/claude-sonnet-4`
+- WHEN intent is parsed and applied to an openrouter request
+- THEN provider is `openrouter`, nested slug is preserved, and body `model` is the vendor/model suffix
+
+### Requirement: Extension field preservation
+
+`FormatOpenRouter` MUST register in the adapter registry. Same-format round-trips MUST preserve request fields `provider`, `models`, `transforms`, `route` and response metadata via `ProviderExtensions`. Cross-format adaptation MUST strip OpenRouter-only extensions.
+
+#### Scenario: Same-format extension round-trip
+
+- GIVEN openrouter sync or stream payloads with routing extensions and response metadata
+- WHEN encode → decode → encode on the same format
+- THEN all extension fields and metadata survive
+
+#### Scenario: Cross-format strips extensions
+
+- GIVEN an openrouter request with `provider`, `models`, `transforms`, `route`
+- WHEN adapted to a non-openrouter format (e.g. anthropic)
+- THEN those fields are absent from encoded output
+
+### Requirement: SSE keep-alive comment filtering
+
+Stream handling MUST ignore SSE comment lines (`: ping`, `: OPENROUTER PROCESSING`) before JSON decode; `data:` lines MUST still parse.
+
+#### Scenario: Comment lines do not break stream decode
+
+- GIVEN an SSE stream with `: ping` or `: OPENROUTER PROCESSING` between `data:` events
+- WHEN chunks are decoded
+- THEN comments are skipped and subsequent JSON chunks parse without error
+
+## Out of scope
+
+models.dev OpenRouter models; OpenRouter catalog API; attribution headers; App v2 UI; changes to `intent.go`.

--- a/pkg/app/catalog/provider_auth.go
+++ b/pkg/app/catalog/provider_auth.go
@@ -255,6 +255,7 @@ var providerAuthCatalog = map[string][]AuthTypeOption{
 	providers.ProviderMistral:          {apiKeyAuthOption},
 	providers.ProviderGroq:             {apiKeyAuthOption},
 	providers.ProviderDeepSeek:         {apiKeyAuthOption},
+	providers.ProviderOpenRouter:       {apiKeyAuthOption},
 }
 
 func ProviderAuthOptions(code string) []AuthTypeOption {

--- a/pkg/app/catalog/sync.go
+++ b/pkg/app/catalog/sync.go
@@ -44,6 +44,7 @@ var seedProviders = []seedProvider{
 	{providers.ProviderMistral, "Mistral", "openai"},
 	{providers.ProviderGroq, "Groq", "openai"},
 	{providers.ProviderDeepSeek, "DeepSeek", "openai"},
+	{providers.ProviderOpenRouter, "OpenRouter", "openai"},
 }
 
 // modelsDevProviderToCode maps models.dev provider keys to the gateway provider

--- a/pkg/domain/provider/provider.go
+++ b/pkg/domain/provider/provider.go
@@ -28,6 +28,7 @@ const (
 	Mistral          = "mistral"
 	Groq             = "groq"
 	DeepSeek         = "deepseek"
+	OpenRouter       = "openrouter"
 )
 
 // Supported returns every provider name the gateway can route to.
@@ -43,6 +44,7 @@ func Supported() []string {
 		Mistral,
 		Groq,
 		DeepSeek,
+		OpenRouter,
 	}
 }
 
@@ -58,7 +60,8 @@ func IsValid(name string) bool {
 		Azure,
 		Mistral,
 		Groq,
-		DeepSeek:
+		DeepSeek,
+		OpenRouter:
 		return true
 	default:
 		return false

--- a/pkg/infra/providers/adapter/canonical.go
+++ b/pkg/infra/providers/adapter/canonical.go
@@ -34,8 +34,9 @@ type CanonicalRequest struct {
 	TopK           *int                   `json:"top_k,omitempty"`
 	Stop           []string               `json:"stop,omitempty"`
 	Stream         bool                   `json:"stream,omitempty"`
-	ResponseFormat *CanonicalRespFormat   `json:"response_format,omitempty"`
-	Metadata       map[string]interface{} `json:"metadata,omitempty"`
+	ResponseFormat *CanonicalRespFormat          `json:"response_format,omitempty"`
+	Metadata       map[string]interface{}        `json:"metadata,omitempty"`
+	RequestExtensions map[string]json.RawMessage   `json:"request_extensions,omitempty"`
 }
 
 // CanonicalMessage represents a single turn in the conversation.

--- a/pkg/infra/providers/adapter/format.go
+++ b/pkg/infra/providers/adapter/format.go
@@ -34,7 +34,8 @@ const (
 	FormatGroq            Format = "groq"  // wire-compatible with OpenAI Chat Completions
 	FormatVertex          Format = "vertex"
 	FormatMistral         Format = "mistral"
-	FormatDeepSeek        Format = "deepseek" // wire-compatible with OpenAI Chat Completions
+	FormatDeepSeek        Format = "deepseek"   // wire-compatible with OpenAI Chat Completions
+	FormatOpenRouter      Format = "openrouter" // wire-compatible with OpenAI Chat Completions
 )
 
 // GeminiModelsRoutePrefix is the fixed Gemini route segment that carries the
@@ -111,7 +112,7 @@ func (f Format) IsOpenAIFamily() bool {
 func SupportedSourceFormat(f Format) bool {
 	switch f {
 	case FormatOpenAI, FormatOpenAIResponses, FormatAnthropic, FormatGemini,
-		FormatAzure, FormatGroq, FormatVertex, FormatMistral, FormatDeepSeek:
+		FormatAzure, FormatGroq, FormatVertex, FormatMistral, FormatDeepSeek, FormatOpenRouter:
 		return true
 	default:
 		return false
@@ -134,6 +135,8 @@ func resolveProviderWireFormat(providerName string) Format {
 		return FormatGroq
 	case provider.DeepSeek:
 		return FormatDeepSeek
+	case provider.OpenRouter:
+		return FormatOpenRouter
 	case provider.OpenAICompatible:
 		return FormatOpenAI
 	default:
@@ -161,7 +164,7 @@ func ResolveAgentFormat(providerName, sourceFormat string, providerOptions map[s
 		return Format(sourceFormat), nil
 	}
 	switch providerName {
-	case provider.OpenAI, provider.OpenAICompatible, provider.Azure, provider.Groq, provider.DeepSeek:
+	case provider.OpenAI, provider.OpenAICompatible, provider.Azure, provider.Groq, provider.DeepSeek, provider.OpenRouter:
 		return ResolveTargetFormat(providerName, providerOptions), nil
 	case provider.Anthropic:
 		return FormatAnthropic, nil
@@ -186,7 +189,7 @@ func IsSameWireFormat(a, b Format) bool {
 
 func normalizeFormat(f Format) Format {
 	switch f {
-	case FormatAzure, FormatGroq, FormatDeepSeek:
+	case FormatAzure, FormatGroq, FormatDeepSeek, FormatOpenRouter:
 		return FormatOpenAI
 	case FormatVertex:
 		return FormatGemini

--- a/pkg/infra/providers/adapter/openrouter_adapter.go
+++ b/pkg/infra/providers/adapter/openrouter_adapter.go
@@ -1,0 +1,170 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapter
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+var openRouterRequestKeys = []string{"provider", "models", "transforms", "route"}
+
+var openRouterResponseKeys = []string{"provider"}
+
+// OpenRouterAdapter wraps OpenAIAdapter and preserves OpenRouter routing fields.
+type OpenRouterAdapter struct {
+	openai OpenAIAdapter
+}
+
+func (a *OpenRouterAdapter) DecodeRequest(body []byte) (*CanonicalRequest, error) {
+	cr, err := a.openai.DecodeRequest(body)
+	if err != nil {
+		return nil, err
+	}
+	cr.RequestExtensions = extractOpenRouterKeys(body, openRouterRequestKeys)
+	return cr, nil
+}
+
+func (a *OpenRouterAdapter) EncodeRequest(req *CanonicalRequest) ([]byte, error) {
+	out, err := a.openai.EncodeRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	return mergeJSONExtensions(out, req.RequestExtensions)
+}
+
+func (a *OpenRouterAdapter) DecodeResponse(body []byte) (*CanonicalResponse, error) {
+	cr, err := a.openai.DecodeResponse(body)
+	if err != nil {
+		return nil, err
+	}
+	ext := extractOpenRouterKeys(body, openRouterResponseKeys)
+	if len(ext) == 0 {
+		return cr, nil
+	}
+	if cr.ProviderExtensions == nil {
+		cr.ProviderExtensions = make(map[string]json.RawMessage, len(ext))
+	}
+	for k, v := range ext {
+		cr.ProviderExtensions[k] = v
+	}
+	return cr, nil
+}
+
+func (a *OpenRouterAdapter) EncodeResponse(resp *CanonicalResponse) ([]byte, error) {
+	out, err := a.openai.EncodeResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+	return mergeJSONExtensions(out, resp.ProviderExtensions)
+}
+
+func (a *OpenRouterAdapter) DecodeStreamChunk(chunk []byte) (*CanonicalStreamChunk, error) {
+	if isSSECommentLine(chunk) {
+		return nil, nil
+	}
+	payload := sseJSONPayload(chunk)
+	if payload == nil {
+		return nil, nil
+	}
+
+	sc, err := a.openai.DecodeStreamChunk(payload)
+	if err != nil || sc == nil {
+		return sc, err
+	}
+	ext := extractOpenRouterKeys(payload, openRouterResponseKeys)
+	if len(ext) == 0 {
+		return sc, nil
+	}
+	if sc.ProviderExtensions == nil {
+		sc.ProviderExtensions = make(map[string]json.RawMessage, len(ext))
+	}
+	for k, v := range ext {
+		sc.ProviderExtensions[k] = v
+	}
+	return sc, nil
+}
+
+func (a *OpenRouterAdapter) EncodeStreamChunk(chunk *CanonicalStreamChunk) ([][]byte, error) {
+	lines, err := a.openai.EncodeStreamChunk(chunk)
+	if err != nil || len(lines) == 0 || chunk == nil || len(chunk.ProviderExtensions) == 0 {
+		return lines, err
+	}
+
+	for i, line := range lines {
+		if !bytes.HasPrefix(line, []byte("data:")) {
+			continue
+		}
+		payload := bytes.TrimSpace(bytes.TrimPrefix(line, []byte("data:")))
+		merged, merr := mergeJSONExtensions(payload, chunk.ProviderExtensions)
+		if merr != nil {
+			return nil, merr
+		}
+		lines[i] = append([]byte("data: "), merged...)
+		break
+	}
+	return lines, nil
+}
+
+func extractOpenRouterKeys(body []byte, keys []string) map[string]json.RawMessage {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil
+	}
+	ext := make(map[string]json.RawMessage)
+	for _, k := range keys {
+		if v, ok := raw[k]; ok && len(v) > 0 && !isEmptyOrNull(v) {
+			ext[k] = v
+		}
+	}
+	if len(ext) == 0 {
+		return nil
+	}
+	return ext
+}
+
+func mergeJSONExtensions(base []byte, extensions map[string]json.RawMessage) ([]byte, error) {
+	if len(extensions) == 0 {
+		return base, nil
+	}
+	var out map[string]json.RawMessage
+	if err := json.Unmarshal(base, &out); err != nil {
+		return nil, err
+	}
+	for k, v := range extensions {
+		out[k] = v
+	}
+	return json.Marshal(out)
+}
+
+func isSSECommentLine(line []byte) bool {
+	trimmed := bytes.TrimSpace(line)
+	return len(trimmed) > 0 && trimmed[0] == ':'
+}
+
+func sseJSONPayload(line []byte) []byte {
+	trimmed := bytes.TrimSpace(line)
+	if len(trimmed) == 0 {
+		return nil
+	}
+	if bytes.HasPrefix(trimmed, []byte("data:")) {
+		payload := bytes.TrimSpace(bytes.TrimPrefix(trimmed, []byte("data:")))
+		if bytes.Equal(payload, []byte("[DONE]")) {
+			return nil
+		}
+		return payload
+	}
+	return trimmed
+}

--- a/pkg/infra/providers/adapter/openrouter_adapter_test.go
+++ b/pkg/infra/providers/adapter/openrouter_adapter_test.go
@@ -1,0 +1,309 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapter
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const openRouterResponseWithProvider = `{
+  "id": "gen-or-1",
+  "object": "chat.completion",
+  "model": "anthropic/claude-sonnet-4",
+  "provider": "Anthropic",
+  "choices": [{
+    "index": 0,
+    "message": {"role": "assistant", "content": "hello"},
+    "finish_reason": "stop"
+  }],
+  "usage": {
+    "prompt_tokens": 10,
+    "completion_tokens": 5,
+    "total_tokens": 15
+  }
+}`
+
+const openRouterStreamFinalChunk = `{
+  "id": "gen-or-stream",
+  "object": "chat.completion.chunk",
+  "model": "anthropic/claude-sonnet-4",
+  "provider": "Anthropic",
+  "choices": [{
+    "index": 0,
+    "delta": {},
+    "finish_reason": "stop"
+  }],
+  "usage": {
+    "prompt_tokens": 10,
+    "completion_tokens": 5,
+    "total_tokens": 15
+  }
+}`
+
+const openRouterChatRequest = `{
+  "model": "anthropic/claude-sonnet-4",
+  "messages": [{"role": "user", "content": "hi"}],
+  "provider": {"order": ["Anthropic"]},
+  "models": ["anthropic/claude-sonnet-4", "openai/gpt-4o"],
+  "transforms": ["middle-out"],
+  "route": "fallback",
+  "max_tokens": 128
+}`
+
+func openRouterAdapter(t *testing.T) ProviderAdapter {
+	t.Helper()
+	a, err := NewRegistry().GetAdapter(FormatOpenRouter)
+	require.NoError(t, err)
+	return a
+}
+
+func TestOpenRouterAdapter_FormatRegistration(t *testing.T) {
+	assert.Equal(t, Format("openrouter"), FormatOpenRouter)
+
+	reg := NewRegistry()
+	_, err := reg.GetAdapter(FormatOpenRouter)
+	require.NoError(t, err)
+
+	assert.Equal(t, FormatOpenRouter, ResolveTargetFormat("openrouter", nil))
+
+	got, err := ResolveAgentFormat("openrouter", "", nil)
+	require.NoError(t, err)
+	assert.Equal(t, FormatOpenRouter, got)
+
+	assert.True(t, IsSameWireFormat(FormatOpenRouter, FormatOpenAI))
+	assert.True(t, IsSameWireFormat(FormatOpenAI, FormatOpenRouter))
+
+	assert.True(t, ShouldPassthroughSameWireFormat(FormatOpenRouter, FormatOpenRouter))
+	assert.False(t, ShouldPassthroughSameWireFormat(FormatOpenAI, FormatOpenRouter))
+	assert.False(t, ShouldPassthroughSameWireFormat(FormatOpenRouter, FormatOpenAI))
+
+	opts := map[string]any{"api": "responses"}
+	assert.Equal(t, FormatOpenAIResponses, ResolveTargetFormat("openai", opts))
+	assert.Equal(t, FormatOpenRouter, ResolveTargetFormat("openrouter", opts))
+}
+
+func TestOpenRouterAdapter_RoundTripPreservesRequestExtensions(t *testing.T) {
+	a := openRouterAdapter(t)
+
+	cr, err := a.DecodeRequest([]byte(openRouterChatRequest))
+	require.NoError(t, err)
+	require.NotNil(t, cr.RequestExtensions["provider"])
+	require.NotNil(t, cr.RequestExtensions["models"])
+	require.NotNil(t, cr.RequestExtensions["transforms"])
+	require.NotNil(t, cr.RequestExtensions["route"])
+
+	encoded, err := a.EncodeRequest(cr)
+	require.NoError(t, err)
+
+	var parsed map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(encoded, &parsed))
+	require.NotNil(t, parsed["provider"])
+	require.NotNil(t, parsed["models"])
+	require.NotNil(t, parsed["transforms"])
+	require.NotNil(t, parsed["route"])
+}
+
+func TestOpenRouterAdapter_RoundTripPreservesProviderMetadata(t *testing.T) {
+	a := openRouterAdapter(t)
+
+	canonical, err := a.DecodeResponse([]byte(openRouterResponseWithProvider))
+	require.NoError(t, err)
+	require.NotNil(t, canonical.ProviderExtensions["provider"])
+
+	encoded, err := a.EncodeResponse(canonical)
+	require.NoError(t, err)
+
+	var parsed map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(encoded, &parsed))
+	require.NotNil(t, parsed["provider"])
+
+	var provider string
+	require.NoError(t, json.Unmarshal(parsed["provider"], &provider))
+	assert.Equal(t, "Anthropic", provider)
+}
+
+func TestOpenRouterAdapter_StreamFinalChunkPreservesProvider(t *testing.T) {
+	a := openRouterAdapter(t)
+
+	canonical, err := a.DecodeStreamChunk([]byte(openRouterStreamFinalChunk))
+	require.NoError(t, err)
+	require.NotNil(t, canonical)
+	require.NotNil(t, canonical.Usage)
+	assert.Equal(t, 15, canonical.Usage.TotalTokens)
+	require.NotNil(t, canonical.ProviderExtensions["provider"])
+
+	lines, err := a.EncodeStreamChunk(canonical)
+	require.NoError(t, err)
+	require.NotEmpty(t, lines)
+
+	var dataLine string
+	for _, line := range lines {
+		if bytes.HasPrefix(line, []byte("data: ")) {
+			dataLine = string(line)
+			break
+		}
+	}
+	require.NotEmpty(t, dataLine)
+	payload := strings.TrimPrefix(dataLine, "data: ")
+
+	var parsed map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal([]byte(payload), &parsed))
+	require.NotNil(t, parsed["provider"])
+	require.NotNil(t, parsed["usage"])
+}
+
+func TestOpenRouterAdapter_DecodeStreamChunk_SkipsSSEComments(t *testing.T) {
+	a := openRouterAdapter(t)
+
+	for _, line := range []string{
+		": OPENROUTER PROCESSING",
+		": ping",
+		" : ping ",
+	} {
+		sc, err := a.DecodeStreamChunk([]byte(line))
+		require.NoError(t, err)
+		assert.Nil(t, sc, "line %q", line)
+	}
+
+	sc, err := a.DecodeStreamChunk([]byte(`data: {"choices":[{"delta":{"content":"ok"}}]}`))
+	require.NoError(t, err)
+	require.NotNil(t, sc)
+	assert.Equal(t, "ok", sc.Delta)
+}
+
+func TestOpenRouterAdapter_CrossFormatDropsRequestExtensions(t *testing.T) {
+	out, err := NewRegistry().AdaptRequest([]byte(openRouterChatRequest), FormatAnthropic, FormatOpenRouter)
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), `"models"`)
+	assert.NotContains(t, string(out), `"transforms"`)
+	assert.NotContains(t, string(out), `"route"`)
+
+	var probe struct {
+		Provider json.RawMessage `json:"provider"`
+	}
+	require.NoError(t, json.Unmarshal(out, &probe))
+	assert.Nil(t, probe.Provider)
+}
+
+func TestOpenRouterAdapter_CrossFormatDropsProviderMetadata(t *testing.T) {
+	out, err := NewRegistry().AdaptResponse([]byte(openRouterResponseWithProvider), FormatAnthropic, FormatOpenRouter)
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), `"provider"`)
+
+	var probe struct {
+		Type string `json:"type"`
+	}
+	require.NoError(t, json.Unmarshal(out, &probe))
+	assert.Equal(t, "message", probe.Type)
+}
+
+func TestOpenRouterAdapter_CrossFormatDropsProviderMetadataToOpenAI(t *testing.T) {
+	out, err := NewRegistry().AdaptResponse([]byte(openRouterResponseWithProvider), FormatOpenAI, FormatOpenRouter)
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), `"provider"`)
+
+	var parsed struct {
+		Object  string          `json:"object"`
+		Choices json.RawMessage `json:"choices"`
+	}
+	require.NoError(t, json.Unmarshal(out, &parsed))
+	assert.Equal(t, "chat.completion", parsed.Object)
+	require.NotNil(t, parsed.Choices)
+}
+
+func TestOpenRouterAdapter_CrossFormatDropsProviderMetadataStream(t *testing.T) {
+	lines, err := NewRegistry().AdaptStreamChunk([]byte(openRouterStreamFinalChunk), FormatOpenAI, FormatOpenRouter)
+	require.NoError(t, err)
+	require.NotEmpty(t, lines)
+
+	combined := ""
+	for _, line := range lines {
+		combined += string(line) + "\n"
+	}
+	assert.NotContains(t, combined, `"provider"`)
+	assert.Contains(t, combined, "usage")
+	assert.Contains(t, combined, "data: ")
+}
+
+func TestOpenRouterAdapter_RequestMappings(t *testing.T) {
+	reg := NewRegistry()
+	a, err := reg.GetAdapter(FormatOpenRouter)
+	require.NoError(t, err)
+
+	t.Run("provider to canonical request", func(t *testing.T) {
+		cr, err := a.DecodeRequest([]byte(openRouterChatRequest))
+		require.NoError(t, err)
+		assert.Equal(t, "anthropic/claude-sonnet-4", cr.Model)
+		require.Len(t, cr.Messages, 1)
+		assert.Equal(t, "user", cr.Messages[0].Role)
+		require.NotNil(t, cr.RequestExtensions["route"])
+	})
+
+	t.Run("canonical to provider request", func(t *testing.T) {
+		cr, err := a.DecodeRequest([]byte(openRouterChatRequest))
+		require.NoError(t, err)
+
+		encoded, err := a.EncodeRequest(cr)
+		require.NoError(t, err)
+
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal(encoded, &parsed))
+		assert.Equal(t, "anthropic/claude-sonnet-4", parsed["model"])
+		assert.Equal(t, "fallback", parsed["route"])
+	})
+
+	t.Run("provider to canonical response", func(t *testing.T) {
+		cr, err := a.DecodeResponse([]byte(openRouterResponseWithProvider))
+		require.NoError(t, err)
+		require.NotNil(t, cr.ProviderExtensions["provider"])
+		assert.Equal(t, "hello", cr.Content)
+	})
+
+	t.Run("canonical to provider response", func(t *testing.T) {
+		cr, err := a.DecodeResponse([]byte(openRouterResponseWithProvider))
+		require.NoError(t, err)
+
+		encoded, err := a.EncodeResponse(cr)
+		require.NoError(t, err)
+		assert.Contains(t, string(encoded), `"provider"`)
+	})
+
+	t.Run("provider to canonical stream", func(t *testing.T) {
+		sc, err := a.DecodeStreamChunk([]byte(openRouterStreamFinalChunk))
+		require.NoError(t, err)
+		require.NotNil(t, sc)
+		require.NotNil(t, sc.ProviderExtensions["provider"])
+		require.NotNil(t, sc.Usage)
+	})
+
+	t.Run("canonical to provider stream", func(t *testing.T) {
+		sc, err := a.DecodeStreamChunk([]byte(openRouterStreamFinalChunk))
+		require.NoError(t, err)
+
+		lines, err := a.EncodeStreamChunk(sc)
+		require.NoError(t, err)
+		combined := string(lines[0])
+		for _, line := range lines[1:] {
+			combined += string(line)
+		}
+		assert.Contains(t, combined, `"provider"`)
+	})
+}

--- a/pkg/infra/providers/adapter/registry.go
+++ b/pkg/infra/providers/adapter/registry.go
@@ -97,6 +97,7 @@ func NewRegistry() *Registry {
 	r.Register(FormatOpenAI, &OpenAIAdapter{})
 	r.Register(FormatGroq, &OpenAIAdapter{})
 	r.Register(FormatDeepSeek, &OpenAIAdapter{})
+	r.Register(FormatOpenRouter, &OpenRouterAdapter{})
 	r.Register(FormatOpenAIResponses, &OpenAIResponsesAdapter{})
 	r.Register(FormatAnthropic, &AnthropicAdapter{})
 	r.Register(FormatGemini, &GeminiAdapter{})
@@ -112,6 +113,9 @@ func (r *Registry) Register(f Format, a ProviderAdapter) {
 
 // GetAdapter returns the adapter for a format, resolving aliases.
 func (r *Registry) GetAdapter(f Format) (ProviderAdapter, error) {
+	if a, ok := r.adapters[f]; ok {
+		return a, nil
+	}
 	f = normalizeFormat(f)
 	a, ok := r.adapters[f]
 	if !ok {
@@ -141,7 +145,7 @@ func (r *Registry) DecodeRequestFor(body []byte, providerFormat Format) (*Canoni
 }
 
 func (r *Registry) AdaptRequest(body []byte, source, target Format) ([]byte, error) {
-	if IsSameWireFormat(source, target) {
+	if ShouldPassthroughSameWireFormat(source, target) {
 		return body, nil
 	}
 
@@ -161,6 +165,7 @@ func (r *Registry) AdaptRequest(body []byte, source, target Format) ([]byte, err
 		}
 		return nil, fmt.Errorf("adapter request decode (%s): %w", source, err)
 	}
+	dropRequestExtensionsForCrossFormat(source, target, canonical)
 
 	out, err := dstAdapter.EncodeRequest(canonical)
 	if err != nil {
@@ -283,16 +288,21 @@ func (r *Registry) AdaptStreamChunk(chunk []byte, source, target Format) ([][]by
 }
 
 // ShouldPassthroughSameWireFormat reports whether request/response bodies can be
-// forwarded without canonical adaptation. Groq is OpenAI-compatible but not
-// identical (e.g. x_groq), so openai↔groq still goes through the adapter.
+// forwarded without canonical adaptation. Groq and OpenRouter are OpenAI-compatible
+// but not identical, so openai↔groq/openrouter still goes through the adapter.
 func ShouldPassthroughSameWireFormat(source, target Format) bool {
 	if !IsSameWireFormat(source, target) {
 		return false
 	}
-	if source != target && (source == FormatGroq || target == FormatGroq) {
+	if source != target && formatUsesExtensionAdapter(source, target) {
 		return false
 	}
 	return true
+}
+
+func formatUsesExtensionAdapter(source, target Format) bool {
+	return source == FormatGroq || target == FormatGroq ||
+		source == FormatOpenRouter || target == FormatOpenRouter
 }
 
 func dropProviderExtensionsForCrossFormat(source, target Format, resp *CanonicalResponse) {
@@ -310,5 +320,14 @@ func dropStreamProviderExtensionsForCrossFormat(source, target Format, chunk *Ca
 	}
 	if source != target {
 		chunk.ProviderExtensions = nil
+	}
+}
+
+func dropRequestExtensionsForCrossFormat(source, target Format, req *CanonicalRequest) {
+	if req == nil {
+		return
+	}
+	if source != target {
+		req.RequestExtensions = nil
 	}
 }

--- a/pkg/infra/providers/client.go
+++ b/pkg/infra/providers/client.go
@@ -35,6 +35,7 @@ const (
 	ProviderMistral          = provider.Mistral
 	ProviderGroq             = provider.Groq
 	ProviderDeepSeek         = provider.DeepSeek
+	ProviderOpenRouter       = provider.OpenRouter
 )
 
 type Config struct {

--- a/pkg/infra/providers/factory/locator.go
+++ b/pkg/infra/providers/factory/locator.go
@@ -26,6 +26,7 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/groq"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/mistral"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/openai"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/openrouter"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/openaicompat"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/vertex"
 )
@@ -43,6 +44,7 @@ const (
 	ProviderMistral          = providers.ProviderMistral
 	ProviderGroq             = providers.ProviderGroq
 	ProviderDeepSeek         = providers.ProviderDeepSeek
+	ProviderOpenRouter       = providers.ProviderOpenRouter
 )
 
 //go:generate mockery --name=ProviderLocator --dir=. --output=./mocks --filename=provider_locator_mock.go --case=underscore --with-expecter
@@ -73,6 +75,7 @@ func NewProviderLocator() ProviderLocator {
 			ProviderMistral:          mistral.NewMistralClient(),
 			ProviderGroq:             groq.NewGroqClient(),
 			ProviderDeepSeek:         deepseek.NewDeepSeekClient(),
+			ProviderOpenRouter:       openrouter.NewOpenRouterClient(),
 			ProviderVertex:           vertex.NewVertexClient(),
 		},
 	}

--- a/pkg/infra/providers/factory/locator_test.go
+++ b/pkg/infra/providers/factory/locator_test.go
@@ -35,6 +35,7 @@ func TestProviderLocator_Get(t *testing.T) {
 		ProviderMistral,
 		ProviderGroq,
 		ProviderDeepSeek,
+		ProviderOpenRouter,
 	} {
 		t.Run(provider, func(t *testing.T) {
 			client, err := locator.Get(provider)

--- a/pkg/infra/providers/openrouter/client.go
+++ b/pkg/infra/providers/openrouter/client.go
@@ -1,0 +1,52 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openrouter
+
+import (
+	"context"
+	"iter"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/openai"
+)
+
+const chatCompletionsURL = "https://openrouter.ai/api/v1/chat/completions"
+
+type client struct {
+	chat *openai.ChatCompletionsClient
+}
+
+// NewOpenRouterClient builds an OpenRouter chat-completions client.
+func NewOpenRouterClient() providers.Client {
+	return &client{
+		chat: openai.NewChatCompletionsClient(providers.ProviderOpenRouter, nil),
+	}
+}
+
+func (c *client) Completions(
+	ctx context.Context,
+	config *providers.Config,
+	reqBody []byte,
+) ([]byte, error) {
+	return c.chat.Completions(ctx, chatCompletionsURL, config, reqBody, nil)
+}
+
+func (c *client) CompletionsStream(
+	ctx context.Context,
+	config *providers.Config,
+	reqBody []byte,
+) (iter.Seq2[[]byte, error], error) {
+	return c.chat.CompletionsStream(ctx, chatCompletionsURL, config, reqBody, nil)
+}

--- a/pkg/infra/providers/openrouter/client_test.go
+++ b/pkg/infra/providers/openrouter/client_test.go
@@ -1,0 +1,143 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openrouter
+
+import (
+	"context"
+	"encoding/json"
+	"iter"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/openai"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type openRouterClientAt struct {
+	chat *openai.ChatCompletionsClient
+	url  string
+}
+
+func newOpenRouterClientAt(url string) providers.Client {
+	return &openRouterClientAt{
+		chat: openai.NewChatCompletionsClient(providers.ProviderOpenRouter, nil),
+		url:  url,
+	}
+}
+
+func (c *openRouterClientAt) Completions(ctx context.Context, config *providers.Config, reqBody []byte) ([]byte, error) {
+	return c.chat.Completions(ctx, c.url, config, reqBody, nil)
+}
+
+func (c *openRouterClientAt) CompletionsStream(ctx context.Context, config *providers.Config, reqBody []byte) (iter.Seq2[[]byte, error], error) {
+	return c.chat.CompletionsStream(ctx, c.url, config, reqBody, nil)
+}
+
+func TestNewOpenRouterClient(t *testing.T) {
+	assert.NotNil(t, NewOpenRouterClient())
+}
+
+func TestCompletions_MissingAPIKey(t *testing.T) {
+	_, err := NewOpenRouterClient().Completions(context.Background(), &providers.Config{}, []byte(`{}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "API key is required")
+}
+
+func TestCompletions_NonStreamingRoundTrip(t *testing.T) {
+	const wantModel = "anthropic/claude-sonnet-4"
+	var gotAuth, gotModel string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		gotAuth = r.Header.Get("Authorization")
+
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		gotModel, _ = body["model"].(string)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"model":    wantModel,
+			"provider": "Anthropic",
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	resp, err := newOpenRouterClientAt(srv.URL+"/chat/completions").Completions(
+		context.Background(),
+		&providers.Config{Credentials: providers.Credentials{ApiKey: "or-test-key"}},
+		[]byte(`{"model":"`+wantModel+`","messages":[{"role":"user","content":"hello"}]}`),
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Bearer or-test-key", gotAuth)
+	assert.Equal(t, wantModel, gotModel)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(resp, &parsed))
+	assert.Equal(t, wantModel, parsed["model"])
+	assert.Equal(t, "Anthropic", parsed["provider"])
+}
+
+func TestCompletionsStream_RoundTrip(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer or-key", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	t.Cleanup(srv.Close)
+
+	seq, err := newOpenRouterClientAt(srv.URL+"/chat/completions").CompletionsStream(
+		context.Background(),
+		&providers.Config{Credentials: providers.Credentials{ApiKey: "or-key"}},
+		[]byte(`{"model":"anthropic/claude-sonnet-4","stream":true}`),
+	)
+	require.NoError(t, err)
+
+	var lines []string
+	for line, lerr := range seq {
+		require.NoError(t, lerr)
+		lines = append(lines, string(line))
+	}
+	require.NotEmpty(t, lines)
+	assert.Equal(t, `data: {"choices":[{"delta":{"content":"hi"}}]}`, lines[0])
+	assert.Equal(t, `data: [DONE]`, lines[len(lines)-1])
+}
+
+func TestCompletions_RateLimitRetryAfter(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "2")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"rate limit exceeded"}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := newOpenRouterClientAt(srv.URL+"/chat/completions").Completions(
+		context.Background(),
+		&providers.Config{Credentials: providers.Credentials{ApiKey: "key"}},
+		[]byte(`{"model":"anthropic/claude-sonnet-4","messages":[{"role":"user","content":"hi"}]}`),
+	)
+	require.Error(t, err)
+
+	be, ok := registry.IsBackendError(err)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusTooManyRequests, be.StatusCode)
+	assert.Equal(t, "2", be.RetryAfter)
+}

--- a/pkg/infra/providers/openrouter/connection.go
+++ b/pkg/infra/providers/openrouter/connection.go
@@ -1,0 +1,27 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openrouter
+
+import (
+	"context"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+)
+
+const modelsURL = "https://openrouter.ai/api/v1/models"
+
+func (c *client) TestConnection(ctx context.Context, config *providers.Config) providers.ProbeResult {
+	return providers.RunBearerGETProbe(ctx, providers.ProviderOpenRouter, modelsURL, config.Credentials.ApiKey)
+}

--- a/pkg/infra/providers/openrouter/connection_test.go
+++ b/pkg/infra/providers/openrouter/connection_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openrouter
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+	"github.com/stretchr/testify/assert"
+)
+
+type openRouterProbeAt struct {
+	modelsURL string
+}
+
+func (c *openRouterProbeAt) TestConnection(ctx context.Context, config *providers.Config) providers.ProbeResult {
+	return providers.RunBearerGETProbe(ctx, providers.ProviderOpenRouter, c.modelsURL, config.Credentials.ApiKey)
+}
+
+func TestTestConnection_OK(t *testing.T) {
+	var gotAuth, gotPath, gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	got := (&openRouterProbeAt{modelsURL: srv.URL}).TestConnection(context.Background(), &providers.Config{
+		Credentials: providers.Credentials{ApiKey: "or-test"},
+	})
+
+	assert.True(t, got.OK)
+	assert.Equal(t, providers.StageAuthentication, got.Stage)
+	assert.Equal(t, "Bearer or-test", gotAuth)
+	assert.Equal(t, "/", gotPath)
+	assert.Equal(t, http.MethodGet, gotMethod)
+}
+
+func TestTestConnection_MissingAPIKey(t *testing.T) {
+	got := NewOpenRouterClient().(interface {
+		TestConnection(context.Context, *providers.Config) providers.ProbeResult
+	}).TestConnection(context.Background(), &providers.Config{})
+
+	assert.False(t, got.OK)
+	assert.Equal(t, providers.StageAuthentication, got.Stage)
+}
+
+func TestTestConnection_AuthFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(srv.Close)
+
+	got := (&openRouterProbeAt{modelsURL: srv.URL}).TestConnection(context.Background(), &providers.Config{
+		Credentials: providers.Credentials{ApiKey: "or-bad"},
+	})
+	assert.False(t, got.OK)
+}


### PR DESCRIPTION
## Summary
- Register `openrouter` as a first-class TrustGate provider (client, connection probe, factory locator, catalog seed).
- Add `OpenRouterAdapter` preserving routing extension fields (`provider`, `models`, `transforms`, `route`) on same-format round-trips and stripping them on cross-format adaptation.
- Add httptest smoke coverage for sync/stream, connection probe, and adapter extension behavior.

## Linear
RUN-252 — https://linear.app/neuraltrust/issue/RUN-252/featprovider-openrouter-llm-provider
RUN-922, RUN-261, RUN-924

## Test plan
- [x] `go test ./pkg/infra/providers/openrouter/... ./pkg/infra/providers/adapter/... -race`
- [x] `go test ./pkg/app/catalog/... ./pkg/infra/providers/factory/... -race`
- [ ] CI green