### PR TITLE
fix(auth): guard auth deletion against orphaning role_based/mcp consumers

### DIFF
--- a/pkg/app/auth/deleter.go
+++ b/pkg/app/auth/deleter.go
@@ -68,7 +68,7 @@ func (d *deleter) Delete(ctx context.Context, gatewayID ids.GatewayID, id ids.Au
 	if existing.GatewayID != gatewayID {
 		return domain.ErrNotFound
 	}
-	if err := detachAuthFromConsumers(ctx, d.consumerRepo, id); err != nil {
+	if err := guardAndDetachAuth(ctx, d.consumerRepo, d.repo, id); err != nil {
 		return err
 	}
 	if err := d.repo.Delete(ctx, gatewayID, id); err != nil {

--- a/pkg/app/auth/deleter_test.go
+++ b/pkg/app/auth/deleter_test.go
@@ -17,9 +17,11 @@ package auth_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	appauth "github.com/NeuralTrust/TrustGate/pkg/app/auth"
+	commonerrors "github.com/NeuralTrust/TrustGate/pkg/common/errors"
 	domain "github.com/NeuralTrust/TrustGate/pkg/domain/auth"
 	repomocks "github.com/NeuralTrust/TrustGate/pkg/domain/auth/mocks"
 	consumerdomain "github.com/NeuralTrust/TrustGate/pkg/domain/consumer"
@@ -50,6 +52,52 @@ func TestDeleter_Delete_Success(t *testing.T) {
 	}
 	if _, ok := mgr.GetTTLMap(cache.AuthTTLName).Get(id.String()); ok {
 		t.Fatal("expected cache entry to be evicted")
+	}
+}
+
+func TestDeleter_Delete_BlockedWhenSoleIdPOfRoleBased(t *testing.T) {
+	t.Parallel()
+	repo := repomocks.NewRepository(t)
+	id := ids.New[ids.AuthKind]()
+	gwID := ids.New[ids.GatewayKind]()
+	repo.EXPECT().FindByID(mock.Anything, id).Return(&domain.Auth{ID: id, GatewayID: gwID}, nil).Once()
+
+	consumerRepo := consumermocks.NewRepository(t)
+	consumerRepo.EXPECT().ListByAuthID(mock.Anything, id).Return([]*consumerdomain.Consumer{{
+		ID:          ids.New[ids.ConsumerKind](),
+		Slug:        "role-cons",
+		RoutingMode: consumerdomain.RoutingModeRoleBased,
+	}}, nil).Once()
+
+	deleter := appauth.NewDeleter(repo, consumerRepo, newCacheManager(), cachetest.NoopPublisher(), newTestLogger(), nil)
+	err := deleter.Delete(context.Background(), gwID, id)
+	if !errors.Is(err, commonerrors.ErrConflict) {
+		t.Fatalf("err = %v, want ErrConflict when deleting the sole identity provider of a role_based consumer", err)
+	}
+	if !strings.Contains(err.Error(), "before deleting") {
+		t.Fatalf("err = %v, want the message to reference deleting", err)
+	}
+}
+
+func TestDeleter_Delete_BlockedWhenSoleUsableIdPOfMCP(t *testing.T) {
+	t.Parallel()
+	repo := repomocks.NewRepository(t)
+	id := ids.New[ids.AuthKind]()
+	gwID := ids.New[ids.GatewayKind]()
+	repo.EXPECT().FindByID(mock.Anything, id).Return(&domain.Auth{ID: id, GatewayID: gwID}, nil).Once()
+
+	consumerRepo := consumermocks.NewRepository(t)
+	consumerRepo.EXPECT().ListByAuthID(mock.Anything, id).Return([]*consumerdomain.Consumer{{
+		ID:      ids.New[ids.ConsumerKind](),
+		Slug:    "mcp-cons",
+		Type:    consumerdomain.TypeMCP,
+		AuthIDs: []ids.AuthID{id},
+	}}, nil).Once()
+
+	deleter := appauth.NewDeleter(repo, consumerRepo, newCacheManager(), cachetest.NoopPublisher(), newTestLogger(), nil)
+	err := deleter.Delete(context.Background(), gwID, id)
+	if !errors.Is(err, commonerrors.ErrConflict) {
+		t.Fatalf("err = %v, want ErrConflict when deleting the sole usable identity provider of an MCP consumer", err)
 	}
 }
 

--- a/pkg/app/auth/guard.go
+++ b/pkg/app/auth/guard.go
@@ -57,12 +57,16 @@ func guardAuthDisable(ctx context.Context, consumers consumerAuthRefs, auths dom
 	if err != nil {
 		return err
 	}
+	return evaluateAuthRemoval(ctx, auths, refs, authID, "disabling")
+}
+
+func evaluateAuthRemoval(ctx context.Context, auths domain.Repository, refs []*consumerdomain.Consumer, authID ids.AuthID, action string) error {
 	for _, c := range refs {
 		switch {
 		case c.RoutingMode == consumerdomain.RoutingModeRoleBased:
 			return fmt.Errorf(
-				"%w: auth is the only identity provider of role_based consumer %q; reassign it before disabling",
-				commonerrors.ErrConflict, c.Slug,
+				"%w: auth is the only identity provider of role_based consumer %q; reassign it before %s",
+				commonerrors.ErrConflict, c.Slug, action,
 			)
 		case c.Type == consumerdomain.TypeMCP:
 			hasAlternative, err := consumerHasOtherUsableAuth(ctx, auths, c, authID)
@@ -71,8 +75,8 @@ func guardAuthDisable(ctx context.Context, consumers consumerAuthRefs, auths dom
 			}
 			if !hasAlternative {
 				return fmt.Errorf(
-					"%w: auth is the only usable identity provider of MCP consumer %q; reassign it before disabling",
-					commonerrors.ErrConflict, c.Slug,
+					"%w: auth is the only usable identity provider of MCP consumer %q; reassign it before %s",
+					commonerrors.ErrConflict, c.Slug, action,
 				)
 			}
 		}
@@ -99,9 +103,12 @@ func consumerHasOtherUsableAuth(ctx context.Context, auths domain.Repository, c 
 	return false, nil
 }
 
-func detachAuthFromConsumers(ctx context.Context, consumers consumerAuthRefs, authID ids.AuthID) error {
+func guardAndDetachAuth(ctx context.Context, consumers consumerAuthRefs, auths domain.Repository, authID ids.AuthID) error {
 	refs, err := referencingConsumers(ctx, consumers, authID)
 	if err != nil {
+		return err
+	}
+	if err := evaluateAuthRemoval(ctx, auths, refs, authID, "deleting"); err != nil {
 		return err
 	}
 	for _, c := range refs {


### PR DESCRIPTION
## Summary

Deleting an auth previously detached it from every referencing consumer **with no guard**, which could leave a `role_based` consumer (or an `mcp` consumer with a single usable auth) without its required identity provider — corrupting consumer state. The **disable** path already blocked exactly that.

This makes DELETE consistent with disable: the removal check is shared between both paths, so `DELETE /v1/gateways/{id}/auths/{id}` now returns **409 Conflict** with `reassign it before deleting` instead of orphaning the consumer.

## Changes

- `pkg/app/auth/guard.go`: extract `evaluateAuthRemoval` (pure over the referencing consumers, verb-parameterized) reused by disable and delete; add `guardAndDetachAuth` which lists referencing consumers **once**, runs the guard (`deleting`), then detaches. `guardAuthDisable` keeps its exact `disabling` message (no regression).
- `pkg/app/auth/deleter.go`: `Delete` now calls `guardAndDetachAuth` before removing the auth.
- `pkg/app/auth/deleter_test.go`: new unit tests for the role_based block (asserts the `deleting` verb) and the mcp sole-usable-auth block; existing delete tests unchanged (single list call preserved).

## Behavior

- Deleting the sole identity provider of a `role_based` consumer → 409.
- Deleting the sole usable identity provider of an `mcp` consumer → 409.
- Deleting an auth attached to a plain inline consumer → still auto-detaches and succeeds (unchanged).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./pkg/app/auth/...`
- [x] `go test -race ./pkg/app/auth/...`
- [x] `golangci-lint run ./pkg/app/auth/...` (0 issues)
- [ ] Optional: frontend (repo `app`) error mapping for the new conflict on delete (`v2Gateway.apiErrors.*`)

## Notes

Follow-up (out of scope): add a `v2Gateway.apiErrors` key so the v2 UI surfaces a friendly message for this conflict on delete.

Made with [Cursor](https://cursor.com)