### PR TITLE
docs(demo): TrustGate env guide for Guard orchestrator

### DIFF
--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -1,0 +1,50 @@
+# TrustGate — Demo bootstrap (orchestrated from TrustGuard)
+
+The **demo orchestrator lives in TrustGuard**, not in this repo:
+
+```bash
+# In TrustGuard repo
+./scripts/demo/run.sh --env dev --team <APP_TEAM_UUID> --pack sales
+```
+
+TrustGate is provisioned via admin API calls from `TrustGuard/scripts/demo/lib/apply_gate.py`.
+
+## Required deployment wiring
+
+For Gateway → Runtime inspection (`trustguard` plugin), the TrustGate deployment must have platform OAuth credentials that match TrustGuard:
+
+| TrustGate env | TrustGuard env |
+|---------------|----------------|
+| `TRUSTGUARD_CLIENT_ID` | `TRUSTGUARD_PLATFORM_CLIENT_ID` |
+| `TRUSTGUARD_CLIENT_SECRET` | `TRUSTGUARD_PLATFORM_CLIENT_SECRET` |
+| `TRUSTGUARD_BASE_URL` | Guard admin/public URL |
+
+Without this, the plugin cannot call `/v1/evaluate` on behalf of the gateway.
+
+## Variables for TrustGuard `profiles/dev.env`
+
+Copy `docs/demo/dev.env.example` into TrustGuard `scripts/demo/profiles/dev.env` together with Guard vars.
+
+| Variable | Description |
+|----------|-------------|
+| `GATE_ADMIN_URL` | Admin plane URL (e.g. `https://trustgate-admin.develop.neuraltrust.ai`) |
+| `GATE_PROXY_URL` | Proxy plane URL (e.g. `https://trustgate.develop.neuraltrust.ai`) |
+| `GATE_ADMIN_TOKEN` | Bearer JWT for admin API |
+| `OPENAI_API_KEY` | Upstream OpenAI key for allow scenarios (block scenarios work without it) |
+
+### Obtaining `GATE_ADMIN_TOKEN`
+
+Use the same admin JWT flow as TrustGate Postman collections, or `scripts/generate_jwt_token.sh` in this repo with `SERVER_SECRET_KEY` matching the admin server.
+
+## Smoke check (optional)
+
+```bash
+curl -sf "$GATE_ADMIN_URL/readyz"
+curl -sf -H "Authorization: Bearer $GATE_ADMIN_TOKEN" "$GATE_ADMIN_URL/v1/gateways"
+```
+
+## Reference
+
+- Postman: `postman/TrustGate-TrustGuard-E2E.postman_collection.json`
+- TrustGuard demo docs: `TrustGuard/scripts/demo/docs/README.md`
+- Linear: [RUN-957](https://linear.app/neuraltrust/issue/RUN-957)

--- a/docs/demo/dev.env.example
+++ b/docs/demo/dev.env.example
@@ -1,0 +1,14 @@
+# TrustGate variables for TrustGuard demo orchestrator
+# Copy relevant lines into TrustGuard/scripts/demo/profiles/dev.env
+
+GATE_ADMIN_URL=https://trustgate-admin.develop.neuraltrust.ai
+GATE_PROXY_URL=https://trustgate.develop.neuraltrust.ai
+GATE_ADMIN_TOKEN=
+
+# Required for DEMO-G02 (allow path); SQLi block (DEMO-G01) works without a real key
+OPENAI_API_KEY=
+
+# Deployment-side (not passed to run.sh — must exist on TrustGate pods):
+# TRUSTGUARD_CLIENT_ID=<same as TrustGuard TRUSTGUARD_PLATFORM_CLIENT_ID>
+# TRUSTGUARD_CLIENT_SECRET=<same as TrustGuard TRUSTGUARD_PLATFORM_CLIENT_SECRET>
+# TRUSTGUARD_BASE_URL=<Guard URL reachable from TrustGate>

--- a/scripts/demo/smoke_admin.sh
+++ b/scripts/demo/smoke_admin.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Optional smoke: admin plane health + list gateways.
+set -euo pipefail
+: "${GATE_ADMIN_URL:?}"
+: "${GATE_ADMIN_TOKEN:?}"
+curl -sf "${GATE_ADMIN_URL%/}/readyz" >/dev/null
+echo "readyz OK"
+curl -sf -H "Authorization: Bearer ${GATE_ADMIN_TOKEN}" \
+  "${GATE_ADMIN_URL%/}/v1/gateways" >/dev/null
+echo "list gateways OK"


### PR DESCRIPTION
## Summary
- Documents env vars and platform OAuth wiring for the TrustGuard `scripts/demo` orchestrator
- Adds `docs/demo/dev.env.example` and optional `scripts/demo/smoke_admin.sh`
- No duplicate bootstrap in TrustGate — orchestrator lives in TrustGuard

## Linear
RUN-957 — https://linear.app/neuraltrust/issue/RUN-957
RUN-958 — https://linear.app/neuraltrust/issue/RUN-958

## Test plan
- [ ] Read `docs/demo/README.md` alongside TrustGuard `scripts/demo/docs/README.md`
- [ ] `GATE_ADMIN_URL=... GATE_ADMIN_TOKEN=... ./scripts/demo/smoke_admin.sh`