### PR TITLE
fix: backfill gateway tenant_id and drop legacy team_id

### DIFF
--- a/pkg/domain/gateway/gateway.go
+++ b/pkg/domain/gateway/gateway.go
@@ -28,6 +28,11 @@ import (
 
 const MetadataTenantIDKey = "tenant_id"
 
+// MetadataLegacyTeamIDKey is the pre-tenant client key. It is never persisted:
+// callers that still send it have their value dropped so tenant partitioning
+// relies solely on the server-stamped tenant_id.
+const MetadataLegacyTeamIDKey = "team_id"
+
 type Gateway struct {
 	ID              ids.GatewayID        `json:"id"`
 	Slug            string               `json:"slug"`
@@ -49,7 +54,7 @@ func (g *Gateway) TenantID() string {
 }
 
 func isReservedMetadataKey(key string) bool {
-	return key == MetadataTenantIDKey
+	return key == MetadataTenantIDKey || key == MetadataLegacyTeamIDKey
 }
 
 func SanitizeClientMetadata(metadata map[string]string) map[string]string {

--- a/pkg/domain/gateway/gateway_test.go
+++ b/pkg/domain/gateway/gateway_test.go
@@ -219,6 +219,18 @@ func TestSanitizeClientMetadata(t *testing.T) {
 		}
 	})
 
+	t.Run("strips legacy team_id", func(t *testing.T) {
+		t.Parallel()
+		in := map[string]string{MetadataLegacyTeamIDKey: "team-1", "env": "prod"}
+		out := SanitizeClientMetadata(in)
+		if _, ok := out[MetadataLegacyTeamIDKey]; ok {
+			t.Fatalf("legacy team_id survived sanitization: %v", out)
+		}
+		if out["env"] != "prod" {
+			t.Fatalf("non-reserved key dropped: %v", out)
+		}
+	})
+
 	t.Run("nil input stays nil", func(t *testing.T) {
 		t.Parallel()
 		if out := SanitizeClientMetadata(nil); out != nil {
@@ -228,8 +240,9 @@ func TestSanitizeClientMetadata(t *testing.T) {
 
 	t.Run("only reserved keys collapse to nil", func(t *testing.T) {
 		t.Parallel()
-		if out := SanitizeClientMetadata(map[string]string{MetadataTenantIDKey: "x"}); out != nil {
-			t.Fatalf("expected nil after removing sole reserved key, got %v", out)
+		in := map[string]string{MetadataTenantIDKey: "x", MetadataLegacyTeamIDKey: "y"}
+		if out := SanitizeClientMetadata(in); out != nil {
+			t.Fatalf("expected nil after removing sole reserved keys, got %v", out)
 		}
 	})
 }

--- a/pkg/infra/database/migrations/20260710120000_backfill_gateway_tenant_id.go
+++ b/pkg/infra/database/migrations/20260710120000_backfill_gateway_tenant_id.go
@@ -1,0 +1,54 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrations
+
+import (
+	"context"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/database"
+	"github.com/jackc/pgx/v5"
+)
+
+func init() {
+	database.RegisterMigration(database.Migration{
+		ID:   "20260710120000_backfill_gateway_tenant_id",
+		Name: "backfill gateways.metadata.tenant_id from legacy team_id and drop team_id",
+		Up: func(ctx context.Context, tx pgx.Tx) error {
+			// Older gateways were created carrying only the legacy client key
+			// team_id (same UUID as the tenant). Tenant partitioning reads
+			// metadata.tenant_id, so seed it from team_id where it is missing or
+			// empty, then drop team_id everywhere. Both statements are guarded on
+			// the key's presence, so the migration is idempotent.
+			const backfill = `
+				UPDATE gateways
+				SET metadata = jsonb_set(metadata, '{tenant_id}', metadata -> 'team_id', true)
+				WHERE metadata ? 'team_id'
+				  AND COALESCE(NULLIF(metadata ->> 'tenant_id', ''), '') = '';`
+			if _, err := tx.Exec(ctx, backfill); err != nil {
+				return err
+			}
+
+			const dropLegacy = `
+				UPDATE gateways
+				SET metadata = metadata - 'team_id'
+				WHERE metadata ? 'team_id';`
+			_, err := tx.Exec(ctx, dropLegacy)
+			return err
+		},
+		Down: func(_ context.Context, _ pgx.Tx) error {
+			return nil
+		},
+	})
+}


### PR DESCRIPTION
## Summary
- Older gateways were created carrying only the legacy client key `metadata.team_id` (same UUID as the tenant), leaving `metadata.tenant_id` empty. Those gateways miss tenant partitioning (config-snapshot scope, metrics, telemetry) because runtime reads `TenantID()` = `metadata.tenant_id`.
- Adds an idempotent data migration that seeds `tenant_id` from `team_id` where it is missing/empty, then drops `team_id` from all gateways.
- Treats `team_id` as a reserved metadata key in `SanitizeClientMetadata`, so a client that still sends it never re-persists the legacy key.

## Changes
- `pkg/infra/database/migrations/20260710120000_backfill_gateway_tenant_id.go`: backfill + purge (idempotent, guarded on key presence).
- `pkg/domain/gateway/gateway.go`: new `MetadataLegacyTeamIDKey` constant; `isReservedMetadataKey` now also drops `team_id`.
- `pkg/domain/gateway/gateway_test.go`: coverage for stripping legacy `team_id`.

## Related
Paired with the app PR that stops sending `metadata.team_id` on gateway creation.

## Test plan
- [x] `go test ./pkg/domain/gateway/... ./pkg/app/gateway/...`
- [x] pre-commit hook (golangci-lint + gosec + tests) green
- [ ] Verify in prod after deploy: existing gateway `ef4cb538-…` gains `tenant_id` and loses `team_id`.

Made with [Cursor](https://cursor.com)