### PR TITLE
feat(frontend): make gateway slug optional in create dialog

### DIFF
--- a/frontend/src/app/actions.ts
+++ b/frontend/src/app/actions.ts
@@ -19,14 +19,11 @@ export async function setActiveGateway(gatewayId: string): Promise<void> {
 }
 
 export async function createGatewayAction(formData: FormData): Promise<{ error?: string }> {
-  const name = String(formData.get("name") ?? "").trim();
-  if (!name) {
-    return { error: "Gateway name is required." };
-  }
+  const slug = String(formData.get("slug") ?? "").trim();
 
   const res = await adminFetch("/v1/gateways", {
     method: "POST",
-    body: JSON.stringify({ name }),
+    body: JSON.stringify(slug ? { slug } : {}),
   });
 
   if (res.status >= 400) {

--- a/frontend/src/components/layout/gateway-switcher.tsx
+++ b/frontend/src/components/layout/gateway-switcher.tsx
@@ -37,7 +37,7 @@ export function GatewaySwitcher() {
             className="flex items-center gap-2 rounded-(--radius) border border-border bg-surface-2 h-9 pl-2.5 pr-2 text-[13px] text-fg hover:border-border-strong transition-colors outline-none focus-visible:ring-2 focus-visible:ring-accent/40 max-w-56"
           >
             <Layers className="h-4 w-4 text-accent shrink-0" />
-            <span className="truncate font-medium">{active.name}</span>
+            <span className="truncate font-medium">{active.slug}</span>
             <ChevronsUpDown className="h-3.5 w-3.5 text-faint shrink-0" />
           </button>
         </DropdownMenu.Trigger>
@@ -66,7 +66,7 @@ export function GatewaySwitcher() {
                   >
                     <Check className="h-3.5 w-3.5" />
                   </span>
-                  <span className="truncate flex-1">{g.name}</span>
+                  <span className="truncate flex-1">{g.slug}</span>
                 </DropdownMenu.Item>
               ))}
             </div>
@@ -101,18 +101,18 @@ function CreateGatewayDialog({
 }) {
   const router = useRouter();
   const { toast } = useToast();
-  const [name, setName] = useState("");
+  const [slug, setSlug] = useState("");
   const [submitting, setSubmitting] = useState(false);
 
   async function submit() {
-    if (!name.trim()) return;
     setSubmitting(true);
     try {
-      const gw = await api.post<Gateway>("/v1/gateways", { name: name.trim() });
+      const trimmed = slug.trim();
+      const gw = await api.post<Gateway>("/v1/gateways", trimmed ? { slug: trimmed } : {});
       await setActiveGateway(gw.id);
-      toast({ variant: "success", title: "Gateway created", description: gw.name });
+      toast({ variant: "success", title: "Gateway created", description: gw.slug });
       onOpenChange(false);
-      setName("");
+      setSlug("");
       router.refresh();
     } catch (err) {
       toast({
@@ -130,11 +130,11 @@ function CreateGatewayDialog({
       <DialogContent>
         <DialogHeader title="Create gateway" description="A gateway is an isolated routing environment." />
         <DialogBody>
-          <Field label="Name">
+          <Field label="Slug" hint="Optional — auto-generated if empty">
             <Input
               autoFocus
-              value={name}
-              onChange={(e) => setName(e.target.value)}
+              value={slug}
+              onChange={(e) => setSlug(e.target.value)}
               onKeyDown={(e) => e.key === "Enter" && submit()}
               placeholder="e.g. staging-gateway"
             />

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -12,7 +12,7 @@ export interface ApiError {
 
 export interface Gateway {
   id: string;
-  name: string;
+  slug: string;
   status: string;
   session_config?: SessionConfig | null;
   created_at: string;


### PR DESCRIPTION
## Summary
- Aligns the console with the API change (slug optional / auto-generated):
  - Create-gateway dialog no longer requires input; the field is now an optional **Slug** (hint: auto-generated if empty).
  - Submits `{ slug }` only when provided, otherwise `{}` so the server generates one.
  - `Gateway` type and switcher display now use `slug` instead of the dropped `name` field; `createGatewayAction` no longer requires a name.

## Notes
- Depends on the backend PR #197 (optional/auto-generated slug + `slug` in the response).

## Test plan
- [x] `tsc --noEmit` (typecheck) green
- [ ] Manual: open the gateway switcher → Create gateway with empty slug → gateway created with a generated slug and becomes active
- [ ] Manual: create with an explicit slug still works

## Related
- Backend PR: #197

Made with [Cursor](https://cursor.com)