### PR TITLE
feat: stamp tenant_id from admin JWT claim (RUN-931)

### DIFF
--- a/pkg/api/handler/http/gateway/create_gateway_handler.go
+++ b/pkg/api/handler/http/gateway/create_gateway_handler.go
@@ -22,6 +22,7 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/api/handler/http/httpio"
 	appgateway "github.com/NeuralTrust/TrustGate/pkg/app/gateway"
 	commonerrors "github.com/NeuralTrust/TrustGate/pkg/common/errors"
+	infracontext "github.com/NeuralTrust/TrustGate/pkg/infra/context"
 	"github.com/gofiber/fiber/v2"
 )
 
@@ -60,6 +61,7 @@ func (h *CreateGatewayHandler) Handle(c *fiber.Ctx) error {
 	g, err := h.creator.Create(c.UserContext(), appgateway.CreateInput{
 		Slug:            req.Slug,
 		Domain:          req.Domain,
+		TenantID:        tenantIDFromContext(c),
 		Metadata:        req.Metadata,
 		Telemetry:       req.Telemetry,
 		ClientTLSConfig: req.ClientTLSConfig,
@@ -69,4 +71,13 @@ func (h *CreateGatewayHandler) Handle(c *fiber.Ctx) error {
 		return httpio.WriteError(c, err)
 	}
 	return httpio.WriteCreated(c, response.FromDomain(g, h.baseDomain, h.mcpBaseDomain))
+}
+
+// tenantIDFromContext returns the tenant identifier stamped by the admin auth
+// middleware from the JWT claim. It is empty when the token carries no tenant.
+func tenantIDFromContext(c *fiber.Ctx) string {
+	if v, ok := c.Locals(string(infracontext.TenantIDContextKey)).(string); ok {
+		return v
+	}
+	return ""
 }

--- a/pkg/api/handler/http/gateway/update_gateway_handler.go
+++ b/pkg/api/handler/http/gateway/update_gateway_handler.go
@@ -70,6 +70,7 @@ func (h *UpdateGatewayHandler) Handle(c *fiber.Ctx) error {
 		Slug:            req.Slug,
 		Status:          req.Status,
 		Domain:          req.Domain,
+		TenantID:        tenantIDFromContext(c),
 		Metadata:        req.Metadata,
 		Telemetry:       req.Telemetry,
 		ClientTLSConfig: req.ClientTLSConfig,

--- a/pkg/app/gateway/creator.go
+++ b/pkg/app/gateway/creator.go
@@ -28,6 +28,7 @@ import (
 type CreateInput struct {
 	Slug            string
 	Domain          string
+	TenantID        string
 	Metadata        map[string]string
 	Telemetry       *telemetry.Telemetry
 	ClientTLSConfig domain.ClientTLSConfig
@@ -74,7 +75,7 @@ func (c *creator) Create(ctx context.Context, in CreateInput) (*domain.Gateway, 
 		return nil, err
 	}
 	g.Domain = in.Domain
-	g.Metadata = domain.SanitizeClientMetadata(in.Metadata)
+	g.Metadata = domain.WithTenantID(domain.SanitizeClientMetadata(in.Metadata), in.TenantID)
 	g.Telemetry = in.Telemetry
 	g.ClientTLSConfig = in.ClientTLSConfig
 	g.SessionConfig = in.SessionConfig

--- a/pkg/app/gateway/creator_test.go
+++ b/pkg/app/gateway/creator_test.go
@@ -184,6 +184,31 @@ func TestCreator_Create_StripsClientProvidedTenantID(t *testing.T) {
 	}
 }
 
+func TestCreator_Create_StampsTenantIDFromContext(t *testing.T) {
+	t.Parallel()
+	repo := repomocks.NewRepository(t)
+	repo.EXPECT().
+		Save(mock.Anything, mock.MatchedBy(func(g *domain.Gateway) bool {
+			return g.TenantID() == "acme" && g.Metadata["env"] == "prod"
+		})).
+		Return(nil).
+		Once()
+
+	creator := appgateway.NewCreator(repo, newCacheManager(), nil, newTestLogger(), nil)
+
+	g, err := creator.Create(context.Background(), appgateway.CreateInput{
+		Slug:     "prod",
+		TenantID: "acme",
+		Metadata: map[string]string{domain.MetadataTenantIDKey: "attacker-team", "env": "prod"},
+	})
+	if err != nil {
+		t.Fatalf("Create error: %v", err)
+	}
+	if g.TenantID() != "acme" {
+		t.Fatalf("tenant_id from context was not stamped: got %q, want acme", g.TenantID())
+	}
+}
+
 func TestCreator_Create_PropagatesRepoError(t *testing.T) {
 	t.Parallel()
 	repo := repomocks.NewRepository(t)

--- a/pkg/app/gateway/updater.go
+++ b/pkg/app/gateway/updater.go
@@ -32,6 +32,7 @@ type UpdateInput struct {
 	Slug            *string
 	Status          *string
 	Domain          *string
+	TenantID        string
 	Metadata        map[string]string
 	Telemetry       *telemetry.Telemetry
 	ClientTLSConfig *domain.ClientTLSConfig
@@ -90,8 +91,14 @@ func (u *updater) Update(ctx context.Context, in UpdateInput) (*domain.Gateway, 
 	if in.Domain != nil {
 		g.Domain = *in.Domain
 	}
+	tenantID := old.TenantID()
+	if tenantID == "" {
+		tenantID = in.TenantID
+	}
 	if in.Metadata != nil {
-		g.Metadata = domain.WithTenantID(domain.SanitizeClientMetadata(in.Metadata), old.TenantID())
+		g.Metadata = domain.WithTenantID(domain.SanitizeClientMetadata(in.Metadata), tenantID)
+	} else if old.TenantID() == "" {
+		g.Metadata = domain.WithTenantID(g.Metadata, tenantID)
 	}
 	if in.Telemetry != nil {
 		g.Telemetry = in.Telemetry

--- a/pkg/app/gateway/updater_test.go
+++ b/pkg/app/gateway/updater_test.go
@@ -184,6 +184,66 @@ func TestUpdater_Update_TenantIDIsServerOnlyAndImmutable(t *testing.T) {
 	}
 }
 
+func TestUpdater_Update_HealsEmptyTenantFromContext(t *testing.T) {
+	t.Parallel()
+	repo := repomocks.NewRepository(t)
+	id := ids.New[ids.GatewayKind]()
+	now := time.Now().UTC()
+	existing := domain.Rehydrate(id, "old", "active", "", nil, nil, nil, now, now)
+	existing.Metadata = map[string]string{"env": "prod"}
+
+	repo.EXPECT().FindByID(mock.Anything, id).Return(existing, nil).Once()
+	repo.EXPECT().
+		Update(mock.Anything, mock.MatchedBy(func(g *domain.Gateway) bool {
+			return g.TenantID() == "acme" && g.Metadata["env"] == "prod"
+		})).
+		Return(nil).
+		Once()
+
+	updater := appgateway.NewUpdater(repo, newCacheManager(), cachetest.NoopPublisher(), nil, newTestLogger(), nil)
+	got, err := updater.Update(context.Background(), appgateway.UpdateInput{
+		ID:       id,
+		TenantID: "acme",
+		Slug:     ptr("renamed"),
+	})
+	if err != nil {
+		t.Fatalf("Update error: %v", err)
+	}
+	if got.TenantID() != "acme" {
+		t.Fatalf("empty tenant_id was not healed from context: got %q, want acme", got.TenantID())
+	}
+}
+
+func TestUpdater_Update_ContextTenantDoesNotOverrideExisting(t *testing.T) {
+	t.Parallel()
+	repo := repomocks.NewRepository(t)
+	id := ids.New[ids.GatewayKind]()
+	now := time.Now().UTC()
+	existing := domain.Rehydrate(id, "old", "active", "", nil, nil, nil, now, now)
+	existing.Metadata = map[string]string{domain.MetadataTenantIDKey: "acme"}
+
+	repo.EXPECT().FindByID(mock.Anything, id).Return(existing, nil).Once()
+	repo.EXPECT().
+		Update(mock.Anything, mock.MatchedBy(func(g *domain.Gateway) bool {
+			return g.TenantID() == "acme"
+		})).
+		Return(nil).
+		Once()
+
+	updater := appgateway.NewUpdater(repo, newCacheManager(), cachetest.NoopPublisher(), nil, newTestLogger(), nil)
+	got, err := updater.Update(context.Background(), appgateway.UpdateInput{
+		ID:       id,
+		TenantID: "globex",
+		Slug:     ptr("renamed"),
+	})
+	if err != nil {
+		t.Fatalf("Update error: %v", err)
+	}
+	if got.TenantID() != "acme" {
+		t.Fatalf("existing tenant_id must win over context: got %q, want acme", got.TenantID())
+	}
+}
+
 func TestUpdater_Update_RejectsEmptySlug(t *testing.T) {
 	t.Parallel()
 	repo := repomocks.NewRepository(t)


### PR DESCRIPTION
## Summary
- Gateways were being created without a `tenant_id` in their metadata, so TrustGate emitted telemetry logs without the `trustgate.tenant_id` attribute. DataCore's `trustgate_events_mv` filters on `mapContains(LogAttributes, 'trustgate.tenant_id')`, so those events never landed in `trustgate_events`.
- On **create**, read the tenant from the admin JWT claim (exposed by `admin_auth` middleware via fiber `Locals`) and stamp it onto the gateway metadata.
- On **update**, heal gateways with an empty tenant using the same context, while keeping an already-set tenant immutable (a different token can never move a gateway's tenant). Client-provided `tenant_id` in metadata keeps being stripped (anti-spoofing).

## Changes
- `pkg/app/gateway/creator.go`: `CreateInput.TenantID`; stamp via `domain.WithTenantID(SanitizeClientMetadata(...), in.TenantID)`.
- `pkg/app/gateway/updater.go`: `UpdateInput.TenantID`; prefer existing tenant, fallback to context, heal empty even when metadata is not sent.
- `pkg/api/handler/http/gateway/{create,update}_gateway_handler.go`: read tenant from `Locals(TenantIDContextKey)` and pass it in; add `tenantIDFromContext` helper.

## Front dependency
For end-to-end flow, the frontend must sign the JWT with the `tenant_id` claim (TrustGate's `admin_auth` reads `claims.TenantID` / json `tenant_id`). TrustGate is now ready to consume it.

## Test plan
- [x] `go build -mod=mod ./...`
- [x] `go test -race ./pkg/app/gateway/... ./pkg/api/handler/http/gateway/... ./pkg/domain/gateway/...`
- New tests: `TestCreator_Create_StampsTenantIDFromContext`, `TestUpdater_Update_HealsEmptyTenantFromContext`, `TestUpdater_Update_ContextTenantDoesNotOverrideExisting`.

## Linear
RUN-931 — https://linear.app/neuraltrust/issue/RUN-931

Made with [Cursor](https://cursor.com)