### PR TITLE
feat(providers): add databricks, fireworks, oracle, and perplexity

### DIFF
--- a/openspec/changes/tier2-llm-providers/proposal.md
+++ b/openspec/changes/tier2-llm-providers/proposal.md
@@ -1,0 +1,30 @@
+---
+type: feat
+changelog: "Add Databricks, Fireworks, Oracle OCI, and Perplexity LLM registry providers."
+---
+
+# Proposal: Tier-2 LLM providers (Databricks, Fireworks, Oracle, Perplexity)
+
+## Why
+
+TrustGate v2 needs first-class registry providers for tier-2 upstreams exercised by the
+multi-agent compatibility matrix: Databricks Model Serving, Fireworks, Oracle OCI
+Generative AI (OpenAI-compatible), and Perplexity.
+
+## What changes
+
+- **Provider clients** under `pkg/infra/providers/{databricks,fireworks,oracle,perplexity}/`
+- **Options decoding** in `pkg/infra/providers/options.go` (base URL, region, project)
+- **Factory registration** and adapter format routing for OpenAI-compatible wire paths
+- **Catalog** auth/options seeds for registry create UI and API validation
+
+## Out of scope
+
+- OAuth token refresh for Databricks route-optimized endpoints
+- Oracle IAM signing (Generative AI API keys only)
+
+## QA checklist
+
+- [ ] `go test ./pkg/infra/providers/databricks/... ./pkg/infra/providers/fireworks/... ./pkg/infra/providers/oracle/... ./pkg/infra/providers/perplexity/...`
+- [ ] Registry create with each provider via admin API or Postman
+- [ ] `ag-matrix` cross-format cells for each new upstream (multi-agent-tests repo)

--- a/pkg/app/catalog/provider_auth.go
+++ b/pkg/app/catalog/provider_auth.go
@@ -259,6 +259,10 @@ var providerAuthCatalog = map[string][]AuthTypeOption{
 	providers.ProviderCerebras:         {apiKeyAuthOption},
 	providers.ProviderOpenRouter:       {apiKeyAuthOption},
 	providers.ProviderCohere:           {apiKeyAuthOption},
+	providers.ProviderPerplexity:       {apiKeyAuthOption},
+	providers.ProviderFireworks:      {apiKeyAuthOption},
+	providers.ProviderDatabricks:       {apiKeyAuthOption},
+	providers.ProviderOracle:           {apiKeyAuthOption},
 }
 
 func ProviderAuthOptions(code string) []AuthTypeOption {

--- a/pkg/app/catalog/provider_options.go
+++ b/pkg/app/catalog/provider_options.go
@@ -94,6 +94,47 @@ var providerOptionsCatalog = map[string][]ProviderOptionField{
 			Default:     "v1",
 		},
 	},
+	providers.ProviderDatabricks: {
+		{
+			Key:         "base_url",
+			Label:       "Serving endpoint URL",
+			Type:        OptionFieldTypeString,
+			Description: "Databricks Model Serving base URL up to the endpoint name (e.g. https://adb-123.azuredatabricks.net/serving-endpoints/my-llm).",
+			Required:    true,
+		},
+		{
+			Key:         "headers",
+			Label:       "Headers",
+			Type:        OptionFieldTypeMap,
+			Description: "Extra HTTP headers sent with every upstream request.",
+		},
+	},
+	providers.ProviderOracle: {
+		{
+			Key:         "region",
+			Label:       "OCI Region",
+			Type:        OptionFieldTypeString,
+			Description: "OCI region for Generative AI (e.g. us-chicago-1). Required unless Base URL is set.",
+		},
+		{
+			Key:         "project",
+			Label:       "Generative AI Project OCID",
+			Type:        OptionFieldTypeString,
+			Description: "Optional OCI Generative AI project OCID (sent as OpenAI-Project header).",
+		},
+		{
+			Key:         "base_url",
+			Label:       "Base URL",
+			Type:        OptionFieldTypeString,
+			Description: "Optional override for the OCI OpenAI-compatible base URL (http/https).",
+		},
+		{
+			Key:         "headers",
+			Label:       "Headers",
+			Type:        OptionFieldTypeMap,
+			Description: "Extra HTTP headers sent with every upstream request.",
+		},
+	},
 }
 
 func ProviderOptions(code string) []ProviderOptionField {

--- a/pkg/app/catalog/sync.go
+++ b/pkg/app/catalog/sync.go
@@ -73,6 +73,10 @@ var seedProviders = []seedProvider{
 	{providers.ProviderCerebras, "Cerebras", "openai"},
 	{providers.ProviderOpenRouter, "OpenRouter", "openai"},
 	{providers.ProviderCohere, "Cohere", "cohere"},
+	{providers.ProviderPerplexity, "Perplexity", "openai"},
+	{providers.ProviderFireworks, "Fireworks", "openai"},
+	{providers.ProviderDatabricks, "Databricks", "openai"},
+	{providers.ProviderOracle, "Oracle OCI", "openai"},
 }
 
 var cohereSeedModels = []seedModel{

--- a/pkg/domain/provider/provider.go
+++ b/pkg/domain/provider/provider.go
@@ -32,6 +32,10 @@ const (
 	Cerebras         = "cerebras"
 	OpenRouter       = "openrouter"
 	Cohere           = "cohere"
+	Perplexity       = "perplexity"
+	Fireworks        = "fireworks"
+	Databricks       = "databricks"
+	Oracle           = "oracle"
 )
 
 // Supported returns every provider name the gateway can route to.
@@ -51,6 +55,10 @@ func Supported() []string {
 		Cerebras,
 		OpenRouter,
 		Cohere,
+		Perplexity,
+		Fireworks,
+		Databricks,
+		Oracle,
 	}
 }
 
@@ -70,7 +78,11 @@ func IsValid(name string) bool {
 		XAI,
 		Cerebras,
 		OpenRouter,
-		Cohere:
+		Cohere,
+		Perplexity,
+		Fireworks,
+		Databricks,
+		Oracle:
 		return true
 	default:
 		return false

--- a/pkg/infra/providers/adapter/format.go
+++ b/pkg/infra/providers/adapter/format.go
@@ -146,6 +146,8 @@ func resolveProviderWireFormat(providerName string) Format {
 		return FormatXAI
 	case provider.Cerebras:
 		return FormatOpenAI
+	case provider.Perplexity, provider.Fireworks, provider.Databricks, provider.Oracle:
+		return FormatOpenAI
 	case provider.OpenRouter:
 		return FormatOpenRouter
 	case provider.Cohere:
@@ -177,7 +179,7 @@ func ResolveAgentFormat(providerName, sourceFormat string, providerOptions map[s
 		return Format(sourceFormat), nil
 	}
 	switch providerName {
-	case provider.OpenAI, provider.OpenAICompatible, provider.Azure, provider.Groq, provider.DeepSeek, provider.XAI, provider.Cerebras, provider.OpenRouter:
+	case provider.OpenAI, provider.OpenAICompatible, provider.Azure, provider.Groq, provider.DeepSeek, provider.XAI, provider.Cerebras, provider.Perplexity, provider.Fireworks, provider.Databricks, provider.Oracle, provider.OpenRouter:
 		return ResolveTargetFormat(providerName, providerOptions), nil
 	case provider.Anthropic:
 		return FormatAnthropic, nil

--- a/pkg/infra/providers/client.go
+++ b/pkg/infra/providers/client.go
@@ -39,6 +39,10 @@ const (
 	ProviderCerebras         = provider.Cerebras
 	ProviderOpenRouter       = provider.OpenRouter
 	ProviderCohere           = provider.Cohere
+	ProviderPerplexity       = provider.Perplexity
+	ProviderFireworks        = provider.Fireworks
+	ProviderDatabricks       = provider.Databricks
+	ProviderOracle           = provider.Oracle
 )
 
 type Config struct {

--- a/pkg/infra/providers/databricks/client.go
+++ b/pkg/infra/providers/databricks/client.go
@@ -1,0 +1,65 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package databricks
+
+import (
+	"context"
+	"iter"
+	"strings"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/openai"
+)
+
+const invocationsPath = "/invocations"
+
+type client struct {
+	chat *openai.ChatCompletionsClient
+}
+
+func NewDatabricksClient() providers.Client {
+	pool := providers.NewHTTPClientPool()
+	return &client{
+		chat: openai.NewChatCompletionsClient(providers.ProviderDatabricks, pool),
+	}
+}
+
+func (c *client) Completions(
+	ctx context.Context,
+	config *providers.Config,
+	reqBody []byte,
+) ([]byte, error) {
+	opts, err := providers.DecodeDatabricksOptions(config.Options)
+	if err != nil {
+		return nil, err
+	}
+	return c.chat.Completions(ctx, invocationsURL(opts), config, reqBody, opts.Headers)
+}
+
+func (c *client) CompletionsStream(
+	ctx context.Context,
+	config *providers.Config,
+	reqBody []byte,
+) (iter.Seq2[[]byte, error], error) {
+	opts, err := providers.DecodeDatabricksOptions(config.Options)
+	if err != nil {
+		return nil, err
+	}
+	return c.chat.CompletionsStream(ctx, invocationsURL(opts), config, reqBody, opts.Headers)
+}
+
+func invocationsURL(opts providers.DatabricksOptions) string {
+	return strings.TrimRight(opts.BaseURL, "/") + invocationsPath
+}

--- a/pkg/infra/providers/databricks/client_test.go
+++ b/pkg/infra/providers/databricks/client_test.go
@@ -1,0 +1,102 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package databricks
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDatabricksClient(t *testing.T) {
+	assert.NotNil(t, NewDatabricksClient())
+}
+
+func TestCompletions_MissingBaseURL(t *testing.T) {
+	_, err := NewDatabricksClient().Completions(
+		context.Background(),
+		&providers.Config{Credentials: providers.Credentials{ApiKey: "token"}},
+		[]byte(`{}`),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "base_url is required")
+}
+
+func TestCompletions_InvocationsRoundTrip(t *testing.T) {
+	const wantModel = "databricks-meta-llama-3-1-70b-instruct"
+	var gotAuth, gotPath, gotModel string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		gotModel, _ = body["model"].(string)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"model": wantModel})
+	}))
+	t.Cleanup(srv.Close)
+
+	baseURL := srv.URL + "/serving-endpoints/my-endpoint"
+	resp, err := NewDatabricksClient().Completions(
+		context.Background(),
+		&providers.Config{
+			Credentials: providers.Credentials{ApiKey: "databricks-token"},
+			Options: map[string]any{
+				"base_url": baseURL,
+			},
+		},
+		[]byte(`{"model":"`+wantModel+`","messages":[{"role":"user","content":"hello"}]}`),
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "/serving-endpoints/my-endpoint/invocations", gotPath)
+	assert.Equal(t, "Bearer databricks-token", gotAuth)
+	assert.Equal(t, wantModel, gotModel)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(resp, &parsed))
+	assert.Equal(t, wantModel, parsed["model"])
+}
+
+func TestTestConnection_MethodNotAllowedIsOK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	result := NewDatabricksClient().(providers.ConnectionTester).TestConnection(
+		context.Background(),
+		&providers.Config{
+			Credentials: providers.Credentials{ApiKey: "token"},
+			Options: map[string]any{
+				"base_url": srv.URL + "/serving-endpoints/demo",
+			},
+		},
+	)
+	assert.True(t, result.OK)
+}

--- a/pkg/infra/providers/databricks/connection.go
+++ b/pkg/infra/providers/databricks/connection.go
@@ -1,0 +1,50 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package databricks
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+)
+
+func (c *client) TestConnection(ctx context.Context, config *providers.Config) providers.ProbeResult {
+	opts, err := providers.DecodeDatabricksOptions(config.Options)
+	if err != nil {
+		return providers.ProbeResult{
+			OK:      false,
+			Stage:   providers.StageProvider,
+			Message: err.Error(),
+		}
+	}
+	result := providers.RunBearerGETProbe(
+		ctx,
+		providers.ProviderDatabricks,
+		invocationsURL(opts),
+		config.Credentials.ApiKey,
+	)
+	if result.OK {
+		return result
+	}
+	if result.StatusCode == http.StatusMethodNotAllowed {
+		return providers.ProbeResult{
+			OK:         true,
+			Stage:      providers.StageAuthentication,
+			StatusCode: result.StatusCode,
+		}
+	}
+	return result
+}

--- a/pkg/infra/providers/factory/locator.go
+++ b/pkg/infra/providers/factory/locator.go
@@ -23,13 +23,17 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/bedrock"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/cerebras"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/cohere"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/databricks"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/deepseek"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/fireworks"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/google"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/groq"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/mistral"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/openai"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/openrouter"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/openaicompat"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/oracle"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/perplexity"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/vertex"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/xai"
 )
@@ -51,6 +55,10 @@ const (
 	ProviderCerebras         = providers.ProviderCerebras
 	ProviderOpenRouter       = providers.ProviderOpenRouter
 	ProviderCohere           = providers.ProviderCohere
+	ProviderPerplexity       = providers.ProviderPerplexity
+	ProviderFireworks        = providers.ProviderFireworks
+	ProviderDatabricks       = providers.ProviderDatabricks
+	ProviderOracle           = providers.ProviderOracle
 )
 
 //go:generate mockery --name=ProviderLocator --dir=. --output=./mocks --filename=provider_locator_mock.go --case=underscore --with-expecter
@@ -86,6 +94,10 @@ func NewProviderLocator() ProviderLocator {
 			ProviderOpenRouter:       openrouter.NewOpenRouterClient(),
 			ProviderVertex:           vertex.NewVertexClient(),
 			ProviderCohere:           cohere.NewCohereClient(),
+			ProviderPerplexity:       perplexity.NewPerplexityClient(),
+			ProviderFireworks:        fireworks.NewFireworksClient(),
+			ProviderDatabricks:       databricks.NewDatabricksClient(),
+			ProviderOracle:           oracle.NewOracleClient(),
 		},
 	}
 }

--- a/pkg/infra/providers/factory/locator_test.go
+++ b/pkg/infra/providers/factory/locator_test.go
@@ -39,6 +39,10 @@ func TestProviderLocator_Get(t *testing.T) {
 		ProviderCerebras,
 		ProviderOpenRouter,
 		ProviderCohere,
+		ProviderPerplexity,
+		ProviderFireworks,
+		ProviderDatabricks,
+		ProviderOracle,
 	} {
 		t.Run(provider, func(t *testing.T) {
 			client, err := locator.Get(provider)

--- a/pkg/infra/providers/fireworks/client.go
+++ b/pkg/infra/providers/fireworks/client.go
@@ -1,0 +1,51 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fireworks
+
+import (
+	"context"
+	"iter"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/openai"
+)
+
+const chatCompletionsURL = "https://api.fireworks.ai/inference/v1/chat/completions"
+
+type client struct {
+	chat *openai.ChatCompletionsClient
+}
+
+func NewFireworksClient() providers.Client {
+	return &client{
+		chat: openai.NewChatCompletionsClient(providers.ProviderFireworks, nil),
+	}
+}
+
+func (c *client) Completions(
+	ctx context.Context,
+	config *providers.Config,
+	reqBody []byte,
+) ([]byte, error) {
+	return c.chat.Completions(ctx, chatCompletionsURL, config, reqBody, nil)
+}
+
+func (c *client) CompletionsStream(
+	ctx context.Context,
+	config *providers.Config,
+	reqBody []byte,
+) (iter.Seq2[[]byte, error], error) {
+	return c.chat.CompletionsStream(ctx, chatCompletionsURL, config, reqBody, nil)
+}

--- a/pkg/infra/providers/fireworks/client_test.go
+++ b/pkg/infra/providers/fireworks/client_test.go
@@ -1,0 +1,136 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fireworks
+
+import (
+	"context"
+	"encoding/json"
+	"iter"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/openai"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fireworksClientAt struct {
+	chat *openai.ChatCompletionsClient
+	url  string
+}
+
+func newFireworksClientAt(url string) providers.Client {
+	return &fireworksClientAt{
+		chat: openai.NewChatCompletionsClient(providers.ProviderFireworks, nil),
+		url:  url,
+	}
+}
+
+func (c *fireworksClientAt) Completions(ctx context.Context, config *providers.Config, reqBody []byte) ([]byte, error) {
+	return c.chat.Completions(ctx, c.url, config, reqBody, nil)
+}
+
+func (c *fireworksClientAt) CompletionsStream(ctx context.Context, config *providers.Config, reqBody []byte) (iter.Seq2[[]byte, error], error) {
+	return c.chat.CompletionsStream(ctx, c.url, config, reqBody, nil)
+}
+
+func TestNewFireworksClient(t *testing.T) {
+	assert.NotNil(t, NewFireworksClient())
+}
+
+func TestCompletions_MissingAPIKey(t *testing.T) {
+	_, err := NewFireworksClient().Completions(context.Background(), &providers.Config{}, []byte(`{}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "API key is required")
+}
+
+func TestCompletions_NonStreamingRoundTrip(t *testing.T) {
+	const wantModel = "accounts/fireworks/models/llama-v3p1-70b-instruct"
+	var gotAuth, gotModel string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		gotAuth = r.Header.Get("Authorization")
+
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		gotModel, _ = body["model"].(string)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"model": wantModel})
+	}))
+	t.Cleanup(srv.Close)
+
+	resp, err := newFireworksClientAt(srv.URL+"/chat/completions").Completions(
+		context.Background(),
+		&providers.Config{Credentials: providers.Credentials{ApiKey: "fireworks-test-key"}},
+		[]byte(`{"model":"`+wantModel+`","messages":[{"role":"user","content":"hello"}]}`),
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Bearer fireworks-test-key", gotAuth)
+	assert.Equal(t, wantModel, gotModel)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(resp, &parsed))
+	assert.Equal(t, wantModel, parsed["model"])
+}
+
+func TestCompletionsStream_RoundTrip(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer fireworks-key", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	t.Cleanup(srv.Close)
+
+	seq, err := newFireworksClientAt(srv.URL+"/chat/completions").CompletionsStream(
+		context.Background(),
+		&providers.Config{Credentials: providers.Credentials{ApiKey: "fireworks-key"}},
+		[]byte(`{"model":"accounts/fireworks/models/llama-v3p1-70b-instruct","stream":true}`),
+	)
+	require.NoError(t, err)
+
+	var lines []string
+	for line, lerr := range seq {
+		require.NoError(t, lerr)
+		lines = append(lines, string(line))
+	}
+	require.NotEmpty(t, lines)
+}
+
+func TestCompletions_RateLimitRetryAfter(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "2")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"rate limit exceeded"}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := newFireworksClientAt(srv.URL+"/chat/completions").Completions(
+		context.Background(),
+		&providers.Config{Credentials: providers.Credentials{ApiKey: "key"}},
+		[]byte(`{"model":"accounts/fireworks/models/llama-v3p1-70b-instruct","messages":[{"role":"user","content":"hi"}]}`),
+	)
+	require.Error(t, err)
+
+	be, ok := registry.IsBackendError(err)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusTooManyRequests, be.StatusCode)
+}

--- a/pkg/infra/providers/fireworks/connection.go
+++ b/pkg/infra/providers/fireworks/connection.go
@@ -12,26 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package providers
+package fireworks
 
-func ValidateProviderOptions(provider string, options map[string]any) error {
-	switch provider {
-	case ProviderOpenAICompatible:
-		_, err := DecodeOpenAICompatibleOptions(options)
-		return err
-	case ProviderOpenAI:
-		_, err := DecodeOpenAIOptions(options)
-		return err
-	case ProviderVertex:
-		_, err := DecodeVertexOptions(options)
-		return err
-	case ProviderDatabricks:
-		_, err := DecodeDatabricksOptions(options)
-		return err
-	case ProviderOracle:
-		_, err := DecodeOracleOptions(options)
-		return err
-	default:
-		return nil
-	}
+import (
+	"context"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+)
+
+const modelsURL = "https://api.fireworks.ai/inference/v1/models"
+
+func (c *client) TestConnection(ctx context.Context, config *providers.Config) providers.ProbeResult {
+	return providers.RunBearerGETProbe(ctx, providers.ProviderFireworks, modelsURL, config.Credentials.ApiKey)
 }

--- a/pkg/infra/providers/options.go
+++ b/pkg/infra/providers/options.go
@@ -34,6 +34,18 @@ type OpenAICompatibleOptions struct {
 	Headers map[string]string `mapstructure:"headers"`
 }
 
+type DatabricksOptions struct {
+	BaseURL string            `mapstructure:"base_url"`
+	Headers map[string]string `mapstructure:"headers"`
+}
+
+type OracleOptions struct {
+	Region  string            `mapstructure:"region"`
+	Project string            `mapstructure:"project"`
+	BaseURL string            `mapstructure:"base_url"`
+	Headers map[string]string `mapstructure:"headers"`
+}
+
 func DecodeOpenAICompatibleOptions(options map[string]any) (OpenAICompatibleOptions, error) {
 	var opts OpenAICompatibleOptions
 	if len(options) > 0 {
@@ -48,6 +60,53 @@ func DecodeOpenAICompatibleOptions(options map[string]any) (OpenAICompatibleOpti
 	}
 	if err := validateHTTPBaseURL(opts.BaseURL); err != nil {
 		return OpenAICompatibleOptions{}, fmt.Errorf("openai_compatible: %w", err)
+	}
+
+	return opts, nil
+}
+
+func DecodeDatabricksOptions(options map[string]any) (DatabricksOptions, error) {
+	var opts DatabricksOptions
+	if len(options) > 0 {
+		if err := mapstructure.Decode(options, &opts); err != nil {
+			return DatabricksOptions{}, fmt.Errorf("databricks: invalid provider_options: %w", err)
+		}
+	}
+
+	opts.BaseURL = strings.TrimSpace(opts.BaseURL)
+	if opts.BaseURL == "" {
+		return DatabricksOptions{}, fmt.Errorf("databricks: base_url is required")
+	}
+	if err := validateHTTPBaseURL(opts.BaseURL); err != nil {
+		return DatabricksOptions{}, fmt.Errorf("databricks: %w", err)
+	}
+
+	return opts, nil
+}
+
+func DecodeOracleOptions(options map[string]any) (OracleOptions, error) {
+	var opts OracleOptions
+	if len(options) > 0 {
+		if err := mapstructure.Decode(options, &opts); err != nil {
+			return OracleOptions{}, fmt.Errorf("oracle: invalid provider_options: %w", err)
+		}
+	}
+
+	opts.Region = strings.TrimSpace(opts.Region)
+	opts.Project = strings.TrimSpace(opts.Project)
+	opts.BaseURL = strings.TrimSpace(opts.BaseURL)
+
+	if opts.BaseURL == "" {
+		if opts.Region == "" {
+			return OracleOptions{}, fmt.Errorf("oracle: region or base_url is required")
+		}
+		opts.BaseURL = fmt.Sprintf(
+			"https://inference.generativeai.%s.oci.oraclecloud.com/openai/v1",
+			opts.Region,
+		)
+	}
+	if err := validateHTTPBaseURL(opts.BaseURL); err != nil {
+		return OracleOptions{}, fmt.Errorf("oracle: %w", err)
 	}
 
 	return opts, nil

--- a/pkg/infra/providers/oracle/client.go
+++ b/pkg/infra/providers/oracle/client.go
@@ -1,0 +1,76 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oracle
+
+import (
+	"context"
+	"iter"
+	"strings"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/openai"
+)
+
+const chatCompletionsPath = "/chat/completions"
+
+type client struct {
+	chat *openai.ChatCompletionsClient
+}
+
+func NewOracleClient() providers.Client {
+	pool := providers.NewHTTPClientPool()
+	return &client{
+		chat: openai.NewChatCompletionsClient(providers.ProviderOracle, pool),
+	}
+}
+
+func (c *client) Completions(
+	ctx context.Context,
+	config *providers.Config,
+	reqBody []byte,
+) ([]byte, error) {
+	opts, err := providers.DecodeOracleOptions(config.Options)
+	if err != nil {
+		return nil, err
+	}
+	return c.chat.Completions(ctx, chatCompletionsURL(opts), config, reqBody, requestHeaders(opts))
+}
+
+func (c *client) CompletionsStream(
+	ctx context.Context,
+	config *providers.Config,
+	reqBody []byte,
+) (iter.Seq2[[]byte, error], error) {
+	opts, err := providers.DecodeOracleOptions(config.Options)
+	if err != nil {
+		return nil, err
+	}
+	return c.chat.CompletionsStream(ctx, chatCompletionsURL(opts), config, reqBody, requestHeaders(opts))
+}
+
+func chatCompletionsURL(opts providers.OracleOptions) string {
+	return strings.TrimRight(opts.BaseURL, "/") + chatCompletionsPath
+}
+
+func requestHeaders(opts providers.OracleOptions) map[string]string {
+	headers := make(map[string]string, len(opts.Headers)+1)
+	for key, value := range opts.Headers {
+		headers[key] = value
+	}
+	if opts.Project != "" {
+		headers["OpenAI-Project"] = opts.Project
+	}
+	return headers
+}

--- a/pkg/infra/providers/oracle/client_test.go
+++ b/pkg/infra/providers/oracle/client_test.go
@@ -1,0 +1,80 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oracle
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewOracleClient(t *testing.T) {
+	assert.NotNil(t, NewOracleClient())
+}
+
+func TestCompletions_MissingRegionAndBaseURL(t *testing.T) {
+	_, err := NewOracleClient().Completions(
+		context.Background(),
+		&providers.Config{Credentials: providers.Credentials{ApiKey: "key"}},
+		[]byte(`{}`),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "region or base_url is required")
+}
+
+func TestCompletions_RegionBuildsURLAndProjectHeader(t *testing.T) {
+	const wantModel = "meta.llama-3.3-70b-instruct"
+	var gotPath, gotProject string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotProject = r.Header.Get("OpenAI-Project")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"model": wantModel})
+	}))
+	t.Cleanup(srv.Close)
+
+	baseURL := srv.URL + "/openai/v1"
+	_, err := NewOracleClient().Completions(
+		context.Background(),
+		&providers.Config{
+			Credentials: providers.Credentials{ApiKey: "oci-key"},
+			Options: map[string]any{
+				"base_url": baseURL,
+				"project":  "ocid1.generativeaiproject.oc1.test",
+			},
+		},
+		[]byte(`{"model":"`+wantModel+`","messages":[{"role":"user","content":"hi"}]}`),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "/openai/v1/chat/completions", gotPath)
+	assert.Equal(t, "ocid1.generativeaiproject.oc1.test", gotProject)
+}
+
+func TestDecodeOracleOptions_BuildsRegionalBaseURL(t *testing.T) {
+	opts, err := providers.DecodeOracleOptions(map[string]any{"region": "us-chicago-1"})
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		"https://inference.generativeai.us-chicago-1.oci.oraclecloud.com/openai/v1",
+		opts.BaseURL,
+	)
+}

--- a/pkg/infra/providers/oracle/connection.go
+++ b/pkg/infra/providers/oracle/connection.go
@@ -1,0 +1,52 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oracle
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+)
+
+const modelsPath = "/models"
+
+func (c *client) TestConnection(ctx context.Context, config *providers.Config) providers.ProbeResult {
+	opts, err := providers.DecodeOracleOptions(config.Options)
+	if err != nil {
+		return providers.ProbeResult{
+			OK:      false,
+			Stage:   providers.StageProvider,
+			Message: err.Error(),
+		}
+	}
+	base := strings.TrimRight(opts.BaseURL, "/")
+	return providers.RunAPIKeyGETProbe(
+		ctx,
+		providers.ProviderOracle,
+		base+modelsPath,
+		config.Credentials.ApiKey,
+		func(req *http.Request, key string) {
+			req.Header.Set("Authorization", "Bearer "+key)
+			for k, v := range requestHeaders(opts) {
+				if k == "" {
+					continue
+				}
+				req.Header.Set(k, v)
+			}
+		},
+	)
+}

--- a/pkg/infra/providers/perplexity/client.go
+++ b/pkg/infra/providers/perplexity/client.go
@@ -1,0 +1,51 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package perplexity
+
+import (
+	"context"
+	"iter"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/openai"
+)
+
+const chatCompletionsURL = "https://api.perplexity.ai/v1/chat/completions"
+
+type client struct {
+	chat *openai.ChatCompletionsClient
+}
+
+func NewPerplexityClient() providers.Client {
+	return &client{
+		chat: openai.NewChatCompletionsClient(providers.ProviderPerplexity, nil),
+	}
+}
+
+func (c *client) Completions(
+	ctx context.Context,
+	config *providers.Config,
+	reqBody []byte,
+) ([]byte, error) {
+	return c.chat.Completions(ctx, chatCompletionsURL, config, reqBody, nil)
+}
+
+func (c *client) CompletionsStream(
+	ctx context.Context,
+	config *providers.Config,
+	reqBody []byte,
+) (iter.Seq2[[]byte, error], error) {
+	return c.chat.CompletionsStream(ctx, chatCompletionsURL, config, reqBody, nil)
+}

--- a/pkg/infra/providers/perplexity/client.go
+++ b/pkg/infra/providers/perplexity/client.go
@@ -22,7 +22,8 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/openai"
 )
 
-const chatCompletionsURL = "https://api.perplexity.ai/v1/chat/completions"
+// Perplexity accepts OpenAI-style POST /chat/completions; /v1/chat/completions returns 404.
+const chatCompletionsURL = "https://api.perplexity.ai/chat/completions"
 
 type client struct {
 	chat *openai.ChatCompletionsClient

--- a/pkg/infra/providers/perplexity/client_test.go
+++ b/pkg/infra/providers/perplexity/client_test.go
@@ -1,0 +1,140 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package perplexity
+
+import (
+	"context"
+	"encoding/json"
+	"iter"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/openai"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type perplexityClientAt struct {
+	chat *openai.ChatCompletionsClient
+	url  string
+}
+
+func newPerplexityClientAt(url string) providers.Client {
+	return &perplexityClientAt{
+		chat: openai.NewChatCompletionsClient(providers.ProviderPerplexity, nil),
+		url:  url,
+	}
+}
+
+func (c *perplexityClientAt) Completions(ctx context.Context, config *providers.Config, reqBody []byte) ([]byte, error) {
+	return c.chat.Completions(ctx, c.url, config, reqBody, nil)
+}
+
+func (c *perplexityClientAt) CompletionsStream(ctx context.Context, config *providers.Config, reqBody []byte) (iter.Seq2[[]byte, error], error) {
+	return c.chat.CompletionsStream(ctx, c.url, config, reqBody, nil)
+}
+
+func TestNewPerplexityClient(t *testing.T) {
+	assert.NotNil(t, NewPerplexityClient())
+}
+
+func TestCompletions_MissingAPIKey(t *testing.T) {
+	_, err := NewPerplexityClient().Completions(context.Background(), &providers.Config{}, []byte(`{}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "API key is required")
+}
+
+func TestCompletions_NonStreamingRoundTrip(t *testing.T) {
+	const wantModel = "sonar"
+	var gotAuth, gotModel string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		gotAuth = r.Header.Get("Authorization")
+
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		gotModel, _ = body["model"].(string)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"model": wantModel,
+			"usage": map[string]any{"total_tokens": 42},
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	resp, err := newPerplexityClientAt(srv.URL+"/v1/chat/completions").Completions(
+		context.Background(),
+		&providers.Config{Credentials: providers.Credentials{ApiKey: "perplexity-test-key"}},
+		[]byte(`{"model":"`+wantModel+`","messages":[{"role":"user","content":"hello"}]}`),
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Bearer perplexity-test-key", gotAuth)
+	assert.Equal(t, wantModel, gotModel)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(resp, &parsed))
+	assert.Equal(t, wantModel, parsed["model"])
+}
+
+func TestCompletionsStream_RoundTrip(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer perplexity-key", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	t.Cleanup(srv.Close)
+
+	seq, err := newPerplexityClientAt(srv.URL+"/v1/chat/completions").CompletionsStream(
+		context.Background(),
+		&providers.Config{Credentials: providers.Credentials{ApiKey: "perplexity-key"}},
+		[]byte(`{"model":"sonar","stream":true}`),
+	)
+	require.NoError(t, err)
+
+	var lines []string
+	for line, lerr := range seq {
+		require.NoError(t, lerr)
+		lines = append(lines, string(line))
+	}
+	require.NotEmpty(t, lines)
+}
+
+func TestCompletions_RateLimitRetryAfter(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "2")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"rate limit exceeded"}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := newPerplexityClientAt(srv.URL+"/v1/chat/completions").Completions(
+		context.Background(),
+		&providers.Config{Credentials: providers.Credentials{ApiKey: "key"}},
+		[]byte(`{"model":"sonar","messages":[{"role":"user","content":"hi"}]}`),
+	)
+	require.Error(t, err)
+
+	be, ok := registry.IsBackendError(err)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusTooManyRequests, be.StatusCode)
+	assert.Equal(t, "2", be.RetryAfter)
+}

--- a/pkg/infra/providers/perplexity/connection.go
+++ b/pkg/infra/providers/perplexity/connection.go
@@ -12,26 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package providers
+package perplexity
 
-func ValidateProviderOptions(provider string, options map[string]any) error {
-	switch provider {
-	case ProviderOpenAICompatible:
-		_, err := DecodeOpenAICompatibleOptions(options)
-		return err
-	case ProviderOpenAI:
-		_, err := DecodeOpenAIOptions(options)
-		return err
-	case ProviderVertex:
-		_, err := DecodeVertexOptions(options)
-		return err
-	case ProviderDatabricks:
-		_, err := DecodeDatabricksOptions(options)
-		return err
-	case ProviderOracle:
-		_, err := DecodeOracleOptions(options)
-		return err
-	default:
-		return nil
-	}
+import (
+	"context"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+)
+
+const modelsURL = "https://api.perplexity.ai/v1/models"
+
+func (c *client) TestConnection(ctx context.Context, config *providers.Config) providers.ProbeResult {
+	return providers.RunBearerGETProbe(ctx, providers.ProviderPerplexity, modelsURL, config.Credentials.ApiKey)
 }


### PR DESCRIPTION
## Summary

- Add registry provider clients for **Databricks** (Model Serving `/invocations`), **Fireworks**, **Oracle OCI Generative AI** (regional OpenAI-compatible base URL + optional project header), and **Perplexity**.
- Wire factory, adapter format routing, catalog auth/options, and openspec proposal `tier2-llm-providers`.

## Paired PR

- multi-agent-tests: tier-2 matrix catalog + LLM wrappers (draft, merge after this lands)

## Test plan

- [x] `go test ./pkg/infra/providers/databricks/... ./pkg/infra/providers/fireworks/... ./pkg/infra/providers/oracle/... ./pkg/infra/providers/perplexity/... ./pkg/infra/providers/factory/...`
- [ ] Registry create smoke per provider (admin API)
- [ ] `ag-matrix` cross-format cells with multi-agent-tests PR branch