### PR TITLE
fix(oauth): send no-store on MCP connect pages

### DIFF
--- a/pkg/api/handler/http/oauth/pages.go
+++ b/pkg/api/handler/http/oauth/pages.go
@@ -213,5 +213,10 @@ func renderHTML(c *fiber.Ctx, tmpl *template.Template, data any) error {
 		return err
 	}
 	c.Set(fiber.HeaderContentType, fiber.MIMETextHTMLCharsetUTF8)
+	// Ticket- and principal-scoped OAuth pages must never be reused from a
+	// browser/proxy cache: a reload (same ticket URL) would otherwise show a
+	// stale provider list after registries or linked accounts change.
+	c.Set(fiber.HeaderCacheControl, "no-store, must-revalidate")
+	c.Set(fiber.HeaderPragma, "no-cache")
 	return c.Status(fiber.StatusOK).Send(buf.Bytes())
 }

--- a/pkg/api/handler/http/oauth/pages_test.go
+++ b/pkg/api/handler/http/oauth/pages_test.go
@@ -36,6 +36,24 @@ func renderToString(t *testing.T, handler fiber.Handler) string {
 	return string(body)
 }
 
+func TestRenderedPagesAreNotCacheable(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+	app.Get("/page", func(c *fiber.Ctx) error {
+		return renderConnectPage(c, &appoauth.ConnectPage{
+			ConsumerPath: "/v1/mcp/dev",
+			Providers:    []appoauth.ProviderStatus{{Provider: "linear", Registry: "linear-mcp"}},
+		}, "tk", "")
+	})
+	res, err := app.Test(httptest.NewRequest("GET", "/page", nil))
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if got := res.Header.Get(fiber.HeaderCacheControl); !strings.Contains(got, "no-store") {
+		t.Fatalf("connect page must send a no-store Cache-Control, got %q", got)
+	}
+}
+
 func TestConnectPage_RendersCustomSchemeResume(t *testing.T) {
 	t.Parallel()
 	body := renderToString(t, func(c *fiber.Ctx) error {


### PR DESCRIPTION
## Summary
- The MCP OAuth connect page (`/{consumer}/mcp/connect?ticket=...`) and the deep-link page were rendered without any `Cache-Control` header.
- Because the response was a cacheable `200 text/html`, the browser (and any intermediary) could cache the HTML keyed by the ticket URL. Reloading (F5) the same connect link then served a **stale provider list** after registries or linked accounts changed, while opening a fresh ticket URL rendered correctly.
- `renderHTML` now sets `Cache-Control: no-store, must-revalidate` + `Pragma: no-cache`, so these ticket- and principal-scoped pages always revalidate against the server. This also avoids caching pages that reflect a user's connected OAuth accounts (security hygiene).

## Changes
- `pkg/api/handler/http/oauth/pages.go`: add no-store headers in `renderHTML` (covers connect + deep-link pages).
- `pkg/api/handler/http/oauth/pages_test.go`: assert the connect page responds with a `no-store` `Cache-Control`.

## Test plan
- [x] `go test ./pkg/api/handler/http/oauth/...`
- [x] `go vet ./pkg/api/handler/http/oauth/...`
- [ ] Manual: open the connect page, remove/add a registry in Admin, wait for config-sync, then **F5** the same ticket URL → provider list reflects the current config (no longer stale).

## Notes
Out of scope (config/operational, no code change): config-sync propagation latency, `fail_mode=closed` blanking tools when a forwarded-OAuth provider is not yet connected, and the `mcp_target.code` prefill in the dashboard.

Made with [Cursor](https://cursor.com)