### PR TITLE
fix: namespace raw exporter migration table per service

### DIFF
--- a/docs/telemetry-exporter-split.md
+++ b/docs/telemetry-exporter-split.md
@@ -276,7 +276,7 @@ advisory lock**). ENG-1020 adds a dedicated runner in `infra/telemetry/postgres`
 - Opens the sensible pool via `pgx` from the resolved DSN.
 - Takes a **Postgres advisory lock** (`pg_advisory_lock(<const key>)`) so multiple replicas don't race
   the first-time DDL.
-- Ensures a `schema_migrations` table in the sensible DB and applies pending `Migration.UpSQL` from the
+- Ensures a `trustgate_migration_versions` table in the sensible DB and applies pending `Migration.UpSQL` from the
   module in order, idempotently (`CREATE TABLE IF NOT EXISTS`).
 - Runs **only when the `postgres` exporter is enabled** (first build), not at global boot.
 

--- a/pkg/infra/telemetry/postgres/migrate.go
+++ b/pkg/infra/telemetry/postgres/migrate.go
@@ -30,6 +30,10 @@ const unlockTimeout = 5 * time.Second
 // exporter concurrently. The value is arbitrary but must stay stable (ENG-1020).
 const advisoryLockKey int64 = 942_020
 
+// legacyVersionTableName is the shared tracking table used before it was
+// namespaced per service; kept only to migrate existing deployments.
+const legacyVersionTableName = "migration_versions"
+
 func runMigrations(ctx context.Context, pool *pgxpool.Pool, logger *slog.Logger) error {
 	conn, err := pool.Acquire(ctx)
 	if err != nil {
@@ -55,6 +59,11 @@ func runMigrations(ctx context.Context, pool *pgxpool.Pool, logger *slog.Logger)
 		conn.Release()
 	}()
 
+	// Must run before ensuring the namespaced table: otherwise the CREATE below
+	// would leave an empty ledger and force every migration to re-run.
+	if err := renameLegacyVersionTable(ctx, conn); err != nil {
+		return err
+	}
 	if _, err := conn.Exec(ctx, metrics.MigrationVersionTableDDL); err != nil {
 		return fmt.Errorf("postgres: ensure %s: %w", metrics.MigrationVersionTable, err)
 	}
@@ -69,6 +78,22 @@ func runMigrations(ctx context.Context, pool *pgxpool.Pool, logger *slog.Logger)
 		if err := applyMigration(ctx, conn, m); err != nil {
 			return fmt.Errorf("postgres: apply migration %q: %w", m.ID, err)
 		}
+	}
+	return nil
+}
+
+func renameLegacyVersionTable(ctx context.Context, conn *pgxpool.Conn) error {
+	if legacyVersionTableName == metrics.MigrationVersionTable {
+		return nil
+	}
+	sql := fmt.Sprintf(`DO $$
+BEGIN
+    IF to_regclass('%[1]s') IS NOT NULL AND to_regclass('%[2]s') IS NULL THEN
+        ALTER TABLE %[1]s RENAME TO %[2]s;
+    END IF;
+END $$;`, legacyVersionTableName, metrics.MigrationVersionTable)
+	if _, err := conn.Exec(ctx, sql); err != nil {
+		return fmt.Errorf("postgres: rename legacy %s to %s: %w", legacyVersionTableName, metrics.MigrationVersionTable, err)
 	}
 	return nil
 }

--- a/pkg/infra/telemetry/postgres/migrate_integration_test.go
+++ b/pkg/infra/telemetry/postgres/migrate_integration_test.go
@@ -59,6 +59,38 @@ func TestRunMigrationsIsIdempotent(t *testing.T) {
 	require.Equal(t, len(metrics.Migrations()), count)
 }
 
+func TestRunMigrationsRenamesLegacyVersionTable(t *testing.T) {
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, integrationDSN(t))
+	require.NoError(t, err)
+	defer pool.Close()
+
+	_, err = pool.Exec(ctx, "DROP TABLE IF EXISTS "+metrics.MigrationVersionTable+", "+legacyVersionTableName)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), "DROP TABLE IF EXISTS "+legacyVersionTableName)
+	})
+
+	_, err = pool.Exec(ctx, "CREATE TABLE "+legacyVersionTableName+` (
+    id         TEXT        PRIMARY KEY,
+    name       TEXT        NOT NULL,
+    applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);`)
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx, "INSERT INTO "+legacyVersionTableName+" (id, name) VALUES ('0001', 'create_trustgate_data')")
+	require.NoError(t, err)
+
+	require.NoError(t, runMigrations(ctx, pool, discardLogger()))
+
+	var legacy *string
+	require.NoError(t, pool.QueryRow(ctx, "SELECT to_regclass('"+legacyVersionTableName+"')::text").Scan(&legacy))
+	require.Nil(t, legacy)
+
+	var count int
+	require.NoError(t, pool.QueryRow(ctx, "SELECT count(*) FROM "+metrics.MigrationVersionTable).Scan(&count))
+	require.Equal(t, len(metrics.Migrations()), count)
+}
+
 func TestExporterInsertsSensibleRowIdempotently(t *testing.T) {
 	ctx := context.Background()
 	pool, err := pgxpool.New(ctx, integrationDSN(t))

--- a/pkg/metrics/migrations/migration.go
+++ b/pkg/metrics/migrations/migration.go
@@ -16,9 +16,9 @@ package migrations
 
 import "sort"
 
-const VersionTableName = "migration_versions"
+const VersionTableName = "trustgate_migration_versions"
 
-const VersionTableDDL = `CREATE TABLE IF NOT EXISTS migration_versions (
+const VersionTableDDL = `CREATE TABLE IF NOT EXISTS trustgate_migration_versions (
     id         TEXT        PRIMARY KEY,
     name       TEXT        NOT NULL,
     applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()


### PR DESCRIPTION
## Summary
- The raw Postgres exporter tracked applied migrations in a shared `migration_versions` table with overlapping IDs (`0001`, ...). If TrustGate and TrustGuard point their raw sinks at the same database, they collide on that ledger: whichever runs first marks `0001` as applied, and the other service skips its own `0001` and never creates its data table.
- Rename the tracking table to `trustgate_migration_versions` so each service owns its ledger and both can safely share one database.
- Add an idempotent bootstrap rename in the migrator, executed inside the advisory lock and **before** the version table is ensured, so existing deployments keep their history and never re-run past migrations. A registry migration cannot do this: the tracking table is bootstrapped before any migration runs.

## Behavior
| Environment state | Result |
|---|---|
| Fresh DB | no-op, namespaced table created normally |
| Existing (`migration_versions` present) | renamed, history preserved, nothing re-runs |
| Already migrated | no-op |

## Test plan
- [x] `go build` + `go vet` clean
- [x] Unit tests green (`pkg/metrics`, `pkg/infra/telemetry/postgres`)
- [x] Added integration test for the legacy-table rename path (guarded by `integration` build tag + `SENSIBLE_PG_TEST_DSN`)

Made with [Cursor](https://cursor.com)