### PR TITLE
fix: support Redis ACL username via REDIS_USERNAME

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,8 @@ DB_CONNECT_TIMEOUT=5s
 # Redis Configuration
 REDIS_HOST=localhost
 REDIS_PORT=6379
+# Optional Redis 6+ ACL username (e.g. AWS ElastiCache user group). Empty = default user.
+REDIS_USERNAME=
 REDIS_PASSWORD=
 REDIS_DB=3
 REDIS_TLS_ENABLED=false

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -235,6 +235,7 @@ type DatabaseConfig struct {
 type RedisConfig struct {
 	Host              string
 	Port              int
+	Username          string
 	Password          string
 	DB                int
 	TLSEnabled        bool
@@ -434,6 +435,7 @@ func getRedisConfig() RedisConfig {
 	return RedisConfig{
 		Host:              getEnv("REDIS_HOST", defaultRedisHost),
 		Port:              getEnvInt("REDIS_PORT", defaultRedisPort),
+		Username:          getEnv("REDIS_USERNAME", ""),
 		Password:          getEnv("REDIS_PASSWORD", ""),
 		DB:                getEnvInt("REDIS_DB", defaultRedisDB),
 		TLSEnabled:        getEnvBool("REDIS_TLS_ENABLED", defaultRedisTLS),

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -206,6 +206,9 @@ func TestLoadConfig_B1RuntimeDefaultsAndOverrides(t *testing.T) {
 	if cfg.Redis.TLSEnabled {
 		t.Errorf("Redis.TLSEnabled default = true, want false")
 	}
+	if cfg.Redis.Username != "" {
+		t.Errorf("Redis.Username default = %q, want empty", cfg.Redis.Username)
+	}
 	if cfg.Telemetry.KafkaTopic != defaultTelemetryKafkaTopic {
 		t.Errorf("Telemetry.KafkaTopic = %q, want %q", cfg.Telemetry.KafkaTopic, defaultTelemetryKafkaTopic)
 	}
@@ -221,6 +224,7 @@ func TestLoadConfig_B1RuntimeDefaultsAndOverrides(t *testing.T) {
 
 	t.Setenv("REDIS_TLS_ENABLED", "true")
 	t.Setenv("REDIS_TLS_INSECURE_VERIFY", "true")
+	t.Setenv("REDIS_USERNAME", "cacheuser")
 	t.Setenv("TELEMETRY_KAFKA_TOPIC", "custom.requests")
 	t.Setenv("METRICS_QUEUE_SIZE", "42")
 	t.Setenv("METRICS_WORKER_COUNT", "3")
@@ -236,6 +240,9 @@ func TestLoadConfig_B1RuntimeDefaultsAndOverrides(t *testing.T) {
 	}
 	if !cfg.Redis.TLSEnabled || !cfg.Redis.TLSInsecureVerify {
 		t.Errorf("Redis TLS override not applied: %+v", cfg.Redis)
+	}
+	if cfg.Redis.Username != "cacheuser" {
+		t.Errorf("Redis.Username override = %q, want %q", cfg.Redis.Username, "cacheuser")
 	}
 	if cfg.Telemetry.KafkaTopic != "custom.requests" {
 		t.Errorf("Telemetry override not applied: %+v", cfg.Telemetry)

--- a/pkg/container/modules/cache.go
+++ b/pkg/container/modules/cache.go
@@ -40,6 +40,7 @@ func Cache(c *container.Container) error {
 		return cache.NewClient(cache.Config{
 			Host:              cfg.Redis.Host,
 			Port:              cfg.Redis.Port,
+			Username:          cfg.Redis.Username,
 			Password:          cfg.Redis.Password,
 			DB:                cfg.Redis.DB,
 			TLSEnabled:        cfg.Redis.TLSEnabled,

--- a/pkg/infra/cache/client.go
+++ b/pkg/infra/cache/client.go
@@ -53,6 +53,7 @@ type Client interface {
 type Config struct {
 	Host              string
 	Port              int
+	Username          string
 	Password          string // #nosec G117 -- Config field for Redis password
 	DB                int
 	TLSEnabled        bool
@@ -71,6 +72,7 @@ type client struct {
 func NewClient(config Config, manager *TTLMapManager, logger *slog.Logger) (Client, error) {
 	options := &redis.Options{
 		Addr:     fmt.Sprintf("%s:%d", config.Host, config.Port),
+		Username: config.Username,
 		Password: config.Password,
 		DB:       config.DB,
 	}


### PR DESCRIPTION
## Summary

TrustGate's Redis client only authenticated with a password, so it always connected as the **default** ACL user. Managed Redis that enforces a Redis 6+ ACL user (e.g. AWS ElastiCache Serverless user groups) could not authenticate — the connection failed even after TLS was enabled.

This adds first-class ACL username support:
- `RedisConfig.Username` read from a new `REDIS_USERNAME` env var (`pkg/config/config.go`)
- `cache.Config.Username` plumbed through the container module (`pkg/container/modules/cache.go`)
- `redis.Options.Username` set on the go-redis client (`pkg/infra/cache/client.go`)
- Documented in `.env.example`

Empty `REDIS_USERNAME` preserves today's behavior (default user), so this is backward-compatible.

Context: the umbrella Helm chart already emits `REDIS_USERNAME` for the AgentGateway (TrustGate v2) workloads, but the binary ignored it; this closes that gap for TLS-only managed Redis deployments.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/config/... ./pkg/infra/cache/...`
- [x] Unit test asserts `REDIS_USERNAME` default (empty) and override (`cacheuser`) in `pkg/config/config_test.go`
- [ ] Manual: deploy against ACL-enabled managed Redis and confirm AUTH succeeds as the configured user