### PR TITLE
feat: support AWS IAM authentication for PostgreSQL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,11 @@ DB_PASSWORD=postgres
 DB_NAME=agentgateway
 DB_SSL_MODE=disable
 DB_SSL_ROOT_CERT=
+# Postgres authentication mode: default (static DB_PASSWORD) | aws (RDS/Aurora IAM
+# auth via IRSA). With aws the password is ignored and a short-lived IAM token is
+# generated per connection; AWS_REGION and a native RDS endpoint are required and
+# DB_SSL_MODE must be require|verify-ca|verify-full.
+POSTGRES_LOGIN=default
 
 # Database Connection Pool Configuration (pgxpool)
 DB_MIN_CONNS=1

--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ See [`.env.example`](.env.example) for the full set with safe defaults.
 
 `POSTGRES_LOGIN=default` (the default) authenticates the primary PostgreSQL pool with `DB_PASSWORD`.
 
-`POSTGRES_LOGIN=aws` uses the AWS SDK v2 default credential chain, including IRSA, and its resolved region. `DB_HOST` must be the native RDS or Aurora endpoint, and the existing PostgreSQL TLS settings must validate it. A fresh IAM token is created before each physical connection; tokens are not retained in the pool configuration, and authentication failures never fall back to `DB_PASSWORD`.
+`POSTGRES_LOGIN=aws` uses the AWS SDK v2 default credential chain, including IRSA, and its resolved region. `DB_HOST` must be the native RDS or Aurora endpoint, and `DB_SSL_MODE` must be `require`, `verify-ca`, or `verify-full`. A fresh IAM token is created before each physical connection; tokens are not retained in the pool configuration, and authentication failures never fall back to `DB_PASSWORD`.
 
 ### Telemetry exporters (OTLP)
 

--- a/README.md
+++ b/README.md
@@ -344,6 +344,12 @@ OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 
 See [`.env.example`](.env.example) for the full set with safe defaults.
 
+### PostgreSQL authentication
+
+`POSTGRES_LOGIN=default` (the default) authenticates the primary PostgreSQL pool with `DB_PASSWORD`.
+
+`POSTGRES_LOGIN=aws` uses the AWS SDK v2 default credential chain, including IRSA, and its resolved region. `DB_HOST` must be the native RDS or Aurora endpoint, and the existing PostgreSQL TLS settings must validate it. A fresh IAM token is created before each physical connection; tokens are not retained in the pool configuration, and authentication failures never fall back to `DB_PASSWORD`.
+
 ### Telemetry exporters (OTLP)
 
 Every completed request is turned into a sanitized business event and fanned out

--- a/README.md
+++ b/README.md
@@ -345,11 +345,7 @@ OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 See [`.env.example`](.env.example) for the full set with safe defaults.
 
 ### PostgreSQL authentication
-
-`POSTGRES_LOGIN=default` (the default) authenticates the primary PostgreSQL pool with `DB_PASSWORD`.
-
-`POSTGRES_LOGIN=aws` uses the AWS SDK v2 default credential chain, including IRSA, and its resolved region. `DB_HOST` must be the native RDS or Aurora endpoint, and `DB_SSL_MODE` must be `require`, `verify-ca`, or `verify-full`. A fresh IAM token is created before each physical connection; tokens are not retained in the pool configuration, and authentication failures never fall back to `DB_PASSWORD`.
-
+`POSTGRES_LOGIN=default` (the default) authenticates the primary PostgreSQL pool with `DB_PASSWORD`. `POSTGRES_LOGIN=aws` uses the AWS SDK v2 default credential chain, including IRSA, and its resolved region. `DB_HOST` must be the native RDS or Aurora endpoint, and `DB_SSL_MODE` must be `require`, `verify-ca`, or `verify-full`. A fresh IAM token is created before each physical connection; tokens are not retained in the pool configuration, and authentication failures never fall back to `DB_PASSWORD`.
 ### Telemetry exporters (OTLP)
 
 Every completed request is turned into a sanitized business event and fanned out

--- a/go.mod
+++ b/go.mod
@@ -133,7 +133,10 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-require github.com/NeuralTrust/TrustGate/pkg/metrics v0.0.0
+require (
+	github.com/NeuralTrust/TrustGate/pkg/metrics v0.0.0
+	github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.6.25
+)
 
 replace github.com/NeuralTrust/TrustGate/pkg/metrics => ./pkg/metrics
 

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/aws/aws-sdk-go-v2/credentials v1.19.19 h1:yuFzSV1U0aRNYCQGVaTY2zW2M/L
 github.com/aws/aws-sdk-go-v2/credentials v1.19.19/go.mod h1:7y63L1kGzeoDlJaQ3Z578KrnmfBut96JjvJUzGwR+YE=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.25 h1:0w6dCiO8iez+YKwRhRBlL1CH/E3GTfdkuzrwj1by8vo=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.25/go.mod h1:9FDWUothyr5RCRAHc45XOiVCzUR8n/IhCYX+uVqw6vk=
+github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.6.25 h1:EeK30mZmhopHcNmKykyGF0LwmFB1ZwQNr+FeyRjcN0U=
+github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.6.25/go.mod h1:tudVnwAJyXgCh4N6ABYdzUM+i+PXsx8700FOyhMn+4k=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.25 h1:Uii3frf9ztec/ABM2/FSH9/z7PLzxfpG8h4RpkUFflQ=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.25/go.mod h1:G6kntsA2GorAxDPbap6xgB2F+amSLUF8GJTi7PUoX44=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.25 h1:r1+/l6m+WaUJF9HISEsNOLHSNj5EXYQxK8VX6Cz9NlA=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -726,6 +726,12 @@ func (c *Config) Validate() error {
 		if c.Database.Name == "" {
 			return fmt.Errorf("%w: DB_NAME is required", errors.ErrInvalidConfig)
 		}
+		if c.Database.Login == postgresLoginAWS {
+			c.Database.SSLMode = strings.ToLower(strings.TrimSpace(c.Database.SSLMode))
+			if c.Database.SSLMode != "require" && c.Database.SSLMode != "verify-ca" && c.Database.SSLMode != "verify-full" {
+				return fmt.Errorf("%w: DB_SSL_MODE must be %q, %q or %q when POSTGRES_LOGIN=%q", errors.ErrInvalidConfig, "require", "verify-ca", "verify-full", postgresLoginAWS)
+			}
+		}
 	}
 	if c.Redis.Host == "" {
 		return fmt.Errorf("%w: REDIS_HOST is required", errors.ErrInvalidConfig)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -56,6 +56,9 @@ const (
 	defaultDBHealthCheckPeriod       = time.Minute
 	defaultDBConnectTimeout          = 5 * time.Second
 
+	postgresLoginDefault = "default"
+	postgresLoginAWS     = "aws"
+
 	defaultRedisHost = "localhost"
 	defaultRedisPort = 6379
 	defaultRedisDB   = 3
@@ -213,6 +216,7 @@ type ServerConfig struct {
 }
 
 type DatabaseConfig struct {
+	Login             string
 	Host              string
 	Port              int
 	User              string
@@ -394,11 +398,18 @@ func getServerConfig() ServerConfig {
 }
 
 func getDatabaseConfig() DatabaseConfig {
+	login := normalizePostgresLogin(os.Getenv("POSTGRES_LOGIN"))
+	passwordDefault := defaultDBPassword
+	if login == postgresLoginAWS {
+		passwordDefault = ""
+	}
+
 	return DatabaseConfig{
+		Login:             login,
 		Host:              getEnv("DB_HOST", defaultDBHost),
 		Port:              getEnvInt("DB_PORT", defaultDBPort),
 		User:              getEnv("DB_USER", defaultDBUser),
-		Password:          getEnv("DB_PASSWORD", defaultDBPassword),
+		Password:          getEnv("DB_PASSWORD", passwordDefault),
 		Name:              getEnv("DB_NAME", defaultDBName),
 		SSLMode:           getEnv("DB_SSL_MODE", defaultDBSSLMode),
 		SSLRootCert:       getEnv("DB_SSL_ROOT_CERT", ""),
@@ -409,6 +420,14 @@ func getDatabaseConfig() DatabaseConfig {
 		HealthCheckPeriod: getEnvDuration("DB_HEALTH_CHECK_PERIOD", defaultDBHealthCheckPeriod),
 		ConnectTimeout:    getEnvDuration("DB_CONNECT_TIMEOUT", defaultDBConnectTimeout),
 	}
+}
+
+func normalizePostgresLogin(login string) string {
+	normalized := strings.ToLower(strings.TrimSpace(login))
+	if normalized == "" {
+		return postgresLoginDefault
+	}
+	return normalized
 }
 
 func getRedisConfig() RedisConfig {
@@ -681,6 +700,12 @@ func (cs ConfigSyncConfig) Validate() error {
 }
 
 func (c *Config) Validate() error {
+	c.Database.Login = normalizePostgresLogin(c.Database.Login)
+	switch c.Database.Login {
+	case postgresLoginDefault, postgresLoginAWS:
+	default:
+		return fmt.Errorf("%w: POSTGRES_LOGIN must be %q or %q", errors.ErrInvalidConfig, postgresLoginDefault, postgresLoginAWS)
+	}
 	if c.Server.GatewayDiscoveryMode != GatewayDiscoveryModeHeader &&
 		c.Server.GatewayDiscoveryMode != GatewayDiscoveryModeSubdomain {
 		return fmt.Errorf(

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -399,9 +399,9 @@ func getServerConfig() ServerConfig {
 
 func getDatabaseConfig() DatabaseConfig {
 	login := normalizePostgresLogin(os.Getenv("POSTGRES_LOGIN"))
-	passwordDefault := defaultDBPassword
+	password := getEnv("DB_PASSWORD", defaultDBPassword)
 	if login == postgresLoginAWS {
-		passwordDefault = ""
+		password = ""
 	}
 
 	return DatabaseConfig{
@@ -409,7 +409,7 @@ func getDatabaseConfig() DatabaseConfig {
 		Host:              getEnv("DB_HOST", defaultDBHost),
 		Port:              getEnvInt("DB_PORT", defaultDBPort),
 		User:              getEnv("DB_USER", defaultDBUser),
-		Password:          getEnv("DB_PASSWORD", passwordDefault),
+		Password:          password,
 		Name:              getEnv("DB_NAME", defaultDBName),
 		SSLMode:           getEnv("DB_SSL_MODE", defaultDBSSLMode),
 		SSLRootCert:       getEnv("DB_SSL_ROOT_CERT", ""),

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -18,6 +18,7 @@ import (
 	"encoding/base64"
 	stderrors "errors"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -26,6 +27,7 @@ import (
 
 func minimumEnv(t *testing.T) {
 	t.Helper()
+	t.Setenv("POSTGRES_LOGIN", "")
 	t.Setenv("DB_HOST", "db.example")
 	t.Setenv("DB_USER", "u")
 	t.Setenv("DB_NAME", "n")
@@ -55,6 +57,99 @@ func TestLoadConfig_AppliesDefaults(t *testing.T) {
 	}
 	if cfg.Database.MaxConns != defaultDBMaxConns {
 		t.Errorf("DB.MaxConns default = %d, want %d", cfg.Database.MaxConns, defaultDBMaxConns)
+	}
+}
+
+func TestLoadConfig_PostgresLoginModes(t *testing.T) {
+	tests := []struct {
+		name         string
+		login        string
+		password     string
+		wantLogin    string
+		wantPassword string
+	}{
+		{
+			name:         "blank defaults to default",
+			wantLogin:    postgresLoginDefault,
+			wantPassword: defaultDBPassword,
+		},
+		{
+			name:         "whitespace defaults to default",
+			login:        " \t ",
+			wantLogin:    postgresLoginDefault,
+			wantPassword: defaultDBPassword,
+		},
+		{
+			name:         "default is trimmed and lowercased",
+			login:        " DeFaUlT ",
+			wantLogin:    postgresLoginDefault,
+			wantPassword: defaultDBPassword,
+		},
+		{
+			name:         "default preserves configured password",
+			login:        postgresLoginDefault,
+			password:     "configured-password",
+			wantLogin:    postgresLoginDefault,
+			wantPassword: "configured-password",
+		},
+		{
+			name:      "aws is trimmed and lowercased without password",
+			login:     " AwS ",
+			wantLogin: postgresLoginAWS,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			minimumEnv(t)
+			t.Setenv("POSTGRES_LOGIN", tc.login)
+			t.Setenv("DB_PASSWORD", tc.password)
+
+			cfg, err := LoadConfig()
+			if err != nil {
+				t.Fatalf("LoadConfig: %v", err)
+			}
+			if cfg.Database.Login != tc.wantLogin {
+				t.Errorf("Database.Login = %q, want %q", cfg.Database.Login, tc.wantLogin)
+			}
+			if cfg.Database.Password != tc.wantPassword {
+				t.Errorf("Database.Password = %q, want %q", cfg.Database.Password, tc.wantPassword)
+			}
+		})
+	}
+}
+
+func TestLoadConfig_RejectsInvalidPostgresLogin(t *testing.T) {
+	tests := []struct {
+		name   string
+		dbLess bool
+	}{
+		{name: "postgres graph"},
+		{name: "DB-less graph", dbLess: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			minimumEnv(t)
+			t.Setenv("POSTGRES_LOGIN", " unsupported ")
+			if tc.dbLess {
+				t.Setenv("CONFIG_SYNC_DATA_PLANE_ENABLED", "true")
+				t.Setenv("CONFIG_SYNC_TOKEN", "config-sync-token")
+				t.Setenv("CONFIG_SYNC_GRPC_ENDPOINT", "control.example:8083")
+				t.Setenv("CONFIG_SYNC_LKG_KEY", aes256Key())
+			}
+
+			_, err := LoadConfig()
+			if err == nil {
+				t.Fatal("expected validation error for POSTGRES_LOGIN")
+			}
+			if !stderrors.Is(err, errors.ErrInvalidConfig) {
+				t.Errorf("error %v is not ErrInvalidConfig", err)
+			}
+			if !strings.Contains(err.Error(), "POSTGRES_LOGIN") {
+				t.Errorf("error %q does not name POSTGRES_LOGIN", err)
+			}
+		})
 	}
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -68,35 +68,11 @@ func TestLoadConfig_PostgresLoginModes(t *testing.T) {
 		wantLogin    string
 		wantPassword string
 	}{
-		{
-			name:         "blank defaults to default",
-			wantLogin:    postgresLoginDefault,
-			wantPassword: defaultDBPassword,
-		},
-		{
-			name:         "whitespace defaults to default",
-			login:        " \t ",
-			wantLogin:    postgresLoginDefault,
-			wantPassword: defaultDBPassword,
-		},
-		{
-			name:         "default is trimmed and lowercased",
-			login:        " DeFaUlT ",
-			wantLogin:    postgresLoginDefault,
-			wantPassword: defaultDBPassword,
-		},
-		{
-			name:         "default preserves configured password",
-			login:        postgresLoginDefault,
-			password:     "configured-password",
-			wantLogin:    postgresLoginDefault,
-			wantPassword: "configured-password",
-		},
-		{
-			name:      "aws is trimmed and lowercased without password",
-			login:     " AwS ",
-			wantLogin: postgresLoginAWS,
-		},
+		{name: "blank defaults to default", wantLogin: postgresLoginDefault, wantPassword: defaultDBPassword},
+		{name: "whitespace defaults to default", login: " \t ", wantLogin: postgresLoginDefault, wantPassword: defaultDBPassword},
+		{name: "default is trimmed and lowercased", login: " DeFaUlT ", wantLogin: postgresLoginDefault, wantPassword: defaultDBPassword},
+		{name: "default preserves configured password", login: postgresLoginDefault, password: "configured-password", wantLogin: postgresLoginDefault, wantPassword: "configured-password"},
+		{name: "aws is normalized and drops configured password", login: " AwS ", password: "configured-password", wantLogin: postgresLoginAWS},
 	}
 
 	for _, tc := range tests {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -62,68 +62,45 @@ func TestLoadConfig_AppliesDefaults(t *testing.T) {
 
 func TestLoadConfig_PostgresLoginModes(t *testing.T) {
 	tests := []struct {
-		name         string
-		login        string
-		password     string
-		wantLogin    string
-		wantPassword string
+		name, login, password, sslMode, wantLogin, wantPassword string
 	}{
 		{name: "blank defaults to default", wantLogin: postgresLoginDefault, wantPassword: defaultDBPassword},
 		{name: "whitespace defaults to default", login: " \t ", wantLogin: postgresLoginDefault, wantPassword: defaultDBPassword},
 		{name: "default is trimmed and lowercased", login: " DeFaUlT ", wantLogin: postgresLoginDefault, wantPassword: defaultDBPassword},
 		{name: "default preserves configured password", login: postgresLoginDefault, password: "configured-password", wantLogin: postgresLoginDefault, wantPassword: "configured-password"},
-		{name: "aws is normalized and drops configured password", login: " AwS ", password: "configured-password", wantLogin: postgresLoginAWS},
+		{name: "aws is normalized and drops configured password", login: " AwS ", password: "configured-password", sslMode: "require", wantLogin: postgresLoginAWS},
 	}
-
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			minimumEnv(t)
 			t.Setenv("POSTGRES_LOGIN", tc.login)
 			t.Setenv("DB_PASSWORD", tc.password)
-
+			t.Setenv("DB_SSL_MODE", tc.sslMode)
 			cfg, err := LoadConfig()
 			if err != nil {
 				t.Fatalf("LoadConfig: %v", err)
 			}
-			if cfg.Database.Login != tc.wantLogin {
-				t.Errorf("Database.Login = %q, want %q", cfg.Database.Login, tc.wantLogin)
-			}
-			if cfg.Database.Password != tc.wantPassword {
-				t.Errorf("Database.Password = %q, want %q", cfg.Database.Password, tc.wantPassword)
+			if cfg.Database.Login != tc.wantLogin || cfg.Database.Password != tc.wantPassword {
+				t.Errorf("database login/password = %q/%q, want %q/%q", cfg.Database.Login, cfg.Database.Password, tc.wantLogin, tc.wantPassword)
 			}
 		})
 	}
 }
 
 func TestLoadConfig_RejectsInvalidPostgresLogin(t *testing.T) {
-	tests := []struct {
-		name   string
-		dbLess bool
-	}{
-		{name: "postgres graph"},
-		{name: "DB-less graph", dbLess: true},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+	for name, dbLess := range map[string]bool{"postgres graph": false, "DB-less graph": true} {
+		t.Run(name, func(t *testing.T) {
 			minimumEnv(t)
 			t.Setenv("POSTGRES_LOGIN", " unsupported ")
-			if tc.dbLess {
+			if dbLess {
 				t.Setenv("CONFIG_SYNC_DATA_PLANE_ENABLED", "true")
 				t.Setenv("CONFIG_SYNC_TOKEN", "config-sync-token")
 				t.Setenv("CONFIG_SYNC_GRPC_ENDPOINT", "control.example:8083")
 				t.Setenv("CONFIG_SYNC_LKG_KEY", aes256Key())
 			}
-
 			_, err := LoadConfig()
-			if err == nil {
-				t.Fatal("expected validation error for POSTGRES_LOGIN")
-			}
-			if !stderrors.Is(err, errors.ErrInvalidConfig) {
-				t.Errorf("error %v is not ErrInvalidConfig", err)
-			}
-			if !strings.Contains(err.Error(), "POSTGRES_LOGIN") {
-				t.Errorf("error %q does not name POSTGRES_LOGIN", err)
+			if err == nil || !stderrors.Is(err, errors.ErrInvalidConfig) || !strings.Contains(err.Error(), "POSTGRES_LOGIN") {
+				t.Fatalf("error %q must be ErrInvalidConfig naming POSTGRES_LOGIN", err)
 			}
 		})
 	}
@@ -512,8 +489,28 @@ func TestValidate_PostgresGraphStillValidates(t *testing.T) {
 	}
 }
 
+func TestValidate_AWSSSLModes(t *testing.T) {
+	for mode, valid := range map[string]bool{" ReQuIrE ": true, " VERIFY-CA ": true, "verify-full": true, "disable": false, "allow": false, "prefer": false, "": false, "unknown": false} {
+		t.Run(mode, func(t *testing.T) {
+			cfg := postgresValid()
+			cfg.Database.Login, cfg.Database.SSLMode = postgresLoginAWS, mode
+			err := cfg.Validate()
+			if valid {
+				if err != nil || cfg.Database.SSLMode != strings.ToLower(strings.TrimSpace(mode)) {
+					t.Fatalf("secure AWS DB_SSL_MODE %q rejected or not normalized: mode=%q err=%v", mode, cfg.Database.SSLMode, err)
+				}
+				return
+			}
+			if !stderrors.Is(err, errors.ErrInvalidConfig) || !strings.Contains(err.Error(), "DB_SSL_MODE") {
+				t.Fatalf("insecure AWS DB_SSL_MODE %q error must be ErrInvalidConfig naming DB_SSL_MODE: %v", mode, err)
+			}
+		})
+	}
+}
+
 func TestValidate_DBLessSkipsDatabaseFields(t *testing.T) {
 	cfg := dbLessValid()
+	cfg.Database.Login, cfg.Database.SSLMode = postgresLoginAWS, "disable"
 	if cfg.Database.Host != "" || cfg.Database.User != "" || cfg.Database.Name != "" {
 		t.Fatal("dbLessValid should leave DB fields blank")
 	}

--- a/pkg/container/di_smoke_test.go
+++ b/pkg/container/di_smoke_test.go
@@ -53,6 +53,17 @@ func TestDISmoke_PlaneAwareModuleSets_Register(t *testing.T) {
 }
 
 func TestDISmoke_DBLessDataPlane_ResolvesRepositoriesWithoutPool(t *testing.T) {
+	t.Setenv("POSTGRES_LOGIN", "aws")
+	for _, key := range []string{
+		"AWS_REGION",
+		"AWS_DEFAULT_REGION",
+		"DB_HOST",
+		"DB_USER",
+		"DB_PASSWORD",
+		"DB_NAME",
+	} {
+		t.Setenv(key, "")
+	}
 	for _, plane := range []string{"proxy", "mcp"} {
 		t.Run(plane, func(t *testing.T) {
 			c, err := container.New(modules.All(plane, true)...)

--- a/pkg/container/di_smoke_test.go
+++ b/pkg/container/di_smoke_test.go
@@ -54,6 +54,10 @@ func TestDISmoke_PlaneAwareModuleSets_Register(t *testing.T) {
 
 func TestDISmoke_DBLessDataPlane_ResolvesRepositoriesWithoutPool(t *testing.T) {
 	t.Setenv("POSTGRES_LOGIN", "aws")
+	t.Setenv("CONFIG_SYNC_DATA_PLANE_ENABLED", "true")
+	t.Setenv("CONFIG_SYNC_TOKEN", "smoke-token")
+	t.Setenv("CONFIG_SYNC_GRPC_ENDPOINT", "admin.example.com:8083")
+	t.Setenv("CONFIG_SYNC_LKG_KEY", base64.StdEncoding.EncodeToString(make([]byte, 32)))
 	for _, key := range []string{
 		"AWS_REGION",
 		"AWS_DEFAULT_REGION",

--- a/pkg/infra/database/auth.go
+++ b/pkg/infra/database/auth.go
@@ -67,6 +67,11 @@ func newPoolAuthStrategy(ctx context.Context, login string, dependencies authDep
 					return fmt.Errorf("run database connection hook: %w", err)
 				}
 			}
+			if connConfig.ConnectTimeout > 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, connConfig.ConnectTimeout)
+				defer cancel()
+			}
 			endpoint := net.JoinHostPort(connConfig.Host, strconv.Itoa(int(connConfig.Port)))
 			token, err := buildToken(ctx, endpoint, region, connConfig.User, credentials)
 			if err != nil {

--- a/pkg/infra/database/auth.go
+++ b/pkg/infra/database/auth.go
@@ -1,0 +1,79 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	rdsauth "github.com/aws/aws-sdk-go-v2/feature/rds/auth"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+var errAWSRegionRequired = errors.New("aws region is required")
+
+type poolAuthStrategy func(*pgxpool.Config)
+type awsConfigLoader func(context.Context, ...func(*awsconfig.LoadOptions) error) (aws.Config, error)
+type authTokenBuilder func(context.Context, string, string, string, aws.CredentialsProvider) (string, error)
+type authDependencies struct {
+	loadConfig awsConfigLoader
+	buildToken authTokenBuilder
+}
+
+func defaultAuthDependencies() authDependencies {
+	return authDependencies{loadConfig: awsconfig.LoadDefaultConfig, buildToken: buildAuthToken}
+}
+func buildAuthToken(ctx context.Context, endpoint, region, user string, credentials aws.CredentialsProvider) (string, error) {
+	return rdsauth.BuildAuthToken(ctx, endpoint, region, user, credentials)
+}
+func newPoolAuthStrategy(ctx context.Context, login string, dependencies authDependencies) (poolAuthStrategy, error) {
+	if login != "aws" {
+		return func(*pgxpool.Config) {}, nil
+	}
+	awsConfig, err := dependencies.loadConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("load aws database authentication config: %w", err)
+	}
+	region := awsConfig.Region
+	if region == "" {
+		return nil, errAWSRegionRequired
+	}
+	credentials := awsConfig.Credentials
+	buildToken := dependencies.buildToken
+	return func(poolConfig *pgxpool.Config) {
+		previousHook := poolConfig.BeforeConnect
+		poolConfig.ConnConfig.Password = ""
+		poolConfig.BeforeConnect = func(ctx context.Context, connConfig *pgx.ConnConfig) error {
+			if previousHook != nil {
+				if err := previousHook(ctx, connConfig); err != nil {
+					return fmt.Errorf("run database connection hook: %w", err)
+				}
+			}
+			endpoint := net.JoinHostPort(connConfig.Host, strconv.Itoa(int(connConfig.Port)))
+			token, err := buildToken(ctx, endpoint, region, connConfig.User, credentials)
+			if err != nil {
+				return fmt.Errorf("build database authentication token: %w", err)
+			}
+			connConfig.Password = token
+			return nil
+		}
+	}, nil
+}

--- a/pkg/infra/database/auth_test.go
+++ b/pkg/infra/database/auth_test.go
@@ -91,6 +91,7 @@ func TestAWSAuthStrategyHookBehavior(t *testing.T) {
 	poolConfig.HealthCheckPeriod = 11 * time.Second
 	poolConfig.BeforeConnect = func(_ context.Context, config *pgx.ConnConfig) error {
 		config.Host, config.Port, config.User = "2001:db8::1", 6432, "hook-user"
+		config.ConnectTimeout = 5 * time.Second
 		return nil
 	}
 	settings := []any{poolConfig.ConnConfig.TLSConfig, poolConfig.MaxConns, poolConfig.MinConns, poolConfig.MaxConnLifetime, poolConfig.MaxConnIdleTime, poolConfig.HealthCheckPeriod}
@@ -105,11 +106,11 @@ func TestAWSAuthStrategyHookBehavior(t *testing.T) {
 		require.Equal(t, fmt.Sprintf("token-%d", index), config.Password)
 	}
 	require.Len(t, calls, 2)
-	for _, call := range calls {
-		require.Equal(t, []string{"[2001:db8::1]:6432", "eu-west-1", "hook-user"}, []string{call.endpoint, call.region, call.user})
-		require.Equal(t, provider, call.credentials)
+	for index, call := range calls {
+		require.Equal(t, []any{"[2001:db8::1]:6432", "eu-west-1", "hook-user", provider, index + 1}, []any{call.endpoint, call.region, call.user, call.credentials, call.ctx.Value(contextKey{})})
+		_, ok := call.ctx.Deadline()
+		require.True(t, ok)
 	}
-	require.Equal(t, []any{1, 2}, []any{calls[0].ctx.Value(contextKey{}), calls[1].ctx.Value(contextKey{})})
 	const concurrentHooks = 32
 	t.Cleanup(func() { require.Len(t, calls, concurrentHooks+2) })
 	for index := range concurrentHooks {

--- a/pkg/infra/database/auth_test.go
+++ b/pkg/infra/database/auth_test.go
@@ -1,0 +1,173 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	appconfig "github.com/NeuralTrust/TrustGate/pkg/config"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPoolAuthStrategy(t *testing.T) {
+	loadErr := errors.New("load failed")
+	tests := []struct {
+		name, login, region string
+		loadErr, wantErr    error
+		wantLoads           int
+	}{
+		{name: "default parity", login: "default"},
+		{name: "load error", login: "aws", loadErr: loadErr, wantErr: loadErr, wantLoads: 1},
+		{name: "empty region", login: "aws", wantErr: errAWSRegionRequired, wantLoads: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			loads := 0
+			strategy, err := newPoolAuthStrategy(t.Context(), tt.login, authDependencies{
+				loadConfig: func(context.Context, ...func(*awsconfig.LoadOptions) error) (aws.Config, error) {
+					loads++
+					return aws.Config{Region: tt.region}, tt.loadErr
+				},
+			})
+			require.ErrorIs(t, err, tt.wantErr)
+			require.Equal(t, tt.wantLoads, loads)
+			if err != nil {
+				return
+			}
+			poolConfig := mustPoolConfig(t)
+			password := poolConfig.ConnConfig.Password
+			strategy(poolConfig)
+			require.Equal(t, password, poolConfig.ConnConfig.Password)
+			require.Nil(t, poolConfig.BeforeConnect)
+		})
+	}
+}
+func TestAWSAuthStrategyHookBehavior(t *testing.T) {
+	type tokenCall struct {
+		ctx                    context.Context
+		endpoint, region, user string
+		credentials            aws.CredentialsProvider
+	}
+	provider := aws.AnonymousCredentials{}
+	var mutex sync.Mutex
+	var calls []tokenCall
+	strategy, err := newPoolAuthStrategy(t.Context(), "aws", authDependencies{
+		loadConfig: func(context.Context, ...func(*awsconfig.LoadOptions) error) (aws.Config, error) {
+			return aws.Config{Region: "eu-west-1", Credentials: provider}, nil
+		},
+		buildToken: func(ctx context.Context, endpoint, region, user string, credentials aws.CredentialsProvider) (string, error) {
+			mutex.Lock()
+			defer mutex.Unlock()
+			token := fmt.Sprintf("token-%d", len(calls)+1)
+			calls = append(calls, tokenCall{ctx, endpoint, region, user, credentials})
+			return token, nil
+		},
+	})
+	require.NoError(t, err)
+	poolConfig := mustPoolConfig(t)
+	poolConfig.MaxConns, poolConfig.MinConns = 17, 3
+	poolConfig.MaxConnLifetime, poolConfig.MaxConnIdleTime = 2*time.Hour, 7*time.Minute
+	poolConfig.HealthCheckPeriod = 11 * time.Second
+	poolConfig.BeforeConnect = func(_ context.Context, config *pgx.ConnConfig) error {
+		config.Host, config.Port, config.User = "2001:db8::1", 6432, "hook-user"
+		return nil
+	}
+	settings := []any{poolConfig.ConnConfig.TLSConfig, poolConfig.MaxConns, poolConfig.MinConns, poolConfig.MaxConnLifetime, poolConfig.MaxConnIdleTime, poolConfig.HealthCheckPeriod}
+	strategy(poolConfig)
+	require.Empty(t, poolConfig.ConnConfig.Password)
+	require.Equal(t, settings, []any{poolConfig.ConnConfig.TLSConfig, poolConfig.MaxConns, poolConfig.MinConns, poolConfig.MaxConnLifetime, poolConfig.MaxConnIdleTime, poolConfig.HealthCheckPeriod})
+	type contextKey struct{}
+	for index := 1; index <= 2; index++ {
+		hookCtx := context.WithValue(t.Context(), contextKey{}, index)
+		config := poolConfig.ConnConfig.Copy()
+		require.NoError(t, poolConfig.BeforeConnect(hookCtx, config))
+		require.Equal(t, fmt.Sprintf("token-%d", index), config.Password)
+	}
+	require.Len(t, calls, 2)
+	for _, call := range calls {
+		require.Equal(t, []string{"[2001:db8::1]:6432", "eu-west-1", "hook-user"}, []string{call.endpoint, call.region, call.user})
+		require.Equal(t, provider, call.credentials)
+	}
+	require.Equal(t, []any{1, 2}, []any{calls[0].ctx.Value(contextKey{}), calls[1].ctx.Value(contextKey{})})
+	const concurrentHooks = 32
+	t.Cleanup(func() { require.Len(t, calls, concurrentHooks+2) })
+	for index := range concurrentHooks {
+		t.Run(fmt.Sprintf("concurrent-%d", index), func(t *testing.T) {
+			t.Parallel()
+			config := poolConfig.ConnConfig.Copy()
+			require.NoError(t, poolConfig.BeforeConnect(t.Context(), config))
+		})
+	}
+}
+func TestBuildPoolConfigAWSDoesNotParseStaticPassword(t *testing.T) {
+	t.Setenv("AWS_REGION", "us-east-1")
+	poolConfig, err := buildPoolConfig(t.Context(), &appconfig.DatabaseConfig{Login: "aws", Host: "db.example.com", Port: 5432, User: "db-user", Password: "'", Name: "trustgate", SSLMode: "require"})
+	require.NoError(t, err)
+	require.Empty(t, poolConfig.ConnConfig.Password)
+	require.NotNil(t, poolConfig.BeforeConnect)
+}
+func TestAWSAuthStrategyErrors(t *testing.T) {
+	priorErr, tokenErr := errors.New("prior failed"), errors.New("token failed")
+	tests := []struct {
+		name              string
+		previousHook      func(context.Context, *pgx.ConnConfig) error
+		tokenErr, wantErr error
+		wantCalls         int
+	}{
+		{name: "prior hook stops signing", previousHook: func(context.Context, *pgx.ConnConfig) error { return priorErr }, wantErr: priorErr},
+		{name: "token error has no fallback", tokenErr: tokenErr, wantErr: tokenErr, wantCalls: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builderCalls := 0
+			strategy, err := newPoolAuthStrategy(t.Context(), "aws", authDependencies{
+				loadConfig: func(context.Context, ...func(*awsconfig.LoadOptions) error) (aws.Config, error) {
+					return aws.Config{Region: "us-east-1", Credentials: aws.AnonymousCredentials{}}, nil
+				},
+				buildToken: func(context.Context, string, string, string, aws.CredentialsProvider) (string, error) {
+					builderCalls++
+					return "fake-token", tt.tokenErr
+				},
+			})
+			require.NoError(t, err)
+			poolConfig := mustPoolConfig(t)
+			poolConfig.BeforeConnect = tt.previousHook
+			strategy(poolConfig)
+			config := poolConfig.ConnConfig.Copy()
+			err = poolConfig.BeforeConnect(t.Context(), config)
+			require.ErrorIs(t, err, tt.wantErr)
+			require.Equal(t, tt.wantCalls, builderCalls)
+			require.Equal(t, []string{"", ""}, []string{poolConfig.ConnConfig.Password, config.Password})
+			for _, secret := range []string{"static-password", "fake-token", "db.example.com:5432", "db-user", "host=db.example.com port=5432 user=db-user password=static-password dbname=trustgate sslmode=require"} {
+				require.NotContains(t, err.Error(), secret)
+			}
+		})
+	}
+}
+func mustPoolConfig(t *testing.T) *pgxpool.Config {
+	t.Helper()
+	config, err := pgxpool.ParseConfig("host=db.example.com port=5432 user=db-user password=static-password dbname=trustgate sslmode=require")
+	require.NoError(t, err)
+	return config
+}

--- a/pkg/infra/database/connection.go
+++ b/pkg/infra/database/connection.go
@@ -31,9 +31,9 @@ type Connection struct {
 }
 
 func NewConnection(ctx context.Context, cfg *config.DatabaseConfig) (*Connection, error) {
-	conf, err := buildPoolConfig(cfg)
+	conf, err := buildPoolConfig(ctx, cfg)
 	if err != nil {
-		return nil, fmt.Errorf("%w: build pool config: %v", errors.ErrBoot, err)
+		return nil, fmt.Errorf("%w: build pool config: %w", errors.ErrBoot, err)
 	}
 	pool, err := pgxpool.NewWithConfig(ctx, conf)
 	if err != nil {
@@ -58,10 +58,14 @@ func (c *Connection) HealthCheck(ctx context.Context) error {
 	return c.Pool.Ping(ctx)
 }
 
-func buildPoolConfig(cfg *config.DatabaseConfig) (*pgxpool.Config, error) {
+func buildPoolConfig(ctx context.Context, cfg *config.DatabaseConfig) (*pgxpool.Config, error) {
+	password := cfg.Password
+	if cfg.Login == "aws" {
+		password = ""
+	}
 	dsn := fmt.Sprintf(
 		"host=%s port=%d user=%s password=%s dbname=%s sslmode=%s",
-		cfg.Host, cfg.Port, cfg.User, cfg.Password, cfg.Name, cfg.SSLMode,
+		cfg.Host, cfg.Port, cfg.User, password, cfg.Name, cfg.SSLMode,
 	)
 	if cfg.SSLRootCert != "" {
 		dsn += " sslrootcert=" + cfg.SSLRootCert
@@ -77,5 +81,10 @@ func buildPoolConfig(cfg *config.DatabaseConfig) (*pgxpool.Config, error) {
 	conf.MaxConnIdleTime = cfg.MaxConnIdleTime
 	conf.HealthCheckPeriod = cfg.HealthCheckPeriod
 	conf.ConnConfig.ConnectTimeout = cfg.ConnectTimeout
+	strategy, err := newPoolAuthStrategy(ctx, cfg.Login, defaultAuthDependencies())
+	if err != nil {
+		return nil, fmt.Errorf("configure database authentication: %w", err)
+	}
+	strategy(conf)
 	return conf, nil
 }


### PR DESCRIPTION
## Summary
- add `POSTGRES_LOGIN=default|aws` with backward-compatible password authentication
- generate a fresh RDS IAM token in `pgx.BeforeConnect` for every physical AWS connection
- require TLS for AWS login, bound token generation by `DB_CONNECT_TIMEOUT`, and preserve DB-less data-plane startup

## Linear
RUN-961 — https://linear.app/neuraltrust/issue/RUN-961/featdatabase-support-aws-iam-authentication-for-postgresql

## Test plan
- [x] `make lint`
- [x] `make test-race`
- [x] `go vet ./...`
- [x] focused config, database auth, and DB-less DI tests with `-race`
- [x] `go mod tidy -diff` and `go mod verify`
- [ ] validate Aurora/IRSA authorization and token rollover after 15 minutes in the AWS environment

## Scope
Application connection code only. No deployment, IAM, Aurora, data-plane, telemetry, or `.env*` changes.