### PR TITLE
feat: Tier 1 LLM providers batch (Cerebras, OpenRouter, Cohere)

### DIFF
--- a/docs/sdd/cohere-llm-provider/explore.md
+++ b/docs/sdd/cohere-llm-provider/explore.md
@@ -1,0 +1,245 @@
+## Exploration: Cohere LLM provider (RUN-925)
+
+### Current State
+
+TrustGate routes LLM traffic through a single catch-all proxy (`pkg/server/router/proxy_router.go` → `ForwardedHandler.Handle`). Supported **fixed chat routes** are resolved in `pkg/api/resolver/proxy_path_resolver.go`:
+
+| Gateway path | Source format | Upstream pattern |
+|---|---|---|
+| `/{slug}/v1/chat/completions` | `openai` | Provider-specific chat URL |
+| `/{slug}/v1/messages` | `anthropic` | Anthropic Messages API |
+| `/{slug}/v1/responses` | `openai_responses` | OpenAI Responses API |
+| `/{slug}/v1beta/models/{model}:generateContent` | `google` | Gemini |
+
+**`/v1/embeddings` is not a supported proxy route** — functional test `TestProxyPaths_FixedRoutes` asserts it returns **404** (`tests/functional/payload_normalization_test.go`). **Rerank does not exist** anywhere in the codebase (no routes, adapters, or clients).
+
+Provider wiring follows a consistent hexagonal pattern:
+
+1. **Constants & validation** — `pkg/infra/providers/client.go` (`ProviderX`, `SupportedProviders`, `IsValidProvider`); registry validation in `pkg/domain/registry/llm_target.go`.
+2. **HTTP client** — `pkg/infra/providers/{provider}/client.go` implementing `providers.Client` (`Completions`, `CompletionsStream`).
+3. **Connection test** — `pkg/infra/providers/{provider}/connection.go` implementing `providers.ConnectionTester` via `RunBearerGETProbe` / `RunAPIKeyGETProbe`.
+4. **Factory** — `pkg/infra/providers/factory/locator.go` maps provider name → client singleton.
+5. **Format adapter** — `pkg/infra/providers/adapter/{provider}_adapter.go` registered in `adapter/registry.go`.
+6. **Format resolution** — `adapter/format.go` (`ResolveTargetFormat`, `ResolveAgentFormat`, `SupportedSourceFormat`).
+7. **Invocation** — `pkg/app/proxy/provider.go` (`providerInvoker.prepare`) adapts request/response/stream via canonical model.
+8. **Catalog seed** — `pkg/app/catalog/sync.go` (`seedProviders`, `modelsDevProviderToCode`).
+9. **DI** — `pkg/container/modules/providers.go`, `proxy.go`.
+
+**Reference implementations for Cohere:**
+
+| Pattern | Provider | Notes |
+|---|---|---|
+| Native non-OpenAI API | **Anthropic** | Raw POST to fixed URL; `AnthropicAdapter` (~800 LOC + tests); client mirrors mistral HTTP pool pattern |
+| OpenAI-wire reuse | **Groq** | Delegates to `openai.ChatCompletionsClient`; `OpenAIAdapter` registered as `FormatGroq` |
+| OpenAI-wire + tweaks | **Mistral** | Own HTTP client + `MistralAdapter` wrapping `OpenAIAdapter` |
+| Embeddings (internal only) | **OpenAI** | `pkg/infra/embedding/openai/creator.go` — used by semantic-cache plugin, **not** exposed as gateway proxy |
+
+There is **no Cohere code** in the worktree today. `normalize.go` mentions Cohere only in a comment about OpenAI SDK compatibility.
+
+### Affected Areas
+
+#### Chat (sync + stream) — required
+
+| File / area | Why |
+|---|---|
+| `pkg/infra/providers/client.go` | Add `ProviderCohere = "cohere"` to constants, `SupportedProviders`, `IsValidProvider` |
+| `pkg/infra/providers/cohere/client.go` | **New** — POST `https://api.cohere.com/v2/chat`; Bearer auth; sync + SSE stream via `providers.StreamResponse` |
+| `pkg/infra/providers/cohere/connection.go` | **New** — probe (likely GET models or minimal POST); `RunBearerGETProbe` pattern like groq/mistral |
+| `pkg/infra/providers/cohere/client_test.go` | **New** — httptest round-trips (follow `groq/client_test.go`, `anthropic/client_test.go`) |
+| `pkg/infra/providers/cohere/connection_test.go` | **New** — probe classification tests |
+| `pkg/infra/providers/factory/locator.go` | Register `cohere.NewCohereClient()` |
+| `pkg/infra/providers/factory/locator_test.go` | Add `ProviderCohere` case |
+| `pkg/infra/providers/adapter/format.go` | Add `FormatCohere`; extend `ResolveTargetFormat`, `ResolveAgentFormat`, `SupportedSourceFormat` |
+| `pkg/infra/providers/adapter/cohere_adapter.go` | **New** — native v2 chat ↔ canonical (messages, tools, stream events) |
+| `pkg/infra/providers/adapter/cohere_adapter_test.go` | **New** — roundtrip + cross-format tests (pattern: `anthropic_adapter_test.go`) |
+| `pkg/infra/providers/adapter/registry.go` | `r.Register(FormatCohere, &CohereAdapter{})` |
+| `pkg/app/proxy/provider.go` | Add `FormatCohere` to `injectStreamTrue` list in `InvokeStream` if Cohere uses `stream` boolean |
+| `pkg/api/resolver/proxy_path_resolver.go` | Add fixed route for Cohere native client (proposed: `RouteChatV2 = "/v2/chat"` → `FormatCohere`) |
+| `pkg/api/resolver/proxy_path_resolver_test.go` | Route + unknown-route cases |
+| `pkg/app/catalog/sync.go` | Seed provider + optional `modelsDevProviderToCode` entry |
+| `pkg/domain/registry/llm_target.go` | Automatic via `IsValidProvider` once constant added |
+| `pkg/container/modules/providers.go` | No change if locator handles registration |
+
+#### Embeddings proxy — new capability (not just provider client)
+
+| File / area | Why |
+|---|---|
+| `pkg/api/resolver/proxy_path_resolver.go` | Add `RouteEmbeddings = "/v1/embeddings"` with source format (likely `openai_embeddings` or reuse `openai`) |
+| `pkg/app/proxy/` | **New or extended forwarder** — current `providers.Client` only supports chat completions; embeddings need `Embed(ctx, cfg, body)` or a dedicated `EmbeddingInvoker` |
+| `pkg/infra/providers/cohere/embed.go` (or `client_embed.go`) | POST `https://api.cohere.com/v2/embed` |
+| `pkg/infra/providers/adapter/cohere_embed_adapter.go` | OpenAI `/v1/embeddings` ↔ Cohere v2 embed schema |
+| `pkg/infra/embedding/cohere/creator.go` | Optional — for semantic-cache internal use mirroring openai embedding package |
+| `pkg/container/modules/loadbalancer.go` | Register cohere embedding creator if semantic-cache should use Cohere backends |
+| `tests/functional/` | **New** embed proxy e2e (currently only 404 test exists) |
+
+#### Rerank proxy — greenfield
+
+| File / area | Why |
+|---|---|
+| `pkg/api/resolver/proxy_path_resolver.go` | Add `RouteRerank = "/v1/rerank"` (or `/v2/rerank`) — **no prior art** |
+| `pkg/infra/providers/cohere/rerank.go` | POST `https://api.cohere.com/v2/rerank` |
+| `pkg/infra/providers/adapter/cohere_rerank_adapter.go` | Gateway request/response shape TBD |
+| `pkg/app/proxy/` | Same capability-gap as embeddings — needs non-chat forward path |
+| `tests/functional/` | **New** rerank e2e |
+
+#### Catalog / admin / docs
+
+| File / area | Why |
+|---|---|
+| `pkg/app/catalog/sync.go` | Manual seed for Cohere models + capabilities (`chat`, `embed`, `rerank`) when models.dev lacks Cohere |
+| `pkg/infra/database/migrations/` | Possible migration to upsert Cohere catalog rows if not relying solely on sync |
+| `docs/docs.go` / swagger | New proxy routes if OpenAPI is regenerated |
+| `postman/TrustGate.postman_collection.json` | Example requests (optional) |
+
+#### Out of scope (TrustGate worktree) but epic-linked
+
+- **App v2 registry** — separate repo (`app`); TrustGate exposes `/v1/providers-catalog` consumed by App v2
+
+### Provider Wiring Comparison (existing)
+
+```
+Client request → ResolveProxyPath (source format)
+              → Forwarder (routing, plugins, model policy)
+              → ProviderInvoker.prepare
+                   ├─ locator.Get(provider)
+                   ├─ AdaptRequest(source → target)  [if cross-format]
+                   ├─ NormalizeRequestForProvider
+                   └─ EnforceModel
+              → client.Completions / CompletionsStream
+              → AdaptResponse / AdaptStreamChunk (if cross-format)
+```
+
+- **Groq**: OpenAI wire end-to-end; `FormatGroq` uses `OpenAIAdapter` with Groq-specific normalization.
+- **Mistral**: OpenAI wire; custom HTTP client + `MistralAdapter` ID/tool fixes.
+- **Anthropic**: Native `/v1/messages` wire; dedicated client + large `AnthropicAdapter`; cross-format from `/v1/chat/completions` supported.
+
+**Cohere (ticket constraint: native v2, not OpenAI-compatible)** aligns with **Anthropic**, not Groq.
+
+### Approaches
+
+#### 1. Full native stack (Anthropic-style) — **recommended**
+
+Add `cohere` provider package + `CohereAdapter` + `/v2/chat` gateway route. Cross-format adaptation allows OpenAI clients on `/v1/chat/completions` to reach Cohere backends.
+
+- **Pros**: Matches RUN-925 "native Chat API v2"; reuses proven adapter/invoker pipeline; supports `@cohere/model` routing intent; sync + stream in one flow.
+- **Cons**: Largest adapter surface (Cohere v2 message/tool/stream semantics); ~800–1200 LOC for adapter + tests alone.
+- **Effort**: High
+
+#### 2. OpenAI-compatible shim (reject per ticket)
+
+Point Cohere at an OpenAI-compat endpoint or treat as `openai_compatible`.
+
+- **Pros**: Minimal code (groq-like).
+- **Cons**: **Violates ticket** — Cohere v2 chat is not OpenAI-compatible; wrong tool/message/stream mapping.
+- **Effort**: Low (but invalid)
+
+#### 3. Embeddings/rerank as opaque pass-through proxy
+
+Add routes that inject Bearer token and forward body to Cohere with **no** canonical adaptation (provider registry must be `cohere`).
+
+- **Pros**: Fast to ship; smaller diff.
+- **Cons**: Clients must speak Cohere-native JSON on gateway paths; breaks OpenAI SDK expectations for `/v1/embeddings`.
+- **Effort**: Medium
+
+#### 4. Embeddings/rerank with format adapters (recommended for acceptance criteria)
+
+Extend proxy with capability-aware invoker: OpenAI-shaped `/v1/embeddings` ↔ Cohere `/v2/embed`; gateway `/v1/rerank` ↔ Cohere `/v2/rerank`.
+
+- **Pros**: Matches "proxied through gateway" with usable client ergonomics; consistent with chat adaptation philosophy.
+- **Cons**: Requires new abstractions beyond `providers.Client`; touches resolver, forwarder, invoker; no existing rerank pattern.
+- **Effort**: High
+
+#### 5. Chained PRs (delivery strategy)
+
+Split given 400-line review budget:
+
+| PR | Scope | Est. lines |
+|---|---|---|
+| PR-1 | Chat: provider client, adapter, locator, `/v2/chat`, connection test, unit tests | ~600–900 |
+| PR-2 | Embeddings: route, embed client, adapter, functional test | ~350–500 |
+| PR-3 | Rerank: route, client, adapter, catalog seed, functional test | ~300–450 |
+
+- **Pros**: Reviewable slices; incremental merge risk.
+- **Cons**: Integration testing spans PRs; catalog incomplete until PR-3.
+- **Effort**: Medium (coordination)
+
+### Recommendation
+
+**Approach 1 + 4 + 5**: Implement Cohere as a first-class native provider (Anthropic pattern) for chat, add format adapters for embeddings and rerank proxy routes, and ship as **3 chained PRs**.
+
+**Chat implementation sketch:**
+
+1. `pkg/infra/providers/cohere/` — `client.go` (v2/chat), `connection.go` (Bearer probe to `GET https://api.cohere.com/v1/models` or v2-compatible endpoint — **verify at design time**).
+2. `CohereAdapter` — map Cohere v2 `messages`/`tools`/`stream` events ↔ `CanonicalRequest`/`CanonicalResponse`/`CanonicalStreamChunk`.
+3. Register `FormatCohere`; add proxy route `/v2/chat`.
+4. Wire `ResolveAgentFormat("cohere", …) → FormatCohere`.
+5. Allow cross-format: OpenAI `/v1/chat/completions` → Cohere backend (primary consumer path).
+
+**Embeddings/rerank:**
+
+1. Introduce `Capability` dimension on proxy routes (chat | embed | rerank) or separate handlers sharing auth/routing.
+2. Add `/v1/embeddings` and `/v1/rerank` to `proxy_path_resolver.go`.
+3. Implement Cohere embed/rerank HTTP calls + adapters (OpenAI embed shape in; Cohere native out).
+4. Catalog: seed Cohere provider (`wire_format: cohere`) and models with `capabilities: {chat, embed, rerank}` — manual seed in `sync.go` if models.dev has no `cohere` key.
+
+### Connection Testing
+
+Follow existing pattern:
+
+```go
+// groq/connection.go — Bearer GET /models
+func (c *client) TestConnection(ctx context.Context, config *providers.Config) providers.ProbeResult {
+    return providers.RunBearerGETProbe(ctx, providers.ProviderCohere, modelsURL, config.Credentials.ApiKey)
+}
+```
+
+Admin path: `TestRegistryConnection` handler → `locator.GetTester(provider)` (`pkg/server/router/admin_router.go`). Cohere client must implement `ConnectionTester` on the same struct as `Client` (embedded pattern used by groq, anthropic, mistral).
+
+### Test Patterns
+
+| Layer | Pattern | Reference files |
+|---|---|---|
+| Unit — client | httptest server, assert headers/body/status | `groq/client_test.go`, `mistral/client_test.go` |
+| Unit — connection | Mock HTTP status → `ProbeResult` stage | `openai/connection_test.go`, `connection_tester_test.go` |
+| Unit — adapter | JSON fixtures, canonical roundtrip, cross-format | `anthropic_adapter_test.go`, `mistral_adapter_test.go` |
+| Unit — invoker | Mock locator, assert adapt + enforce model | `provider_invoker_test.go` |
+| Unit — locator | Table of provider names | `factory/locator_test.go` |
+| Functional | `fakeUpstream` + admin API setup + `proxyPost` | `routing_intent_test.go`, `payload_normalization_test.go` |
+| Functional — embed | **New** — assert `/v1/embeddings` returns 200 (today expects 404) | `payload_normalization_test.go` (invert case) |
+
+Run tests: `go test ./pkg/infra/providers/cohere/...`, `go test ./pkg/infra/providers/adapter/...`, `go test -tags=functional ./tests/functional/...`
+
+### Risks
+
+- **Scope vs. 400-line PR budget** — chat adapter alone likely exceeds budget; chained PRs mandatory.
+- **Embeddings/rerank require new proxy capability** — `providers.Client` is chat-only; forwarder/invoker must grow or split.
+- **Cohere v2 stream format** — SSE event shapes differ from OpenAI; adapter complexity similar to Anthropic multi-line SSE.
+- **Model catalog** — `models.dev` mapping has no `cohere` entry today; manual seed + capabilities metadata required for App v2 epic criterion.
+- **Open questions block design** — client wire format for embed/rerank routes (see below).
+- **Tool calling / message roles** — Cohere v2 semantics may not map 1:1 to canonical model; expect edge-case normalization.
+- **App v2** — out of TrustGate worktree; catalog API must expose capabilities but UI work is separate.
+
+### Open Questions
+
+| # | Question | Code hint |
+|---|---|---|
+| 1 | Gateway chat route: `/v2/chat` only, or also require `/v1/chat/completions` cross-format? | Anthropic uses `/v1/messages` native + cross-format from OpenAI route |
+| 2 | Connection probe URL — Cohere v1 `/models` vs v2 health endpoint? | groq uses `GET /openai/v1/models` |
+| 3 | Embeddings gateway wire: OpenAI `/v1/embeddings` JSON in, OpenAI JSON out? | Acceptance says "proxied" — likely OpenAI-compatible facade |
+| 4 | Rerank gateway path and wire format? | No existing route; propose `/v1/rerank` with Cohere-native or thin wrapper |
+| 5 | Should semantic-cache plugin get `embedding/cohere` creator? | Only if Cohere registries used with semantic cache |
+| 6 | models.dev sync for Cohere models or static seed only? | `modelsDevProviderToCode` has no `cohere` key |
+| 7 | Catalog `capabilities` JSON schema for embed/rerank models? | `domain/catalog.Model.Capabilities map[string]any` — schema undefined in code |
+| 8 | Epic "App v2 registry complete" — TrustGate-only seed sufficient? | Confirm with App v2 team |
+
+### Ready for Proposal
+
+**Yes** — exploration confirms feasibility via Anthropic-style native provider. Proposal should:
+
+1. Lock gateway routes (`/v2/chat`, `/v1/embeddings`, `/v1/rerank`).
+2. Decide embed/rerank wire formats (recommend OpenAI-shaped gateway facades).
+3. Confirm chained PR split (chat → embed → rerank + catalog).
+4. Resolve connection probe endpoint against Cohere docs.
+5. Scope App v2 catalog as TrustGate seed + API vs. separate ticket.
+
+**400-line budget forecast:** High — chained PRs recommended (`Decision needed before apply: Yes`, `Chained PRs recommended: Yes`, `400-line budget risk: High`).

--- a/docs/sdd/cohere-llm-provider/tasks.md
+++ b/docs/sdd/cohere-llm-provider/tasks.md
@@ -1,0 +1,141 @@
+# Tasks: Cohere LLM Provider (RUN-925)
+
+**Linear:** RUN-925 · **Branch:** `feat/cohere-llm-provider` · **Worktree:** TrustGate-cohere-llm-provider
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines (total) | 1250–1850 |
+| 400-line budget risk | High |
+| Chained PRs recommended | Yes |
+| Suggested split | PR-1 chat → PR-2 embeddings → PR-3 rerank+catalog |
+| Delivery strategy | auto-chain |
+| Chain strategy | stacked-to-main |
+
+Decision needed before apply: No
+Chained PRs recommended: Yes
+Chain strategy: stacked-to-main
+400-line budget risk: High
+
+### Suggested Work Units
+
+| Unit | Goal | Likely PR | Base branch | Est. lines |
+|------|------|-----------|-------------|------------|
+| 1 | Native v2 chat (sync+stream), connection test, cross-format from OpenAI | PR-1 | `main` | 600–900 |
+| 2 | `/v1/embeddings` proxy + Cohere v2 embed adapter | PR-2 | `main` (after PR-1) | 350–500 |
+| 3 | `/v1/rerank` proxy + catalog seed with capabilities | PR-3 | `main` (after PR-2) | 300–450 |
+
+**Out of scope (TrustGate):** App v2 registry UI — separate `app` repo ticket after catalog API exposes Cohere.
+
+**Artifact note:** Spec/design not in Engram; tasks derived from `explore.md` + RUN-925 acceptance criteria.
+
+---
+
+## Phase 1: PR-1 — Chat foundation (Work Unit 1)
+
+**Review Workload Forecast:** 180–250 lines · budget risk Medium · PR-1 slice 1/3
+
+**Files:** `pkg/infra/providers/client.go`, `pkg/infra/providers/cohere/client.go`, `pkg/infra/providers/cohere/connection.go`, `pkg/infra/providers/factory/locator.go`
+
+- [ ] 1.1 Add `ProviderCohere = "cohere"` to `pkg/infra/providers/client.go` (`SupportedProviders`, `IsValidProvider`)
+- [ ] 1.2 Create `pkg/infra/providers/cohere/client.go`: POST `https://api.cohere.com/v2/chat` sync + SSE stream (pattern: `anthropic/client.go`)
+- [ ] 1.3 Create `pkg/infra/providers/cohere/connection.go`: `TestConnection` via `RunBearerGETProbe` to `GET https://api.cohere.com/v1/models`
+- [ ] 1.4 Register `cohere.NewCohereClient()` in `pkg/infra/providers/factory/locator.go` (+ `ProviderCohere` alias)
+
+---
+
+## Phase 2: PR-1 — Chat adapter & routing (Work Unit 1)
+
+**Review Workload Forecast:** 350–500 lines · budget risk High · PR-1 slice 2/3
+
+**Files:** `pkg/infra/providers/adapter/format.go`, `cohere_adapter.go`, `registry.go`, `pkg/api/resolver/proxy_path_resolver.go`, `pkg/app/proxy/provider.go`, `pkg/app/catalog/sync.go`
+
+- [ ] 2.1 Add `FormatCohere` to `adapter/format.go`; extend `ResolveTargetFormat`, `ResolveAgentFormat`, `SupportedSourceFormat` for `cohere`
+- [ ] 2.2 Create `adapter/cohere_adapter.go`: Cohere v2 messages/tools/stream ↔ canonical (pattern: `anthropic_adapter.go`)
+- [ ] 2.3 Register `FormatCohere` in `adapter/registry.go`
+- [ ] 2.4 Add `RouteChatV2 = "/v2/chat"` → `FormatCohere` in `proxy_path_resolver.go` (+ resolver tests)
+- [ ] 2.5 Add `FormatCohere` to `injectStreamTrue` branch in `pkg/app/proxy/provider.go` if v2 uses `stream` boolean
+- [ ] 2.6 Seed Cohere provider row in `pkg/app/catalog/sync.go` (`wire_format: cohere`, `api_key` auth); no models.dev mapping
+
+---
+
+## Phase 3: PR-1 — Chat tests & ship (Work Unit 1)
+
+**Review Workload Forecast:** 120–180 lines · budget risk Low · PR-1 slice 3/3
+
+**Files:** `pkg/infra/providers/cohere/*_test.go`, `adapter/cohere_adapter_test.go`, `factory/locator_test.go`, `tests/functional/`, `openspec/changes/cohere-llm-provider-chat/`
+
+- [ ] 3.1 Unit tests: `cohere/client_test.go`, `connection_test.go` (httptest headers, status, body)
+- [ ] 3.2 Unit tests: `cohere_adapter_test.go` — same-format roundtrip, OpenAI→Cohere cross-format, stream chunks
+- [ ] 3.3 Update `factory/locator_test.go` and `validate_test.go` for `ProviderCohere`
+- [ ] 3.4 Functional: Cohere registry + sync+stream via `/{slug}/v2/chat`; cross-format via `/{slug}/v1/chat/completions`
+- [ ] 3.5 Add `openspec/changes/cohere-llm-provider-chat/proposal.md` (frontmatter: `linear: RUN-925`, `type: feat`)
+- [ ] 3.6 Verify: `go test -race ./pkg/infra/providers/cohere/... ./pkg/infra/providers/adapter/...`
+
+---
+
+## Phase 4: PR-2 — Embeddings capability (Work Unit 2)
+
+**Review Workload Forecast:** 280–400 lines · budget risk Medium · PR-2
+
+**Files:** `pkg/infra/providers/embed.go` (new interface), `cohere/embed.go`, `adapter/cohere_embed_adapter.go`, `proxy_path_resolver.go`, `pkg/app/proxy/embed_invoker.go`, `forwarder.go`, `factory/locator.go`
+
+- [ ] 4.1 Introduce `providers.Embedder` interface (`Embed(ctx, cfg, body) ([]byte, error)`) in `pkg/infra/providers/` (or `embed.go`)
+- [ ] 4.2 Create `cohere/embed.go`: POST `https://api.cohere.com/v2/embed` with Bearer auth
+- [ ] 4.3 Create `adapter/cohere_embed_adapter.go`: OpenAI `/v1/embeddings` request/response ↔ Cohere v2 embed
+- [ ] 4.4 Add `RouteEmbeddings = "/v1/embeddings"` → `FormatOpenAI` (embed source) in `proxy_path_resolver.go`
+- [ ] 4.5 Create `pkg/app/proxy/embed_invoker.go`: adapt request, enforce model, call `Embedder`, adapt response
+- [ ] 4.6 Wire embed path in `forwarder.go` (dispatch by route capability, not chat invoker)
+- [ ] 4.7 Extend `factory/locator.go` with `GetEmbedder("cohere")` returning cohere client
+
+---
+
+## Phase 5: PR-2 — Embeddings tests & ship (Work Unit 2)
+
+**Review Workload Forecast:** 80–120 lines · budget risk Low · PR-2
+
+**Files:** `adapter/cohere_embed_adapter_test.go`, `proxy_path_resolver_test.go`, `tests/functional/payload_normalization_test.go`, `openspec/changes/cohere-llm-provider-embed/`
+
+- [ ] 5.1 Unit tests: `cohere_embed_adapter_test.go` — model, input array, dimensions mapping
+- [ ] 5.2 Resolver tests: `/{slug}/v1/embeddings` resolves (no longer `ErrUnknownProxyPath`)
+- [ ] 5.3 Functional: Cohere target + `POST /{slug}/v1/embeddings` returns 200 with OpenAI-shaped response
+- [ ] 5.4 Update `TestProxyPaths_FixedRoutes` — embeddings 404 only when route unsupported, not when Cohere wired
+- [ ] 5.5 Add `openspec/changes/cohere-llm-provider-embed/proposal.md`
+- [ ] 5.6 Verify: `go test -race ./pkg/...` + `go test -tags=functional ./tests/functional/... -run Embeddings`
+
+---
+
+## Phase 6: PR-3 — Rerank & catalog (Work Unit 3)
+
+**Review Workload Forecast:** 220–320 lines · budget risk Medium · PR-3 slice 1/2
+
+**Files:** `cohere/rerank.go`, `adapter/cohere_rerank_adapter.go`, `adapter/format.go`, `proxy_path_resolver.go`, `pkg/app/proxy/rerank_invoker.go`, `forwarder.go`, `pkg/app/catalog/sync.go`
+
+- [ ] 6.1 Create `cohere/rerank.go`: POST `https://api.cohere.com/v2/rerank`
+- [ ] 6.2 Add gateway wire format constant (e.g. `FormatCohereRerank` or `FormatRerank`) and `RouteRerank = "/v1/rerank"` in resolver
+- [ ] 6.3 Create `adapter/cohere_rerank_adapter.go`: gateway rerank JSON ↔ Cohere v2 rerank
+- [ ] 6.4 Create `pkg/app/proxy/rerank_invoker.go` + `forwarder.go` dispatch (mirror embed invoker)
+- [ ] 6.5 Extend locator with `GetReranker("cohere")` or unified capability getter on cohere client
+- [ ] 6.6 Manual catalog seed in `sync.go`: Cohere models (`command-r-plus`, `embed-english-v3.0`, etc.) with `capabilities: {chat, embed, rerank}`
+
+---
+
+## Phase 7: PR-3 — Verification & changelog (Work Unit 3)
+
+**Review Workload Forecast:** 80–130 lines · budget risk Low · PR-3 slice 2/2
+
+**Files:** `*_test.go`, `tests/functional/`, `openspec/changes/cohere-llm-provider-rerank/`
+
+- [ ] 7.1 Unit tests: `cohere_rerank_adapter_test.go`, rerank client httptest
+- [ ] 7.2 Functional: `POST /{slug}/v1/rerank` through Cohere registry returns ranked results
+- [ ] 7.3 Catalog sync test: provider + model rows exist with expected capabilities
+- [ ] 7.4 Add `openspec/changes/cohere-llm-provider-rerank/proposal.md` (changelog entry for merge)
+- [ ] 7.5 Full verify: `go test -race ./...` and functional suite for chat+embed+rerank
+- [ ] 7.6 Confirm `/v1/providers-catalog` exposes Cohere for App v2 (manual smoke); file App v2 follow-up ticket
+
+---
+
+## Phase 8: App v2 registry (out of scope — separate repo)
+
+- [ ] 8.1 **Deferred:** App v2 provider picker + model capabilities UI in `app` repo (consumes TrustGate catalog API)

--- a/openspec/changes/cerebras-llm-provider/proposal.md
+++ b/openspec/changes/cerebras-llm-provider/proposal.md
@@ -1,0 +1,26 @@
+---
+linear: RUN-259
+type: feat
+changelog: "Add Cerebras as an OpenAI-compatible LLM provider with catalog sync and connection probe."
+---
+
+# Proposal: Cerebras LLM provider (RUN-251 / RUN-259)
+
+## Why
+
+Cerebras Inference exposes an OpenAI-compatible Chat Completions API. TrustGate needs
+first-class routing, catalog seeding from models.dev, and connection testing so registries
+can target Cerebras like Groq or DeepSeek.
+
+## What
+
+- `provider: cerebras` client at `https://api.cerebras.ai/v1`
+- GET `/v1/models` connection probe
+- Catalog seed + models.dev mapping (`cerebras` key)
+- FormatOpenAI wire passthrough (no dedicated adapter format)
+- httptest smoke tests for sync, stream, and rate-limit handling
+
+## Out of scope
+
+- App v2 registry UI (RUN-920, separate PR)
+- multi-agent matrix tests (RUN-260 canceled)

--- a/openspec/changes/cohere-llm-provider/proposal.md
+++ b/openspec/changes/cohere-llm-provider/proposal.md
@@ -1,0 +1,39 @@
+---
+linear: RUN-925
+type: feat
+changelog: "Add Cohere LLM provider with native v2 chat, embeddings, and rerank proxy routes."
+---
+
+# Proposal: Cohere LLM provider (RUN-925)
+
+## Why
+
+TrustGate needs first-class Cohere support so gateways can route native Cohere v2 chat, OpenAI-shaped embeddings, and rerank traffic through a single provider integration with catalog seeding for App v2.
+
+## What changes
+
+- **Provider client** (`pkg/infra/providers/cohere/`): sync chat, embeddings, rerank, and connection test against Cohere API.
+- **Adapters** (`pkg/infra/providers/adapter/cohere_*.go`): Cohere v2 chat, OpenAI embeddings ↔ Cohere embed, and rerank wire formats.
+- **Proxy routing** (`pkg/api/resolver/proxy_path_resolver.go`): `/v2/chat`, `/v1/embeddings`, `/v1/rerank` fixed routes with capability metadata.
+- **Provider invoker** (`pkg/app/proxy/provider.go`): capability-aware prepare/invoke for chat, embeddings, and rerank.
+- **Factory** (`pkg/infra/providers/factory/locator.go`): register `cohere.NewCohereClient()`.
+- **Catalog** (`pkg/app/catalog/sync.go`): seed Cohere provider and manual model rows with capabilities.
+
+## Behavior
+
+| Route | Source format | Cohere upstream |
+|-------|---------------|-----------------|
+| `/{slug}/v2/chat` | Cohere v2 chat | `POST /v2/chat` |
+| `/{slug}/v1/chat/completions` | OpenAI (cross-format) | `POST /v2/chat` |
+| `/{slug}/v1/embeddings` | OpenAI embeddings | `POST /v2/embed` |
+| `/{slug}/v1/rerank` | Cohere rerank | `POST /v2/rerank` |
+
+## Out of scope
+
+- App v2 registry UI for Cohere model capabilities (separate app repo ticket).
+
+## QA checklist
+
+- [ ] `go test ./pkg/infra/providers/... ./pkg/infra/providers/adapter/... ./pkg/api/resolver/... ./pkg/app/proxy/...`
+- [ ] `go test -tags=functional ./tests/functional/... -run CohereProvider`
+- [ ] Catalog sync exposes Cohere provider and seeded models with capabilities

--- a/openspec/changes/openrouter-llm-provider/design.md
+++ b/openspec/changes/openrouter-llm-provider/design.md
@@ -1,0 +1,113 @@
+# Design: OpenRouter LLM provider (RUN-252)
+
+## Technical Approach
+
+Add a first-class `openrouter` provider by mirroring the **groq** infra pattern: thin `pkg/infra/providers/openrouter/` client over `openai.ChatCompletionsClient`, factory locator wiring, `FormatOpenRouter` in the adapter layer, and catalog **seed-only** registration (no models.dev import). `@openrouter/vendor/model` routing already exists in `pkg/domain/routing/intent.go` and `pkg/app/proxy/routing.go`; this change completes registry CRUD, connection probe, proxy forwarding, and extension-aware adaptation.
+
+Hexagonal binding: **infra** owns HTTP client + format adapters; **app/catalog** owns provider seed + auth catalog; **domain** gains no new types (validates via `IsValidProvider`); wiring stays in `pkg/infra/providers/factory/locator.go`.
+
+## Architecture Decisions
+
+| Decision | Choice | Rejected | Rationale |
+|----------|--------|----------|-----------|
+| Client shape | Dedicated `openrouter` package (groq clone) | `openai_compatible` + `base_url` | Registry needs `provider: "openrouter"`; intent `@openrouter/...` must match; separate telemetry pool |
+| Adapter shape | `OpenRouterAdapter` wraps `OpenAIAdapter` (Mistral pattern) | Register bare `OpenAIAdapter` like groq | OpenRouter has request fields (`provider`, `models`, `transforms`, `route`), response metadata, and SSE comment keep-alives groq does not |
+| Request extensions | `RequestExtensions map[string]json.RawMessage` on `CanonicalRequest` | Typed fields only in `openaiRequest` | Four optional keys; map matches existing `ProviderExtensions` response pattern |
+| Wire passthrough | `normalizeFormat` → `openai`; `ShouldPassthroughSameWireFormat` forces adapter for openrouter↔openai | Always passthrough | Same lesson as groq/`x_groq`: wire-similar ≠ byte-identical |
+| Catalog models | Seed row only (`wire_format: openai`) | models.dev mapping | Prior OpenRouter catalog purged; free-form `vendor/model` slugs are runtime-only |
+| Optional headers | Defer `HTTP-Referer` / `X-Title` | v1 attribution headers | Not in codebase; `ChatCompletionsClient` custom headers can follow later |
+| Delivery | Three chained PRs: core → adapter → tests | Single PR | ~400-line review budget; slices align RUN-922 / RUN-261 / RUN-924 |
+
+## Data Flow
+
+### Sync completion
+
+```
+Client ──► Proxy forwarder ──► ResolveAgentFormat("openrouter") → FormatOpenRouter
+                │                        │
+                │              Registry.AdaptRequest(source → openrouter)
+                ▼                        ▼
+         applyIntentToBody          OpenRouterAdapter.EncodeRequest
+         (model = vendor/slug)              │
+                │                           ▼
+                └──────────► factory.Get("openrouter") ──► openrouter.client
+                                              │
+                                              ▼
+                              POST https://openrouter.ai/api/v1/chat/completions
+                                              │
+                ◄─────────────────────────────┘
+         Registry.AdaptResponse(openrouter → source) ──► Client
+```
+
+### Connection probe
+
+```
+Admin API ──► GetTester("openrouter") ──► RunBearerGETProbe
+                              GET https://openrouter.ai/api/v1/models
+```
+
+### Streaming (adapter slice)
+
+```
+openrouter SSE line ──► OpenRouterAdapter.DecodeStreamChunk
+         │                      │ skip lines starting with ":" (ping / processing)
+         │                      ▼
+         └────► OpenAIAdapter decode/encode ──► Registry.AdaptStreamChunk → client
+```
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `pkg/infra/providers/openrouter/client.go` | Create | `NewOpenRouterClient()`; `ChatCompletionsClient` → `https://openrouter.ai/api/v1/chat/completions` |
+| `pkg/infra/providers/openrouter/connection.go` | Create | `TestConnection` via `GET …/api/v1/models` + `RunBearerGETProbe` |
+| `pkg/infra/providers/openrouter/client_test.go` | Create | httptest sync/stream (copy `groq/client_test.go` + `openRouterClientAt`) |
+| `pkg/infra/providers/openrouter/connection_test.go` | Create | httptest probe success/failure |
+| `pkg/infra/providers/client.go` | Modify | `ProviderOpenRouter`; extend `SupportedProviders` / `IsValidProvider` |
+| `pkg/infra/providers/factory/locator.go` | Modify | Map `ProviderOpenRouter` → `openrouter.NewOpenRouterClient()` |
+| `pkg/infra/providers/factory/locator_test.go` | Modify | Assert openrouter in locator table |
+| `pkg/infra/providers/adapter/format.go` | Modify | `FormatOpenRouter`; `resolveProviderWireFormat`, `ResolveAgentFormat`, `SupportedSourceFormat`, `normalizeFormat` |
+| `pkg/infra/providers/adapter/openrouter_adapter.go` | Create | Wrap `OpenAIAdapter`; peel/merge request + response extensions; filter SSE comments |
+| `pkg/infra/providers/adapter/openrouter_adapter_test.go` | Create | Round-trip extensions; cross-format strip (mirror `groq_adapter_test.go`) |
+| `pkg/infra/providers/adapter/registry.go` | Modify | `Register(FormatOpenRouter, &OpenRouterAdapter{})`; extend `ShouldPassthroughSameWireFormat` |
+| `pkg/infra/providers/adapter/canonical.go` | Modify | Add `RequestExtensions` on `CanonicalRequest` |
+| `pkg/app/catalog/sync.go` | Modify | Seed `{ProviderOpenRouter, "OpenRouter", "openai"}`; **no** `modelsDevProviderToCode` entry |
+| `pkg/app/catalog/provider_auth.go` | Modify | `providerAuthCatalog[ProviderOpenRouter] = {apiKeyAuthOption}` |
+| `pkg/app/catalog/sync_test.go` | Modify | Seed count follows `len(seedProviders)` automatically |
+
+**Out of scope:** `pkg/domain/routing/intent.go`, models.dev sync, OpenRouter catalog API, attribution headers.
+
+## Interfaces / Contracts
+
+```go
+// pkg/infra/providers/client.go
+const ProviderOpenRouter = "openrouter"
+
+// pkg/infra/providers/adapter/format.go
+const FormatOpenRouter Format = "openrouter"
+
+// pkg/infra/providers/adapter/canonical.go
+type CanonicalRequest struct {
+    // ...existing fields...
+    RequestExtensions map[string]json.RawMessage `json:"request_extensions,omitempty"`
+}
+```
+
+OpenRouter request extension keys (preserve on openrouter round-trip, strip on cross-format): `provider`, `models`, `transforms`, `route`. Response keys land in `ProviderExtensions` (e.g. OpenRouter usage/provider metadata).
+
+## Testing Strategy
+
+| Layer | What | Approach |
+|-------|------|----------|
+| Unit | Client, probe, adapter | httptest; table-driven; `-race` |
+| Adapter | Extension round-trip + cross-format strip | Copy `groq_adapter_test.go` patterns |
+| Functional | `@openrouter/vendor/model` routing | Fake upstream; existing intent tests + new smoke |
+
+## Migration / Rollout
+
+No migration required. Catalog sync adds one provider row on next sync. Existing purged `source='openrouter'` model rows stay absent.
+
+## Open Questions
+
+- [ ] Exact OpenRouter response extension keys to preserve beyond usage (confirm against live API during RUN-261)
+- [ ] Whether SSE comment filtering belongs only in `OpenRouterAdapter.DecodeStreamChunk` or also in shared stream reader (default: adapter-only)

--- a/openspec/changes/openrouter-llm-provider/exploration.md
+++ b/openspec/changes/openrouter-llm-provider/exploration.md
@@ -1,0 +1,105 @@
+## Exploration: OpenRouter LLM provider (RUN-252)
+
+### Current State
+
+TrustGate routes LLM traffic through provider packages under `pkg/infra/providers/`, a factory locator, and format adapters. OpenAI-compatible providers (**groq**, **deepseek**) are the closest siblings: thin wrappers over `openai.ChatCompletionsClient` with a fixed endpoint, `RunBearerGETProbe` connection test, and a dedicated `Format*` in `adapter/format.go` registered in `adapter/registry.go`.
+
+**OpenRouter does not exist yet** — no `pkg/infra/providers/openrouter/`, no `ProviderOpenRouter` constant, no catalog seed row.
+
+**Routing intent for `@openrouter` is already implemented** in `pkg/domain/routing/intent.go`:
+- `@openrouter/anthropic/claude-sonnet-4` → `{Provider: "openrouter", Model: "anthropic/claude-sonnet-4"}`
+- Nested slashes preserved (test at `intent_test.go:36`)
+- `applyIntentToBody` in `pkg/app/proxy/routing.go` rewrites qualified intents to native `vendor/model` before upstream call
+- `CandidateSet.resolveQualified` filters by registry provider + allowlist
+
+**Catalog policy:** models sync from **models.dev only** (`pkg/app/catalog/sync.go`). A prior OpenRouter catalog was purged (`migrations/20260617000000_purge_openrouter_catalog.go`). OpenRouter gets a **provider seed row only** — no `modelsDevProviderToCode` entry.
+
+**Extension pattern (groq):** `x_groq` preserved via typed fields + `ProviderExtensions` in `openai_completions_adapter.go`; `ShouldPassthroughSameWireFormat` forces openai↔groq through adapter; cross-format strips extensions in `registry.go`.
+
+### Affected Areas
+
+#### RUN-922 — Core integration
+
+| File | Why |
+|------|-----|
+| `pkg/infra/providers/client.go` | Add `ProviderOpenRouter`, `SupportedProviders()`, `IsValidProvider()` |
+| `pkg/infra/providers/openrouter/client.go` | **New** — groq pattern: `ChatCompletionsClient` → `https://openrouter.ai/api/v1/chat/completions` |
+| `pkg/infra/providers/openrouter/connection.go` | **New** — `GET https://openrouter.ai/api/v1/models` probe |
+| `pkg/infra/providers/factory/locator.go` | Wire `openrouter.NewOpenRouterClient()` |
+| `pkg/infra/providers/factory/locator_test.go` | Assert openrouter in locator map |
+| `pkg/infra/providers/adapter/format.go` | `FormatOpenRouter`, `ResolveAgentFormat`, `SupportedSourceFormat`, `normalizeFormat` |
+| `pkg/app/catalog/sync.go` | Add to `seedProviders` (wire_format `openai`); **do not** add to `modelsDevProviderToCode` |
+| `pkg/app/catalog/provider_auth.go` | `providerAuthCatalog[ProviderOpenRouter] = {apiKeyAuthOption}` |
+| `pkg/app/catalog/sync_test.go` | Update expected seed count |
+| `pkg/domain/registry/llm_target.go` | Auto-validates via `IsValidProvider` (no direct edit if constant added) |
+
+**Not needed for RUN-922:** changes to `pkg/domain/routing/intent.go` (already supports `@openrouter/vendor/model`).
+
+#### RUN-261 — Adapter extensions
+
+| File | Why |
+|------|-----|
+| `pkg/infra/providers/adapter/openrouter_adapter.go` | **New** — wrap `OpenAIAdapter`; preserve OpenRouter request fields (`provider`, `models`, `transforms`, `route`) and response metadata |
+| `pkg/infra/providers/adapter/openrouter_adapter_test.go` | **New** — round-trip + cross-format strip (mirror `groq_adapter_test.go`) |
+| `pkg/infra/providers/adapter/registry.go` | `Register(FormatOpenRouter, &OpenRouterAdapter{})`; extend `ShouldPassthroughSameWireFormat` for openrouter↔openai |
+| `pkg/infra/providers/adapter/openai_completions_adapter.go` | Likely extend decode/encode for OpenRouter extension fields OR handle in dedicated adapter |
+| `pkg/infra/providers/adapter/canonical.go` | Possibly `RequestExtensions map[string]json.RawMessage` on `CanonicalRequest` if passthrough cannot use typed fields |
+| `pkg/infra/providers/stream.go` or adapter | Filter SSE comment lines (`: ping`, `: OPENROUTER PROCESSING`) before JSON decode |
+
+#### RUN-924 — Functional smoke tests
+
+| File | Why |
+|------|-----|
+| `pkg/infra/providers/openrouter/client_test.go` | httptest sync+stream (copy `groq/client_test.go` + `groqClientAt` pattern) |
+| `pkg/infra/providers/openrouter/connection_test.go` | httptest `TestConnection` |
+| `pkg/infra/providers/adapter/openrouter_adapter_test.go` | Extension round-trip, cross-format strip |
+| `tests/functional/routing_intent_test.go` or new `openrouter_*_test.go` | E2E `@openrouter/vendor/model` with fake upstream |
+
+#### Cross-cutting (verify after each slice)
+
+| File | Why |
+|------|-----|
+| `pkg/infra/providers/validate.go` | No options validation needed (like groq/mistral) unless optional headers added later |
+| `pkg/api/handler/http/catalog/response/catalog_response.go` | Picks up auth via `ProviderAuthOptions` automatically |
+
+### Approaches
+
+| Approach | Pros | Cons | Effort |
+|----------|------|------|--------|
+| **A. Dedicated `openrouter` package + `FormatOpenRouter` adapter (groq model)** | First-class provider; extension preservation; matches epic + sub-issue split; catalog seed without models.dev pollution | More files than alias | **Medium** |
+| **B. Reuse `openai_compatible` with `base_url: https://openrouter.ai/api/v1`** | Zero new client code | No `provider:openrouter` in catalog/API; no extension adapter; routing intent `@openrouter/...` won't match registry provider; fails acceptance | Low |
+| **C. Extend `openai` client with OpenRouter endpoint flag** | Single client | Conflates providers; breaks locator/factory pattern; poor telemetry separation | Medium–High |
+
+### Recommendation
+
+**Approach A** — mirror **groq** for the HTTP client (`ChatCompletionsClient` + fixed URL) and **groq adapter tests** for extension round-trip / cross-format stripping. Use a dedicated `OpenRouterAdapter` (like `MistralAdapter` wraps `OpenAIAdapter`) for OpenRouter-specific request/response fields and SSE keep-alive filtering.
+
+**Implementation order:**
+1. **RUN-922** — unblocks registry creation, catalog listing, connection probe, basic sync/stream to OpenRouter
+2. **RUN-261** — required for extension field preservation and SSE keep-alive (acceptance criteria)
+3. **RUN-924** — httptest + functional smoke; can start unit tests in parallel with 261
+
+**PR strategy:** Three chained PRs aligned to RUN-922 → RUN-261 → RUN-924 (~400-line budget each). Total forecast **Medium–High** risk of exceeding single-PR budget.
+
+### Open Questions
+
+| Question | Resolution from code |
+|----------|---------------------|
+| Is `@openrouter/vendor/model` routing implemented? | **Yes** — `ParseModelRef` + `applyIntentToBody`; only missing `IsValidProvider("openrouter")` for registry CRUD |
+| Catalog models for OpenRouter? | **No** — seed provider only; no `modelsDevProviderToCode`; migration already purged old `source='openrouter'` rows |
+| Free-form `vendor/model` strings (app v2)? | Works when consumer has **no allowlist** (`Candidate.Allowed == nil` → `AllowsModel` returns true); qualified intent passes full slug via `OverrideModel` |
+| OpenRouter optional headers (`HTTP-Referer`, `X-Title`)? | **Not in codebase** — defer unless epic requires; could add via `ChatCompletionsClient` `customHeaders` later |
+| SSE `: ping` keep-alives? | **Not filtered today** — `StreamSSE` yields all lines; implement skip in `OpenRouterAdapter.DecodeStreamChunk` or proxy stream handler |
+| Request fields `provider`/`models`/`transforms`/`route`? | **Not in codebase** — RUN-261 must add (groq's `x_groq` / `ProviderExtensions` is the response-side pattern) |
+| Closest sibling? | **groq** (client) + **groq_adapter_test** (extensions); mistral only if tool-call ID normalization needed (unlikely for OpenRouter) |
+
+### Risks
+
+- OpenRouter response extensions may differ from groq's `x_groq` — adapter design must use flexible `ProviderExtensions` / `RequestExtensions` maps
+- SSE comment lines may break stream JSON parsing if not filtered before `DecodeStreamChunk`
+- Allowlisted consumers will reject unknown `vendor/model` slugs unless UI uses free-form (nil allowlist) or catalog picks models.dev slugs only
+- No openspec change folder existed before this explore artifact — proposal/spec phases should create full SDD tree
+
+### Ready for Proposal
+
+**Yes** — recommend `sdd-propose` with Approach A, three PR slices (RUN-922 / RUN-261 / RUN-924), and explicit out-of-scope: models.dev sync, OpenRouter catalog API, optional attribution headers (unless product requires in v1).

--- a/openspec/changes/openrouter-llm-provider/proposal.md
+++ b/openspec/changes/openrouter-llm-provider/proposal.md
@@ -1,0 +1,76 @@
+---
+linear: RUN-252
+type: feat
+changelog: "Add OpenRouter as a first-class LLM provider with groq-style client, extension adapter, and smoke tests."
+---
+
+# Proposal: OpenRouter LLM provider (RUN-252)
+
+## Intent
+
+TrustGate must route LLM traffic to OpenRouter as a first-class provider. Routing intent (`@openrouter/vendor/model`) and body rewrite already exist in `pkg/domain/routing/intent.go`, but registry CRUD, catalog listing, connection probe, and proxy upstream calls fail because `openrouter` is not registered — no client, factory entry, format adapter, or catalog seed.
+
+## Scope
+
+### In Scope
+- **RUN-922 (core):** `ProviderOpenRouter`; `pkg/infra/providers/openrouter/` client + connection probe; factory locator; `FormatOpenRouter` in `format.go`; catalog seed row + API-key auth; sync/stream to `https://openrouter.ai/api/v1/chat/completions`
+- **RUN-261 (adapter):** `OpenRouterAdapter` preserving request fields (`provider`, `models`, `transforms`, `route`) and response metadata; SSE comment-line filtering; registry passthrough for openrouter↔openai
+- **RUN-924 (tests):** httptest client/connection tests; adapter round-trip; functional smoke for `@openrouter/vendor/model`
+
+### Out of Scope
+- models.dev catalog sync (seed provider only; prior OpenRouter catalog purged)
+- OpenRouter catalog API; optional `HTTP-Referer` / `X-Title` headers
+- `openai_compatible` base-URL alias (no registry provider match, no extensions)
+
+## Capabilities
+
+### New Capabilities
+- `openrouter-llm-provider`: first-class OpenRouter integration — registry validation, proxy sync/stream, extension preservation, qualified routing intent
+
+### Modified Capabilities
+- None (routing intent already implemented; no existing provider spec in `openspec/specs/`)
+
+## Approach
+
+**Approach A** — dedicated `openrouter` package + `FormatOpenRouter`, mirroring **groq**: thin wrapper over `openai.ChatCompletionsClient` with fixed endpoint; `RunBearerGETProbe` on `GET /api/v1/models`; dedicated adapter wrapping `OpenAIAdapter` (Mistral/groq pattern) for OpenRouter-specific fields and `ProviderExtensions` / request extension maps.
+
+**Delivery:** three chained PRs aligned to Linear sub-issues, ~400-line budget each: **RUN-922 → RUN-261 → RUN-924**.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `pkg/infra/providers/openrouter/` | New | Client, connection, tests |
+| `pkg/infra/providers/client.go` | Modified | Constant, `SupportedProviders`, `IsValidProvider` |
+| `pkg/infra/providers/factory/locator.go` | Modified | Wire `NewOpenRouterClient()` |
+| `pkg/infra/providers/adapter/` | Modified/New | `FormatOpenRouter`, `OpenRouterAdapter`, registry |
+| `pkg/app/catalog/sync.go` | Modified | Seed row; no `modelsDevProviderToCode` entry |
+| `pkg/app/catalog/provider_auth.go` | Modified | API key auth catalog entry |
+| `tests/functional/` | New | Routing smoke with fake upstream |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| OpenRouter extensions differ from groq `x_groq` | Med | Flexible extension maps on canonical model |
+| SSE `: ping` lines break stream JSON decode | Med | Filter comment lines before `DecodeStreamChunk` (RUN-261) |
+| Allowlisted consumers reject free-form `vendor/model` | Med | Document nil-allowlist behavior; no models.dev rows |
+| Single PR exceeds 400-line budget | High | Three chained PRs per sub-issue |
+
+## Rollback Plan
+
+Additive change. Revert by removing the `openrouter` package, factory locator entry, adapter registration, `FormatOpenRouter`, catalog seed, and provider constant. No migrations or schema changes. Existing providers unaffected.
+
+## Dependencies
+
+- OpenRouter Chat Completions API (OpenAI-compatible wire format)
+- Existing `openai.ChatCompletionsClient` and HTTP client pool
+
+## Success Criteria
+
+- [ ] Registry CRUD and connection probe accept `provider=openrouter`
+- [ ] `@openrouter/vendor/model` proxies sync + stream to OpenRouter
+- [ ] OpenRouter request/response extensions round-trip same-wire; stripped cross-format
+- [ ] SSE keep-alive comments do not break streaming
+- [ ] Catalog lists OpenRouter with API key auth; no models.dev sync rows
+- [ ] `-race`-clean unit and functional tests per RUN-922 / RUN-261 / RUN-924

--- a/openspec/changes/openrouter-llm-provider/spec.md
+++ b/openspec/changes/openrouter-llm-provider/spec.md
@@ -1,0 +1,79 @@
+# OpenRouter LLM Provider Specification
+
+**Linear:** RUN-252 · RUN-922 · RUN-261 · RUN-924 · **Change:** `openrouter-llm-provider`
+
+## Purpose
+
+Add OpenRouter as a first-class OpenAI-wire-compatible LLM provider. Catalog seeds the provider only (no models.dev import). `@openrouter/vendor/model` routing intent already exists and MUST remain unchanged.
+
+## ADDED Requirements
+
+### Requirement: Provider registration
+
+TrustGate MUST register `openrouter` in `SupportedProviders`, `IsValidProvider`, the factory locator, `FormatOpenRouter`, and catalog auth (`api_key`). Completions MUST use `https://openrouter.ai/api/v1/chat/completions`. Connection test MUST probe `GET https://openrouter.ai/api/v1/models` with Bearer auth.
+
+#### Scenario: Registry and locator accept openrouter
+
+- GIVEN `provider: openrouter` with valid API key
+- WHEN an operator creates a registry target or runs test-connection
+- THEN validation succeeds, the locator returns an OpenRouter client, and the models probe succeeds
+
+### Requirement: Sync and stream completions
+
+The client MUST proxy sync and stream chat completions with `vendor/model` slugs (e.g. `anthropic/claude-sonnet-4`) unchanged, using `Bearer {api_key}`. Missing credentials MUST fail before upstream call.
+
+#### Scenario: Sync and stream with vendor/model slug
+
+- GIVEN an openrouter target and model `anthropic/claude-sonnet-4`
+- WHEN sync or streaming completion is proxied
+- THEN the upstream body retains the model slug and responses complete (sync body or SSE chunks)
+
+### Requirement: Catalog provider seed without models.dev models
+
+Catalog sync MUST seed an `openrouter` provider row (wire format `openai`). OpenRouter MUST NOT appear in `modelsDevProviderToCode`; no OpenRouter model rows MAY be imported from models.dev.
+
+#### Scenario: Provider seeded, models not imported
+
+- GIVEN catalog sync runs
+- WHEN providers seed and models.dev import complete
+- THEN an `openrouter` provider with `api_key` auth exists and zero catalog models reference `openrouter`
+
+### Requirement: Routing intent compatibility (unchanged)
+
+`ParseModelRef` / `applyIntentToBody` for `@openrouter/...` MUST NOT change. Nested slashes MUST be preserved. This change only enables `IsValidProvider("openrouter")` for registry CRUD and candidate resolution.
+
+#### Scenario: Intent parses and rewrites model
+
+- GIVEN ref `@openrouter/meta-llama/llama-3-70b` or `@openrouter/anthropic/claude-sonnet-4`
+- WHEN intent is parsed and applied to an openrouter request
+- THEN provider is `openrouter`, nested slug is preserved, and body `model` is the vendor/model suffix
+
+### Requirement: Extension field preservation
+
+`FormatOpenRouter` MUST register in the adapter registry. Same-format round-trips MUST preserve request fields `provider`, `models`, `transforms`, `route` and response metadata via `ProviderExtensions`. Cross-format adaptation MUST strip OpenRouter-only extensions.
+
+#### Scenario: Same-format extension round-trip
+
+- GIVEN openrouter sync or stream payloads with routing extensions and response metadata
+- WHEN encode → decode → encode on the same format
+- THEN all extension fields and metadata survive
+
+#### Scenario: Cross-format strips extensions
+
+- GIVEN an openrouter request with `provider`, `models`, `transforms`, `route`
+- WHEN adapted to a non-openrouter format (e.g. anthropic)
+- THEN those fields are absent from encoded output
+
+### Requirement: SSE keep-alive comment filtering
+
+Stream handling MUST ignore SSE comment lines (`: ping`, `: OPENROUTER PROCESSING`) before JSON decode; `data:` lines MUST still parse.
+
+#### Scenario: Comment lines do not break stream decode
+
+- GIVEN an SSE stream with `: ping` or `: OPENROUTER PROCESSING` between `data:` events
+- WHEN chunks are decoded
+- THEN comments are skipped and subsequent JSON chunks parse without error
+
+## Out of scope
+
+models.dev OpenRouter models; OpenRouter catalog API; attribution headers; App v2 UI; changes to `intent.go`.

--- a/pkg/api/handler/http/proxy/proxy_handler.go
+++ b/pkg/api/handler/http/proxy/proxy_handler.go
@@ -332,6 +332,7 @@ func buildRequestContext(c *fiber.Ctx, gatewayID ids.GatewayID, route apiresolve
 		IP:           c.IP(),
 		SessionID:    sessionIDFromContext(c),
 		SourceFormat: string(route.SourceFormat),
+		ProxyCapability: string(route.Capability),
 	}
 }
 

--- a/pkg/api/resolver/proxy_path_resolver.go
+++ b/pkg/api/resolver/proxy_path_resolver.go
@@ -29,11 +29,22 @@ const (
 	RouteChatCompletions = "/v1/chat/completions"
 	RouteMessages        = "/v1/messages"
 	RouteResponses       = "/v1/responses"
+	RouteCohereChat      = "/v2/chat"
+	RouteEmbeddings      = "/v1/embeddings"
+	RouteRerank          = "/v1/rerank"
 )
 
 const pathSeparator = "/"
 
 var ErrUnknownProxyPath = errors.New("no fixed proxy route matches the request path")
+
+type ProxyCapability string
+
+const (
+	CapabilityChat       ProxyCapability = "chat"
+	CapabilityEmbeddings ProxyCapability = "embeddings"
+	CapabilityRerank     ProxyCapability = "rerank"
+)
 
 // ProxyRoute is the result of parsing a proxy request path of the form
 // /{consumer_slug}/{fixed route}, where the fixed route determines the
@@ -41,6 +52,7 @@ var ErrUnknownProxyPath = errors.New("no fixed proxy route matches the request p
 type ProxyRoute struct {
 	ConsumerSlug string
 	SourceFormat adapter.Format
+	Capability   ProxyCapability
 	Rest         string
 }
 
@@ -54,24 +66,35 @@ func ResolveProxyPath(path string) (ProxyRoute, error) {
 	if len(rest) > 1 {
 		rest = strings.TrimRight(rest, pathSeparator)
 	}
-	format, err := formatForRoute(rest)
+	format, capability, err := formatForRoute(rest)
 	if err != nil {
 		return ProxyRoute{}, err
 	}
-	return ProxyRoute{ConsumerSlug: slug, SourceFormat: format, Rest: rest}, nil
+	return ProxyRoute{
+		ConsumerSlug: slug,
+		SourceFormat: format,
+		Capability:   capability,
+		Rest:         rest,
+	}, nil
 }
 
-func formatForRoute(rest string) (adapter.Format, error) {
+func formatForRoute(rest string) (adapter.Format, ProxyCapability, error) {
 	switch rest {
 	case RouteChatCompletions:
-		return adapter.FormatOpenAI, nil
+		return adapter.FormatOpenAI, CapabilityChat, nil
 	case RouteMessages:
-		return adapter.FormatAnthropic, nil
+		return adapter.FormatAnthropic, CapabilityChat, nil
 	case RouteResponses:
-		return adapter.FormatOpenAIResponses, nil
+		return adapter.FormatOpenAIResponses, CapabilityChat, nil
+	case RouteCohereChat:
+		return adapter.FormatCohere, CapabilityChat, nil
+	case RouteEmbeddings:
+		return adapter.FormatOpenAIEmbeddings, CapabilityEmbeddings, nil
+	case RouteRerank:
+		return adapter.FormatCohereRerank, CapabilityRerank, nil
 	}
 	if strings.HasPrefix(rest, adapter.GeminiModelsRoutePrefix) && adapter.GeminiModelFromPath(rest) != "" {
-		return adapter.FormatGemini, nil
+		return adapter.FormatGemini, CapabilityChat, nil
 	}
-	return "", ErrUnknownProxyPath
+	return "", "", ErrUnknownProxyPath
 }

--- a/pkg/api/resolver/proxy_path_resolver_test.go
+++ b/pkg/api/resolver/proxy_path_resolver_test.go
@@ -24,16 +24,20 @@ import (
 func TestResolveProxyPath(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
-		path       string
-		wantSlug   string
-		wantFormat adapter.Format
+		path             string
+		wantSlug         string
+		wantFormat       adapter.Format
+		wantCapability   ProxyCapability
 	}{
-		{"/X84Yhsy8/v1/chat/completions", "X84Yhsy8", adapter.FormatOpenAI},
-		{"/X84Yhsy8/v1/chat/completions/", "X84Yhsy8", adapter.FormatOpenAI},
-		{"/X84Yhsy8/v1/messages", "X84Yhsy8", adapter.FormatAnthropic},
-		{"/X84Yhsy8/v1/responses", "X84Yhsy8", adapter.FormatOpenAIResponses},
-		{"/X84Yhsy8/v1beta/models/gemini-pro:generateContent", "X84Yhsy8", adapter.FormatGemini},
-		{"/X84Yhsy8/v1beta/models/gemini-pro:streamGenerateContent", "X84Yhsy8", adapter.FormatGemini},
+		{"/X84Yhsy8/v1/chat/completions", "X84Yhsy8", adapter.FormatOpenAI, CapabilityChat},
+		{"/X84Yhsy8/v1/chat/completions/", "X84Yhsy8", adapter.FormatOpenAI, CapabilityChat},
+		{"/X84Yhsy8/v1/messages", "X84Yhsy8", adapter.FormatAnthropic, CapabilityChat},
+		{"/X84Yhsy8/v1/responses", "X84Yhsy8", adapter.FormatOpenAIResponses, CapabilityChat},
+		{"/X84Yhsy8/v2/chat", "X84Yhsy8", adapter.FormatCohere, CapabilityChat},
+		{"/X84Yhsy8/v1/embeddings", "X84Yhsy8", adapter.FormatOpenAIEmbeddings, CapabilityEmbeddings},
+		{"/X84Yhsy8/v1/rerank", "X84Yhsy8", adapter.FormatCohereRerank, CapabilityRerank},
+		{"/X84Yhsy8/v1beta/models/gemini-pro:generateContent", "X84Yhsy8", adapter.FormatGemini, CapabilityChat},
+		{"/X84Yhsy8/v1beta/models/gemini-pro:streamGenerateContent", "X84Yhsy8", adapter.FormatGemini, CapabilityChat},
 	}
 	for _, tc := range cases {
 		route, err := ResolveProxyPath(tc.path)
@@ -46,6 +50,9 @@ func TestResolveProxyPath(t *testing.T) {
 		if route.SourceFormat != tc.wantFormat {
 			t.Fatalf("ResolveProxyPath(%q).SourceFormat = %q, want %q", tc.path, route.SourceFormat, tc.wantFormat)
 		}
+		if route.Capability != tc.wantCapability {
+			t.Fatalf("ResolveProxyPath(%q).Capability = %q, want %q", tc.path, route.Capability, tc.wantCapability)
+		}
 	}
 }
 
@@ -55,7 +62,6 @@ func TestResolveProxyPath_UnknownRoutes(t *testing.T) {
 		"/",
 		"/X84Yhsy8",
 		"/X84Yhsy8/",
-		"/X84Yhsy8/v1/embeddings",
 		"/X84Yhsy8/v2/chat/completions",
 		"/X84Yhsy8/v1beta/models/",
 		"/X84Yhsy8/v1beta/models/:generateContent",
@@ -70,12 +76,12 @@ func TestResolveProxyPath_UnknownRoutes(t *testing.T) {
 func TestGeminiModelFromPath(t *testing.T) {
 	t.Parallel()
 	cases := map[string]string{
-		"/v1beta/models/gemini-pro:generateContent":             "gemini-pro",
+		"/v1beta/models/gemini-pro:generateContent":               "gemini-pro",
 		"/v1beta/models/gemini-1.5-flash:streamGenerateContent": "gemini-1.5-flash",
-		"/v1beta/models/gemini-pro":                             "gemini-pro",
+		"/v1beta/models/gemini-pro":                               "gemini-pro",
 		"/slug/v1beta/models/gemini-pro:generateContent":        "gemini-pro",
-		"/v1beta/models/:generateContent":                       "",
-		"/v1/chat/completions":                                  "",
+		"/v1beta/models/:generateContent":                         "",
+		"/v1/chat/completions":                                    "",
 	}
 	for rest, want := range cases {
 		if got := adapter.GeminiModelFromPath(rest); got != want {

--- a/pkg/app/catalog/provider_auth.go
+++ b/pkg/app/catalog/provider_auth.go
@@ -255,6 +255,7 @@ var providerAuthCatalog = map[string][]AuthTypeOption{
 	providers.ProviderMistral:          {apiKeyAuthOption},
 	providers.ProviderGroq:             {apiKeyAuthOption},
 	providers.ProviderDeepSeek:         {apiKeyAuthOption},
+	providers.ProviderOpenRouter:       {apiKeyAuthOption},
 }
 
 func ProviderAuthOptions(code string) []AuthTypeOption {

--- a/pkg/app/catalog/provider_auth.go
+++ b/pkg/app/catalog/provider_auth.go
@@ -256,6 +256,7 @@ var providerAuthCatalog = map[string][]AuthTypeOption{
 	providers.ProviderGroq:             {apiKeyAuthOption},
 	providers.ProviderDeepSeek:         {apiKeyAuthOption},
 	providers.ProviderXAI:              {apiKeyAuthOption},
+	providers.ProviderCerebras:         {apiKeyAuthOption},
 }
 
 func ProviderAuthOptions(code string) []AuthTypeOption {

--- a/pkg/app/catalog/sync.go
+++ b/pkg/app/catalog/sync.go
@@ -45,6 +45,7 @@ var seedProviders = []seedProvider{
 	{providers.ProviderGroq, "Groq", "openai"},
 	{providers.ProviderDeepSeek, "DeepSeek", "openai"},
 	{providers.ProviderXAI, "xAI", "openai"},
+	{providers.ProviderCerebras, "Cerebras", "openai"},
 }
 
 // modelsDevProviderToCode maps models.dev provider keys to the gateway provider
@@ -60,6 +61,7 @@ var modelsDevProviderToCode = map[string]string{
 	"groq":           providers.ProviderGroq,
 	"deepseek":       providers.ProviderDeepSeek,
 	"xai":            providers.ProviderXAI,
+	"cerebras":       providers.ProviderCerebras,
 }
 
 //go:generate mockery --name=Syncer --dir=. --output=./mocks --filename=catalog_syncer_mock.go --case=underscore --with-expecter

--- a/pkg/app/catalog/sync.go
+++ b/pkg/app/catalog/sync.go
@@ -44,6 +44,7 @@ var seedProviders = []seedProvider{
 	{providers.ProviderMistral, "Mistral", "openai"},
 	{providers.ProviderGroq, "Groq", "openai"},
 	{providers.ProviderDeepSeek, "DeepSeek", "openai"},
+	{providers.ProviderOpenRouter, "OpenRouter", "openai"},
 }
 
 // modelsDevProviderToCode maps models.dev provider keys to the gateway provider

--- a/pkg/app/catalog/sync.go
+++ b/pkg/app/catalog/sync.go
@@ -26,11 +26,19 @@ import (
 )
 
 const sourceModelsDev = "models.dev"
+const sourceManualSeed = "seed"
 
 type seedProvider struct {
 	code        string
 	displayName string
 	wireFormat  string
+}
+
+type seedModel struct {
+	slug         string
+	externalID   string
+	displayName  string
+	capabilities map[string]any
 }
 
 var seedProviders = []seedProvider{
@@ -44,6 +52,35 @@ var seedProviders = []seedProvider{
 	{providers.ProviderMistral, "Mistral", "openai"},
 	{providers.ProviderGroq, "Groq", "openai"},
 	{providers.ProviderDeepSeek, "DeepSeek", "openai"},
+	{providers.ProviderCohere, "Cohere", "cohere"},
+}
+
+var cohereSeedModels = []seedModel{
+	{
+		slug:        "command-r-plus",
+		externalID:  "command-r-plus",
+		displayName: "Command R+",
+		capabilities: map[string]any{
+			"chat":   true,
+			"rerank": true,
+		},
+	},
+	{
+		slug:        "embed-english-v3.0",
+		externalID:  "embed-english-v3.0",
+		displayName: "Embed English v3.0",
+		capabilities: map[string]any{
+			"embed": true,
+		},
+	},
+	{
+		slug:        "rerank-english-v3.0",
+		externalID:  "rerank-english-v3.0",
+		displayName: "Rerank English v3.0",
+		capabilities: map[string]any{
+			"rerank": true,
+		},
+	},
 }
 
 // modelsDevProviderToCode maps models.dev provider keys to the gateway provider
@@ -58,6 +95,7 @@ var modelsDevProviderToCode = map[string]string{
 	"mistral":        providers.ProviderMistral,
 	"groq":           providers.ProviderGroq,
 	"deepseek":       providers.ProviderDeepSeek,
+	"cohere":         providers.ProviderCohere,
 }
 
 //go:generate mockery --name=Syncer --dir=. --output=./mocks --filename=catalog_syncer_mock.go --case=underscore --with-expecter
@@ -85,6 +123,10 @@ func (s *syncer) Sync(ctx context.Context) error {
 
 	codeToProvider, err := s.providerIndex(ctx)
 	if err != nil {
+		return err
+	}
+
+	if err := s.seedManualModels(ctx, codeToProvider); err != nil {
 		return err
 	}
 
@@ -145,6 +187,28 @@ func (s *syncer) seedProviders(ctx context.Context) error {
 			Source:      "seed",
 		}
 		if err := s.repo.UpsertProvider(ctx, entity); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *syncer) seedManualModels(ctx context.Context, codeToProvider map[string]domain.Provider) error {
+	provider, ok := codeToProvider[providers.ProviderCohere]
+	if !ok {
+		return nil
+	}
+	for _, m := range cohereSeedModels {
+		entity := &domain.Model{
+			ProviderID:    provider.ID,
+			Slug:          m.slug,
+			ExternalID:    m.externalID,
+			DisplayName:   m.displayName,
+			Capabilities:  m.capabilities,
+			Enabled:       true,
+			Source:        sourceManualSeed,
+		}
+		if err := s.repo.UpsertModel(ctx, entity); err != nil {
 			return err
 		}
 	}

--- a/pkg/app/catalog/sync_test.go
+++ b/pkg/app/catalog/sync_test.go
@@ -123,8 +123,8 @@ func TestSyncer_Sync(t *testing.T) {
 	if len(repo.providers) != len(seedProviders) {
 		t.Fatalf("expected %d providers seeded, got %d", len(seedProviders), len(repo.providers))
 	}
-	if len(repo.upsertedModels) != 2 {
-		t.Fatalf("expected 2 mapped models upserted (unknown vendor skipped), got %d", len(repo.upsertedModels))
+	if len(repo.upsertedModels) != 2+len(cohereSeedModels) {
+		t.Fatalf("expected %d mapped models upserted (unknown vendor skipped), got %d", 2+len(cohereSeedModels), len(repo.upsertedModels))
 	}
 	for _, m := range repo.upsertedModels {
 		if !m.Enabled {

--- a/pkg/app/proxy/provider.go
+++ b/pkg/app/proxy/provider.go
@@ -39,6 +39,10 @@ const (
 
 	responsesTurnIDPrefix = "resp_"
 	fieldPreviousResponse = "previous_response_id"
+
+	capabilityChat       = "chat"
+	capabilityEmbeddings = "embeddings"
+	capabilityRerank     = "rerank"
 )
 
 var ErrInvalidRequestPayload = errors.New("invalid request payload")
@@ -117,6 +121,7 @@ type preparedInvocation struct {
 	sourceFormat adapter.Format
 	targetFormat adapter.Format
 	crossFormat  bool
+	capability   string
 }
 
 func (p *providerInvoker) Invoke(
@@ -129,7 +134,7 @@ func (p *providerInvoker) Invoke(
 		return nil, err
 	}
 
-	respBody, err := prep.client.Completions(ctx, prep.cfg, prep.body)
+	respBody, err := p.invokeUpstream(ctx, prep)
 	if err != nil {
 		if be, ok := registry.IsBackendError(err); ok {
 			return &ProviderResponse{
@@ -138,13 +143,14 @@ func (p *providerInvoker) Invoke(
 				Body:       be.Body,
 			}, nil
 		}
-		return nil, fmt.Errorf("provider completions: %w", err)
+		return nil, err
 	}
 
 	usage, model, finishReason, responseID := p.decodeResponseMeta(respBody, prep.targetFormat)
 
 	if prep.crossFormat {
-		if adapted, aerr := p.registry.AdaptResponse(respBody, prep.sourceFormat, prep.targetFormat); aerr != nil {
+		adapted, aerr := p.adaptResponseBody(respBody, prep)
+		if aerr != nil {
 			p.logger.Warn("failed to adapt response, returning raw",
 				slog.String("error", aerr.Error()))
 		} else {
@@ -230,7 +236,8 @@ func (p *providerInvoker) prepare(
 	}
 
 	sourceFormat := sourceFormatFromRequest(req)
-	targetFormat := adapter.ResolveTargetFormat(bk.Provider(), bk.ProviderOptions())
+	capability := capabilityFromRequest(req)
+	targetFormat := adapter.ResolveTargetFormatForCapability(bk.Provider(), capability, bk.ProviderOptions())
 
 	req.Provider = bk.Provider()
 	req.SourceFormat = string(sourceFormat)
@@ -240,7 +247,7 @@ func (p *providerInvoker) prepare(
 
 	body := req.Body
 	if crossFormat {
-		body, err = p.registry.AdaptRequest(req.Body, sourceFormat, targetFormat)
+		body, err = p.adaptRequestBody(req.Body, sourceFormat, targetFormat, capability)
 		if err != nil {
 			if adapter.IsRequestDecodeError(err) {
 				return nil, fmt.Errorf("%w: %s", ErrInvalidRequestPayload, err.Error())
@@ -280,7 +287,92 @@ func (p *providerInvoker) prepare(
 		sourceFormat: sourceFormat,
 		targetFormat: targetFormat,
 		crossFormat:  crossFormat,
+		capability:   capability,
 	}, nil
+}
+
+func capabilityFromRequest(req *infracontext.RequestContext) string {
+	switch req.ProxyCapability {
+	case capabilityEmbeddings:
+		return capabilityEmbeddings
+	case capabilityRerank:
+		return capabilityRerank
+	default:
+		return capabilityChat
+	}
+}
+
+func (p *providerInvoker) adaptRequestBody(
+	body []byte,
+	sourceFormat, targetFormat adapter.Format,
+	capability string,
+) ([]byte, error) {
+	switch capability {
+	case capabilityEmbeddings:
+		reg, ok := p.registry.(*adapter.Registry)
+		if !ok {
+			return nil, fmt.Errorf("embedding adaptation requires concrete adapter registry")
+		}
+		return adapter.AdaptEmbeddingRequest(reg, body, sourceFormat, targetFormat)
+	case capabilityRerank:
+		reg, ok := p.registry.(*adapter.Registry)
+		if !ok {
+			return nil, fmt.Errorf("rerank adaptation requires concrete adapter registry")
+		}
+		return adapter.AdaptRerankRequest(reg, body, sourceFormat, targetFormat)
+	default:
+		return p.registry.AdaptRequest(body, sourceFormat, targetFormat)
+	}
+}
+
+func (p *providerInvoker) adaptResponseBody(body []byte, prep *preparedInvocation) ([]byte, error) {
+	switch prep.capability {
+	case capabilityEmbeddings:
+		reg, ok := p.registry.(*adapter.Registry)
+		if !ok {
+			return nil, fmt.Errorf("embedding adaptation requires concrete adapter registry")
+		}
+		return adapter.AdaptEmbeddingResponse(reg, body, prep.sourceFormat, prep.targetFormat)
+	case capabilityRerank:
+		reg, ok := p.registry.(*adapter.Registry)
+		if !ok {
+			return nil, fmt.Errorf("rerank adaptation requires concrete adapter registry")
+		}
+		return adapter.AdaptRerankResponse(reg, body, prep.sourceFormat, prep.targetFormat)
+	default:
+		return p.registry.AdaptResponse(body, prep.sourceFormat, prep.targetFormat)
+	}
+}
+
+func (p *providerInvoker) invokeUpstream(ctx context.Context, prep *preparedInvocation) ([]byte, error) {
+	switch prep.capability {
+	case capabilityEmbeddings:
+		embedder, ok := prep.client.(providers.EmbeddingsClient)
+		if !ok {
+			return nil, fmt.Errorf("provider does not support embeddings")
+		}
+		respBody, err := embedder.Embeddings(ctx, prep.cfg, prep.body)
+		if err != nil {
+			return nil, fmt.Errorf("provider embeddings: %w", err)
+		}
+		return respBody, nil
+	case capabilityRerank:
+		reranker, ok := prep.client.(providers.RerankClient)
+		if !ok {
+			return nil, fmt.Errorf("provider does not support rerank")
+		}
+		respBody, err := reranker.Rerank(ctx, prep.cfg, prep.body)
+		if err != nil {
+			return nil, fmt.Errorf("provider rerank: %w", err)
+		}
+		return respBody, nil
+	default:
+		respBody, err := prep.client.Completions(ctx, prep.cfg, prep.body)
+		if err != nil {
+			return nil, fmt.Errorf("provider completions: %w", err)
+		}
+		return respBody, nil
+	}
 }
 
 func injectPreviousResponseID(body []byte, targetFormat adapter.Format, previousResponseID string) []byte {

--- a/pkg/app/proxy/provider_cohere_test.go
+++ b/pkg/app/proxy/provider_cohere_test.go
@@ -1,0 +1,160 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy_test
+
+import (
+	"context"
+	"encoding/json"
+	"iter"
+	"net/http"
+	"testing"
+
+	appproxy "github.com/NeuralTrust/TrustGate/pkg/app/proxy"
+	infracontext "github.com/NeuralTrust/TrustGate/pkg/infra/context"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/adapter"
+	factorymocks "github.com/NeuralTrust/TrustGate/pkg/infra/providers/factory/mocks"
+	providermocks "github.com/NeuralTrust/TrustGate/pkg/infra/providers/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type cohereTestClient struct {
+	completionsFn func(ctx context.Context, cfg *providers.Config, body []byte) ([]byte, error)
+	embeddingsFn  func(ctx context.Context, cfg *providers.Config, body []byte) ([]byte, error)
+	rerankFn      func(ctx context.Context, cfg *providers.Config, body []byte) ([]byte, error)
+}
+
+func (c *cohereTestClient) Completions(ctx context.Context, cfg *providers.Config, body []byte) ([]byte, error) {
+	return c.completionsFn(ctx, cfg, body)
+}
+
+func (c *cohereTestClient) CompletionsStream(context.Context, *providers.Config, []byte) (iter.Seq2[[]byte, error], error) {
+	return nil, nil
+}
+
+func (c *cohereTestClient) Embeddings(ctx context.Context, cfg *providers.Config, body []byte) ([]byte, error) {
+	return c.embeddingsFn(ctx, cfg, body)
+}
+
+func (c *cohereTestClient) Rerank(ctx context.Context, cfg *providers.Config, body []byte) ([]byte, error) {
+	return c.rerankFn(ctx, cfg, body)
+}
+
+func TestProviderInvoke_CohereEmbeddingsCrossFormat(t *testing.T) {
+	var sentBody []byte
+	client := &cohereTestClient{
+		embeddingsFn: func(_ context.Context, _ *providers.Config, body []byte) ([]byte, error) {
+			sentBody = body
+			return []byte(`{"embeddings":[[0.1,0.2]]}`), nil
+		},
+	}
+
+	locator := factorymocks.NewProviderLocator(t)
+	locator.EXPECT().Get("cohere").Return(client, nil).Once()
+
+	inv := appproxy.NewProviderInvoker(locator, adapter.NewRegistry(), newTestLogger())
+
+	req := &infracontext.RequestContext{
+		Body:            []byte(`{"model":"embed-english-v3.0","input":["hello"]}`),
+		SourceFormat:    string(adapter.FormatOpenAIEmbeddings),
+		ProxyCapability: "embeddings",
+	}
+	resp, err := inv.Invoke(context.Background(), apiKeyTarget("cohere"), req)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "cohere_embed", req.TargetFormat)
+
+	var cohereReq map[string]any
+	require.NoError(t, json.Unmarshal(sentBody, &cohereReq))
+	assert.Equal(t, "embed-english-v3.0", cohereReq["model"])
+	assert.Equal(t, []any{"hello"}, cohereReq["texts"])
+
+	var openaiResp map[string]any
+	require.NoError(t, json.Unmarshal(resp.Body, &openaiResp))
+	data := openaiResp["data"].([]any)
+	assert.Len(t, data, 1)
+}
+
+func TestProviderInvoke_CohereRerankPassthrough(t *testing.T) {
+	var sentBody []byte
+	client := &cohereTestClient{
+		rerankFn: func(_ context.Context, _ *providers.Config, body []byte) ([]byte, error) {
+			sentBody = body
+			return []byte(`{"results":[{"index":0,"relevance_score":0.9}]}`), nil
+		},
+	}
+
+	locator := factorymocks.NewProviderLocator(t)
+	locator.EXPECT().Get("cohere").Return(client, nil).Once()
+
+	inv := appproxy.NewProviderInvoker(locator, adapter.NewRegistry(), newTestLogger())
+
+	body := `{"model":"rerank-english-v3.0","query":"q","documents":["a"]}`
+	req := &infracontext.RequestContext{
+		Body:            []byte(body),
+		SourceFormat:    string(adapter.FormatCohereRerank),
+		ProxyCapability: "rerank",
+	}
+	resp, err := inv.Invoke(context.Background(), apiKeyTarget("cohere"), req)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.JSONEq(t, body, string(sentBody))
+	assert.JSONEq(t, `{"results":[{"index":0,"relevance_score":0.9}]}`, string(resp.Body))
+}
+
+func TestProviderInvoke_CohereChatNativeFormat(t *testing.T) {
+	client := &cohereTestClient{
+		completionsFn: func(_ context.Context, _ *providers.Config, _ []byte) ([]byte, error) {
+			return []byte(`{"id":"chat-1","finish_reason":"COMPLETE","message":{"role":"assistant","content":[{"type":"text","text":"hi"}]}}`), nil
+		},
+	}
+
+	locator := factorymocks.NewProviderLocator(t)
+	locator.EXPECT().Get("cohere").Return(client, nil).Once()
+
+	inv := appproxy.NewProviderInvoker(locator, adapter.NewRegistry(), newTestLogger())
+
+	req := &infracontext.RequestContext{
+		Body:         []byte(`{"model":"command-r-plus","messages":[{"role":"user","content":"hi"}]}`),
+		SourceFormat: string(adapter.FormatCohere),
+	}
+	resp, err := inv.Invoke(context.Background(), apiKeyTarget("cohere"), req)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, string(resp.Body), `"text":"hi"`)
+}
+
+func TestProviderInvoke_CohereEmbeddingsUnsupportedProvider(t *testing.T) {
+	client := providermocks.NewClient(t)
+
+	locator := factorymocks.NewProviderLocator(t)
+	locator.EXPECT().Get("openai").Return(client, nil).Once()
+
+	inv := appproxy.NewProviderInvoker(locator, adapter.NewRegistry(), newTestLogger())
+
+	req := &infracontext.RequestContext{
+		Body:            []byte(`{"model":"text-embedding-3-small","input":"hi"}`),
+		SourceFormat:    string(adapter.FormatOpenAIEmbeddings),
+		ProxyCapability: "embeddings",
+	}
+	_, err := inv.Invoke(context.Background(), apiKeyTarget("openai"), req)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not support embeddings")
+}

--- a/pkg/domain/provider/provider.go
+++ b/pkg/domain/provider/provider.go
@@ -28,6 +28,7 @@ const (
 	Mistral          = "mistral"
 	Groq             = "groq"
 	DeepSeek         = "deepseek"
+	OpenRouter       = "openrouter"
 )
 
 // Supported returns every provider name the gateway can route to.
@@ -43,6 +44,7 @@ func Supported() []string {
 		Mistral,
 		Groq,
 		DeepSeek,
+		OpenRouter,
 	}
 }
 
@@ -58,7 +60,8 @@ func IsValid(name string) bool {
 		Azure,
 		Mistral,
 		Groq,
-		DeepSeek:
+		DeepSeek,
+		OpenRouter:
 		return true
 	default:
 		return false

--- a/pkg/domain/provider/provider.go
+++ b/pkg/domain/provider/provider.go
@@ -29,6 +29,7 @@ const (
 	Groq             = "groq"
 	DeepSeek         = "deepseek"
 	XAI              = "xai"
+	Cerebras         = "cerebras"
 )
 
 // Supported returns every provider name the gateway can route to.
@@ -45,6 +46,7 @@ func Supported() []string {
 		Groq,
 		DeepSeek,
 		XAI,
+		Cerebras,
 	}
 }
 
@@ -61,7 +63,8 @@ func IsValid(name string) bool {
 		Mistral,
 		Groq,
 		DeepSeek,
-		XAI:
+		XAI,
+		Cerebras:
 		return true
 	default:
 		return false

--- a/pkg/domain/provider/provider.go
+++ b/pkg/domain/provider/provider.go
@@ -28,6 +28,7 @@ const (
 	Mistral          = "mistral"
 	Groq             = "groq"
 	DeepSeek         = "deepseek"
+	Cohere           = "cohere"
 )
 
 // Supported returns every provider name the gateway can route to.
@@ -43,6 +44,7 @@ func Supported() []string {
 		Mistral,
 		Groq,
 		DeepSeek,
+		Cohere,
 	}
 }
 
@@ -58,7 +60,8 @@ func IsValid(name string) bool {
 		Azure,
 		Mistral,
 		Groq,
-		DeepSeek:
+		DeepSeek,
+		Cohere:
 		return true
 	default:
 		return false

--- a/pkg/infra/context/request_context.go
+++ b/pkg/infra/context/request_context.go
@@ -46,6 +46,7 @@ type RequestContext struct {
 	Provider           string
 	SourceFormat       string
 	TargetFormat       string
+	ProxyCapability    string
 	AllowedModels      []string
 	DefaultModel       string
 	RequestedModel     string

--- a/pkg/infra/providers/adapter/adapter_test.go
+++ b/pkg/infra/providers/adapter/adapter_test.go
@@ -168,6 +168,7 @@ func TestResolveAgentFormat_KnownProviders(t *testing.T) {
 		{"vertex", FormatVertex},
 		{"groq", FormatGroq},
 		{"deepseek", FormatDeepSeek},
+		{"cerebras", FormatOpenAI},
 	}
 	for _, tt := range tests {
 		t.Run(tt.provider, func(t *testing.T) {

--- a/pkg/infra/providers/adapter/canonical.go
+++ b/pkg/infra/providers/adapter/canonical.go
@@ -34,8 +34,9 @@ type CanonicalRequest struct {
 	TopK           *int                   `json:"top_k,omitempty"`
 	Stop           []string               `json:"stop,omitempty"`
 	Stream         bool                   `json:"stream,omitempty"`
-	ResponseFormat *CanonicalRespFormat   `json:"response_format,omitempty"`
-	Metadata       map[string]interface{} `json:"metadata,omitempty"`
+	ResponseFormat *CanonicalRespFormat          `json:"response_format,omitempty"`
+	Metadata       map[string]interface{}        `json:"metadata,omitempty"`
+	RequestExtensions map[string]json.RawMessage   `json:"request_extensions,omitempty"`
 }
 
 // CanonicalMessage represents a single turn in the conversation.

--- a/pkg/infra/providers/adapter/cohere_adapter.go
+++ b/pkg/infra/providers/adapter/cohere_adapter.go
@@ -1,0 +1,492 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapter
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+type CohereAdapter struct{}
+
+type cohereRequest struct {
+	Model       string                 `json:"model,omitempty"`
+	Messages    []cohereMessage        `json:"messages"`
+	MaxTokens   *int                   `json:"max_tokens,omitempty"`
+	Temperature *float64               `json:"temperature,omitempty"`
+	TopP        *float64               `json:"p,omitempty"`
+	Stream      *bool                  `json:"stream,omitempty"`
+	Tools       []cohereTool           `json:"tools,omitempty"`
+	ToolChoice  *cohereToolChoice      `json:"tool_choice,omitempty"`
+	StopSeqs    []string               `json:"stop_sequences,omitempty"`
+}
+
+type cohereMessage struct {
+	Role       string          `json:"role"`
+	Content    json.RawMessage `json:"content,omitempty"`
+	ToolCalls  []cohereToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string          `json:"tool_call_id,omitempty"`
+}
+
+type cohereTool struct {
+	Type     string              `json:"type"`
+	Function cohereToolFunction  `json:"function"`
+}
+
+type cohereToolFunction struct {
+	Name        string                 `json:"name"`
+	Description string                 `json:"description,omitempty"`
+	Parameters  map[string]interface{} `json:"parameters"`
+}
+
+type cohereToolChoice struct {
+	Type string `json:"type"`
+	Name string `json:"name,omitempty"`
+}
+
+type cohereToolCall struct {
+	ID       string                 `json:"id"`
+	Type     string                 `json:"type"`
+	Function cohereToolCallFunction `json:"function"`
+}
+
+type cohereToolCallFunction struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+type cohereResponse struct {
+	ID           string                 `json:"id"`
+	FinishReason string                 `json:"finish_reason"`
+	Message      cohereAssistantMessage `json:"message"`
+	Usage        *cohereUsage           `json:"usage,omitempty"`
+}
+
+type cohereAssistantMessage struct {
+	Role      string                  `json:"role"`
+	Content   []cohereContentBlock    `json:"content,omitempty"`
+	ToolCalls []cohereToolCall        `json:"tool_calls,omitempty"`
+}
+
+type cohereContentBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+}
+
+type cohereUsage struct {
+	Tokens *cohereUsageTokens `json:"tokens,omitempty"`
+}
+
+type cohereUsageTokens struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+}
+
+type cohereStreamEvent struct {
+	Type  string          `json:"type"`
+	Index int             `json:"index,omitempty"`
+	Delta json.RawMessage `json:"delta,omitempty"`
+}
+
+type cohereContentDelta struct {
+	Message *cohereContentDeltaMessage `json:"message,omitempty"`
+}
+
+type cohereContentDeltaMessage struct {
+	Content *cohereContentBlock `json:"content,omitempty"`
+}
+
+type cohereMessageEndDelta struct {
+	FinishReason string       `json:"finish_reason,omitempty"`
+	Usage        *cohereUsage `json:"usage,omitempty"`
+}
+
+type cohereToolCallDelta struct {
+	ID       string                 `json:"id,omitempty"`
+	Function *cohereToolCallFunction `json:"function,omitempty"`
+}
+
+func cohereUsageToCanonical(u *cohereUsage) *CanonicalUsage {
+	if u == nil || u.Tokens == nil {
+		return nil
+	}
+	return newCanonicalUsage(u.Tokens.InputTokens, u.Tokens.OutputTokens, 0)
+}
+
+func cohereFinishToCanonical(reason string) string {
+	switch strings.ToUpper(reason) {
+	case "COMPLETE":
+		return "stop"
+	case "MAX_TOKENS":
+		return "length"
+	case "TOOL_CALL":
+		return "tool_calls"
+	case "STOP_SEQUENCE":
+		return "stop"
+	default:
+		return strings.ToLower(reason)
+	}
+}
+
+func canonicalFinishToCohere(reason string) string {
+	switch reason {
+	case "stop":
+		return "COMPLETE"
+	case "length":
+		return "MAX_TOKENS"
+	case "tool_calls":
+		return "TOOL_CALL"
+	default:
+		return "COMPLETE"
+	}
+}
+
+func decodeCohereMessageContent(role string, content json.RawMessage) []CanonicalMessage {
+	if content == nil {
+		return []CanonicalMessage{{Role: role}}
+	}
+	var s string
+	if json.Unmarshal(content, &s) == nil {
+		return []CanonicalMessage{{Role: role, Content: s}}
+	}
+	var blocks []cohereContentBlock
+	if json.Unmarshal(content, &blocks) != nil {
+		return []CanonicalMessage{{Role: role, Content: contentToString(content)}}
+	}
+	var parts []string
+	for _, b := range blocks {
+		if b.Type == "text" && b.Text != "" {
+			parts = append(parts, b.Text)
+		}
+	}
+	return []CanonicalMessage{{Role: role, Content: strings.Join(parts, "\n")}}
+}
+
+func (a *CohereAdapter) DecodeRequest(body []byte) (*CanonicalRequest, error) {
+	var req cohereRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, err
+	}
+	cr := &CanonicalRequest{
+		Model:       req.Model,
+		Temperature: req.Temperature,
+		TopP:        req.TopP,
+		Stop:        req.StopSeqs,
+	}
+	if req.MaxTokens != nil {
+		cr.MaxTokens = *req.MaxTokens
+	}
+	if req.Stream != nil {
+		cr.Stream = *req.Stream
+	}
+	for _, m := range req.Messages {
+		switch m.Role {
+		case "system":
+			for _, cm := range decodeCohereMessageContent(m.Role, m.Content) {
+				if cm.Content != "" {
+					cr.System = cm.Content
+				}
+			}
+		case "tool":
+			cr.Messages = append(cr.Messages, CanonicalMessage{
+				Role:       "tool",
+				ToolCallID: m.ToolCallID,
+				Content:    contentToString(m.Content),
+			})
+		case "assistant":
+			msg := CanonicalMessage{Role: "assistant"}
+			for _, cm := range decodeCohereMessageContent(m.Role, m.Content) {
+				msg.Content = cm.Content
+			}
+			for _, tc := range m.ToolCalls {
+				msg.ToolCalls = append(msg.ToolCalls, CanonicalToolCall{
+					ID:        tc.ID,
+					Name:      tc.Function.Name,
+					Arguments: tc.Function.Arguments,
+				})
+			}
+			cr.Messages = append(cr.Messages, msg)
+		default:
+			cr.Messages = append(cr.Messages, decodeCohereMessageContent(m.Role, m.Content)...)
+		}
+	}
+	for _, t := range req.Tools {
+		cr.Tools = append(cr.Tools, CanonicalTool{
+			Name:        t.Function.Name,
+			Description: t.Function.Description,
+			Schema:      t.Function.Parameters,
+		})
+	}
+	if req.ToolChoice != nil {
+		cr.ToolChoice = &CanonicalToolChoice{
+			Type: req.ToolChoice.Type,
+			Name: req.ToolChoice.Name,
+		}
+	}
+	return cr, nil
+}
+
+func (a *CohereAdapter) EncodeRequest(req *CanonicalRequest) ([]byte, error) {
+	out := cohereRequest{
+		Model:       req.Model,
+		Temperature: req.Temperature,
+		TopP:        req.TopP,
+		StopSeqs:    req.Stop,
+	}
+	if req.MaxTokens > 0 {
+		out.MaxTokens = &req.MaxTokens
+	}
+	if req.Stream {
+		out.Stream = boolPtr(true)
+	}
+	if req.System != "" {
+		raw, _ := json.Marshal(req.System)
+		out.Messages = append(out.Messages, cohereMessage{Role: "system", Content: raw})
+	}
+	for _, m := range req.Messages {
+		if m.Role == "tool" {
+			raw, _ := json.Marshal(m.Content)
+			out.Messages = append(out.Messages, cohereMessage{
+				Role:       "tool",
+				ToolCallID: m.ToolCallID,
+				Content:    raw,
+			})
+			continue
+		}
+		if m.Role == "assistant" && len(m.ToolCalls) > 0 {
+			msg := cohereMessage{Role: "assistant"}
+			if m.Content != "" {
+				block, _ := json.Marshal([]cohereContentBlock{{Type: "text", Text: m.Content}})
+				msg.Content = block
+			}
+			for _, tc := range m.ToolCalls {
+				msg.ToolCalls = append(msg.ToolCalls, cohereToolCall{
+					ID:   tc.ID,
+					Type: "function",
+					Function: cohereToolCallFunction{
+						Name:      tc.Name,
+						Arguments: tc.Arguments,
+					},
+				})
+			}
+			out.Messages = append(out.Messages, msg)
+			continue
+		}
+		out.Messages = append(out.Messages, cohereMessage{
+			Role:    m.Role,
+			Content: stringToContent(m.Content),
+		})
+	}
+	for _, t := range req.Tools {
+		schema := t.Schema
+		if len(schema) == 0 {
+			schema = map[string]interface{}{"type": "object", "properties": map[string]interface{}{}}
+		}
+		out.Tools = append(out.Tools, cohereTool{
+			Type: "function",
+			Function: cohereToolFunction{
+				Name:        t.Name,
+				Description: t.Description,
+				Parameters:  schema,
+			},
+		})
+	}
+	if req.ToolChoice != nil {
+		out.ToolChoice = &cohereToolChoice{
+			Type: req.ToolChoice.Type,
+			Name: req.ToolChoice.Name,
+		}
+	}
+	return json.Marshal(out)
+}
+
+func (a *CohereAdapter) DecodeResponse(body []byte) (*CanonicalResponse, error) {
+	var resp cohereResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, err
+	}
+	cr := &CanonicalResponse{
+		ID:           resp.ID,
+		Role:         "assistant",
+		FinishReason: cohereFinishToCanonical(resp.FinishReason),
+		Usage:        cohereUsageToCanonical(resp.Usage),
+	}
+	for _, block := range resp.Message.Content {
+		if block.Type == "text" {
+			cr.Content += block.Text
+		}
+	}
+	for _, tc := range resp.Message.ToolCalls {
+		cr.ToolCalls = append(cr.ToolCalls, CanonicalToolCall{
+			ID:        tc.ID,
+			Name:      tc.Function.Name,
+			Arguments: tc.Function.Arguments,
+		})
+	}
+	return cr, nil
+}
+
+func (a *CohereAdapter) EncodeResponse(resp *CanonicalResponse) ([]byte, error) {
+	var content []cohereContentBlock
+	if resp.Content != "" {
+		content = append(content, cohereContentBlock{Type: "text", Text: resp.Content})
+	}
+	var toolCalls []cohereToolCall
+	for _, tc := range resp.ToolCalls {
+		toolCalls = append(toolCalls, cohereToolCall{
+			ID:   tc.ID,
+			Type: "function",
+			Function: cohereToolCallFunction{
+				Name:      tc.Name,
+				Arguments: tc.Arguments,
+			},
+		})
+	}
+	out := cohereResponse{
+		ID:           resp.ID,
+		FinishReason: canonicalFinishToCohere(resp.FinishReason),
+		Message: cohereAssistantMessage{
+			Role:      "assistant",
+			Content:   content,
+			ToolCalls: toolCalls,
+		},
+	}
+	if resp.Usage != nil {
+		out.Usage = &cohereUsage{
+			Tokens: &cohereUsageTokens{
+				InputTokens:  resp.Usage.InputTokens,
+				OutputTokens: resp.Usage.OutputTokens,
+			},
+		}
+	}
+	return json.Marshal(out)
+}
+
+func (a *CohereAdapter) DecodeStreamChunk(chunk []byte) (*CanonicalStreamChunk, error) {
+	var event cohereStreamEvent
+	if err := json.Unmarshal(chunk, &event); err != nil {
+		return nil, nil
+	}
+	switch event.Type {
+	case "content-delta":
+		var delta cohereContentDelta
+		if err := json.Unmarshal(event.Delta, &delta); err != nil || delta.Message == nil || delta.Message.Content == nil {
+			return nil, nil
+		}
+		if delta.Message.Content.Text == "" {
+			return nil, nil
+		}
+		return &CanonicalStreamChunk{Delta: delta.Message.Content.Text}, nil
+	case "tool-call-delta":
+		var delta cohereToolCallDelta
+		if err := json.Unmarshal(event.Delta, &delta); err != nil {
+			return nil, nil
+		}
+		args := ""
+		if delta.Function != nil {
+			args = delta.Function.Arguments
+		}
+		return &CanonicalStreamChunk{
+			ToolCallDeltas: []StreamToolCallDelta{{
+				Index:          event.Index,
+				ID:             delta.ID,
+				Name:           deltaFunctionName(delta.Function),
+				ArgumentsDelta: args,
+			}},
+		}, nil
+	case "message-end":
+		var delta cohereMessageEndDelta
+		if err := json.Unmarshal(event.Delta, &delta); err != nil {
+			return nil, nil
+		}
+		sc := &CanonicalStreamChunk{}
+		if delta.FinishReason != "" {
+			sc.FinishReason = cohereFinishToCanonical(delta.FinishReason)
+		}
+		sc.Usage = cohereUsageToCanonical(delta.Usage)
+		if sc.FinishReason == "" && sc.Usage == nil {
+			return nil, nil
+		}
+		return sc, nil
+	default:
+		return nil, nil
+	}
+}
+
+func deltaFunctionName(fn *cohereToolCallFunction) string {
+	if fn == nil {
+		return ""
+	}
+	return fn.Name
+}
+
+func (a *CohereAdapter) EncodeStreamChunk(chunk *CanonicalStreamChunk) ([][]byte, error) {
+	if chunk == nil {
+		return nil, nil
+	}
+	var lines [][]byte
+	if chunk.Delta != "" {
+		payload, _ := json.Marshal(cohereStreamEvent{
+			Type: "content-delta",
+			Delta: mustMarshal(cohereContentDelta{
+				Message: &cohereContentDeltaMessage{
+					Content: &cohereContentBlock{Type: "text", Text: chunk.Delta},
+				},
+			}),
+		})
+		lines = append(lines, SSEEvent("content-delta", payload)...)
+	}
+	if len(chunk.ToolCallDeltas) > 0 {
+		for _, tc := range chunk.ToolCallDeltas {
+			payload, _ := json.Marshal(cohereStreamEvent{
+				Type:  "tool-call-delta",
+				Index: tc.Index,
+				Delta: mustMarshal(cohereToolCallDelta{
+					ID: tc.ID,
+					Function: &cohereToolCallFunction{
+						Name:      tc.Name,
+						Arguments: tc.ArgumentsDelta,
+					},
+				}),
+			})
+			lines = append(lines, SSEEvent("tool-call-delta", payload)...)
+		}
+	}
+	if chunk.FinishReason != "" || chunk.Usage != nil {
+		delta := cohereMessageEndDelta{FinishReason: canonicalFinishToCohere(chunk.FinishReason)}
+		if chunk.Usage != nil {
+			delta.Usage = &cohereUsage{
+				Tokens: &cohereUsageTokens{
+					InputTokens:  chunk.Usage.InputTokens,
+					OutputTokens: chunk.Usage.OutputTokens,
+				},
+			}
+		}
+		payload, _ := json.Marshal(cohereStreamEvent{
+			Type:  "message-end",
+			Delta: mustMarshal(delta),
+		})
+		lines = append(lines, SSEEvent("message-end", payload)...)
+	}
+	if len(lines) == 0 {
+		return nil, nil
+	}
+	return lines, nil
+}
+
+func mustMarshal(v any) json.RawMessage {
+	b, _ := json.Marshal(v)
+	return b
+}

--- a/pkg/infra/providers/adapter/cohere_adapter_test.go
+++ b/pkg/infra/providers/adapter/cohere_adapter_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapter
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCohereAdapter_RoundtripRequest(t *testing.T) {
+	input := `{
+		"model": "command-r-plus",
+		"messages": [{"role": "user", "content": "Hello"}],
+		"max_tokens": 100,
+		"temperature": 0.7
+	}`
+
+	a := &CohereAdapter{}
+	canonical, err := a.DecodeRequest([]byte(input))
+	require.NoError(t, err)
+	assert.Equal(t, "command-r-plus", canonical.Model)
+	assert.Len(t, canonical.Messages, 1)
+
+	encoded, err := a.EncodeRequest(canonical)
+	require.NoError(t, err)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(encoded, &result))
+	assert.Equal(t, "command-r-plus", result["model"])
+}
+
+func TestCohereAdapter_OpenAIToCohereCrossFormat(t *testing.T) {
+	reg := NewRegistry()
+	openaiReq := `{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}`
+
+	out, err := reg.AdaptRequest([]byte(openaiReq), FormatOpenAI, FormatCohere)
+	require.NoError(t, err)
+
+	var cohereReq map[string]any
+	require.NoError(t, json.Unmarshal(out, &cohereReq))
+	assert.Equal(t, "gpt-4", cohereReq["model"])
+	msgs := cohereReq["messages"].([]any)
+	assert.Len(t, msgs, 1)
+}
+
+func TestCohereAdapter_StreamChunkContentDelta(t *testing.T) {
+	a := &CohereAdapter{}
+	chunk := []byte(`{"type":"content-delta","delta":{"message":{"content":{"type":"text","text":"hi"}}}}`)
+
+	got, err := a.DecodeStreamChunk(chunk)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "hi", got.Delta)
+}
+
+func TestCohereEmbedAdapter_OpenAIToCohere(t *testing.T) {
+	reg := NewRegistry()
+	openaiReq := `{"model":"embed-english-v3.0","input":["hello","world"]}`
+
+	out, err := AdaptEmbeddingRequest(reg, []byte(openaiReq), FormatOpenAIEmbeddings, FormatCohereEmbed)
+	require.NoError(t, err)
+
+	var cohereReq map[string]any
+	require.NoError(t, json.Unmarshal(out, &cohereReq))
+	assert.Equal(t, "embed-english-v3.0", cohereReq["model"])
+	assert.Equal(t, []any{"hello", "world"}, cohereReq["texts"])
+}
+
+func TestCohereRerankAdapter_DecodeRequest_Model(t *testing.T) {
+	a := &CohereRerankAdapter{}
+	body := []byte(`{"model":"rerank-english-v3.0","query":"q","documents":["a"]}`)
+
+	got, err := a.DecodeRequest(body)
+	require.NoError(t, err)
+	assert.Equal(t, "rerank-english-v3.0", got.Model)
+}

--- a/pkg/infra/providers/adapter/cohere_embed_adapter.go
+++ b/pkg/infra/providers/adapter/cohere_embed_adapter.go
@@ -1,0 +1,323 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapter
+
+import "encoding/json"
+
+type CanonicalEmbeddingRequest struct {
+	Model     string   `json:"model,omitempty"`
+	Inputs    []string `json:"inputs,omitempty"`
+	InputType string   `json:"input_type,omitempty"`
+}
+
+type CanonicalEmbeddingResponse struct {
+	Model      string       `json:"model,omitempty"`
+	Embeddings [][]float64  `json:"embeddings,omitempty"`
+	Usage      *CanonicalUsage `json:"usage,omitempty"`
+}
+
+type OpenAIEmbeddingsAdapter struct{}
+
+type openAIEmbeddingRequest struct {
+	Model string          `json:"model"`
+	Input json.RawMessage `json:"input"`
+}
+
+type openAIEmbeddingResponse struct {
+	Model string `json:"model"`
+	Data  []struct {
+		Index     int       `json:"index"`
+		Embedding []float64 `json:"embedding"`
+	} `json:"data"`
+	Usage *struct {
+		PromptTokens int `json:"prompt_tokens"`
+		TotalTokens  int `json:"total_tokens"`
+	} `json:"usage,omitempty"`
+}
+
+func (a *OpenAIEmbeddingsAdapter) DecodeRequest(body []byte) (*CanonicalRequest, error) {
+	var req openAIEmbeddingRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, err
+	}
+	inputs, err := decodeEmbeddingInputs(req.Input)
+	if err != nil {
+		return nil, err
+	}
+	emb := &CanonicalEmbeddingRequest{Model: req.Model, Inputs: inputs}
+	raw, err := json.Marshal(emb)
+	if err != nil {
+		return nil, err
+	}
+	return &CanonicalRequest{Model: req.Model, Metadata: map[string]interface{}{"embedding": json.RawMessage(raw)}}, nil
+}
+
+func (a *OpenAIEmbeddingsAdapter) EncodeRequest(req *CanonicalRequest) ([]byte, error) {
+	emb, err := embeddingFromCanonical(req)
+	if err != nil {
+		return nil, err
+	}
+	inputRaw, err := encodeEmbeddingInputs(emb.Inputs)
+	if err != nil {
+		return nil, err
+	}
+	out := openAIEmbeddingRequest{Model: emb.Model, Input: inputRaw}
+	return json.Marshal(out)
+}
+
+func (a *OpenAIEmbeddingsAdapter) DecodeResponse(body []byte) (*CanonicalResponse, error) {
+	var resp openAIEmbeddingResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, err
+	}
+	emb := &CanonicalEmbeddingResponse{Model: resp.Model}
+	for _, item := range resp.Data {
+		emb.Embeddings = append(emb.Embeddings, item.Embedding)
+	}
+	if resp.Usage != nil {
+		emb.Usage = newCanonicalUsage(resp.Usage.PromptTokens, 0, resp.Usage.TotalTokens)
+	}
+	raw, err := json.Marshal(emb)
+	if err != nil {
+		return nil, err
+	}
+	return &CanonicalResponse{
+		Model: resp.Model,
+		ProviderExtensions: map[string]json.RawMessage{
+			"embedding": raw,
+		},
+	}, nil
+}
+
+func (a *OpenAIEmbeddingsAdapter) EncodeResponse(resp *CanonicalResponse) ([]byte, error) {
+	emb, err := embeddingResponseFromCanonical(resp)
+	if err != nil {
+		return nil, err
+	}
+	out := openAIEmbeddingResponse{Model: emb.Model}
+	for i, vec := range emb.Embeddings {
+		out.Data = append(out.Data, struct {
+			Index     int       `json:"index"`
+			Embedding []float64 `json:"embedding"`
+		}{Index: i, Embedding: vec})
+	}
+	if emb.Usage != nil {
+		out.Usage = &struct {
+			PromptTokens int `json:"prompt_tokens"`
+			TotalTokens  int `json:"total_tokens"`
+		}{
+			PromptTokens: emb.Usage.InputTokens,
+			TotalTokens:  emb.Usage.TotalTokens,
+		}
+	}
+	return json.Marshal(out)
+}
+
+func (a *OpenAIEmbeddingsAdapter) DecodeStreamChunk([]byte) (*CanonicalStreamChunk, error) {
+	return nil, nil
+}
+
+func (a *OpenAIEmbeddingsAdapter) EncodeStreamChunk(*CanonicalStreamChunk) ([][]byte, error) {
+	return nil, nil
+}
+
+type CohereEmbedAdapter struct{}
+
+type cohereEmbedRequest struct {
+	Model           string   `json:"model"`
+	Texts           []string `json:"texts"`
+	InputType       string   `json:"input_type"`
+	EmbeddingTypes  []string `json:"embedding_types,omitempty"`
+}
+
+type cohereEmbedResponse struct {
+	ID         string        `json:"id,omitempty"`
+	Embeddings [][]float64   `json:"embeddings"`
+}
+
+func (a *CohereEmbedAdapter) DecodeRequest(body []byte) (*CanonicalRequest, error) {
+	var req cohereEmbedRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, err
+	}
+	emb := &CanonicalEmbeddingRequest{
+		Model:     req.Model,
+		Inputs:    req.Texts,
+		InputType: req.InputType,
+	}
+	raw, err := json.Marshal(emb)
+	if err != nil {
+		return nil, err
+	}
+	return &CanonicalRequest{Model: req.Model, Metadata: map[string]interface{}{"embedding": json.RawMessage(raw)}}, nil
+}
+
+func (a *CohereEmbedAdapter) EncodeRequest(req *CanonicalRequest) ([]byte, error) {
+	emb, err := embeddingFromCanonical(req)
+	if err != nil {
+		return nil, err
+	}
+	inputType := emb.InputType
+	if inputType == "" {
+		inputType = "search_document"
+	}
+	out := cohereEmbedRequest{
+		Model:          emb.Model,
+		Texts:          emb.Inputs,
+		InputType:      inputType,
+		EmbeddingTypes: []string{"float"},
+	}
+	return json.Marshal(out)
+}
+
+func (a *CohereEmbedAdapter) DecodeResponse(body []byte) (*CanonicalResponse, error) {
+	var resp cohereEmbedResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, err
+	}
+	emb := &CanonicalEmbeddingResponse{Embeddings: resp.Embeddings}
+	raw, err := json.Marshal(emb)
+	if err != nil {
+		return nil, err
+	}
+	return &CanonicalResponse{
+		ProviderExtensions: map[string]json.RawMessage{
+			"embedding": raw,
+		},
+	}, nil
+}
+
+func (a *CohereEmbedAdapter) EncodeResponse(resp *CanonicalResponse) ([]byte, error) {
+	emb, err := embeddingResponseFromCanonical(resp)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(cohereEmbedResponse{Embeddings: emb.Embeddings})
+}
+
+func (a *CohereEmbedAdapter) DecodeStreamChunk([]byte) (*CanonicalStreamChunk, error) {
+	return nil, nil
+}
+
+func (a *CohereEmbedAdapter) EncodeStreamChunk(*CanonicalStreamChunk) ([][]byte, error) {
+	return nil, nil
+}
+
+func decodeEmbeddingInputs(raw json.RawMessage) ([]string, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return []string{s}, nil
+	}
+	var arr []string
+	if err := json.Unmarshal(raw, &arr); err != nil {
+		return nil, err
+	}
+	return arr, nil
+}
+
+func encodeEmbeddingInputs(inputs []string) (json.RawMessage, error) {
+	if len(inputs) == 1 {
+		return json.Marshal(inputs[0])
+	}
+	return json.Marshal(inputs)
+}
+
+func embeddingFromCanonical(req *CanonicalRequest) (*CanonicalEmbeddingRequest, error) {
+	if req == nil || req.Metadata == nil {
+		return &CanonicalEmbeddingRequest{Model: req.Model}, nil
+	}
+	raw, ok := req.Metadata["embedding"]
+	if !ok {
+		return &CanonicalEmbeddingRequest{Model: req.Model}, nil
+	}
+	var emb CanonicalEmbeddingRequest
+	switch v := raw.(type) {
+	case json.RawMessage:
+		if err := json.Unmarshal(v, &emb); err != nil {
+			return nil, err
+		}
+	case map[string]interface{}:
+		b, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		if err := json.Unmarshal(b, &emb); err != nil {
+			return nil, err
+		}
+	}
+	if emb.Model == "" {
+		emb.Model = req.Model
+	}
+	return &emb, nil
+}
+
+func embeddingResponseFromCanonical(resp *CanonicalResponse) (*CanonicalEmbeddingResponse, error) {
+	if resp == nil {
+		return &CanonicalEmbeddingResponse{}, nil
+	}
+	raw, ok := resp.ProviderExtensions["embedding"]
+	if !ok {
+		return &CanonicalEmbeddingResponse{Model: resp.Model}, nil
+	}
+	var emb CanonicalEmbeddingResponse
+	if err := json.Unmarshal(raw, &emb); err != nil {
+		return nil, err
+	}
+	if emb.Model == "" {
+		emb.Model = resp.Model
+	}
+	return &emb, nil
+}
+
+func AdaptEmbeddingRequest(registry *Registry, body []byte, source, target Format) ([]byte, error) {
+	if source == target {
+		return body, nil
+	}
+	src, err := registry.GetAdapter(source)
+	if err != nil {
+		return nil, err
+	}
+	dst, err := registry.GetAdapter(target)
+	if err != nil {
+		return nil, err
+	}
+	canonical, err := src.DecodeRequest(body)
+	if err != nil {
+		return nil, err
+	}
+	return dst.EncodeRequest(canonical)
+}
+
+func AdaptEmbeddingResponse(registry *Registry, body []byte, source, target Format) ([]byte, error) {
+	if source == target {
+		return body, nil
+	}
+	src, err := registry.GetAdapter(source)
+	if err != nil {
+		return nil, err
+	}
+	dst, err := registry.GetAdapter(target)
+	if err != nil {
+		return nil, err
+	}
+	canonical, err := dst.DecodeResponse(body)
+	if err != nil {
+		return nil, err
+	}
+	return src.EncodeResponse(canonical)
+}

--- a/pkg/infra/providers/adapter/cohere_rerank_adapter.go
+++ b/pkg/infra/providers/adapter/cohere_rerank_adapter.go
@@ -1,0 +1,95 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapter
+
+import "encoding/json"
+
+type cohereRerankWireRequest struct {
+	Model string `json:"model"`
+}
+
+// CohereRerankAdapter maps gateway /v1/rerank payloads to Cohere v2 rerank wire format.
+// The gateway speaks the same JSON shape as Cohere v2 rerank, so encode/decode are identity.
+type CohereRerankAdapter struct{}
+
+func (a *CohereRerankAdapter) DecodeRequest(body []byte) (*CanonicalRequest, error) {
+	var req cohereRerankWireRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, err
+	}
+	return &CanonicalRequest{
+		Model:    req.Model,
+		Metadata: map[string]interface{}{"rerank": body},
+	}, nil
+}
+
+func (a *CohereRerankAdapter) EncodeRequest(req *CanonicalRequest) ([]byte, error) {
+	if req == nil || req.Metadata == nil {
+		return []byte("{}"), nil
+	}
+	raw, ok := req.Metadata["rerank"]
+	if !ok {
+		return []byte("{}"), nil
+	}
+	switch v := raw.(type) {
+	case []byte:
+		return v, nil
+	case string:
+		return []byte(v), nil
+	default:
+		return []byte("{}"), nil
+	}
+}
+
+func (a *CohereRerankAdapter) DecodeResponse(body []byte) (*CanonicalResponse, error) {
+	return &CanonicalResponse{
+		ProviderExtensions: map[string]json.RawMessage{
+			"rerank": body,
+		},
+	}, nil
+}
+
+func (a *CohereRerankAdapter) EncodeResponse(resp *CanonicalResponse) ([]byte, error) {
+	if resp == nil {
+		return []byte("{}"), nil
+	}
+	raw, ok := resp.ProviderExtensions["rerank"]
+	if !ok {
+		return []byte("{}"), nil
+	}
+	return raw, nil
+}
+
+func (a *CohereRerankAdapter) DecodeStreamChunk([]byte) (*CanonicalStreamChunk, error) {
+	return nil, nil
+}
+
+func (a *CohereRerankAdapter) EncodeStreamChunk(*CanonicalStreamChunk) ([][]byte, error) {
+	return nil, nil
+}
+
+func AdaptRerankRequest(registry *Registry, body []byte, source, target Format) ([]byte, error) {
+	if source == target {
+		return body, nil
+	}
+	return AdaptEmbeddingRequest(registry, body, source, target)
+}
+
+func AdaptRerankResponse(registry *Registry, body []byte, source, target Format) ([]byte, error) {
+	if source == target {
+		return body, nil
+	}
+	return AdaptEmbeddingResponse(registry, body, source, target)
+}

--- a/pkg/infra/providers/adapter/format.go
+++ b/pkg/infra/providers/adapter/format.go
@@ -34,7 +34,8 @@ const (
 	FormatGroq            Format = "groq"  // wire-compatible with OpenAI Chat Completions
 	FormatVertex          Format = "vertex"
 	FormatMistral         Format = "mistral"
-	FormatDeepSeek        Format = "deepseek" // wire-compatible with OpenAI Chat Completions
+	FormatDeepSeek        Format = "deepseek"   // wire-compatible with OpenAI Chat Completions
+	FormatOpenRouter      Format = "openrouter" // wire-compatible with OpenAI Chat Completions
 )
 
 // GeminiModelsRoutePrefix is the fixed Gemini route segment that carries the
@@ -111,7 +112,7 @@ func (f Format) IsOpenAIFamily() bool {
 func SupportedSourceFormat(f Format) bool {
 	switch f {
 	case FormatOpenAI, FormatOpenAIResponses, FormatAnthropic, FormatGemini,
-		FormatAzure, FormatGroq, FormatVertex, FormatMistral, FormatDeepSeek:
+		FormatAzure, FormatGroq, FormatVertex, FormatMistral, FormatDeepSeek, FormatOpenRouter:
 		return true
 	default:
 		return false
@@ -134,6 +135,8 @@ func resolveProviderWireFormat(providerName string) Format {
 		return FormatGroq
 	case provider.DeepSeek:
 		return FormatDeepSeek
+	case provider.OpenRouter:
+		return FormatOpenRouter
 	case provider.OpenAICompatible:
 		return FormatOpenAI
 	default:
@@ -161,7 +164,7 @@ func ResolveAgentFormat(providerName, sourceFormat string, providerOptions map[s
 		return Format(sourceFormat), nil
 	}
 	switch providerName {
-	case provider.OpenAI, provider.OpenAICompatible, provider.Azure, provider.Groq, provider.DeepSeek:
+	case provider.OpenAI, provider.OpenAICompatible, provider.Azure, provider.Groq, provider.DeepSeek, provider.OpenRouter:
 		return ResolveTargetFormat(providerName, providerOptions), nil
 	case provider.Anthropic:
 		return FormatAnthropic, nil
@@ -186,7 +189,7 @@ func IsSameWireFormat(a, b Format) bool {
 
 func normalizeFormat(f Format) Format {
 	switch f {
-	case FormatAzure, FormatGroq, FormatDeepSeek:
+	case FormatAzure, FormatGroq, FormatDeepSeek, FormatOpenRouter:
 		return FormatOpenAI
 	case FormatVertex:
 		return FormatGemini

--- a/pkg/infra/providers/adapter/format.go
+++ b/pkg/infra/providers/adapter/format.go
@@ -137,6 +137,8 @@ func resolveProviderWireFormat(providerName string) Format {
 		return FormatDeepSeek
 	case provider.XAI:
 		return FormatXAI
+	case provider.Cerebras:
+		return FormatOpenAI
 	case provider.OpenAICompatible:
 		return FormatOpenAI
 	default:
@@ -164,7 +166,7 @@ func ResolveAgentFormat(providerName, sourceFormat string, providerOptions map[s
 		return Format(sourceFormat), nil
 	}
 	switch providerName {
-	case provider.OpenAI, provider.OpenAICompatible, provider.Azure, provider.Groq, provider.DeepSeek, provider.XAI:
+	case provider.OpenAI, provider.OpenAICompatible, provider.Azure, provider.Groq, provider.DeepSeek, provider.XAI, provider.Cerebras:
 		return ResolveTargetFormat(providerName, providerOptions), nil
 	case provider.Anthropic:
 		return FormatAnthropic, nil

--- a/pkg/infra/providers/adapter/format.go
+++ b/pkg/infra/providers/adapter/format.go
@@ -35,6 +35,10 @@ const (
 	FormatVertex          Format = "vertex"
 	FormatMistral         Format = "mistral"
 	FormatDeepSeek        Format = "deepseek" // wire-compatible with OpenAI Chat Completions
+	FormatCohere          Format = "cohere"
+	FormatOpenAIEmbeddings Format = "openai_embeddings"
+	FormatCohereEmbed     Format = "cohere_embed"
+	FormatCohereRerank    Format = "cohere_rerank"
 )
 
 // GeminiModelsRoutePrefix is the fixed Gemini route segment that carries the
@@ -99,7 +103,8 @@ func (f Format) SupportsCanonicalToolCalls() bool {
 	return IsSameWireFormat(f, FormatOpenAI) ||
 		f == FormatOpenAIResponses ||
 		f == FormatAnthropic ||
-		f == FormatMistral
+		f == FormatMistral ||
+		f == FormatCohere
 }
 
 // IsOpenAIFamily reports whether the format speaks an OpenAI-compatible wire
@@ -111,7 +116,8 @@ func (f Format) IsOpenAIFamily() bool {
 func SupportedSourceFormat(f Format) bool {
 	switch f {
 	case FormatOpenAI, FormatOpenAIResponses, FormatAnthropic, FormatGemini,
-		FormatAzure, FormatGroq, FormatVertex, FormatMistral, FormatDeepSeek:
+		FormatAzure, FormatGroq, FormatVertex, FormatMistral, FormatDeepSeek,
+		FormatCohere, FormatOpenAIEmbeddings, FormatCohereEmbed, FormatCohereRerank:
 		return true
 	default:
 		return false
@@ -171,10 +177,27 @@ func ResolveAgentFormat(providerName, sourceFormat string, providerOptions map[s
 		return FormatBedrock, nil
 	case provider.Mistral:
 		return FormatMistral, nil
+	case provider.Cohere:
+		return FormatCohere, nil
 	case provider.Vertex:
 		return FormatVertex, nil
 	default:
 		return "", fmt.Errorf("unsupported provider: %s", providerName)
+	}
+}
+
+// ResolveTargetFormatForCapability picks the provider wire format for a proxy capability.
+func ResolveTargetFormatForCapability(providerName string, capability string, providerOptions map[string]any) Format {
+	switch capability {
+	case "embeddings":
+		if providerName == provider.Cohere {
+			return FormatCohereEmbed
+		}
+		return FormatOpenAIEmbeddings
+	case "rerank":
+		return FormatCohereRerank
+	default:
+		return ResolveTargetFormat(providerName, providerOptions)
 	}
 }
 

--- a/pkg/infra/providers/adapter/openrouter_adapter.go
+++ b/pkg/infra/providers/adapter/openrouter_adapter.go
@@ -1,0 +1,170 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapter
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+var openRouterRequestKeys = []string{"provider", "models", "transforms", "route"}
+
+var openRouterResponseKeys = []string{"provider"}
+
+// OpenRouterAdapter wraps OpenAIAdapter and preserves OpenRouter routing fields.
+type OpenRouterAdapter struct {
+	openai OpenAIAdapter
+}
+
+func (a *OpenRouterAdapter) DecodeRequest(body []byte) (*CanonicalRequest, error) {
+	cr, err := a.openai.DecodeRequest(body)
+	if err != nil {
+		return nil, err
+	}
+	cr.RequestExtensions = extractOpenRouterKeys(body, openRouterRequestKeys)
+	return cr, nil
+}
+
+func (a *OpenRouterAdapter) EncodeRequest(req *CanonicalRequest) ([]byte, error) {
+	out, err := a.openai.EncodeRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	return mergeJSONExtensions(out, req.RequestExtensions)
+}
+
+func (a *OpenRouterAdapter) DecodeResponse(body []byte) (*CanonicalResponse, error) {
+	cr, err := a.openai.DecodeResponse(body)
+	if err != nil {
+		return nil, err
+	}
+	ext := extractOpenRouterKeys(body, openRouterResponseKeys)
+	if len(ext) == 0 {
+		return cr, nil
+	}
+	if cr.ProviderExtensions == nil {
+		cr.ProviderExtensions = make(map[string]json.RawMessage, len(ext))
+	}
+	for k, v := range ext {
+		cr.ProviderExtensions[k] = v
+	}
+	return cr, nil
+}
+
+func (a *OpenRouterAdapter) EncodeResponse(resp *CanonicalResponse) ([]byte, error) {
+	out, err := a.openai.EncodeResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+	return mergeJSONExtensions(out, resp.ProviderExtensions)
+}
+
+func (a *OpenRouterAdapter) DecodeStreamChunk(chunk []byte) (*CanonicalStreamChunk, error) {
+	if isSSECommentLine(chunk) {
+		return nil, nil
+	}
+	payload := sseJSONPayload(chunk)
+	if payload == nil {
+		return nil, nil
+	}
+
+	sc, err := a.openai.DecodeStreamChunk(payload)
+	if err != nil || sc == nil {
+		return sc, err
+	}
+	ext := extractOpenRouterKeys(payload, openRouterResponseKeys)
+	if len(ext) == 0 {
+		return sc, nil
+	}
+	if sc.ProviderExtensions == nil {
+		sc.ProviderExtensions = make(map[string]json.RawMessage, len(ext))
+	}
+	for k, v := range ext {
+		sc.ProviderExtensions[k] = v
+	}
+	return sc, nil
+}
+
+func (a *OpenRouterAdapter) EncodeStreamChunk(chunk *CanonicalStreamChunk) ([][]byte, error) {
+	lines, err := a.openai.EncodeStreamChunk(chunk)
+	if err != nil || len(lines) == 0 || chunk == nil || len(chunk.ProviderExtensions) == 0 {
+		return lines, err
+	}
+
+	for i, line := range lines {
+		if !bytes.HasPrefix(line, []byte("data:")) {
+			continue
+		}
+		payload := bytes.TrimSpace(bytes.TrimPrefix(line, []byte("data:")))
+		merged, merr := mergeJSONExtensions(payload, chunk.ProviderExtensions)
+		if merr != nil {
+			return nil, merr
+		}
+		lines[i] = append([]byte("data: "), merged...)
+		break
+	}
+	return lines, nil
+}
+
+func extractOpenRouterKeys(body []byte, keys []string) map[string]json.RawMessage {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil
+	}
+	ext := make(map[string]json.RawMessage)
+	for _, k := range keys {
+		if v, ok := raw[k]; ok && len(v) > 0 && !isEmptyOrNull(v) {
+			ext[k] = v
+		}
+	}
+	if len(ext) == 0 {
+		return nil
+	}
+	return ext
+}
+
+func mergeJSONExtensions(base []byte, extensions map[string]json.RawMessage) ([]byte, error) {
+	if len(extensions) == 0 {
+		return base, nil
+	}
+	var out map[string]json.RawMessage
+	if err := json.Unmarshal(base, &out); err != nil {
+		return nil, err
+	}
+	for k, v := range extensions {
+		out[k] = v
+	}
+	return json.Marshal(out)
+}
+
+func isSSECommentLine(line []byte) bool {
+	trimmed := bytes.TrimSpace(line)
+	return len(trimmed) > 0 && trimmed[0] == ':'
+}
+
+func sseJSONPayload(line []byte) []byte {
+	trimmed := bytes.TrimSpace(line)
+	if len(trimmed) == 0 {
+		return nil
+	}
+	if bytes.HasPrefix(trimmed, []byte("data:")) {
+		payload := bytes.TrimSpace(bytes.TrimPrefix(trimmed, []byte("data:")))
+		if bytes.Equal(payload, []byte("[DONE]")) {
+			return nil
+		}
+		return payload
+	}
+	return trimmed
+}

--- a/pkg/infra/providers/adapter/openrouter_adapter_test.go
+++ b/pkg/infra/providers/adapter/openrouter_adapter_test.go
@@ -1,0 +1,309 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapter
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const openRouterResponseWithProvider = `{
+  "id": "gen-or-1",
+  "object": "chat.completion",
+  "model": "anthropic/claude-sonnet-4",
+  "provider": "Anthropic",
+  "choices": [{
+    "index": 0,
+    "message": {"role": "assistant", "content": "hello"},
+    "finish_reason": "stop"
+  }],
+  "usage": {
+    "prompt_tokens": 10,
+    "completion_tokens": 5,
+    "total_tokens": 15
+  }
+}`
+
+const openRouterStreamFinalChunk = `{
+  "id": "gen-or-stream",
+  "object": "chat.completion.chunk",
+  "model": "anthropic/claude-sonnet-4",
+  "provider": "Anthropic",
+  "choices": [{
+    "index": 0,
+    "delta": {},
+    "finish_reason": "stop"
+  }],
+  "usage": {
+    "prompt_tokens": 10,
+    "completion_tokens": 5,
+    "total_tokens": 15
+  }
+}`
+
+const openRouterChatRequest = `{
+  "model": "anthropic/claude-sonnet-4",
+  "messages": [{"role": "user", "content": "hi"}],
+  "provider": {"order": ["Anthropic"]},
+  "models": ["anthropic/claude-sonnet-4", "openai/gpt-4o"],
+  "transforms": ["middle-out"],
+  "route": "fallback",
+  "max_tokens": 128
+}`
+
+func openRouterAdapter(t *testing.T) ProviderAdapter {
+	t.Helper()
+	a, err := NewRegistry().GetAdapter(FormatOpenRouter)
+	require.NoError(t, err)
+	return a
+}
+
+func TestOpenRouterAdapter_FormatRegistration(t *testing.T) {
+	assert.Equal(t, Format("openrouter"), FormatOpenRouter)
+
+	reg := NewRegistry()
+	_, err := reg.GetAdapter(FormatOpenRouter)
+	require.NoError(t, err)
+
+	assert.Equal(t, FormatOpenRouter, ResolveTargetFormat("openrouter", nil))
+
+	got, err := ResolveAgentFormat("openrouter", "", nil)
+	require.NoError(t, err)
+	assert.Equal(t, FormatOpenRouter, got)
+
+	assert.True(t, IsSameWireFormat(FormatOpenRouter, FormatOpenAI))
+	assert.True(t, IsSameWireFormat(FormatOpenAI, FormatOpenRouter))
+
+	assert.True(t, ShouldPassthroughSameWireFormat(FormatOpenRouter, FormatOpenRouter))
+	assert.False(t, ShouldPassthroughSameWireFormat(FormatOpenAI, FormatOpenRouter))
+	assert.False(t, ShouldPassthroughSameWireFormat(FormatOpenRouter, FormatOpenAI))
+
+	opts := map[string]any{"api": "responses"}
+	assert.Equal(t, FormatOpenAIResponses, ResolveTargetFormat("openai", opts))
+	assert.Equal(t, FormatOpenRouter, ResolveTargetFormat("openrouter", opts))
+}
+
+func TestOpenRouterAdapter_RoundTripPreservesRequestExtensions(t *testing.T) {
+	a := openRouterAdapter(t)
+
+	cr, err := a.DecodeRequest([]byte(openRouterChatRequest))
+	require.NoError(t, err)
+	require.NotNil(t, cr.RequestExtensions["provider"])
+	require.NotNil(t, cr.RequestExtensions["models"])
+	require.NotNil(t, cr.RequestExtensions["transforms"])
+	require.NotNil(t, cr.RequestExtensions["route"])
+
+	encoded, err := a.EncodeRequest(cr)
+	require.NoError(t, err)
+
+	var parsed map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(encoded, &parsed))
+	require.NotNil(t, parsed["provider"])
+	require.NotNil(t, parsed["models"])
+	require.NotNil(t, parsed["transforms"])
+	require.NotNil(t, parsed["route"])
+}
+
+func TestOpenRouterAdapter_RoundTripPreservesProviderMetadata(t *testing.T) {
+	a := openRouterAdapter(t)
+
+	canonical, err := a.DecodeResponse([]byte(openRouterResponseWithProvider))
+	require.NoError(t, err)
+	require.NotNil(t, canonical.ProviderExtensions["provider"])
+
+	encoded, err := a.EncodeResponse(canonical)
+	require.NoError(t, err)
+
+	var parsed map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(encoded, &parsed))
+	require.NotNil(t, parsed["provider"])
+
+	var provider string
+	require.NoError(t, json.Unmarshal(parsed["provider"], &provider))
+	assert.Equal(t, "Anthropic", provider)
+}
+
+func TestOpenRouterAdapter_StreamFinalChunkPreservesProvider(t *testing.T) {
+	a := openRouterAdapter(t)
+
+	canonical, err := a.DecodeStreamChunk([]byte(openRouterStreamFinalChunk))
+	require.NoError(t, err)
+	require.NotNil(t, canonical)
+	require.NotNil(t, canonical.Usage)
+	assert.Equal(t, 15, canonical.Usage.TotalTokens)
+	require.NotNil(t, canonical.ProviderExtensions["provider"])
+
+	lines, err := a.EncodeStreamChunk(canonical)
+	require.NoError(t, err)
+	require.NotEmpty(t, lines)
+
+	var dataLine string
+	for _, line := range lines {
+		if bytes.HasPrefix(line, []byte("data: ")) {
+			dataLine = string(line)
+			break
+		}
+	}
+	require.NotEmpty(t, dataLine)
+	payload := strings.TrimPrefix(dataLine, "data: ")
+
+	var parsed map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal([]byte(payload), &parsed))
+	require.NotNil(t, parsed["provider"])
+	require.NotNil(t, parsed["usage"])
+}
+
+func TestOpenRouterAdapter_DecodeStreamChunk_SkipsSSEComments(t *testing.T) {
+	a := openRouterAdapter(t)
+
+	for _, line := range []string{
+		": OPENROUTER PROCESSING",
+		": ping",
+		" : ping ",
+	} {
+		sc, err := a.DecodeStreamChunk([]byte(line))
+		require.NoError(t, err)
+		assert.Nil(t, sc, "line %q", line)
+	}
+
+	sc, err := a.DecodeStreamChunk([]byte(`data: {"choices":[{"delta":{"content":"ok"}}]}`))
+	require.NoError(t, err)
+	require.NotNil(t, sc)
+	assert.Equal(t, "ok", sc.Delta)
+}
+
+func TestOpenRouterAdapter_CrossFormatDropsRequestExtensions(t *testing.T) {
+	out, err := NewRegistry().AdaptRequest([]byte(openRouterChatRequest), FormatAnthropic, FormatOpenRouter)
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), `"models"`)
+	assert.NotContains(t, string(out), `"transforms"`)
+	assert.NotContains(t, string(out), `"route"`)
+
+	var probe struct {
+		Provider json.RawMessage `json:"provider"`
+	}
+	require.NoError(t, json.Unmarshal(out, &probe))
+	assert.Nil(t, probe.Provider)
+}
+
+func TestOpenRouterAdapter_CrossFormatDropsProviderMetadata(t *testing.T) {
+	out, err := NewRegistry().AdaptResponse([]byte(openRouterResponseWithProvider), FormatAnthropic, FormatOpenRouter)
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), `"provider"`)
+
+	var probe struct {
+		Type string `json:"type"`
+	}
+	require.NoError(t, json.Unmarshal(out, &probe))
+	assert.Equal(t, "message", probe.Type)
+}
+
+func TestOpenRouterAdapter_CrossFormatDropsProviderMetadataToOpenAI(t *testing.T) {
+	out, err := NewRegistry().AdaptResponse([]byte(openRouterResponseWithProvider), FormatOpenAI, FormatOpenRouter)
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), `"provider"`)
+
+	var parsed struct {
+		Object  string          `json:"object"`
+		Choices json.RawMessage `json:"choices"`
+	}
+	require.NoError(t, json.Unmarshal(out, &parsed))
+	assert.Equal(t, "chat.completion", parsed.Object)
+	require.NotNil(t, parsed.Choices)
+}
+
+func TestOpenRouterAdapter_CrossFormatDropsProviderMetadataStream(t *testing.T) {
+	lines, err := NewRegistry().AdaptStreamChunk([]byte(openRouterStreamFinalChunk), FormatOpenAI, FormatOpenRouter)
+	require.NoError(t, err)
+	require.NotEmpty(t, lines)
+
+	combined := ""
+	for _, line := range lines {
+		combined += string(line) + "\n"
+	}
+	assert.NotContains(t, combined, `"provider"`)
+	assert.Contains(t, combined, "usage")
+	assert.Contains(t, combined, "data: ")
+}
+
+func TestOpenRouterAdapter_RequestMappings(t *testing.T) {
+	reg := NewRegistry()
+	a, err := reg.GetAdapter(FormatOpenRouter)
+	require.NoError(t, err)
+
+	t.Run("provider to canonical request", func(t *testing.T) {
+		cr, err := a.DecodeRequest([]byte(openRouterChatRequest))
+		require.NoError(t, err)
+		assert.Equal(t, "anthropic/claude-sonnet-4", cr.Model)
+		require.Len(t, cr.Messages, 1)
+		assert.Equal(t, "user", cr.Messages[0].Role)
+		require.NotNil(t, cr.RequestExtensions["route"])
+	})
+
+	t.Run("canonical to provider request", func(t *testing.T) {
+		cr, err := a.DecodeRequest([]byte(openRouterChatRequest))
+		require.NoError(t, err)
+
+		encoded, err := a.EncodeRequest(cr)
+		require.NoError(t, err)
+
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal(encoded, &parsed))
+		assert.Equal(t, "anthropic/claude-sonnet-4", parsed["model"])
+		assert.Equal(t, "fallback", parsed["route"])
+	})
+
+	t.Run("provider to canonical response", func(t *testing.T) {
+		cr, err := a.DecodeResponse([]byte(openRouterResponseWithProvider))
+		require.NoError(t, err)
+		require.NotNil(t, cr.ProviderExtensions["provider"])
+		assert.Equal(t, "hello", cr.Content)
+	})
+
+	t.Run("canonical to provider response", func(t *testing.T) {
+		cr, err := a.DecodeResponse([]byte(openRouterResponseWithProvider))
+		require.NoError(t, err)
+
+		encoded, err := a.EncodeResponse(cr)
+		require.NoError(t, err)
+		assert.Contains(t, string(encoded), `"provider"`)
+	})
+
+	t.Run("provider to canonical stream", func(t *testing.T) {
+		sc, err := a.DecodeStreamChunk([]byte(openRouterStreamFinalChunk))
+		require.NoError(t, err)
+		require.NotNil(t, sc)
+		require.NotNil(t, sc.ProviderExtensions["provider"])
+		require.NotNil(t, sc.Usage)
+	})
+
+	t.Run("canonical to provider stream", func(t *testing.T) {
+		sc, err := a.DecodeStreamChunk([]byte(openRouterStreamFinalChunk))
+		require.NoError(t, err)
+
+		lines, err := a.EncodeStreamChunk(sc)
+		require.NoError(t, err)
+		combined := string(lines[0])
+		for _, line := range lines[1:] {
+			combined += string(line)
+		}
+		assert.Contains(t, combined, `"provider"`)
+	})
+}

--- a/pkg/infra/providers/adapter/registry.go
+++ b/pkg/infra/providers/adapter/registry.go
@@ -97,6 +97,7 @@ func NewRegistry() *Registry {
 	r.Register(FormatOpenAI, &OpenAIAdapter{})
 	r.Register(FormatGroq, &OpenAIAdapter{})
 	r.Register(FormatDeepSeek, &OpenAIAdapter{})
+	r.Register(FormatOpenRouter, &OpenRouterAdapter{})
 	r.Register(FormatOpenAIResponses, &OpenAIResponsesAdapter{})
 	r.Register(FormatAnthropic, &AnthropicAdapter{})
 	r.Register(FormatGemini, &GeminiAdapter{})
@@ -112,6 +113,9 @@ func (r *Registry) Register(f Format, a ProviderAdapter) {
 
 // GetAdapter returns the adapter for a format, resolving aliases.
 func (r *Registry) GetAdapter(f Format) (ProviderAdapter, error) {
+	if a, ok := r.adapters[f]; ok {
+		return a, nil
+	}
 	f = normalizeFormat(f)
 	a, ok := r.adapters[f]
 	if !ok {
@@ -141,7 +145,7 @@ func (r *Registry) DecodeRequestFor(body []byte, providerFormat Format) (*Canoni
 }
 
 func (r *Registry) AdaptRequest(body []byte, source, target Format) ([]byte, error) {
-	if IsSameWireFormat(source, target) {
+	if ShouldPassthroughSameWireFormat(source, target) {
 		return body, nil
 	}
 
@@ -161,6 +165,7 @@ func (r *Registry) AdaptRequest(body []byte, source, target Format) ([]byte, err
 		}
 		return nil, fmt.Errorf("adapter request decode (%s): %w", source, err)
 	}
+	dropRequestExtensionsForCrossFormat(source, target, canonical)
 
 	out, err := dstAdapter.EncodeRequest(canonical)
 	if err != nil {
@@ -283,16 +288,21 @@ func (r *Registry) AdaptStreamChunk(chunk []byte, source, target Format) ([][]by
 }
 
 // ShouldPassthroughSameWireFormat reports whether request/response bodies can be
-// forwarded without canonical adaptation. Groq is OpenAI-compatible but not
-// identical (e.g. x_groq), so openai↔groq still goes through the adapter.
+// forwarded without canonical adaptation. Groq and OpenRouter are OpenAI-compatible
+// but not identical, so openai↔groq/openrouter still goes through the adapter.
 func ShouldPassthroughSameWireFormat(source, target Format) bool {
 	if !IsSameWireFormat(source, target) {
 		return false
 	}
-	if source != target && (source == FormatGroq || target == FormatGroq) {
+	if source != target && formatUsesExtensionAdapter(source, target) {
 		return false
 	}
 	return true
+}
+
+func formatUsesExtensionAdapter(source, target Format) bool {
+	return source == FormatGroq || target == FormatGroq ||
+		source == FormatOpenRouter || target == FormatOpenRouter
 }
 
 func dropProviderExtensionsForCrossFormat(source, target Format, resp *CanonicalResponse) {
@@ -310,5 +320,14 @@ func dropStreamProviderExtensionsForCrossFormat(source, target Format, chunk *Ca
 	}
 	if source != target {
 		chunk.ProviderExtensions = nil
+	}
+}
+
+func dropRequestExtensionsForCrossFormat(source, target Format, req *CanonicalRequest) {
+	if req == nil {
+		return
+	}
+	if source != target {
+		req.RequestExtensions = nil
 	}
 }

--- a/pkg/infra/providers/adapter/registry.go
+++ b/pkg/infra/providers/adapter/registry.go
@@ -102,6 +102,10 @@ func NewRegistry() *Registry {
 	r.Register(FormatGemini, &GeminiAdapter{})
 	r.Register(FormatBedrock, &BedrockAdapter{})
 	r.Register(FormatMistral, &MistralAdapter{})
+	r.Register(FormatCohere, &CohereAdapter{})
+	r.Register(FormatOpenAIEmbeddings, &OpenAIEmbeddingsAdapter{})
+	r.Register(FormatCohereEmbed, &CohereEmbedAdapter{})
+	r.Register(FormatCohereRerank, &CohereRerankAdapter{})
 	return r
 }
 

--- a/pkg/infra/providers/cerebras/client.go
+++ b/pkg/infra/providers/cerebras/client.go
@@ -1,0 +1,51 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cerebras
+
+import (
+	"context"
+	"iter"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/openai"
+)
+
+const chatCompletionsURL = "https://api.cerebras.ai/v1/chat/completions"
+
+type client struct {
+	chat *openai.ChatCompletionsClient
+}
+
+func NewCerebrasClient() providers.Client {
+	return &client{
+		chat: openai.NewChatCompletionsClient(providers.ProviderCerebras, nil),
+	}
+}
+
+func (c *client) Completions(
+	ctx context.Context,
+	config *providers.Config,
+	reqBody []byte,
+) ([]byte, error) {
+	return c.chat.Completions(ctx, chatCompletionsURL, config, reqBody, nil)
+}
+
+func (c *client) CompletionsStream(
+	ctx context.Context,
+	config *providers.Config,
+	reqBody []byte,
+) (iter.Seq2[[]byte, error], error) {
+	return c.chat.CompletionsStream(ctx, chatCompletionsURL, config, reqBody, nil)
+}

--- a/pkg/infra/providers/cerebras/client_test.go
+++ b/pkg/infra/providers/cerebras/client_test.go
@@ -1,0 +1,145 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cerebras
+
+import (
+	"context"
+	"encoding/json"
+	"iter"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/openai"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// cerebrasClientAt is a test-only wrapper that targets a custom URL so the
+// OpenAI-compatible round trip can be exercised against an httptest server.
+type cerebrasClientAt struct {
+	chat *openai.ChatCompletionsClient
+	url  string
+}
+
+func newCerebrasClientAt(url string) providers.Client {
+	return &cerebrasClientAt{
+		chat: openai.NewChatCompletionsClient(providers.ProviderCerebras, nil),
+		url:  url,
+	}
+}
+
+func (c *cerebrasClientAt) Completions(ctx context.Context, config *providers.Config, reqBody []byte) ([]byte, error) {
+	return c.chat.Completions(ctx, c.url, config, reqBody, nil)
+}
+
+func (c *cerebrasClientAt) CompletionsStream(ctx context.Context, config *providers.Config, reqBody []byte) (iter.Seq2[[]byte, error], error) {
+	return c.chat.CompletionsStream(ctx, c.url, config, reqBody, nil)
+}
+
+func TestNewCerebrasClient(t *testing.T) {
+	assert.NotNil(t, NewCerebrasClient())
+}
+
+func TestCompletions_MissingAPIKey(t *testing.T) {
+	_, err := NewCerebrasClient().Completions(context.Background(), &providers.Config{}, []byte(`{}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "API key is required")
+}
+
+func TestCompletions_NonStreamingRoundTrip(t *testing.T) {
+	const wantModel = "llama-3.3-70b"
+	var gotAuth, gotModel string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		gotAuth = r.Header.Get("Authorization")
+
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		gotModel, _ = body["model"].(string)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"model": wantModel,
+			"usage": map[string]any{"total_tokens": 42},
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	resp, err := newCerebrasClientAt(srv.URL+"/chat/completions").Completions(
+		context.Background(),
+		&providers.Config{Credentials: providers.Credentials{ApiKey: "cerebras-test-key"}},
+		[]byte(`{"model":"`+wantModel+`","messages":[{"role":"user","content":"hello"}]}`),
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Bearer cerebras-test-key", gotAuth)
+	assert.Equal(t, wantModel, gotModel)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(resp, &parsed))
+	assert.Equal(t, wantModel, parsed["model"])
+	assert.NotNil(t, parsed["usage"], "usage must survive verbatim passthrough")
+}
+
+func TestCompletionsStream_RoundTrip(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer cerebras-key", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	t.Cleanup(srv.Close)
+
+	seq, err := newCerebrasClientAt(srv.URL+"/chat/completions").CompletionsStream(
+		context.Background(),
+		&providers.Config{Credentials: providers.Credentials{ApiKey: "cerebras-key"}},
+		[]byte(`{"model":"llama-3.3-70b","stream":true}`),
+	)
+	require.NoError(t, err)
+
+	var lines []string
+	for line, lerr := range seq {
+		require.NoError(t, lerr)
+		lines = append(lines, string(line))
+	}
+	require.NotEmpty(t, lines)
+	assert.Equal(t, `data: {"choices":[{"delta":{"content":"hi"}}]}`, lines[0])
+	assert.Equal(t, `data: [DONE]`, lines[len(lines)-1])
+}
+
+func TestCompletions_RateLimitRetryAfter(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "2")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"rate limit exceeded"}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := newCerebrasClientAt(srv.URL+"/chat/completions").Completions(
+		context.Background(),
+		&providers.Config{Credentials: providers.Credentials{ApiKey: "key"}},
+		[]byte(`{"model":"llama-3.3-70b","messages":[{"role":"user","content":"hi"}]}`),
+	)
+	require.Error(t, err)
+
+	be, ok := registry.IsBackendError(err)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusTooManyRequests, be.StatusCode)
+	assert.Equal(t, "2", be.RetryAfter)
+}

--- a/pkg/infra/providers/cerebras/connection.go
+++ b/pkg/infra/providers/cerebras/connection.go
@@ -1,0 +1,27 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cerebras
+
+import (
+	"context"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+)
+
+const modelsURL = "https://api.cerebras.ai/v1/models"
+
+func (c *client) TestConnection(ctx context.Context, config *providers.Config) providers.ProbeResult {
+	return providers.RunBearerGETProbe(ctx, providers.ProviderCerebras, modelsURL, config.Credentials.ApiKey)
+}

--- a/pkg/infra/providers/client.go
+++ b/pkg/infra/providers/client.go
@@ -36,6 +36,7 @@ const (
 	ProviderGroq             = provider.Groq
 	ProviderDeepSeek         = provider.DeepSeek
 	ProviderXAI              = provider.XAI
+	ProviderCerebras         = provider.Cerebras
 )
 
 type Config struct {

--- a/pkg/infra/providers/client.go
+++ b/pkg/infra/providers/client.go
@@ -35,6 +35,7 @@ const (
 	ProviderMistral          = provider.Mistral
 	ProviderGroq             = provider.Groq
 	ProviderDeepSeek         = provider.DeepSeek
+	ProviderCohere           = provider.Cohere
 )
 
 type Config struct {
@@ -98,4 +99,14 @@ type Client interface {
 		config *Config,
 		reqBody []byte,
 	) (iter.Seq2[[]byte, error], error)
+}
+
+// EmbeddingsClient performs non-streaming embedding requests.
+type EmbeddingsClient interface {
+	Embeddings(ctx context.Context, config *Config, reqBody []byte) ([]byte, error)
+}
+
+// RerankClient performs non-streaming rerank requests.
+type RerankClient interface {
+	Rerank(ctx context.Context, config *Config, reqBody []byte) ([]byte, error)
 }

--- a/pkg/infra/providers/client.go
+++ b/pkg/infra/providers/client.go
@@ -35,6 +35,7 @@ const (
 	ProviderMistral          = provider.Mistral
 	ProviderGroq             = provider.Groq
 	ProviderDeepSeek         = provider.DeepSeek
+	ProviderOpenRouter       = provider.OpenRouter
 )
 
 type Config struct {

--- a/pkg/infra/providers/cohere/client.go
+++ b/pkg/infra/providers/cohere/client.go
@@ -1,0 +1,152 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cohere
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"iter"
+	"net/http"
+
+	"github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+)
+
+type client struct {
+	pool *providers.HTTPClientPool
+}
+
+func NewCohereClient() providers.Client {
+	return &client{
+		pool: providers.NewHTTPClientPool(),
+	}
+}
+
+func (c *client) Completions(
+	ctx context.Context,
+	config *providers.Config,
+	reqBody []byte,
+) ([]byte, error) {
+	if config.Credentials.ApiKey == "" {
+		return nil, fmt.Errorf("API key is required")
+	}
+	url, err := chatURL(config.Options)
+	if err != nil {
+		return nil, err
+	}
+	return c.rawPost(ctx, url, config.Credentials.ApiKey, reqBody)
+}
+
+func (c *client) CompletionsStream(
+	ctx context.Context,
+	config *providers.Config,
+	reqBody []byte,
+) (iter.Seq2[[]byte, error], error) {
+	if config.Credentials.ApiKey == "" {
+		return nil, fmt.Errorf("API key is required")
+	}
+	url, err := chatURL(config.Options)
+	if err != nil {
+		return nil, err
+	}
+
+	httpClient := c.pool.GetStream(providers.ProviderCohere)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+	setHeaders(httpReq, config.Credentials.ApiKey)
+
+	resp, err := httpClient.Do(httpReq) // #nosec G704 -- URL from provider options or compile-time default host
+	if err != nil {
+		return nil, fmt.Errorf("HTTP request failed: %w", err)
+	}
+	if registry.IsHTTPError(resp.StatusCode) {
+		var preview bytes.Buffer
+		_, _ = io.CopyN(&preview, resp.Body, 64*1024)
+		providers.DrainBody(resp.Body)
+		return nil, registry.NewBackendHTTPError(resp.StatusCode, preview.Bytes(), resp.Header)
+	}
+
+	return providers.StreamResponse(ctx, resp.Body), nil
+}
+
+func (c *client) Embeddings(
+	ctx context.Context,
+	config *providers.Config,
+	reqBody []byte,
+) ([]byte, error) {
+	if config.Credentials.ApiKey == "" {
+		return nil, fmt.Errorf("API key is required")
+	}
+	url, err := embedURL(config.Options)
+	if err != nil {
+		return nil, err
+	}
+	return c.rawPost(ctx, url, config.Credentials.ApiKey, reqBody)
+}
+
+func (c *client) Rerank(
+	ctx context.Context,
+	config *providers.Config,
+	reqBody []byte,
+) ([]byte, error) {
+	if config.Credentials.ApiKey == "" {
+		return nil, fmt.Errorf("API key is required")
+	}
+	url, err := rerankURL(config.Options)
+	if err != nil {
+		return nil, err
+	}
+	return c.rawPost(ctx, url, config.Credentials.ApiKey, reqBody)
+}
+
+func (c *client) rawPost(
+	ctx context.Context,
+	url, apiKey string,
+	reqBody []byte,
+) ([]byte, error) {
+	httpClient := c.pool.Get(providers.ProviderCohere, providers.DefaultHTTPTimeout)
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+	setHeaders(httpReq, apiKey)
+
+	resp, err := httpClient.Do(httpReq) // #nosec G704 -- URL from provider options or compile-time default host
+	if err != nil {
+		return nil, fmt.Errorf("HTTP request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var body bytes.Buffer
+	if _, err := body.ReadFrom(resp.Body); err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if registry.IsHTTPError(resp.StatusCode) {
+		return nil, registry.NewBackendHTTPError(resp.StatusCode, body.Bytes(), resp.Header)
+	}
+
+	return body.Bytes(), nil
+}
+
+func setHeaders(req *http.Request, apiKey string) {
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+}

--- a/pkg/infra/providers/cohere/client_test.go
+++ b/pkg/infra/providers/cohere/client_test.go
@@ -1,0 +1,122 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cohere
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCohereClient(t *testing.T) {
+	assert.NotNil(t, NewCohereClient())
+}
+
+func TestCompletions_MissingAPIKey(t *testing.T) {
+	_, err := NewCohereClient().Completions(context.Background(), &providers.Config{}, []byte(`{}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "API key is required")
+}
+
+func TestEmbeddings_MissingAPIKey(t *testing.T) {
+	c := NewCohereClient().(providers.EmbeddingsClient)
+	_, err := c.Embeddings(context.Background(), &providers.Config{}, []byte(`{}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "API key is required")
+}
+
+func TestRerank_MissingAPIKey(t *testing.T) {
+	c := NewCohereClient().(providers.RerankClient)
+	_, err := c.Rerank(context.Background(), &providers.Config{}, []byte(`{}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "API key is required")
+}
+
+func TestRawPost_RoundTrip(t *testing.T) {
+	var gotAuth, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotPath = r.URL.Path
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chat-1"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := &client{pool: providers.NewHTTPClientPool()}
+	resp, err := c.rawPost(context.Background(), srv.URL+"/v2/chat", "cohere-key", []byte(`{"model":"command-r-plus"}`))
+	require.NoError(t, err)
+
+	assert.Equal(t, "Bearer cohere-key", gotAuth)
+	assert.Equal(t, "/v2/chat", gotPath)
+	assert.JSONEq(t, `{"id":"chat-1"}`, string(resp))
+}
+
+func TestEmbeddings_RoundTrip(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v2/embed", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"embeddings":[[0.1,0.2]]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewCohereClient().(providers.EmbeddingsClient)
+	resp, err := c.Embeddings(context.Background(), &providers.Config{
+		Credentials: providers.Credentials{ApiKey: "cohere-key"},
+		Options:     map[string]any{"base_url": srv.URL},
+	}, []byte(`{"model":"embed-english-v3.0","texts":["hi"],"input_type":"search_document"}`))
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"embeddings":[[0.1,0.2]]}`, string(resp))
+}
+
+func TestRerank_RoundTrip(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v2/rerank", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[{"index":0,"relevance_score":0.9}]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewCohereClient().(providers.RerankClient)
+	resp, err := c.Rerank(context.Background(), &providers.Config{
+		Credentials: providers.Credentials{ApiKey: "cohere-key"},
+		Options:     map[string]any{"base_url": srv.URL},
+	}, []byte(`{"model":"rerank-english-v3.0","query":"q","documents":["a"]}`))
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"results":[{"index":0,"relevance_score":0.9}]}`, string(resp))
+}
+
+func TestRawPost_BackendErrorPassthrough(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"invalid key"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := &client{pool: providers.NewHTTPClientPool()}
+	_, err := c.rawPost(context.Background(), srv.URL, "bad", []byte(`{}`))
+	require.Error(t, err)
+
+	be, ok := registry.IsBackendError(err)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusUnauthorized, be.StatusCode)
+	assert.JSONEq(t, `{"message":"invalid key"}`, string(be.Body))
+}

--- a/pkg/infra/providers/cohere/connection.go
+++ b/pkg/infra/providers/cohere/connection.go
@@ -1,0 +1,33 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cohere
+
+import (
+	"context"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+)
+
+func (c *client) TestConnection(ctx context.Context, config *providers.Config) providers.ProbeResult {
+	url, err := modelsURL(config.Options)
+	if err != nil {
+		return providers.ProbeResult{
+			OK:      false,
+			Stage:   providers.StageProvider,
+			Message: err.Error(),
+		}
+	}
+	return providers.RunBearerGETProbe(ctx, providers.ProviderCohere, url, config.Credentials.ApiKey)
+}

--- a/pkg/infra/providers/cohere/connection_test.go
+++ b/pkg/infra/providers/cohere/connection_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cohere
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestModelsURL_DefaultHost(t *testing.T) {
+	got, err := modelsURL(nil)
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.cohere.com/v1/models", got)
+}
+
+func TestModelsURL_CustomBaseURL(t *testing.T) {
+	srv := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(srv.Close)
+
+	got, err := modelsURL(map[string]any{"base_url": srv.URL})
+	require.NoError(t, err)
+	assert.Equal(t, srv.URL+"/v1/models", got)
+}
+
+func TestTestConnection_MissingAPIKey(t *testing.T) {
+	got := NewCohereClient().(*client).TestConnection(context.Background(), &providers.Config{})
+	assert.False(t, got.OK)
+	assert.Equal(t, providers.StageAuthentication, got.Stage)
+}
+
+func TestTestConnection_OK(t *testing.T) {
+	var gotAuth, gotPath, gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"models":[]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	got := NewCohereClient().(*client).TestConnection(context.Background(), &providers.Config{
+		Credentials: providers.Credentials{ApiKey: "cohere-key"},
+		Options:     map[string]any{"base_url": srv.URL},
+	})
+
+	assert.True(t, got.OK)
+	assert.Equal(t, "Bearer cohere-key", gotAuth)
+	assert.Equal(t, "/v1/models", gotPath)
+	assert.Equal(t, http.MethodGet, gotMethod)
+}

--- a/pkg/infra/providers/cohere/urls.go
+++ b/pkg/infra/providers/cohere/urls.go
@@ -1,0 +1,66 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cohere
+
+import (
+	"strings"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+)
+
+const defaultAPIHost = "https://api.cohere.com"
+
+func apiHost(options map[string]any) (string, error) {
+	opts, err := providers.DecodeCohereOptions(options)
+	if err != nil {
+		return "", err
+	}
+	if opts.BaseURL != "" {
+		return strings.TrimRight(opts.BaseURL, "/"), nil
+	}
+	return defaultAPIHost, nil
+}
+
+func chatURL(options map[string]any) (string, error) {
+	host, err := apiHost(options)
+	if err != nil {
+		return "", err
+	}
+	return host + "/v2/chat", nil
+}
+
+func embedURL(options map[string]any) (string, error) {
+	host, err := apiHost(options)
+	if err != nil {
+		return "", err
+	}
+	return host + "/v2/embed", nil
+}
+
+func rerankURL(options map[string]any) (string, error) {
+	host, err := apiHost(options)
+	if err != nil {
+		return "", err
+	}
+	return host + "/v2/rerank", nil
+}
+
+func modelsURL(options map[string]any) (string, error) {
+	host, err := apiHost(options)
+	if err != nil {
+		return "", err
+	}
+	return host + "/v1/models", nil
+}

--- a/pkg/infra/providers/factory/locator.go
+++ b/pkg/infra/providers/factory/locator.go
@@ -21,6 +21,7 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/anthropic"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/azure"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/bedrock"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/cohere"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/deepseek"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/google"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/groq"
@@ -43,6 +44,7 @@ const (
 	ProviderMistral          = providers.ProviderMistral
 	ProviderGroq             = providers.ProviderGroq
 	ProviderDeepSeek         = providers.ProviderDeepSeek
+	ProviderCohere           = providers.ProviderCohere
 )
 
 //go:generate mockery --name=ProviderLocator --dir=. --output=./mocks --filename=provider_locator_mock.go --case=underscore --with-expecter
@@ -74,6 +76,7 @@ func NewProviderLocator() ProviderLocator {
 			ProviderGroq:             groq.NewGroqClient(),
 			ProviderDeepSeek:         deepseek.NewDeepSeekClient(),
 			ProviderVertex:           vertex.NewVertexClient(),
+			ProviderCohere:           cohere.NewCohereClient(),
 		},
 	}
 }

--- a/pkg/infra/providers/factory/locator.go
+++ b/pkg/infra/providers/factory/locator.go
@@ -21,6 +21,7 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/anthropic"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/azure"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/bedrock"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/cerebras"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/deepseek"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/google"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/groq"
@@ -45,6 +46,7 @@ const (
 	ProviderGroq             = providers.ProviderGroq
 	ProviderDeepSeek         = providers.ProviderDeepSeek
 	ProviderXAI              = providers.ProviderXAI
+	ProviderCerebras         = providers.ProviderCerebras
 )
 
 //go:generate mockery --name=ProviderLocator --dir=. --output=./mocks --filename=provider_locator_mock.go --case=underscore --with-expecter
@@ -76,6 +78,7 @@ func NewProviderLocator() ProviderLocator {
 			ProviderGroq:             groq.NewGroqClient(),
 			ProviderDeepSeek:         deepseek.NewDeepSeekClient(),
 			ProviderXAI:              xai.NewXAIClient(),
+			ProviderCerebras:         cerebras.NewCerebrasClient(),
 			ProviderVertex:           vertex.NewVertexClient(),
 		},
 	}

--- a/pkg/infra/providers/factory/locator.go
+++ b/pkg/infra/providers/factory/locator.go
@@ -26,6 +26,7 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/groq"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/mistral"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/openai"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/openrouter"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/openaicompat"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/vertex"
 )
@@ -43,6 +44,7 @@ const (
 	ProviderMistral          = providers.ProviderMistral
 	ProviderGroq             = providers.ProviderGroq
 	ProviderDeepSeek         = providers.ProviderDeepSeek
+	ProviderOpenRouter       = providers.ProviderOpenRouter
 )
 
 //go:generate mockery --name=ProviderLocator --dir=. --output=./mocks --filename=provider_locator_mock.go --case=underscore --with-expecter
@@ -73,6 +75,7 @@ func NewProviderLocator() ProviderLocator {
 			ProviderMistral:          mistral.NewMistralClient(),
 			ProviderGroq:             groq.NewGroqClient(),
 			ProviderDeepSeek:         deepseek.NewDeepSeekClient(),
+			ProviderOpenRouter:       openrouter.NewOpenRouterClient(),
 			ProviderVertex:           vertex.NewVertexClient(),
 		},
 	}

--- a/pkg/infra/providers/factory/locator_test.go
+++ b/pkg/infra/providers/factory/locator_test.go
@@ -36,6 +36,7 @@ func TestProviderLocator_Get(t *testing.T) {
 		ProviderGroq,
 		ProviderDeepSeek,
 		ProviderXAI,
+		ProviderCerebras,
 	} {
 		t.Run(provider, func(t *testing.T) {
 			client, err := locator.Get(provider)

--- a/pkg/infra/providers/factory/locator_test.go
+++ b/pkg/infra/providers/factory/locator_test.go
@@ -35,6 +35,7 @@ func TestProviderLocator_Get(t *testing.T) {
 		ProviderMistral,
 		ProviderGroq,
 		ProviderDeepSeek,
+		ProviderOpenRouter,
 	} {
 		t.Run(provider, func(t *testing.T) {
 			client, err := locator.Get(provider)

--- a/pkg/infra/providers/factory/locator_test.go
+++ b/pkg/infra/providers/factory/locator_test.go
@@ -35,6 +35,7 @@ func TestProviderLocator_Get(t *testing.T) {
 		ProviderMistral,
 		ProviderGroq,
 		ProviderDeepSeek,
+		ProviderCohere,
 	} {
 		t.Run(provider, func(t *testing.T) {
 			client, err := locator.Get(provider)

--- a/pkg/infra/providers/openrouter/client.go
+++ b/pkg/infra/providers/openrouter/client.go
@@ -1,0 +1,52 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openrouter
+
+import (
+	"context"
+	"iter"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/openai"
+)
+
+const chatCompletionsURL = "https://openrouter.ai/api/v1/chat/completions"
+
+type client struct {
+	chat *openai.ChatCompletionsClient
+}
+
+// NewOpenRouterClient builds an OpenRouter chat-completions client.
+func NewOpenRouterClient() providers.Client {
+	return &client{
+		chat: openai.NewChatCompletionsClient(providers.ProviderOpenRouter, nil),
+	}
+}
+
+func (c *client) Completions(
+	ctx context.Context,
+	config *providers.Config,
+	reqBody []byte,
+) ([]byte, error) {
+	return c.chat.Completions(ctx, chatCompletionsURL, config, reqBody, nil)
+}
+
+func (c *client) CompletionsStream(
+	ctx context.Context,
+	config *providers.Config,
+	reqBody []byte,
+) (iter.Seq2[[]byte, error], error) {
+	return c.chat.CompletionsStream(ctx, chatCompletionsURL, config, reqBody, nil)
+}

--- a/pkg/infra/providers/openrouter/client_test.go
+++ b/pkg/infra/providers/openrouter/client_test.go
@@ -1,0 +1,143 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openrouter
+
+import (
+	"context"
+	"encoding/json"
+	"iter"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/openai"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type openRouterClientAt struct {
+	chat *openai.ChatCompletionsClient
+	url  string
+}
+
+func newOpenRouterClientAt(url string) providers.Client {
+	return &openRouterClientAt{
+		chat: openai.NewChatCompletionsClient(providers.ProviderOpenRouter, nil),
+		url:  url,
+	}
+}
+
+func (c *openRouterClientAt) Completions(ctx context.Context, config *providers.Config, reqBody []byte) ([]byte, error) {
+	return c.chat.Completions(ctx, c.url, config, reqBody, nil)
+}
+
+func (c *openRouterClientAt) CompletionsStream(ctx context.Context, config *providers.Config, reqBody []byte) (iter.Seq2[[]byte, error], error) {
+	return c.chat.CompletionsStream(ctx, c.url, config, reqBody, nil)
+}
+
+func TestNewOpenRouterClient(t *testing.T) {
+	assert.NotNil(t, NewOpenRouterClient())
+}
+
+func TestCompletions_MissingAPIKey(t *testing.T) {
+	_, err := NewOpenRouterClient().Completions(context.Background(), &providers.Config{}, []byte(`{}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "API key is required")
+}
+
+func TestCompletions_NonStreamingRoundTrip(t *testing.T) {
+	const wantModel = "anthropic/claude-sonnet-4"
+	var gotAuth, gotModel string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		gotAuth = r.Header.Get("Authorization")
+
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		gotModel, _ = body["model"].(string)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"model":    wantModel,
+			"provider": "Anthropic",
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	resp, err := newOpenRouterClientAt(srv.URL+"/chat/completions").Completions(
+		context.Background(),
+		&providers.Config{Credentials: providers.Credentials{ApiKey: "or-test-key"}},
+		[]byte(`{"model":"`+wantModel+`","messages":[{"role":"user","content":"hello"}]}`),
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Bearer or-test-key", gotAuth)
+	assert.Equal(t, wantModel, gotModel)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(resp, &parsed))
+	assert.Equal(t, wantModel, parsed["model"])
+	assert.Equal(t, "Anthropic", parsed["provider"])
+}
+
+func TestCompletionsStream_RoundTrip(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer or-key", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	t.Cleanup(srv.Close)
+
+	seq, err := newOpenRouterClientAt(srv.URL+"/chat/completions").CompletionsStream(
+		context.Background(),
+		&providers.Config{Credentials: providers.Credentials{ApiKey: "or-key"}},
+		[]byte(`{"model":"anthropic/claude-sonnet-4","stream":true}`),
+	)
+	require.NoError(t, err)
+
+	var lines []string
+	for line, lerr := range seq {
+		require.NoError(t, lerr)
+		lines = append(lines, string(line))
+	}
+	require.NotEmpty(t, lines)
+	assert.Equal(t, `data: {"choices":[{"delta":{"content":"hi"}}]}`, lines[0])
+	assert.Equal(t, `data: [DONE]`, lines[len(lines)-1])
+}
+
+func TestCompletions_RateLimitRetryAfter(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "2")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"rate limit exceeded"}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := newOpenRouterClientAt(srv.URL+"/chat/completions").Completions(
+		context.Background(),
+		&providers.Config{Credentials: providers.Credentials{ApiKey: "key"}},
+		[]byte(`{"model":"anthropic/claude-sonnet-4","messages":[{"role":"user","content":"hi"}]}`),
+	)
+	require.Error(t, err)
+
+	be, ok := registry.IsBackendError(err)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusTooManyRequests, be.StatusCode)
+	assert.Equal(t, "2", be.RetryAfter)
+}

--- a/pkg/infra/providers/openrouter/connection.go
+++ b/pkg/infra/providers/openrouter/connection.go
@@ -1,0 +1,27 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openrouter
+
+import (
+	"context"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+)
+
+const modelsURL = "https://openrouter.ai/api/v1/models"
+
+func (c *client) TestConnection(ctx context.Context, config *providers.Config) providers.ProbeResult {
+	return providers.RunBearerGETProbe(ctx, providers.ProviderOpenRouter, modelsURL, config.Credentials.ApiKey)
+}

--- a/pkg/infra/providers/openrouter/connection_test.go
+++ b/pkg/infra/providers/openrouter/connection_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openrouter
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+	"github.com/stretchr/testify/assert"
+)
+
+type openRouterProbeAt struct {
+	modelsURL string
+}
+
+func (c *openRouterProbeAt) TestConnection(ctx context.Context, config *providers.Config) providers.ProbeResult {
+	return providers.RunBearerGETProbe(ctx, providers.ProviderOpenRouter, c.modelsURL, config.Credentials.ApiKey)
+}
+
+func TestTestConnection_OK(t *testing.T) {
+	var gotAuth, gotPath, gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	got := (&openRouterProbeAt{modelsURL: srv.URL}).TestConnection(context.Background(), &providers.Config{
+		Credentials: providers.Credentials{ApiKey: "or-test"},
+	})
+
+	assert.True(t, got.OK)
+	assert.Equal(t, providers.StageAuthentication, got.Stage)
+	assert.Equal(t, "Bearer or-test", gotAuth)
+	assert.Equal(t, "/", gotPath)
+	assert.Equal(t, http.MethodGet, gotMethod)
+}
+
+func TestTestConnection_MissingAPIKey(t *testing.T) {
+	got := NewOpenRouterClient().(interface {
+		TestConnection(context.Context, *providers.Config) providers.ProbeResult
+	}).TestConnection(context.Background(), &providers.Config{})
+
+	assert.False(t, got.OK)
+	assert.Equal(t, providers.StageAuthentication, got.Stage)
+}
+
+func TestTestConnection_AuthFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(srv.Close)
+
+	got := (&openRouterProbeAt{modelsURL: srv.URL}).TestConnection(context.Background(), &providers.Config{
+		Credentials: providers.Credentials{ApiKey: "or-bad"},
+	})
+	assert.False(t, got.OK)
+}

--- a/pkg/infra/providers/options.go
+++ b/pkg/infra/providers/options.go
@@ -114,6 +114,26 @@ func DecodeVertexOptions(options map[string]any) (VertexOptions, error) {
 	return opts, nil
 }
 
+type CohereOptions struct {
+	BaseURL string `mapstructure:"base_url"`
+}
+
+func DecodeCohereOptions(options map[string]any) (CohereOptions, error) {
+	var opts CohereOptions
+	if len(options) > 0 {
+		if err := mapstructure.Decode(options, &opts); err != nil {
+			return CohereOptions{}, fmt.Errorf("cohere: invalid provider_options: %w", err)
+		}
+	}
+	opts.BaseURL = strings.TrimSpace(opts.BaseURL)
+	if opts.BaseURL != "" {
+		if err := validateHTTPBaseURL(opts.BaseURL); err != nil {
+			return CohereOptions{}, fmt.Errorf("cohere: %w", err)
+		}
+	}
+	return opts, nil
+}
+
 func validateHTTPBaseURL(raw string) error {
 	parsed, err := url.Parse(raw)
 	if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {

--- a/tests/functional/cohere_provider_test.go
+++ b/tests/functional/cohere_provider_test.go
@@ -1,0 +1,120 @@
+//go:build functional
+
+package functional_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func cohereBackendPayload(name, baseURL string) map[string]any {
+	return map[string]any{
+		"name":             name,
+		"provider":         "cohere",
+		"weight":           1,
+		"provider_options": map[string]any{"base_url": baseURL},
+		"auth": map[string]any{
+			"type":    "api_key",
+			"api_key": map[string]any{"api_key": "cohere-test"},
+		},
+	}
+}
+
+func newCohereUpstream(t *testing.T) *fakeUpstream {
+	t.Helper()
+	u := &fakeUpstream{}
+	u.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u.record(r)
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v2/chat":
+			_, _ = io.WriteString(w, `{"id":"chat-1","finish_reason":"COMPLETE","message":{"role":"assistant","content":[{"type":"text","text":"cohere-reply"}]}}`)
+		case "/v2/embed":
+			_, _ = io.WriteString(w, `{"embeddings":[[0.1,0.2,0.3]]}`)
+		case "/v2/rerank":
+			_, _ = io.WriteString(w, `{"results":[{"index":0,"relevance_score":0.95}]}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = fmt.Fprintf(w, `{"message":"unknown path %s"}`, r.URL.Path)
+		}
+	}))
+	t.Cleanup(u.server.Close)
+	return u
+}
+
+func setupCohereRoute(t *testing.T, up *fakeUpstream) (string, string) {
+	t.Helper()
+	gatewayID := CreateGateway(t, map[string]any{"slug": uniqueName("cohere-gw")})
+	registryID := CreateRegistry(t, gatewayID, cohereBackendPayload(uniqueName("cohere-be"), up.URL()))
+	coID := CreateConsumer(t, gatewayID, map[string]any{"name": uniqueName("cohere-cons")})
+	AttachRegistry(t, gatewayID, coID, registryID)
+	apiKey := createAndAttachAPIKey(t, gatewayID, coID)
+	return apiKey, ConsumerSlug(t, coID)
+}
+
+func TestCohereProvider_NativeChat(t *testing.T) {
+	defer Track(t, "CohereProvider")()
+
+	up := newCohereUpstream(t)
+	apiKey, slug := setupCohereRoute(t, up)
+
+	status, headers, body := proxyPost(t, apiKey, "/"+slug+"/v2/chat", map[string]any{
+		"model":    "command-r-plus",
+		"messages": []map[string]string{{"role": "user", "content": "Hello"}},
+	})
+
+	assert.Equal(t, http.StatusOK, status, "body: %s", body)
+	assert.Equal(t, "cohere", headers.Get("X-Selected-Provider"))
+	assert.Contains(t, string(body), "cohere-reply")
+	assert.Equal(t, 1, up.Hits())
+}
+
+func TestCohereProvider_EmbeddingsCrossFormat(t *testing.T) {
+	defer Track(t, "CohereProvider")()
+
+	up := newCohereUpstream(t)
+	apiKey, slug := setupCohereRoute(t, up)
+
+	status, headers, body := proxyPost(t, apiKey, "/"+slug+"/v1/embeddings", map[string]any{
+		"model": "embed-english-v3.0",
+		"input": []string{"hello"},
+	})
+
+	assert.Equal(t, http.StatusOK, status, "body: %s", body)
+	assert.Equal(t, "cohere", headers.Get("X-Selected-Provider"))
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(body, &resp))
+	data := resp["data"].([]any)
+	assert.Len(t, data, 1)
+	assert.Equal(t, 1, up.Hits())
+}
+
+func TestCohereProvider_Rerank(t *testing.T) {
+	defer Track(t, "CohereProvider")()
+
+	up := newCohereUpstream(t)
+	apiKey, slug := setupCohereRoute(t, up)
+
+	status, headers, body := proxyPost(t, apiKey, "/"+slug+"/v1/rerank", map[string]any{
+		"model":     "rerank-english-v3.0",
+		"query":     "capital of France",
+		"documents": []string{"Paris is the capital of France."},
+	})
+
+	assert.Equal(t, http.StatusOK, status, "body: %s", body)
+	assert.Equal(t, "cohere", headers.Get("X-Selected-Provider"))
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(body, &resp))
+	results := resp["results"].([]any)
+	assert.Len(t, results, 1)
+	assert.Equal(t, 1, up.Hits())
+}

--- a/tests/functional/payload_normalization_test.go
+++ b/tests/functional/payload_normalization_test.go
@@ -151,7 +151,7 @@ func TestProxyPaths_FixedRoutes(t *testing.T) {
 		up := newJSONUpstream(t, "must-not-serve")
 		apiKey, slug := setupSlugRoute(t, up, []string{"gpt-4o-mini"}, "")
 
-		status, _, _ := proxyPost(t, apiKey, "/"+slug+"/v1/embeddings", chatRequest(false))
+		status, _, _ := proxyPost(t, apiKey, "/"+slug+"/v2/chat/completions", chatRequest(false))
 
 		assert.Equal(t, http.StatusNotFound, status)
 		assert.Equal(t, 0, up.Hits())


### PR DESCRIPTION
## Summary
- Integrates **Cerebras**, **OpenRouter**, and **Cohere** into TrustGate on top of merged xAI (#189).
- Single PR replaces stacked/conflicting PRs #190, #191, #193.
- Conflict resolution in shared registry files (`provider.go`, `format.go`, `locator.go`, `sync.go`).

## Linear
RUN-251, RUN-252, RUN-925 (xAI already merged via #189 / RUN-248)

## Supersedes
- TrustGate #190 (Cerebras)
- TrustGate #191 (OpenRouter)
- TrustGate #193 (Cohere)

## Test plan
- [x] `go test ./pkg/infra/providers/... ./pkg/app/catalog/...` locally
- [ ] CI green on this PR