### PR TITLE
fix: bump Go toolchain to 1.26.5 for CVE-2026-39822 & CVE-2026-42505 (RUN-950)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
       - name: Install addlicense
         run: go install github.com/google/addlicense@latest
@@ -33,7 +33,7 @@ jobs:
     uses: NeuralTrust/workflows/.github/workflows/tests.yml@main
     with:
       language: go
-      language_version: "1.26.4"
+      language_version: "1.26.5"
       go_private_modules: true
       lint_enabled: true
       coverage_enabled: true
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
       - name: Build, vet and test pkg/metrics
         working-directory: pkg/metrics
@@ -64,7 +64,7 @@ jobs:
         with:
           version: v2.12.2
           # Released golangci-lint binaries are built with go1.25 and refuse to
-          # lint this module's go1.26.4 directive; goinstall recompiles it with
+          # lint this module's go1.26.5 directive; goinstall recompiles it with
           # the active setup-go toolchain so the versions match.
           install-mode: goinstall
           working-directory: pkg/metrics
@@ -98,7 +98,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           check-latest: true
           cache: true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM golang:1.26.4-bookworm AS builder
+FROM golang:1.26.5-bookworm AS builder
 
 WORKDIR /build
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/NeuralTrust/TrustGate
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1

--- a/pkg/metrics/go.mod
+++ b/pkg/metrics/go.mod
@@ -1,3 +1,3 @@
 module github.com/NeuralTrust/TrustGate/pkg/metrics
 
-go 1.26.4
+go 1.26.5


### PR DESCRIPTION
## Summary

Bump the pinned Go toolchain from **1.26.4** to **1.26.5** to remediate two Go standard-library vulnerabilities (fixed upstream in Go 1.26.5):

- **CVE-2026-39822** (High, CVSS 7.8) — `os.Root` improperly follows symlinks outside the root on Unix when the final path component is a symlink and the path ends in `/`.
- **CVE-2026-42505** (Medium, CVSS 5.3) — Encrypted Client Hello (ECH) privacy leak in `crypto/tls`.

Version bumped in `go.mod`, `Dockerfile`, and CI workflows (plus `pkg/metrics/go.mod` and `README` where applicable). No application code or dependency changes.

## Test plan

- [ ] CI green (build, lint, tests) on Go 1.26.5
- [ ] Docker image builds

Fixes RUN-950
Linear: https://linear.app/neuraltrust/issue/RUN-950