### PR TITLE
fix(adapter): inject default tool parameters for OpenAI-wire upstreams

### DIFF
--- a/openspec/fixes/gemini-tool-parameters-cerebras/proposal.md
+++ b/openspec/fixes/gemini-tool-parameters-cerebras/proposal.md
@@ -1,0 +1,22 @@
+---
+linear: RUN-946
+type: fix
+changelog: "Inject default tools[].function.parameters on OpenAI-wire requests when Gemini cross-format adaptation omits them."
+---
+
+# Proposal: Default tool parameters for strict OpenAI upstreams
+
+## Why
+
+Gemini agent requests adapted to OpenAI wire format can omit `tools[].function.parameters`.
+Strict upstreams (Cerebras gpt-oss chat template) reject those tools with HTTP 400.
+
+## What
+
+- Extend `NormalizeOpenAIRequest` to inject `{"type":"object","properties":{}}` when parameters are missing, null, or `{}`.
+- Unit tests for missing parameters and Cerebras provider normalization path.
+
+## QA
+
+- `ag-matrix -u cerebras -a google` passes
+- `go test ./pkg/infra/providers/adapter/...`

--- a/pkg/infra/providers/adapter/normalize.go
+++ b/pkg/infra/providers/adapter/normalize.go
@@ -29,6 +29,9 @@ import (
 // Current normalizations:
 //   - Ensures every tool_call object inside messages has "type": "function".
 //     The Mistral SDK omits this field, but OpenAI returns 400 without it.
+//   - Ensures every tools[].function.parameters is a non-empty JSON Schema object.
+//     Gemini cross-format requests often omit parameters; strict OpenAI-wire
+//     upstreams (e.g. Cerebras gpt-oss) reject tools without it.
 //
 // The function is a no-op (returns the original body) when no changes are
 // needed, so it is safe to call unconditionally on every OpenAI-bound request.
@@ -38,44 +41,55 @@ func NormalizeOpenAIRequest(body []byte) []byte {
 		return body
 	}
 
-	msgsRaw, ok := raw["messages"]
-	if !ok {
-		return body
-	}
-
-	var msgs []map[string]json.RawMessage
-	if err := json.Unmarshal(msgsRaw, &msgs); err != nil {
-		return body
-	}
-
 	changed := false
-	for i := range msgs {
-		tcRaw, hasTCs := msgs[i]["tool_calls"]
-		if !hasTCs {
-			continue
-		}
 
-		var tcs []map[string]json.RawMessage
-		if err := json.Unmarshal(tcRaw, &tcs); err != nil {
-			continue
-		}
+	if msgsRaw, ok := raw["messages"]; ok {
+		var msgs []map[string]json.RawMessage
+		if err := json.Unmarshal(msgsRaw, &msgs); err == nil {
+			msgsChanged := false
+			for i := range msgs {
+				tcRaw, hasTCs := msgs[i]["tool_calls"]
+				if !hasTCs {
+					continue
+				}
 
-		tcChanged := false
-		for j := range tcs {
-			typeRaw, hasType := tcs[j]["type"]
-			if !hasType || isEmptyOrNull(typeRaw) {
-				b, _ := json.Marshal("function")
-				tcs[j]["type"] = b
-				tcChanged = true
+				var tcs []map[string]json.RawMessage
+				if err := json.Unmarshal(tcRaw, &tcs); err != nil {
+					continue
+				}
+
+				tcChanged := false
+				for j := range tcs {
+					typeRaw, hasType := tcs[j]["type"]
+					if !hasType || isEmptyOrNull(typeRaw) {
+						b, _ := json.Marshal("function")
+						tcs[j]["type"] = b
+						tcChanged = true
+					}
+				}
+
+				if tcChanged {
+					b, err := json.Marshal(tcs)
+					if err == nil {
+						msgs[i]["tool_calls"] = b
+						msgsChanged = true
+					}
+				}
+			}
+			if msgsChanged {
+				b, err := json.Marshal(msgs)
+				if err == nil {
+					raw["messages"] = b
+					changed = true
+				}
 			}
 		}
+	}
 
-		if tcChanged {
-			b, err := json.Marshal(tcs)
-			if err == nil {
-				msgs[i]["tool_calls"] = b
-				changed = true
-			}
+	if toolsRaw, ok := raw["tools"]; ok {
+		if b, toolsChanged := normalizeToolsFunctionParameters(toolsRaw); toolsChanged {
+			raw["tools"] = b
+			changed = true
 		}
 	}
 
@@ -83,17 +97,55 @@ func NormalizeOpenAIRequest(body []byte) []byte {
 		return body
 	}
 
-	b, err := json.Marshal(msgs)
-	if err != nil {
-		return body
-	}
-	raw["messages"] = b
-
 	out, err := json.Marshal(raw)
 	if err != nil {
 		return body
 	}
 	return out
+}
+
+func normalizeToolsFunctionParameters(toolsRaw json.RawMessage) (json.RawMessage, bool) {
+	if len(toolsRaw) == 0 || string(toolsRaw) == "null" {
+		return toolsRaw, false
+	}
+	var tools []map[string]json.RawMessage
+	if err := json.Unmarshal(toolsRaw, &tools); err != nil {
+		return toolsRaw, false
+	}
+	defaultParams, _ := json.Marshal(map[string]interface{}{
+		"type":       "object",
+		"properties": map[string]interface{}{},
+	})
+	changed := false
+	for i := range tools {
+		fnRaw, ok := tools[i]["function"]
+		if !ok || isEmptyOrNull(fnRaw) {
+			continue
+		}
+		var fn map[string]json.RawMessage
+		if err := json.Unmarshal(fnRaw, &fn); err != nil {
+			continue
+		}
+		paramsRaw, hasParams := fn["parameters"]
+		if hasParams && !isEmptyOrNull(paramsRaw) && string(paramsRaw) != "{}" {
+			continue
+		}
+		fn["parameters"] = defaultParams
+		fnBytes, err := json.Marshal(fn)
+		if err != nil {
+			continue
+		}
+		tools[i]["function"] = fnBytes
+		changed = true
+	}
+	if !changed {
+		return toolsRaw, false
+	}
+	b, err := json.Marshal(tools)
+	if err != nil {
+		return toolsRaw, false
+	}
+	return b, true
 }
 
 // NormalizeGroqRequest applies OpenAI-compatible fixes plus Groq-specific

--- a/pkg/infra/providers/adapter/normalize_test.go
+++ b/pkg/infra/providers/adapter/normalize_test.go
@@ -273,6 +273,89 @@ func TestNormalizeOpenAIRequest_PreservesOtherFields(t *testing.T) {
 	assert.Equal(t, "search", fn["name"])
 }
 
+func TestNormalizeOpenAIRequest_InjectsToolFunctionParametersWhenMissing(t *testing.T) {
+	input := `{
+		"model": "gpt-oss-120b",
+		"messages": [{"role": "user", "content": "hello"}],
+		"tools": [
+			{
+				"type": "function",
+				"function": {
+					"name": "list_all_clients",
+					"description": "List clients"
+				}
+			}
+		]
+	}`
+
+	out := NormalizeOpenAIRequest([]byte(input))
+
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	tools := result["tools"].([]interface{})
+	require.Len(t, tools, 1)
+	fn := tools[0].(map[string]interface{})["function"].(map[string]interface{})
+	params := fn["parameters"].(map[string]interface{})
+	assert.Equal(t, "object", params["type"])
+	assert.NotNil(t, params["properties"])
+}
+
+func TestNormalizeOpenAIRequest_PreservesExistingToolFunctionParameters(t *testing.T) {
+	input := `{
+		"model": "gpt-oss-120b",
+		"messages": [{"role": "user", "content": "hello"}],
+		"tools": [
+			{
+				"type": "function",
+				"function": {
+					"name": "search",
+					"description": "Search",
+					"parameters": {
+						"type": "object",
+						"properties": {"q": {"type": "string"}},
+						"required": ["q"]
+					}
+				}
+			}
+		]
+	}`
+
+	out := NormalizeOpenAIRequest([]byte(input))
+
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	tools := result["tools"].([]interface{})
+	fn := tools[0].(map[string]interface{})["function"].(map[string]interface{})
+	params := fn["parameters"].(map[string]interface{})
+	props := params["properties"].(map[string]interface{})
+	assert.Contains(t, props, "q")
+}
+
+func TestNormalizeRequestForProvider_Cerebras_InjectsToolParameters(t *testing.T) {
+	input := `{
+		"model": "gpt-oss-120b",
+		"messages": [{"role": "user", "content": "hello"}],
+		"tools": [
+			{
+				"type": "function",
+				"function": {"name": "list_all_clients", "description": "List clients"}
+			}
+		]
+	}`
+
+	out := NormalizeRequestForProvider("cerebras", FormatOpenAI, []byte(input))
+
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	tools := result["tools"].([]interface{})
+	fn := tools[0].(map[string]interface{})["function"].(map[string]interface{})
+	params := fn["parameters"].(map[string]interface{})
+	assert.Equal(t, "object", params["type"])
+}
+
 // ---------------------------------------------------------------------------
 // isEmptyOrNull
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Extend `NormalizeOpenAIRequest` to inject `{"type":"object","properties":{}}` when `tools[].function.parameters` is missing, null, or empty.
- Fixes Gemini agent → Cerebras upstream matrix cell (`ag-matrix -u cerebras -a google`) that failed with *Tool "list_all_clients" is missing function parameters*.
- Adds unit tests and openspec fix proposal.

## Linear

RUN-946 — https://linear.app/neuraltrust/issue/RUN-946/fixtrustgate-gemini-agent-tool-schema-lost-on-cerebras-upstream

Related: RUN-945 (multi-agent-tests Tier1 matrix)

## Test plan

- [x] `go test ./pkg/infra/providers/adapter/...`
- [x] `uv run ag-matrix -u cerebras -a google` (local, OK)
- [x] `cerebras → openai_completions` and `cerebras → anthropic` still pass