### PR TITLE
fix(plugins): hide model and tool allowlist from policy catalog

### DIFF
--- a/pkg/app/plugins/catalog.go
+++ b/pkg/app/plugins/catalog.go
@@ -118,6 +118,9 @@ func NewCatalogService(registry Registry) CatalogService {
 func (s *catalogService) Catalog() Catalog {
 	buckets := make(map[string][]CatalogEntry)
 	for _, name := range s.registry.Names() {
+		if _, hidden := hiddenCatalogSlugs[name]; hidden {
+			continue
+		}
 		plugin, ok := s.registry.Get(name)
 		if !ok {
 			continue

--- a/pkg/app/plugins/catalog_metadata.go
+++ b/pkg/app/plugins/catalog_metadata.go
@@ -38,6 +38,12 @@ var groupOrder = []string{
 	groupOther,
 }
 
+// hiddenCatalogSlugs stay registered and executable but are excluded from the catalog.
+var hiddenCatalogSlugs = map[string]struct{}{
+	"model_allowlist": {},
+	"tool_allowlist":  {},
+}
+
 // catalogMeta is the curated, UI-facing metadata for a plugin slug. Stage data
 // is intentionally excluded; it is read from the plugin implementations so the
 // catalog cannot drift from the executor's behaviour.

--- a/pkg/app/plugins/catalog_test.go
+++ b/pkg/app/plugins/catalog_test.go
@@ -37,6 +37,17 @@ var builtinSlugs = []string{
 	"tool_allowlist",
 }
 
+func catalogVisibleSlugs() []string {
+	visible := make([]string, 0, len(builtinSlugs))
+	for _, slug := range builtinSlugs {
+		if _, hidden := hiddenCatalogSlugs[slug]; hidden {
+			continue
+		}
+		visible = append(visible, slug)
+	}
+	return visible
+}
+
 func registerBuiltins(t *testing.T) Registry {
 	t.Helper()
 	reg := NewRegistry()
@@ -79,7 +90,7 @@ func TestCatalogService_GroupsAndOrder(t *testing.T) {
 	}
 	assert.ElementsMatch(t, []string{"rate_limiter", "request_size_limiter", "cors"}, byType[groupTrafficControl])
 	assert.ElementsMatch(t, []string{"token_rate_limiter", "cost_cap"}, byType[groupQuota])
-	assert.ElementsMatch(t, []string{"semantic_cache", "model_allowlist", "tool_allowlist"}, byType[groupRouting])
+	assert.ElementsMatch(t, []string{"semantic_cache"}, byType[groupRouting])
 	assert.Equal(t, []string{"prompt_template"}, byType[groupPromptManagement])
 }
 
@@ -94,8 +105,13 @@ func TestCatalogService_EntriesHaveStagesAndSchema(t *testing.T) {
 		}
 	}
 
-	require.Len(t, entries, len(builtinSlugs))
-	for _, slug := range builtinSlugs {
+	visibleSlugs := catalogVisibleSlugs()
+	require.Len(t, entries, len(visibleSlugs))
+	for slug := range hiddenCatalogSlugs {
+		_, ok := entries[slug]
+		assert.Falsef(t, ok, "hidden slug %q must not appear in the catalog", slug)
+	}
+	for _, slug := range visibleSlugs {
 		entry, ok := entries[slug]
 		require.Truef(t, ok, "slug %q missing from catalog", slug)
 		assert.NotEmptyf(t, entry.Name, "slug %q has empty display name", slug)


### PR DESCRIPTION
## Summary
- Exclude `model_allowlist` and `tool_allowlist` from the policy catalog API response.
- Plugins remain registered and executable for existing policies; they are only hidden from the admin UI when creating new policies.
- Update catalog tests to assert hidden slugs are not served.

## Test plan
- [x] `go test ./pkg/app/plugins/...`
- [ ] Verify policy catalog endpoint no longer lists Model Allowlist or Tool Allowlist
- [ ] Confirm existing policies using these plugins still execute


Made with [Cursor](https://cursor.com)