### PR TITLE
fix: TrustGate dashboard admin JWT tenant_id claim

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -14,5 +14,6 @@ PROXY_API_URL=http://localhost:8081
 SERVER_SECRET_KEY=change-me-to-a-32-byte-random-secret-value
 
 # Optional JWT claims forwarded to the admin API.
-# ADMIN_TEAM_ID=
+# ADMIN_TENANT_ID=   # preferred; workspace / team id
+# ADMIN_TEAM_ID=     # legacy alias for ADMIN_TENANT_ID
 # ADMIN_USER_ID=

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -28,7 +28,8 @@ Copy `.env.example` to `.env.local` for local development:
 | ------------------- | -------- | --------------------------------------------------------------------------- |
 | `SERVER_SECRET_KEY` | yes      | HS256 secret used to sign admin JWTs. **Must match the admin server's key.** |
 | `ADMIN_API_URL`     | no       | Admin API base URL. Defaults to `http://localhost:8080`.                    |
-| `ADMIN_TEAM_ID`     | no       | Optional `team_id` claim forwarded to the admin API.                        |
+| `ADMIN_TENANT_ID` | no       | Optional `tenant_id` claim forwarded to the admin API. |
+| `ADMIN_TEAM_ID`   | no       | Legacy alias for `ADMIN_TENANT_ID`.                      |
 | `ADMIN_USER_ID`     | no       | Optional `user_id` claim forwarded to the admin API.                        |
 
 ## Local development

--- a/frontend/src/lib/jwt.ts
+++ b/frontend/src/lib/jwt.ts
@@ -23,7 +23,10 @@ export async function mintAdminToken(): Promise<string> {
   }
 
   const claims: Record<string, string> = {};
-  if (process.env.ADMIN_TEAM_ID) claims.team_id = process.env.ADMIN_TEAM_ID;
+  const tenantId =
+    process.env.ADMIN_TENANT_ID?.trim() ||
+    process.env.ADMIN_TEAM_ID?.trim();
+  if (tenantId) claims.tenant_id = tenantId;
   if (process.env.ADMIN_USER_ID) claims.user_id = process.env.ADMIN_USER_ID;
 
   const expiresAt = now + TOKEN_TTL_SECONDS;


### PR DESCRIPTION
## Summary
- Dashboard BFF (`frontend/src/lib/jwt.ts`) now emits `tenant_id` instead of `team_id`, matching TrustGate `jwt.Claims`.
- `ADMIN_TEAM_ID` remains supported as a legacy alias for `ADMIN_TENANT_ID`.

## Context
TrustGuard admin API requires `tenant_id` (fixed in app PR #2679). TrustGate admin auth decodes `tenant_id` optionally; this aligns naming for future tenant scoping.

## Test plan
- [ ] Dashboard BFF can still proxy `/api/admin/*` with existing `ADMIN_TEAM_ID` env
- [ ] Optional: set `ADMIN_TENANT_ID` and confirm claim in decoded JWT