### PR TITLE
feat: propagate gateway trace_id to Guard evaluate (RUN-963)

### DIFF
--- a/pkg/infra/plugins/trustguard/client.go
+++ b/pkg/infra/plugins/trustguard/client.go
@@ -28,6 +28,7 @@ import (
 
 const (
 	evaluatePath     = "/v1/evaluate"
+	traceIDHeader    = "X-Trace-ID"
 	maxResponseBytes = 1 << 20
 )
 
@@ -41,7 +42,7 @@ func newClient(timeout time.Duration) *client {
 	return &client{http: &http.Client{Timeout: timeout}}
 }
 
-func (c *client) Guard(ctx context.Context, baseURL, token string, body GuardRequest) (*GuardResponse, error) {
+func (c *client) Guard(ctx context.Context, baseURL, token, traceID string, body GuardRequest) (*GuardResponse, error) {
 	payload, err := json.Marshal(body)
 	if err != nil {
 		return nil, fmt.Errorf("trustguard: marshal request: %w", err)
@@ -53,6 +54,9 @@ func (c *client) Guard(ctx context.Context, baseURL, token string, body GuardReq
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", contentTypeJSON)
+	if traceID != "" {
+		req.Header.Set(traceIDHeader, traceID)
+	}
 	res, err := c.http.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("trustguard: guard call: %w", err)

--- a/pkg/infra/plugins/trustguard/client_test.go
+++ b/pkg/infra/plugins/trustguard/client_test.go
@@ -114,7 +114,7 @@ func TestGuardDecodesResponses(t *testing.T) {
 			defer srv.Close()
 
 			c := newClient(2 * time.Second)
-			resp, err := c.Guard(context.Background(), srv.URL, "secret-key", sampleRequest())
+			resp, err := c.Guard(context.Background(), srv.URL, "secret-key", "", sampleRequest())
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf("expected error, got nil")
@@ -163,7 +163,7 @@ func TestGuardTrimsTrailingSlash(t *testing.T) {
 	defer srv.Close()
 
 	c := newClient(time.Second)
-	if _, err := c.Guard(context.Background(), srv.URL+"/", "k", sampleRequest()); err != nil {
+	if _, err := c.Guard(context.Background(), srv.URL+"/", "k", "", sampleRequest()); err != nil {
 		t.Fatalf("Guard returned error: %v", err)
 	}
 }
@@ -174,7 +174,7 @@ func TestGuardTransportError(t *testing.T) {
 	srv.Close()
 
 	c := newClient(time.Second)
-	if _, err := c.Guard(context.Background(), srv.URL, "k", sampleRequest()); err == nil {
+	if _, err := c.Guard(context.Background(), srv.URL, "k", "", sampleRequest()); err == nil {
 		t.Fatal("expected transport error, got nil")
 	}
 }
@@ -187,7 +187,7 @@ func TestGuardUnauthorizedReturnsSentinel(t *testing.T) {
 	defer srv.Close()
 
 	c := newClient(time.Second)
-	_, err := c.Guard(context.Background(), srv.URL, "stale-token", sampleRequest())
+	_, err := c.Guard(context.Background(), srv.URL, "stale-token", "", sampleRequest())
 	if !errors.Is(err, errUnauthorized) {
 		t.Fatalf("err = %v, want errUnauthorized", err)
 	}
@@ -204,7 +204,40 @@ func TestGuardContextCanceled(t *testing.T) {
 	cancel()
 
 	c := newClient(time.Second)
-	if _, err := c.Guard(ctx, srv.URL, "k", sampleRequest()); err == nil {
+	if _, err := c.Guard(ctx, srv.URL, "k", "", sampleRequest()); err == nil {
 		t.Fatal("expected context error, got nil")
+	}
+}
+
+func TestGuardSetsTraceIDHeader(t *testing.T) {
+	t.Parallel()
+	const wantTraceID = "gateway-trace-abc123"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get(traceIDHeader); got != wantTraceID {
+			t.Errorf("X-Trace-ID header = %q, want %q", got, wantTraceID)
+		}
+		_, _ = io.WriteString(w, `{"status":""}`)
+	}))
+	defer srv.Close()
+
+	c := newClient(time.Second)
+	if _, err := c.Guard(context.Background(), srv.URL, "k", wantTraceID, sampleRequest()); err != nil {
+		t.Fatalf("Guard returned error: %v", err)
+	}
+}
+
+func TestGuardOmitsTraceIDHeaderWhenEmpty(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get(traceIDHeader); got != "" {
+			t.Errorf("X-Trace-ID header = %q, want empty", got)
+		}
+		_, _ = io.WriteString(w, `{"status":""}`)
+	}))
+	defer srv.Close()
+
+	c := newClient(time.Second)
+	if _, err := c.Guard(context.Background(), srv.URL, "k", "", sampleRequest()); err != nil {
+		t.Fatalf("Guard returned error: %v", err)
 	}
 }

--- a/pkg/infra/plugins/trustguard/plugin.go
+++ b/pkg/infra/plugins/trustguard/plugin.go
@@ -27,6 +27,7 @@ import (
 	appplugins "github.com/NeuralTrust/TrustGate/pkg/app/plugins"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/policy"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/adapter"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/trace"
 )
 
 const PluginName = "trustguard"
@@ -215,7 +216,8 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 		},
 	}
 
-	resp, err := p.guard(ctx, baseURL, cfg.CollectorID, body)
+	traceID := gatewayTraceID(ctx)
+	resp, err := p.guard(ctx, baseURL, cfg.CollectorID, traceID, body)
 	if err != nil {
 		p.warn(ctx, "trustguard call failed, failing open",
 			slog.String("plugin", PluginName),
@@ -276,7 +278,15 @@ func configCacheKey(settings map[string]any) string {
 	return fmt.Sprintf("%v\x00%v", settings["inspect"], settings["collector_id"])
 }
 
-func (p *Plugin) guard(ctx context.Context, baseURL, collectorID string, body GuardRequest) (*GuardResponse, error) {
+func gatewayTraceID(ctx context.Context) string {
+	rt := trace.FromContext(ctx)
+	if rt == nil {
+		return ""
+	}
+	return rt.TraceID()
+}
+
+func (p *Plugin) guard(ctx context.Context, baseURL, collectorID, traceID string, body GuardRequest) (*GuardResponse, error) {
 	params := tokenParams{
 		baseURL:     baseURL,
 		collectorID: collectorID,
@@ -286,7 +296,7 @@ func (p *Plugin) guard(ctx context.Context, baseURL, collectorID string, body Gu
 	if err != nil {
 		return nil, err
 	}
-	resp, err := p.client.Guard(ctx, baseURL, token, body)
+	resp, err := p.client.Guard(ctx, baseURL, token, traceID, body)
 	if err == nil {
 		return resp, nil
 	}
@@ -298,7 +308,7 @@ func (p *Plugin) guard(ctx context.Context, baseURL, collectorID string, body Gu
 	if err != nil {
 		return nil, err
 	}
-	return p.client.Guard(ctx, baseURL, token, body)
+	return p.client.Guard(ctx, baseURL, token, traceID, body)
 }
 
 func (p *Plugin) warn(ctx context.Context, msg string, attrs ...any) {

--- a/pkg/infra/plugins/trustguard/plugin_test.go
+++ b/pkg/infra/plugins/trustguard/plugin_test.go
@@ -70,6 +70,7 @@ type fakeGuard struct {
 	lastPath    string
 	lastAuth    string
 	lastCT      string
+	lastTraceID string
 	directions  []string
 	status      int
 	response    GuardResponse
@@ -91,6 +92,7 @@ func (f *fakeGuard) handler() http.HandlerFunc {
 		f.lastPath = r.URL.Path
 		f.lastAuth = r.Header.Get("Authorization")
 		f.lastCT = r.Header.Get("Content-Type")
+		f.lastTraceID = r.Header.Get(traceIDHeader)
 		if r.URL.Path != evaluatePath {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -117,6 +119,12 @@ func (f *fakeGuard) http() (method, path, auth, contentType string) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.lastMethod, f.lastPath, f.lastAuth, f.lastCT
+}
+
+func (f *fakeGuard) traceID() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.lastTraceID
 }
 
 func (f *fakeGuard) seenDirections() []string {
@@ -510,6 +518,41 @@ func TestProtocolFor(t *testing.T) {
 		if got := protocolFor(raw); got != want {
 			t.Fatalf("protocolFor(%q) = %q, want %q", raw, got, want)
 		}
+	}
+}
+
+func TestExecutePropagatesGatewayTraceID(t *testing.T) {
+	t.Parallel()
+
+	const wantTraceID = "gate-trace-xyz789"
+	f := &fakeGuard{response: GuardResponse{Status: "allowed"}}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	rt := trace.New(wantTraceID, trace.Metadata{})
+	ctx := trace.NewContext(context.Background(), rt)
+	in := execInput(policy.StagePreRequest, policy.ModeEnforce, settings(""), requestContext(), nil)
+	if _, err := p.Execute(ctx, in); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := f.traceID(); got != wantTraceID {
+		t.Fatalf("X-Trace-ID = %q, want %q", got, wantTraceID)
+	}
+}
+
+func TestExecuteOmitsTraceIDWithoutRequestTrace(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: GuardResponse{Status: "allowed"}}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	in := execInput(policy.StagePreRequest, policy.ModeEnforce, settings(""), requestContext(), nil)
+	if _, err := p.Execute(context.Background(), in); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := f.traceID(); got != "" {
+		t.Fatalf("X-Trace-ID = %q, want empty", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Read gateway `RequestTrace` from plugin context via `trace.FromContext`
- Propagate the gateway `trace_id` to TrustGuard `POST /v1/evaluate` as `X-Trace-ID`
- Preserve existing behavior when no request trace is present (header omitted)

## Linear

RUN-963 — https://linear.app/neuraltrust/issue/RUN-963/feattrustgate-propagate-gateway-trace-id-to-trustguard-plugin-evaluate

Parent: RUN-962

## Test plan

- [x] `go test ./pkg/infra/plugins/trustguard/... -race`
- [x] `TestGuardSetsTraceIDHeader` / `TestGuardOmitsTraceIDHeaderWhenEmpty` assert client header behavior
- [x] `TestExecutePropagatesGatewayTraceID` / `TestExecuteOmitsTraceIDWithoutRequestTrace` assert plugin propagation from context
- [ ] DEMO-03/DEMO-04: gate trace_id sent on every plugin Guard call (manual QA)