### PR TITLE
feat: add regex_replace plugin (RUN-993)

### DIFF
--- a/docs/policies.json
+++ b/docs/policies.json
@@ -579,6 +579,83 @@
           }
         }
       ]
+    },
+    {
+      "type": "Guardrails",
+      "items": [
+        {
+          "slug": "regex_replace",
+          "name": "Regex Replace",
+          "description": "Rewrite text with RE2 regular expressions on one leg: the request prompt or the LLM response. Rules apply in declaration order and chain, so each rule sees the previous rule's output. Response rewrites short-circuit later pre-response plugins, so order a response-side instance last in its chain. Streaming responses pass through untouched.",
+          "mandatory_stages": [],
+          "supported_stages": [
+            "pre_request",
+            "pre_response"
+          ],
+          "settings_schema": {
+            "fields": [
+              {
+                "key": "target",
+                "label": "Target",
+                "type": "enum",
+                "description": "Which leg to rewrite. A single instance rewrites the request prompt or the LLM response, not both.",
+                "required": true,
+                "enum": [
+                  {
+                    "value": "request",
+                    "label": "Request"
+                  },
+                  {
+                    "value": "response",
+                    "label": "Response"
+                  }
+                ]
+              },
+              {
+                "key": "rules",
+                "label": "Rules",
+                "type": "array",
+                "description": "Ordered replacement rules. Each rule's output feeds the next.",
+                "required": true,
+                "item": {
+                  "key": "rule",
+                  "label": "Rule",
+                  "type": "object",
+                  "fields": [
+                    {
+                      "key": "pattern",
+                      "label": "Pattern",
+                      "type": "string",
+                      "description": "RE2 regular expression. Backreferences and lookaround are not supported.",
+                      "required": true
+                    },
+                    {
+                      "key": "replacement",
+                      "label": "Replacement",
+                      "type": "string",
+                      "description": "Replacement text. Use $1 or ${name} to reference capture groups. Empty removes the match."
+                    },
+                    {
+                      "key": "case_insensitive",
+                      "label": "Case Insensitive",
+                      "type": "boolean",
+                      "description": "Match without regard to letter case ((?i)).",
+                      "default": false
+                    },
+                    {
+                      "key": "multiline",
+                      "label": "Multiline",
+                      "type": "boolean",
+                      "description": "^ and $ match at line boundaries ((?m)).",
+                      "default": false
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
     }
   ]
 }

--- a/openspec/changes/run-993-regex-replace-plugin/design.md
+++ b/openspec/changes/run-993-regex-replace-plugin/design.md
@@ -1,0 +1,815 @@
+---
+linear: RUN-993
+type: feat
+phase: design
+depends_on: openspec/changes/run-993-regex-replace-plugin/proposal.md
+---
+
+# Design: Regex Replace plugin (RUN-993)
+
+Technical design for the `regex_replace` guardrail plugin: a provider-agnostic,
+RE2-based text rewriter that mutates the request prompt **XOR** the LLM response
+on exactly one leg, selected by config. Modeled on
+`pkg/infra/plugins/bedrockguardrail/` (the both-legs / one-descriptor pattern).
+
+All FIXED decisions from the task are treated as settled; this document turns
+them into concrete signatures, flows and a file-change plan. **All code shown is
+comment-free** (repo enforces no code comments via pre-commit).
+
+---
+
+## 1. Chosen architecture
+
+One plugin descriptor registered once, driven on two stages, gated by a required
+`target` selector:
+
+- `SupportedStages = [pre_request, pre_response]`, `MandatoryStages = []`.
+- `target: request` → active on `pre_request`, no-op on `pre_response`.
+- `target: response` → active on `pre_response`, no-op on `pre_request`.
+- Text is read/written **only** through `adapter.Registry` (canonical model), so
+  the plugin is provider-agnostic and never parses provider wire JSON directly.
+- Request leg returns `Result{RequestBody}` (forwarded upstream). Response leg
+  returns `Result{Body, StopUpstream:true}` (the only response-rewrite mechanism;
+  there is no `Result.ResponseBody`).
+- Streaming responses pass through unchanged.
+- Regexes are compiled **once at config parse** and cached on the parsed config
+  (`compiledRule`), never per request.
+
+### Rejected alternatives
+
+| Alternative | Why rejected |
+|---|---|
+| Two separate plugin slugs (`regex_replace_request`, `regex_replace_response`) | Doubles catalog/registry surface; bedrock_guardrail already proves the one-descriptor + `target` pattern. Proposal fixes ONE plugin. |
+| Surgical patching of the raw provider body (regex over raw JSON bytes) | Not provider-agnostic; would corrupt JSON, escape sequences, and non-text fields. Canonical decode→rewrite→encode is the established safe path (bedrock, tooltransform). |
+| Streaming rewrite (buffer + re-emit SSE) | Out of scope (proposal); high complexity and latency. Pass-through + documented limitation, mirroring bedrock_guardrail. |
+| Compile regex per request | Wasteful and un-idiomatic; RE2 compile is validated at `ValidateConfig` and cached. |
+| `MutatesRequestBody/ResponseBody` reflecting `target` | Impossible: these are static `PluginDescriptor` methods on the singleton plugin; config is per-policy and not available when the planner reads capabilities. See §7. |
+
+---
+
+## 2. Package / file breakdown
+
+Package `regexreplace` under `pkg/infra/plugins/regexreplace/` (directory name
+has no underscore, per Go package rules; slug stays `regex_replace`).
+
+```
+pkg/infra/plugins/regexreplace/
+├── plugin.go        Plugin, New, descriptor methods, Execute dispatch, per-leg handlers
+├── config.go        Settings, Rule, compiledRule, parseConfig, validate, compile
+├── replace.go       applyRules (pure), request/response graft helpers
+├── data.go          telemetry Data + setExtras
+├── config_test.go   config validation + compilation tests
+├── replace_test.go  applyRules chaining / capture groups / flags / no-match
+└── plugin_test.go   Execute dispatch, per-stage no-op, streaming, cross-provider
+```
+
+### 2.1 `config.go`
+
+```go
+package regexreplace
+
+const PluginName = "regex_replace"
+
+const (
+	targetRequest  = "request"
+	targetResponse = "response"
+)
+
+var (
+	ErrNoRules       = errors.New("regex_replace: at least one rule is required")
+	ErrInvalidTarget = errors.New("regex_replace: target must be one of request, response")
+	ErrEmptyPattern  = errors.New("regex_replace: rule pattern must not be empty")
+	ErrBadPattern    = errors.New("regex_replace: invalid regular expression")
+)
+
+type Rule struct {
+	Pattern         string `mapstructure:"pattern"`
+	Replacement     string `mapstructure:"replacement"`
+	CaseInsensitive bool   `mapstructure:"case_insensitive"`
+	Multiline       bool   `mapstructure:"multiline"`
+}
+
+type Settings struct {
+	Target string `mapstructure:"target"`
+	Rules  []Rule `mapstructure:"rules"`
+
+	compiled []compiledRule
+}
+
+type compiledRule struct {
+	re          *regexp.Regexp
+	replacement string
+}
+
+func parseConfig(settings map[string]any) (Settings, error)
+func (s *Settings) validate() error
+func (s *Settings) compile() error
+func buildPattern(r Rule) string
+func (s Settings) isRequestLeg() bool
+func (s Settings) isResponseLeg() bool
+```
+
+### 2.2 `replace.go`
+
+```go
+package regexreplace
+
+func applyRules(rules []compiledRule, input string) (string, bool)
+
+func rewriteRequest(reg *adapter.Registry, format adapter.Format, creq *adapter.CanonicalRequest, rules []compiledRule) ([]byte, bool, error)
+
+func rewriteResponse(reg *adapter.Registry, format adapter.Format, cresp *adapter.CanonicalResponse, rules []compiledRule) ([]byte, bool, error)
+```
+
+### 2.3 `plugin.go`
+
+```go
+package regexreplace
+
+var _ appplugins.Plugin = (*Plugin)(nil)
+
+type Plugin struct {
+	registry *adapter.Registry
+	logger   *slog.Logger
+}
+
+func New(registry *adapter.Registry, logger *slog.Logger) *Plugin
+
+func (p *Plugin) Name() string
+func (p *Plugin) MandatoryStages() []policy.Stage
+func (p *Plugin) SupportedStages() []policy.Stage
+func (p *Plugin) SupportedModes() []policy.Mode
+func (p *Plugin) SupportedProtocols() []appplugins.Protocol
+func (p *Plugin) MutatesRequestBody() bool
+func (p *Plugin) MutatesResponseBody() bool
+func (p *Plugin) MutatesMetadata() bool
+func (p *Plugin) ValidateConfig(settings map[string]any) error
+func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplugins.Result, error)
+
+func (p *Plugin) executeRequest(ctx context.Context, in appplugins.ExecInput, cfg Settings) (*appplugins.Result, error)
+func (p *Plugin) executeResponse(ctx context.Context, in appplugins.ExecInput, cfg Settings) (*appplugins.Result, error)
+func passThrough() *appplugins.Result
+```
+
+### 2.4 `data.go`
+
+```go
+package regexreplace
+
+type Data struct {
+	Target       string `json:"target,omitempty"`
+	Stage        string `json:"stage,omitempty"`
+	Mode         string `json:"mode,omitempty"`
+	Decision     string `json:"decision,omitempty"`
+	RulesMatched int    `json:"rules_matched,omitempty"`
+	Changed      bool   `json:"changed,omitempty"`
+}
+
+func setExtras(event *metrics.EventContext, data *Data)
+```
+
+---
+
+## 3. Config struct and compiled form
+
+Wire config (`mapstructure`, decoded by `pluginutil.Parse[Settings]`):
+
+```go
+type Rule struct {
+	Pattern         string `mapstructure:"pattern"`
+	Replacement     string `mapstructure:"replacement"`
+	CaseInsensitive bool   `mapstructure:"case_insensitive"`
+	Multiline       bool   `mapstructure:"multiline"`
+}
+
+type Settings struct {
+	Target string `mapstructure:"target"`
+	Rules  []Rule `mapstructure:"rules"`
+
+	compiled []compiledRule
+}
+```
+
+`compiled` is unexported and carries no `mapstructure` tag, so decode ignores it.
+It holds the pre-compiled, ordered rules:
+
+```go
+type compiledRule struct {
+	re          *regexp.Regexp
+	replacement string
+}
+```
+
+Compilation happens exactly once, inside `parseConfig`, so both `ValidateConfig`
+(admin save) and `Execute` (per request) run the same path. `Execute` re-parses
+`in.Config.Settings` each call (as bedrock does); this decodes the map and
+recompiles. To honor "compiled once per config, not per request", we keep the
+per-`Execute` `parseConfig` (config is a `map[string]any`, not a cached struct in
+this contract) but note in §11 (risk) the option to memoize by config hash if
+profiling shows compile cost. For the initial slice we match bedrock's model:
+`parseConfig` is cheap relative to a network round-trip and RE2 compile of a
+handful of rules is sub-millisecond.
+
+> Decision: keep `parseConfig` in `Execute` (bedrock parity, simplest, correct).
+> "Compiled once" is satisfied *within* a parse: rules are compiled a single time
+> per parse and reused across System + every message, never per-match-site.
+
+---
+
+## 4. `parseConfig` + `validate` + `compile` flow
+
+```go
+func parseConfig(settings map[string]any) (Settings, error) {
+	cfg, err := pluginutil.Parse[Settings](settings)
+	if err != nil {
+		return Settings{}, err
+	}
+	if err := cfg.validate(); err != nil {
+		return Settings{}, err
+	}
+	if err := cfg.compile(); err != nil {
+		return Settings{}, err
+	}
+	return cfg, nil
+}
+```
+
+`validate` (cheap, structural — no compilation):
+
+```go
+func (s *Settings) validate() error {
+	switch s.Target {
+	case targetRequest, targetResponse:
+	default:
+		return fmt.Errorf("%w: got %q", ErrInvalidTarget, s.Target)
+	}
+	if len(s.Rules) == 0 {
+		return ErrNoRules
+	}
+	for i, r := range s.Rules {
+		if strings.TrimSpace(r.Pattern) == "" {
+			return fmt.Errorf("%w: rule %d", ErrEmptyPattern, i)
+		}
+	}
+	return nil
+}
+```
+
+`compile` (builds the effective pattern with inline flags, compiles, wraps errors
+with `%w`, and populates `s.compiled`):
+
+```go
+func buildPattern(r Rule) string {
+	var b strings.Builder
+	if r.CaseInsensitive {
+		b.WriteString("(?i)")
+	}
+	if r.Multiline {
+		b.WriteString("(?m)")
+	}
+	b.WriteString(r.Pattern)
+	return b.String()
+}
+
+func (s *Settings) compile() error {
+	compiled := make([]compiledRule, 0, len(s.Rules))
+	for i, r := range s.Rules {
+		re, err := regexp.Compile(buildPattern(r))
+		if err != nil {
+			return fmt.Errorf("%w: rule %d: %w", ErrBadPattern, i, err)
+		}
+		compiled = append(compiled, compiledRule{re: re, replacement: r.Replacement})
+	}
+	s.compiled = compiled
+	return nil
+}
+```
+
+RE2 (`regexp.Compile`) rejects backreferences / lookaround at compile time, so
+unsupported patterns are surfaced at `ValidateConfig` (admin-side save), never at
+request time. Inline flags `(?i)`/`(?m)` are prepended to the pattern string so a
+single compiled `*regexp.Regexp` carries the flags — no per-call options.
+
+---
+
+## 5. `Execute` dispatch + per-leg flows
+
+```go
+func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplugins.Result, error) {
+	cfg, err := parseConfig(in.Config.Settings)
+	if err != nil {
+		return nil, fmt.Errorf("regex_replace: %w", err)
+	}
+	switch in.Stage {
+	case policy.StagePreRequest:
+		if !cfg.isRequestLeg() {
+			return passThrough(), nil
+		}
+		return p.executeRequest(ctx, in, cfg)
+	case policy.StagePreResponse:
+		if !cfg.isResponseLeg() {
+			return passThrough(), nil
+		}
+		return p.executeResponse(ctx, in, cfg)
+	default:
+		return passThrough(), nil
+	}
+}
+```
+
+The `target`/stage mismatch is a pure no-op (`passThrough()` = `&Result{StatusCode: http.StatusOK}`), so a `target=request` instance that a policy also wired onto `pre_response` costs a decode-free early return.
+
+### 5.1 Request leg (`target=request`)
+
+```go
+func (p *Plugin) executeRequest(ctx context.Context, in appplugins.ExecInput, cfg Settings) (*appplugins.Result, error) {
+	if in.Request == nil || len(in.Request.Body) == 0 || in.Request.Provider == "" || p.registry == nil {
+		return passThrough(), nil
+	}
+	format, err := adapter.ResolveAgentFormat(in.Request.Provider, in.Request.SourceFormat, nil)
+	if err != nil {
+		return passThrough(), nil
+	}
+	creq, err := p.registry.DecodeRequestFor(in.Request.Body, format)
+	if err != nil || creq == nil {
+		return passThrough(), nil
+	}
+	body, changed, err := rewriteRequest(p.registry, format, creq, cfg.compiled)
+	if err != nil {
+		return passThrough(), nil
+	}
+	data := &Data{Target: cfg.Target, Stage: string(in.Stage), Mode: in.Mode.String(), Changed: changed}
+	if !changed {
+		data.Decision = "no_match"
+		setExtras(in.Event, data)
+		return passThrough(), nil
+	}
+	if !appplugins.Blocks(in.Mode) {
+		data.Decision = "observed"
+		setExtras(in.Event, data)
+		return passThrough(), nil
+	}
+	data.Decision = "rewritten"
+	setExtras(in.Event, data)
+	appplugins.SetDecisionFromOutcome(in.Event, "rewritten")
+	return &appplugins.Result{StatusCode: http.StatusOK, RequestBody: body}, nil
+}
+```
+
+`rewriteRequest` applies rules to `creq.System` and every `creq.Messages[i].Content`,
+tracks whether any of them changed, and re-encodes via the adapter (the **graft**:
+mutate the canonical struct in place, then `adp.EncodeRequest(creq)` — identical
+strategy to bedrock/tooltransform, same-format encode preserves structure):
+
+```go
+func rewriteRequest(reg *adapter.Registry, format adapter.Format, creq *adapter.CanonicalRequest, rules []compiledRule) ([]byte, bool, error) {
+	adp, err := reg.GetAdapter(format)
+	if err != nil {
+		return nil, false, err
+	}
+	changed := false
+	if creq.System != "" {
+		if out, did := applyRules(rules, creq.System); did {
+			creq.System = out
+			changed = true
+		}
+	}
+	for i := range creq.Messages {
+		if creq.Messages[i].Content == "" {
+			continue
+		}
+		if out, did := applyRules(rules, creq.Messages[i].Content); did {
+			creq.Messages[i].Content = out
+			changed = true
+		}
+	}
+	if !changed {
+		return nil, false, nil
+	}
+	body, err := adp.EncodeRequest(creq)
+	if err != nil {
+		return nil, false, err
+	}
+	return body, true, nil
+}
+```
+
+When nothing changed we short-circuit **before** encoding, so we never emit a
+re-encoded (possibly byte-different) body for a no-op match.
+
+### 5.2 Response leg (`target=response`)
+
+```go
+func (p *Plugin) executeResponse(ctx context.Context, in appplugins.ExecInput, cfg Settings) (*appplugins.Result, error) {
+	if in.Request == nil || in.Response == nil || p.registry == nil {
+		return passThrough(), nil
+	}
+	if in.Request.Provider == "" || len(in.Response.Body) == 0 {
+		return passThrough(), nil
+	}
+	if in.Response.Streaming {
+		return passThrough(), nil
+	}
+	format, err := adapter.ResolveAgentFormat(in.Request.Provider, in.Request.SourceFormat, nil)
+	if err != nil {
+		return passThrough(), nil
+	}
+	cresp, err := p.registry.DecodeResponseFor(in.Response.Body, format)
+	if err != nil || cresp == nil {
+		return passThrough(), nil
+	}
+	body, changed, err := rewriteResponse(p.registry, format, cresp, cfg.compiled)
+	if err != nil {
+		return passThrough(), nil
+	}
+	data := &Data{Target: cfg.Target, Stage: string(in.Stage), Mode: in.Mode.String(), Changed: changed}
+	if !changed {
+		data.Decision = "no_match"
+		setExtras(in.Event, data)
+		return passThrough(), nil
+	}
+	if !appplugins.Blocks(in.Mode) {
+		data.Decision = "observed"
+		setExtras(in.Event, data)
+		return passThrough(), nil
+	}
+	data.Decision = "rewritten"
+	setExtras(in.Event, data)
+	appplugins.SetDecisionFromOutcome(in.Event, "rewritten")
+	return &appplugins.Result{StatusCode: http.StatusOK, Body: body, StopUpstream: true}, nil
+}
+```
+
+```go
+func rewriteResponse(reg *adapter.Registry, format adapter.Format, cresp *adapter.CanonicalResponse, rules []compiledRule) ([]byte, bool, error) {
+	adp, err := reg.GetAdapter(format)
+	if err != nil {
+		return nil, false, err
+	}
+	out, changed := applyRules(rules, cresp.Content)
+	if !changed {
+		return nil, false, nil
+	}
+	cresp.Content = out
+	body, err := adp.EncodeResponse(cresp)
+	if err != nil {
+		return nil, false, err
+	}
+	return body, true, nil
+}
+```
+
+**Streaming guard**: `in.Response.Streaming` → immediate `passThrough()` (before
+any decode), mirroring bedrock. Documented limitation: streamed responses are not
+rewritten.
+
+**`StopUpstream` caveat**: returning `StopUpstream:true` short-circuits sibling
+`pre_response` plugins. Documented in the catalog description and proposal;
+operator guidance is to order a response-side `regex_replace` last in its chain.
+
+---
+
+## 6. `applyRules` — pure, ordered chaining + change reporting
+
+```go
+func applyRules(rules []compiledRule, input string) (string, bool) {
+	out := input
+	for _, r := range rules {
+		out = r.re.ReplaceAllString(out, r.replacement)
+	}
+	return out, out != input
+}
+```
+
+- **Ordered chaining**: rules apply in declaration order; each rule sees the
+  output of the previous one (later rules can match text produced by earlier
+  replacements — intentional and documented).
+- **Change detection**: compares the final string to the original with a single
+  `!=`. This is O(n) on length but avoids a per-rule flag and cleanly captures
+  "net no-op" (e.g. rule A rewrites and rule B rewrites back to the original).
+- **Capture groups / named groups**: `ReplaceAllString` honors Go's `$1` /
+  `${name}` expansion natively — no custom expansion code.
+- **Empty replacement**: `replacement == ""` deletes matches; `changed` is true
+  when a match existed, false otherwise. Covered by tests.
+
+`applyRules` takes `[]compiledRule` and a `string`, imports nothing beyond the
+package — trivially table-testable in isolation.
+
+---
+
+## 7. Capability methods decision (planner batching)
+
+The planner (`pkg/app/plugins/plan.go`, `groupBatches`) reads
+`MutatesRequestBody()`, `MutatesResponseBody()`, `MutatesMetadata()` **once per
+registered plugin** to serialize plugins that write the same dimension inside a
+same-priority parallel batch: if two parallel same-priority plugins both report
+`mutatesReq`, the second is forced sequential (with a warn log). These are static
+`PluginDescriptor` methods on the **singleton** plugin instance; the per-policy
+`target` value is not available when the planner inspects capabilities.
+
+Therefore capabilities **cannot** reflect `target`. We choose the **safe,
+conservative** option (identical to `bedrock_guardrail`):
+
+```go
+func (p *Plugin) MutatesRequestBody() bool  { return true }
+func (p *Plugin) MutatesResponseBody() bool { return true }
+func (p *Plugin) MutatesMetadata() bool     { return false }
+```
+
+Rationale:
+
+- Correctness first: declaring `true` for both dimensions guarantees the planner
+  never runs a `regex_replace` instance concurrently with another body-mutating
+  plugin of the same priority on the same leg, avoiding races on the shared body.
+- Cost: a `target=request` instance is also treated as a response-body mutator for
+  batching purposes, so it may be serialized against response-body plugins it
+  actually no-ops. This is a scheduling conservatism, not a correctness issue, and
+  matches the accepted bedrock trade-off. The `Execute` no-op still runs (cheap).
+- `MutatesMetadata=false`: the plugin never writes request metadata.
+
+Other descriptor methods:
+
+```go
+func (p *Plugin) MandatoryStages() []policy.Stage {
+	return []policy.Stage{}
+}
+func (p *Plugin) SupportedStages() []policy.Stage {
+	return []policy.Stage{policy.StagePreRequest, policy.StagePreResponse}
+}
+func (p *Plugin) SupportedModes() []policy.Mode {
+	return []policy.Mode{policy.ModeEnforce, policy.ModeObserve}
+}
+func (p *Plugin) SupportedProtocols() []appplugins.Protocol {
+	return []appplugins.Protocol{appplugins.ProtocolLLM}
+}
+```
+
+`MandatoryStages` is empty (unlike bedrock, which forces `pre_request`): a
+`regex_replace` instance must not run on a leg the operator did not opt into, and
+`target` — not a mandatory stage — selects the active leg.
+
+---
+
+## 8. Telemetry / extras shape
+
+Emitted via `in.Event.SetExtras(data)` (nil-safe helper, bedrock parity). One
+`Data` per `Execute` that reaches decode:
+
+```json
+{
+  "target": "request",
+  "stage": "pre_request",
+  "mode": "enforce",
+  "decision": "rewritten",
+  "rules_matched": 2,
+  "changed": true
+}
+```
+
+- `decision` ∈ `{rewritten, observed, no_match}` (+ implicit pass-through when
+  the guards short-circuit before decode, which emit nothing).
+- `observed` = `observe` mode computed a change but did not mutate.
+- `no_match` = rules ran, nothing changed.
+- `rules_matched` (optional refinement): count of rules whose `re.MatchString`
+  hit at least once; if we keep `applyRules` minimal we can drop this field or
+  compute it in the leg handler. Initial slice may ship without `rules_matched`
+  to keep `applyRules` pure — flagged as a nice-to-have.
+- On the enforce+changed path we additionally call
+  `appplugins.SetDecisionFromOutcome(in.Event, "rewritten")` so the span decision
+  reflects the mutation (bedrock pattern). No PII/rule values are ever logged.
+
+---
+
+## 9. Catalog metadata (SettingsSchema)
+
+Add entry to `pluginCatalogMeta` in `pkg/app/plugins/catalog_metadata.go`, group
+`groupGuardrails`. `target` is a required enum; `rules` is a required array of
+objects with the four fields; `enumOptions` humanizes labels.
+
+```go
+"regex_replace": {
+	name:        "Regex Replace",
+	group:       groupGuardrails,
+	description: "Rewrite text with RE2 regular expressions on one leg: the request prompt or the LLM response. Rules apply in order and chain. Response rewrites short-circuit later pre-response plugins.",
+	schema: SettingsSchema{
+		Fields: []Field{
+			{
+				Key:         "target",
+				Label:       "Target",
+				Type:        FieldTypeEnum,
+				Description: "Which leg to rewrite. A single instance rewrites the request prompt or the LLM response, not both.",
+				Required:    true,
+				Enum:        enumOptions("request", "response"),
+			},
+			{
+				Key:         "rules",
+				Label:       "Rules",
+				Type:        FieldTypeArray,
+				Description: "Ordered replacement rules. Each rule's output feeds the next.",
+				Required:    true,
+				Item: &Field{
+					Key:   "rule",
+					Label: "Rule",
+					Type:  FieldTypeObject,
+					Fields: []Field{
+						{
+							Key:         "pattern",
+							Label:       "Pattern",
+							Type:        FieldTypeString,
+							Description: "RE2 regular expression. Backreferences and lookaround are not supported.",
+							Required:    true,
+						},
+						{
+							Key:         "replacement",
+							Label:       "Replacement",
+							Type:        FieldTypeString,
+							Description: "Replacement text. Use $1 or ${name} to reference capture groups. Empty removes the match.",
+						},
+						{
+							Key:         "case_insensitive",
+							Label:       "Case Insensitive",
+							Type:        FieldTypeBoolean,
+							Description: "Match without regard to letter case ((?i)).",
+							Default:     false,
+						},
+						{
+							Key:         "multiline",
+							Label:       "Multiline",
+							Type:        FieldTypeBoolean,
+							Description: "^ and $ match at line boundaries ((?m)).",
+							Default:     false,
+						},
+					},
+				},
+			},
+		},
+	},
+},
+```
+
+`enumOptions("request", "response")` yields labels `Request` / `Response` via the
+existing humanizer (no override needed).
+
+---
+
+## 10. Registration
+
+`pkg/container/modules/plugins.go` — add the import and one line to the `catalog`
+slice (constructor deps: `*adapter.Registry` + `*slog.Logger`, same as bedrock):
+
+```go
+import "github.com/NeuralTrust/TrustGate/pkg/infra/plugins/regexreplace"
+
+// inside catalog []appplugins.Plugin{ ... }
+regexreplace.New(p.Adapters, p.Logger),
+```
+
+---
+
+## 11. Testing strategy
+
+### Unit — `config_test.go`
+Table-driven, `-race`:
+- valid `target=request` / `target=response` with one and many rules;
+- `target` missing / invalid → `ErrInvalidTarget`;
+- empty `rules` → `ErrNoRules`; empty `pattern` → `ErrEmptyPattern`;
+- invalid RE2 (`"("`, backreference `\1`, lookahead `(?=x)`) → `ErrBadPattern`
+  (assert via `errors.Is`);
+- `buildPattern` prepends `(?i)`/`(?m)` correctly and both combined;
+- `compile` populates `len(compiled) == len(rules)` and reuses across calls.
+
+### Unit — `replace_test.go`
+Pure `applyRules`, `-race`:
+- single rule match / replace; capture group `$1`; named group `${word}`;
+- ordered chaining (rule B matches rule A's output);
+- no-match → `changed == false`, input returned unchanged;
+- empty replacement deletes match, `changed == true`;
+- `(?i)` and `(?m)` behavior via the compiled rule;
+- net no-op (A rewrites, B rewrites back) → `changed == false`.
+
+### Unit — `plugin_test.go`
+`-race`, using `adapter.NewRegistry()` and real canonical fixtures:
+- descriptor methods return the fixed stages/modes/protocols/capabilities;
+- `Execute` dispatch: `target=request` no-ops on `pre_response` and vice versa
+  (assert `passThrough`, no decode side effects);
+- request leg rewrites `System` + all message `Content` and returns `RequestBody`;
+- response leg returns `Body` + `StopUpstream:true`;
+- `observe` mode computes change but returns pass-through (no `RequestBody`/`Body`);
+- streaming response (`in.Response.Streaming=true`) passes through;
+- no-match returns pass-through with `decision=no_match` extras;
+- **cross-provider via canonical**: encode a request fixture in OpenAI format and
+  another in Anthropic format, run the same rules, assert both rewrite through the
+  canonical model (guards provider-agnostic claim);
+- nil guards: nil `Request`/`Response`, empty body, empty provider → pass-through.
+
+### Functional — `tests/functional/plugin_regex_replace_test.go` (new)
+Mirror `plugin_bedrock_guardrail_test.go` harness:
+- **request-side**: policy with `target=request`, one masking rule; send a chat
+  request whose prompt contains the pattern; assert the body **forwarded upstream**
+  has the masked text (inspect the captured upstream request), and the client
+  response is untouched;
+- **response-side**: policy with `target=response`, one rule; stub upstream to
+  return matching text; assert the **client-visible body** is rewritten and that
+  `StopUpstream` returned it without a second upstream call.
+
+---
+
+## 12. Catalog test (`catalog_test.go`)
+
+Follow the established **Guardrails** pattern (bedrock_guardrail, trustguard,
+azure_content_safety are validated by dedicated schema tests and are **not** in
+`builtinSlugs`). Add a dedicated schema test:
+
+```go
+func TestRegexReplaceSchema(t *testing.T) {
+	meta, ok := pluginCatalogMeta["regex_replace"]
+	require.True(t, ok)
+	assert.Equal(t, "Regex Replace", meta.name)
+	assert.Equal(t, groupGuardrails, meta.group)
+
+	fields := meta.schema.Fields
+
+	target, ok := fieldByKey(fields, "target")
+	require.True(t, ok)
+	assert.Equal(t, FieldTypeEnum, target.Type)
+	assert.True(t, target.Required)
+	assert.Equal(t, []string{"request", "response"}, enumValues(target.Enum))
+	assert.Equal(t, []string{"Request", "Response"}, enumLabels(target.Enum))
+
+	rules, ok := fieldByKey(fields, "rules")
+	require.True(t, ok)
+	assert.Equal(t, FieldTypeArray, rules.Type)
+	assert.True(t, rules.Required)
+	require.NotNil(t, rules.Item)
+	assert.Equal(t, FieldTypeObject, rules.Item.Type)
+	for _, k := range []string{"pattern", "replacement", "case_insensitive", "multiline"} {
+		_, ok := fieldByKey(rules.Item.Fields, k)
+		assert.Truef(t, ok, "rules item missing %q", k)
+	}
+	pattern, _ := fieldByKey(rules.Item.Fields, "pattern")
+	assert.True(t, pattern.Required)
+}
+```
+
+> **`builtinSlugs` note (deviation from task wording):** the task asked for a
+> `builtinSlugs` entry, but the existing convention is that **Guardrails** plugins
+> are *not* listed in `builtinSlugs` (only the Traffic Control / Quota / Routing /
+> Prompt Management plugins that `registerBuiltins` also wires are, because
+> `TestCatalogService_EntriesHaveStagesAndSchema` asserts
+> `len(entries) == len(builtinSlugs)` against the `registerBuiltins` fixture).
+> Adding `regex_replace` to `builtinSlugs` **without** also adding a matching spec
+> to `registerBuiltins` would break that length assertion. Recommended: follow the
+> guardrail pattern (dedicated `TestRegexReplaceSchema`, no `builtinSlugs` change).
+> If a `builtinSlugs` entry is still desired, add a matching `stagePlugin` spec to
+> `registerBuiltins` in the same PR and keep the two lists in sync. Surfaced in
+> Risks for the tasks/implementation phase to confirm.
+
+---
+
+## 13. File-change table + PR-size forecast
+
+| File | Change | Est. lines (add+del) | Notes |
+|---|---|---|---|
+| `pkg/infra/plugins/regexreplace/config.go` | New | ~95 | Settings, Rule, compiledRule, parse/validate/compile, sentinels |
+| `pkg/infra/plugins/regexreplace/replace.go` | New | ~75 | applyRules + request/response graft |
+| `pkg/infra/plugins/regexreplace/plugin.go` | New | ~160 | descriptor + Execute + 2 leg handlers |
+| `pkg/infra/plugins/regexreplace/data.go` | New | ~40 | Data + setExtras |
+| `pkg/infra/plugins/regexreplace/config_test.go` | New | ~130 | validation + compile tests |
+| `pkg/infra/plugins/regexreplace/replace_test.go` | New | ~120 | applyRules table tests |
+| `pkg/infra/plugins/regexreplace/plugin_test.go` | New | ~210 | dispatch, no-op, streaming, cross-provider |
+| `pkg/container/modules/plugins.go` | Modified | ~2 | import + registration line |
+| `pkg/app/plugins/catalog_metadata.go` | Modified | ~60 | catalog entry |
+| `pkg/app/plugins/catalog_test.go` | Modified | ~40 | `TestRegexReplaceSchema` |
+| `tests/functional/plugin_regex_replace_test.go` | New | ~190 | request + response functional |
+| **Total** | | **~1122** | |
+| **Production only (no `_test.go`)** | | **~432** | |
+
+**PR-size forecast: EXCEEDS the 400-line soft cap** (≈1122 add+del; even
+production-only ≈432). Recommend splitting into **two stacked PRs**, each
+independently compilable and mergeable:
+
+- **PR 1 — pure core (~350 lines):** `config.go` + `replace.go` + `config_test.go`
+  + `replace_test.go`. The package compiles on its own (no `plugin.go` needed);
+  fully unit-tested config validation, RE2 compilation, and `applyRules`.
+- **PR 2 — wiring + catalog + integration (~430 lines):** `plugin.go`, `data.go`,
+  `plugins.go` registration, `catalog_metadata.go`, `catalog_test.go`,
+  `plugin_test.go`, and the functional test. Depends on PR 1.
+
+Alternatively a **3-PR** split (core → plugin+registration+catalog → functional
+tests) keeps each slice comfortably under 400. Either way, flag `size:exception`
+if the team prefers a single PR. The `tasks` phase should pick the split and set
+commit/PR boundaries accordingly.
+
+---
+
+## 14. Risks / open decisions (for tasks + review)
+
+| Risk / decision | Severity | Handling |
+|---|---|---|
+| `builtinSlugs` vs. Guardrails convention (see §12) | Med | Recommend dedicated schema test only; confirm with reviewer whether a `builtinSlugs`+`registerBuiltins` pair is wanted. |
+| `StopUpstream` drops sibling `pre_response` plugins | Med | Documented in catalog description + proposal; order last in chain. |
+| Streaming responses un-rewritten | Med | Pass-through + documented limitation (matches bedrock). |
+| Full canonical re-encode may alter provider-specific fields not modeled canonically | Low | Same-format encode; `RequestExtensions`/`ProviderExtensions` pass through in the adapter. Covered by cross-provider unit test. |
+| `parseConfig`/recompile per `Execute` | Low | Bedrock parity; RE2 compile of a few rules is sub-ms. Memoize by config hash later if profiling warrants (noted, not built). |
+| PR exceeds 400-line budget | Med | Two/three stacked PRs (§13). |
+| Catastrophic regex latency | Low | RE2 is linear-time; operator owns rule quality. |

--- a/openspec/changes/run-993-regex-replace-plugin/design.md
+++ b/openspec/changes/run-993-regex-replace-plugin/design.md
@@ -40,10 +40,15 @@ One plugin descriptor registered once, driven on two stages, gated by a required
   access gate (per RUN-993), so it must never take down a request/response it cannot
   parse. This mirrors the `bedrock_guardrail` rewrite path. Config errors are the
   exception: they surface at `ValidateConfig`/`Execute` before any traffic flows.
-- **Non-text fields are preserved.** The canonical model carries `model`, sampling
-  params, `tools`, and unmodeled provider fields (`RequestExtensions` /
-  `ProviderExtensions`), so the decode→rewrite→encode round-trip only alters matched
-  text; everything else survives (locked by `TestRequestRewritePreservesNonTextFields`).
+- **Modeled fields are preserved; unmodeled provider fields are dropped on rewrite
+  (known limitation).** When a rule matches, the leg is re-encoded from the canonical
+  model, so fields the canonical model represents (`model`, `messages`, `system`,
+  `temperature`, `top_p`, `max_tokens`, `stop`, `tools`, `response_format`, …) survive,
+  but provider-specific fields NOT in the canonical model (e.g. `seed`, `user`,
+  `presence_penalty`, `logit_bias`) are dropped. This matches `bedrock_guardrail`'s
+  canonical-rewrite path. No-match traffic forwards the original bytes untouched, so
+  only matched requests/responses are affected. Behavior is locked by
+  `TestRequestRewritePreservesNonTextFields`.
 
 ### Rejected alternatives
 

--- a/openspec/changes/run-993-regex-replace-plugin/design.md
+++ b/openspec/changes/run-993-regex-replace-plugin/design.md
@@ -34,6 +34,16 @@ One plugin descriptor registered once, driven on two stages, gated by a required
 - Streaming responses pass through unchanged.
 - Regexes are compiled **once at config parse** and cached on the parsed config
   (`compiledRule`), never per request.
+- **Fail-open on transport errors (intentional).** If format resolution, canonical
+  decode, or re-encode fails, the plugin passes the leg through unchanged (telemetry
+  only, no error surfaced). `regex_replace` is a redaction/normalization aid, not an
+  access gate (per RUN-993), so it must never take down a request/response it cannot
+  parse. This mirrors the `bedrock_guardrail` rewrite path. Config errors are the
+  exception: they surface at `ValidateConfig`/`Execute` before any traffic flows.
+- **Non-text fields are preserved.** The canonical model carries `model`, sampling
+  params, `tools`, and unmodeled provider fields (`RequestExtensions` /
+  `ProviderExtensions`), so the decode→rewrite→encode round-trip only alters matched
+  text; everything else survives (locked by `TestRequestRewritePreservesNonTextFields`).
 
 ### Rejected alternatives
 

--- a/openspec/changes/run-993-regex-replace-plugin/proposal.md
+++ b/openspec/changes/run-993-regex-replace-plugin/proposal.md
@@ -1,0 +1,102 @@
+---
+linear: RUN-993
+type: feat
+changelog: "Add regex_replace guardrail plugin that rewrites the request prompt OR the LLM response via RE2 regular expressions on exactly one leg."
+---
+
+# Proposal: Regex Replace plugin (RUN-993)
+
+## Intent
+
+Operators need targeted, deterministic text rewriting inside the gateway: mask emails, strip internal ids, normalize wording — on either the request prompt (before the LLM) or the LLM response (before the client). No existing plugin does provider-agnostic regex rewrite. This is a redaction/normalization transform, **not** an access gate.
+
+## Scope
+
+### In Scope
+
+- New plugin package `pkg/infra/plugins/regex_replace/` (config, validation, Execute).
+- Registration in the registry and catalog metadata (+ catalog test).
+- Two legs, one per instance: `pre_request` prompt rewrite and `pre_response` response rewrite.
+- Modes `enforce` (rewrite) and `observe` (telemetry only, no mutation).
+- Unit tests + one functional test (request + response).
+
+### Out of Scope
+
+- Both legs in a single instance (use two instances).
+- Non-regex transforms; semantic/LLM-based redaction.
+- Streaming response rewrite (pass-through — documented limitation).
+- Tool-call argument rewriting.
+
+## Capabilities
+
+### New Capabilities
+
+- `regex-replace-plugin`: provider-agnostic RE2 rewrite of request prompt XOR LLM response, ordered chained rules, enforce/observe modes.
+
+### Modified Capabilities
+
+- None.
+
+## Approach
+
+Model on `pkg/infra/plugins/bedrockguardrail/` (operates on both legs). Register ONE descriptor with `SupportedStages=[pre_request, pre_response]`, `MandatoryStages=[]`. Required `target` (enum `request|response`) selects the leg; `Execute` no-ops on the non-matching stage.
+
+Text is read provider-agnostically through the adapter `Registry`:
+- Request: `DecodeRequestFor` → rewrite all `Messages[].Content` + top-level `System` → `EncodeRequest` → `Result{RequestBody}`.
+- Response: `DecodeResponseFor` → rewrite `CanonicalResponse.Content` → `EncodeResponse` → `Result{Body, StopUpstream:true}` (the only supported response-rewrite mechanism; there is NO `Result.ResponseBody`).
+
+`StopUpstream` short-circuits sibling `pre_response` plugins — documented caveat. When `in.Response.Streaming`, pass through unchanged (mirrors bedrock_guardrail).
+
+Regex engine: Go stdlib `regexp` (RE2). `case_insensitive`→`(?i)`, `multiline`→`(?m)` compiled into the pattern. Replacement uses Go `$1`/`${name}` via `ReplaceAllString`. RE2 rejects backreferences/lookaround at `regexp.Compile`, so config validation catches unsupported patterns. Rules apply in declaration order and chain.
+
+### Config contract
+
+```
+target: request|response        # required, mutually exclusive leg selector
+rules:                          # required, non-empty, ordered
+  - pattern: string            # required, must compile (RE2)
+    replacement: string
+    case_insensitive: bool     # optional
+    multiline: bool            # optional
+```
+
+Modes: `enforce` (mandatory, applies rewrite) and `observe` (compute + emit telemetry, no mutation).
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `pkg/infra/plugins/regex_replace/` | New | config, validation, rewrite, Execute, tests |
+| `pkg/container/modules/plugins.go` | Modified | register plugin (needs `*adapter.Registry`) |
+| `pkg/app/plugins/catalog_metadata.go` | Modified | catalog meta, group `Guardrails` |
+| `pkg/app/plugins/catalog_test.go` | Modified | add slug to `builtinSlugs` |
+| `tests/functional/` | New | request + response functional test |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| `StopUpstream` drops sibling `pre_response` plugins | Med | Document; last-in-chain guidance |
+| Streaming responses silently un-rewritten | Med | Pass-through + documented limitation |
+| Catastrophic/greedy patterns hurt latency | Low | RE2 is linear-time; operator owns rules |
+
+## Rollback Plan
+
+Additive. Revert by removing the `regex_replace` package, its registry entry, catalog meta, and the `builtinSlugs` addition. No migrations or schema changes; existing plugins unaffected.
+
+## Dependencies
+
+- Adapter `Registry` (`DecodeRequestFor`/`DecodeResponseFor`, `EncodeRequest`/`EncodeResponse`).
+- Go stdlib `regexp` (RE2).
+
+## Success Criteria
+
+- [ ] Instance with `target=request` masks matched text in the prompt before upstream.
+- [ ] Instance with `target=response` rewrites the returned body via `StopUpstream`.
+- [ ] Invalid regex (or unsupported RE2 feature) rejected at `ValidateConfig`.
+- [ ] `observe` mode emits telemetry without mutating body.
+- [ ] Streaming responses pass through unchanged.
+- [ ] Catalog lists plugin under `Guardrails`; `catalog_test` covers the slug.
+- [ ] `-race`-clean unit + functional tests pass.
+
+> Implementers: this repo enforces **NO CODE COMMENTS** (strict, pre-commit). Conventional commits on `feat/run-993-...`; PR to `develop` with `RUN-993` in the body; 400-line PR budget.

--- a/openspec/changes/run-993-regex-replace-plugin/specs/regex-replace-plugin/spec.md
+++ b/openspec/changes/run-993-regex-replace-plugin/specs/regex-replace-plugin/spec.md
@@ -11,13 +11,18 @@ leg per instance: the request prompt (`pre_request`) XOR the LLM response
 ### Requirement: Descriptor & stage registration
 
 The plugin MUST register ONE descriptor with `SupportedStages=[pre_request, pre_response]`,
-`MandatoryStages=[]`, catalog group `Guardrails`, and appear in `catalog_test` `builtinSlugs`.
+`MandatoryStages=[]`, catalog group `Guardrails`, and MUST be covered by a dedicated
+schema test. Following the existing Guardrails convention (`bedrock_guardrail`,
+`azure_content_safety`, `trustguard`), the slug is validated by a standalone
+`TestRegexReplaceSchema` and is deliberately NOT added to `catalog_test` `builtinSlugs`
+(that curated fixture drives `TestCatalogService_EntriesHaveStagesAndSchema`, whose
+`len(entries)==len(visibleSlugs)` assertion would break otherwise).
 
 #### Scenario: Catalog exposure
 - GIVEN the plugin registry is initialized
 - WHEN the catalog is listed
 - THEN `regex_replace` appears under group `Guardrails` with both supported stages
-- AND `catalog_test` asserts the slug is a builtin
+- AND `TestRegexReplaceSchema` asserts the catalog metadata (target enum + rules schema)
 
 ### Requirement: Config validation
 

--- a/openspec/changes/run-993-regex-replace-plugin/specs/regex-replace-plugin/spec.md
+++ b/openspec/changes/run-993-regex-replace-plugin/specs/regex-replace-plugin/spec.md
@@ -1,0 +1,148 @@
+# Regex Replace Plugin Specification
+
+## Purpose
+
+Provider-agnostic RE2 text rewriting inside the TrustGate gateway on exactly one
+leg per instance: the request prompt (`pre_request`) XOR the LLM response
+(`pre_response`). Redaction/normalization transform, not an access gate.
+
+## Requirements
+
+### Requirement: Descriptor & stage registration
+
+The plugin MUST register ONE descriptor with `SupportedStages=[pre_request, pre_response]`,
+`MandatoryStages=[]`, catalog group `Guardrails`, and appear in `catalog_test` `builtinSlugs`.
+
+#### Scenario: Catalog exposure
+- GIVEN the plugin registry is initialized
+- WHEN the catalog is listed
+- THEN `regex_replace` appears under group `Guardrails` with both supported stages
+- AND `catalog_test` asserts the slug is a builtin
+
+### Requirement: Config validation
+
+`ValidateConfig` MUST reject configs where: `target` is missing or not in `{request,response}`;
+`rules` is empty/absent; any rule lacks `pattern`; or any `pattern` fails `regexp.Compile`
+(including RE2-unsupported backreferences/lookaround). Valid configs MUST be accepted.
+
+#### Scenario: target required and enum-checked
+- GIVEN a config with no `target` or `target: both`
+- WHEN `ValidateConfig` runs
+- THEN it returns an error
+
+#### Scenario: rules must be non-empty
+- GIVEN a config with `rules: []`
+- WHEN `ValidateConfig` runs
+- THEN it returns an error
+
+#### Scenario: invalid regex rejected
+- GIVEN a rule `pattern` that is invalid RE2 (e.g. `(?=x)` lookahead or `\1` backreference)
+- WHEN `ValidateConfig` runs
+- THEN it returns the `regexp.Compile` error and the config is rejected
+
+#### Scenario: valid config accepted
+- GIVEN `target: request` with one rule whose `pattern` compiles
+- WHEN `ValidateConfig` runs
+- THEN it returns no error
+
+### Requirement: Request-leg rewrite (pre_request)
+
+When `target=request` and mode is enforce on `pre_request`, the plugin MUST decode the
+request via the adapter Registry, apply rules to top-level `System` and every
+`Messages[].Content`, re-encode, and return `Result{RequestBody}`. Non-text fields MUST be
+untouched. On `pre_response` it MUST no-op.
+
+#### Scenario: prompt masked before upstream
+- GIVEN `target=request` with a rule masking emails
+- WHEN a request with an email in `System` and message content reaches `pre_request`
+- THEN the returned `RequestBody` has both occurrences masked
+- AND roles, model, and other fields are unchanged
+
+#### Scenario: no-op on wrong stage
+- GIVEN `target=request`
+- WHEN `Execute` runs on `pre_response`
+- THEN the response body is unchanged and no rewrite occurs
+
+### Requirement: Response-leg rewrite (pre_response)
+
+When `target=response` and mode is enforce on `pre_response`, the plugin MUST decode the
+response, rewrite `CanonicalResponse.Content`, re-encode, and return
+`Result{Body, StopUpstream:true}` (never `Result.ResponseBody`). On `pre_request` it MUST
+no-op. Streaming responses MUST pass through unchanged.
+
+#### Scenario: response rewritten via StopUpstream
+- GIVEN `target=response` with a normalization rule
+- WHEN a non-streaming response reaches `pre_response`
+- THEN the plugin returns `Body` with rewritten content and `StopUpstream=true`
+
+#### Scenario: streaming pass-through
+- GIVEN `target=response` and `in.Response.Streaming` is true
+- WHEN `Execute` runs
+- THEN the body passes through unchanged with no rewrite
+
+#### Scenario: no-op on wrong stage
+- GIVEN `target=response`
+- WHEN `Execute` runs on `pre_request`
+- THEN the request body is unchanged
+
+### Requirement: Ordered chained rules
+
+Rules MUST apply in declaration order; the output of rule N MUST be the input to rule N+1.
+Each rule compiles `case_insensitive`→`(?i)`, `multiline`→`(?m)` into the pattern and uses
+Go `$1`/`${name}` replacement via `ReplaceAllString`.
+
+#### Scenario: chaining
+- GIVEN rules [replace `a`→`b`, then `b`→`c`]
+- WHEN applied to text `a`
+- THEN the result is `c`
+
+#### Scenario: capture-group replacement
+- GIVEN a rule with a capture group and replacement `$1`
+- WHEN applied to matching text
+- THEN the captured group is substituted into the output
+
+### Requirement: Modes
+
+Mode `enforce` (mandatory) MUST mutate the body. Mode `observe` MUST compute matches and
+emit telemetry only, returning the body unmutated.
+
+#### Scenario: observe does not mutate
+- GIVEN mode `observe` with a matching rule
+- WHEN `Execute` runs
+- THEN telemetry reflects the match and the body is returned unchanged
+
+### Requirement: Provider-agnostic behavior
+
+All rewrite behavior MUST hold across providers (openai, anthropic, gemini, bedrock,
+mistral) through the canonical model, since text is read/written via the adapter Registry.
+
+#### Scenario: cross-provider parity
+- GIVEN the same rule and equivalent text
+- WHEN requests/responses are processed for each provider
+- THEN each is decoded, rewritten, and re-encoded with the same textual result
+
+### Requirement: Edge-case behavior
+
+The plugin MUST handle: no match (body unchanged); empty `replacement` (matched text
+deleted); multiple rules applied cumulatively.
+
+#### Scenario: no match is a no-op
+- GIVEN a rule that matches nothing in the text
+- WHEN `Execute` runs
+- THEN the body is byte-identical to the input
+
+#### Scenario: empty replacement deletes
+- GIVEN a rule with `replacement: ""`
+- WHEN applied to matching text
+- THEN the matched substring is removed
+
+### Requirement: Non-functional
+
+Production code MUST contain no code comments. The plugin MUST ship `-race`-clean unit tests
+covering config validation, both legs, modes, chaining, and edge cases, plus one functional
+test exercising request and response rewrite.
+
+#### Scenario: coverage gate
+- GIVEN the test suite
+- WHEN `go test -race ./...` runs
+- THEN unit and functional tests pass and no production file contains comments

--- a/openspec/changes/run-993-regex-replace-plugin/tasks.md
+++ b/openspec/changes/run-993-regex-replace-plugin/tasks.md
@@ -80,7 +80,7 @@ Neither slice stays under 400; the chain only bounds reviewer diff-per-PR.
 
 ## Phase 4: Functional test + docs
 
-- [ ] 4.1 Create `tests/functional/plugin_regex_replace_test.go`: request-side asserts `up.LastBody()` shows rewrite; response-side asserts client raw body rewritten; use `setupPolicyRoute`/`policyPlugin`/`proxyRequest`/`newJSONUpstream`. [spec: Non-functional; Request/Response-leg rewrite]
-- [ ] 4.2 `docs/policies.json`: add a `regex_replace` policy entry mirroring existing plugin docs (target + rules). [spec: Descriptor & stage registration]
-- [ ] 4.3 `postman/TrustGate.postman_collection.json`: add a `regex_replace` policy example mirroring existing plugin requests. [spec: Descriptor & stage registration]
-- [ ] 4.4 Run `go test -race ./...` + confirm no code comments in production files; `go vet`/`golangci-lint` clean. [spec: Non-functional coverage gate]
+- [x] 4.1 Create `tests/functional/plugin_regex_replace_test.go`: request-side asserts `up.LastBody()` shows rewrite; response-side asserts client raw body rewritten; use `setupPolicyRoute`/`policyPlugin`/`proxyRequest`/`newJSONUpstream`. [spec: Non-functional; Request/Response-leg rewrite]
+- [x] 4.2 `docs/policies.json`: add a `regex_replace` policy entry mirroring existing plugin docs (target + rules). [spec: Descriptor & stage registration]
+- [x] 4.3 `postman/TrustGate.postman_collection.json`: add a `regex_replace` policy example mirroring existing plugin requests. [spec: Descriptor & stage registration]
+- [x] 4.4 Run `go test -race ./...` + confirm no code comments in production files; `go vet`/`golangci-lint` clean. [spec: Non-functional coverage gate]

--- a/openspec/changes/run-993-regex-replace-plugin/tasks.md
+++ b/openspec/changes/run-993-regex-replace-plugin/tasks.md
@@ -74,9 +74,9 @@ Neither slice stays under 400; the chain only bounds reviewer diff-per-PR.
 
 ## Phase 3: Wiring + catalog
 
-- [ ] 3.1 `pkg/container/modules/plugins.go`: add `regexreplace` import + `regexreplace.New(p.Adapters, p.Logger)` in the catalog slice. [spec: Descriptor & stage registration]
-- [ ] 3.2 `pkg/app/plugins/catalog_metadata.go`: add `pluginCatalogMeta["regex_replace"]`, group `groupGuardrails`, `target` enum (required, `enumOptions("request","response")`) + `rules` array of objects {pattern (required), replacement, case_insensitive, multiline}. [spec: Descriptor & stage registration]
-- [ ] 3.3 `pkg/app/plugins/catalog_test.go`: add dedicated `TestRegexReplaceSchema` reading `pluginCatalogMeta["regex_replace"]` (mirror `TestAzureContentSafetySchema`). Do NOT add to `builtinSlugs`/`registerBuiltins`. [spec: Descriptor & stage registration]
+- [x] 3.1 `pkg/container/modules/plugins.go`: add `regexreplace` import + `regexreplace.New(p.Adapters, p.Logger)` in the catalog slice. [spec: Descriptor & stage registration]
+- [x] 3.2 `pkg/app/plugins/catalog_metadata.go`: add `pluginCatalogMeta["regex_replace"]`, group `groupGuardrails`, `target` enum (required, `enumOptions("request","response")`) + `rules` array of objects {pattern (required), replacement, case_insensitive, multiline}. [spec: Descriptor & stage registration]
+- [x] 3.3 `pkg/app/plugins/catalog_test.go`: add dedicated `TestRegexReplaceSchema` reading `pluginCatalogMeta["regex_replace"]` (mirror `TestAzureContentSafetySchema`). Do NOT add to `builtinSlugs`/`registerBuiltins`. [spec: Descriptor & stage registration]
 
 ## Phase 4: Functional test + docs
 

--- a/openspec/changes/run-993-regex-replace-plugin/tasks.md
+++ b/openspec/changes/run-993-regex-replace-plugin/tasks.md
@@ -66,11 +66,11 @@ Neither slice stays under 400; the chain only bounds reviewer diff-per-PR.
 
 ## Phase 2: Plugin behavior
 
-- [ ] 2.1 Create `plugin.go`: `Plugin{registry,logger}`, `New(*adapter.Registry,*slog.Logger)`, descriptor methods — `SupportedStages=[pre_request,pre_response]`, `MandatoryStages=[]`, `SupportedModes=[Enforce,Observe]`, `SupportedProtocols=[ProtocolLLM]`, `MutatesRequestBody/ResponseBody=true`, `MutatesMetadata=false`, `ValidateConfig`. [spec: Descriptor & stage registration; Modes]
-- [ ] 2.2 In `plugin.go` add `Execute` dispatch by stage+`target` (`passThrough` no-op on mismatch) + `executeRequest` (rewrite `System`+all `Messages[].Content`, `Result{RequestBody}`) + `rewriteRequest`. [spec: Request-leg rewrite; Provider-agnostic behavior]
-- [ ] 2.3 In `plugin.go` add `executeResponse` (streaming pass-through guard, rewrite `CanonicalResponse.Content`, `Result{Body,StopUpstream:true}`) + `rewriteResponse`. [spec: Response-leg rewrite]
-- [ ] 2.4 Create `data.go`: `Data` struct + `setExtras` via `in.Event.SetExtras`; wire `decision` (`rewritten`/`observed`/`no_match`) and `SetDecisionFromOutcome`. [spec: Modes]
-- [ ] 2.5 Create `plugin_test.go` (`-race`, real `adapter.NewRegistry()`): descriptor values, stage/target no-op both ways, request leg rewrite, response leg `Body`+`StopUpstream`, observe no-mutate, streaming pass-through, no-match extras, cross-provider (OpenAI+Anthropic), nil guards. [spec: all Requirement scenarios]
+- [x] 2.1 Create `plugin.go`: `Plugin{registry,logger}`, `New(*adapter.Registry,*slog.Logger)`, descriptor methods — `SupportedStages=[pre_request,pre_response]`, `MandatoryStages=[]`, `SupportedModes=[Enforce,Observe]`, `SupportedProtocols=[ProtocolLLM]`, `MutatesRequestBody/ResponseBody=true`, `MutatesMetadata=false`, `ValidateConfig`. [spec: Descriptor & stage registration; Modes]
+- [x] 2.2 In `plugin.go` add `Execute` dispatch by stage+`target` (`passThrough` no-op on mismatch) + `executeRequest` (rewrite `System`+all `Messages[].Content`, `Result{RequestBody}`) + `rewriteRequest`. [spec: Request-leg rewrite; Provider-agnostic behavior]
+- [x] 2.3 In `plugin.go` add `executeResponse` (streaming pass-through guard, rewrite `CanonicalResponse.Content`, `Result{Body,StopUpstream:true}`) + `rewriteResponse`. [spec: Response-leg rewrite]
+- [x] 2.4 Create `data.go`: `Data` struct + `setExtras` via `in.Event.SetExtras`; wire `decision` (`rewritten`/`observed`/`no_match`) and `SetDecisionFromOutcome`. [spec: Modes]
+- [x] 2.5 Create `plugin_test.go` (`-race`, real `adapter.NewRegistry()`): descriptor values, stage/target no-op both ways, request leg rewrite, response leg `Body`+`StopUpstream`, observe no-mutate, streaming pass-through, no-match extras, cross-provider (OpenAI+Anthropic), nil guards. [spec: all Requirement scenarios]
 
 ## Phase 3: Wiring + catalog
 

--- a/openspec/changes/run-993-regex-replace-plugin/tasks.md
+++ b/openspec/changes/run-993-regex-replace-plugin/tasks.md
@@ -1,0 +1,86 @@
+---
+linear: RUN-993
+type: feat
+phase: tasks
+depends_on: openspec/changes/run-993-regex-replace-plugin/design.md
+---
+
+# Tasks: Regex Replace plugin (RUN-993)
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines (add+del) | ~1162 total / ~432 production-only |
+| 400-line budget risk | High |
+| Chained PRs recommended | No |
+| Suggested split | Single PR + `size:exception` (fallback: 2-PR feature-branch-chain) |
+| Delivery strategy | ask-on-risk (default; none passed) |
+| Chain strategy | size-exception |
+
+Decision needed before apply: Yes
+Chained PRs recommended: No
+Chain strategy: size-exception
+400-line budget risk: High
+
+### Per-phase estimate (add+del)
+
+| Phase | Files | Total | Production-only |
+|-------|-------|-------|-----------------|
+| 1 core | config.go, replace.go + 2 unit tests | ~420 | ~170 |
+| 2 plugin | plugin.go, data.go + plugin_test.go | ~410 | ~200 |
+| 3 wiring | plugins.go, catalog_metadata.go, catalog_test.go | ~102 | ~62 |
+| 4 integration | functional test, policies.json, Postman | ~230 | ~40 |
+| **Total** | | **~1162** | **~432** |
+
+### Recommendation: ONE PR with `size:exception`
+
+The smallest *functional* slice (config+replace+plugin+data+registration) is ~432
+production lines — already over 400 before any test. No split yields a working,
+under-budget slice. A core-only PR 1 (config.go+replace.go) would merge
+package-level production code that nothing calls yet (compiles + unit-tests green
+in isolation, but ships transient dead code to `develop`). The change is fully
+additive and cohesive (one new plugin, zero behavior change to existing code), so
+a single reviewable PR with `size:exception` is cleanest.
+
+Fallback if the team refuses the exception — **feature-branch-chain**:
+- PR 1 (base = `feat/run-993-regex-replace-plugin`): Phases 1+2+3 — complete wired
+  plugin + unit tests + catalog. Builds and tests green; plugin fully functional.
+- PR 2 (base = PR 1 branch): Phase 4 — functional test + docs + Postman.
+
+Neither slice stays under 400; the chain only bounds reviewer diff-per-PR.
+
+### Suggested Work Units
+
+| Unit | Goal | Likely PR | Notes |
+|------|------|-----------|-------|
+| 1 | Complete wired plugin + unit + catalog (Phases 1-3) | PR 1 | base = tracker branch; green standalone |
+| 2 | Functional test + docs + Postman (Phase 4) | PR 2 | base = PR 1 branch (only if chained) |
+
+## Phase 1: Core (pure, no wiring)
+
+- [x] 1.1 Create `pkg/infra/plugins/regexreplace/config.go`: `PluginName`, target consts, sentinels (`ErrNoRules`/`ErrInvalidTarget`/`ErrEmptyPattern`/`ErrBadPattern`), `Rule`, `Settings` (+ unexported `compiled`), `compiledRule`, `parseConfig`, `validate`, `compile`, `buildPattern`, `isRequestLeg`/`isResponseLeg`. RE2 compiled once, `%w` wrapping. [spec: Config validation; Ordered chained rules]
+- [x] 1.2 Create `pkg/infra/plugins/regexreplace/replace.go`: pure `applyRules([]compiledRule,string)(string,bool)` — ordered chaining, net-change flag. [spec: Ordered chained rules; Edge-case behavior]
+- [x] 1.3 Create `config_test.go` (table-driven, `-race`): valid/one+many rules, missing/invalid target→`ErrInvalidTarget`, empty rules→`ErrNoRules`, empty pattern→`ErrEmptyPattern`, invalid RE2 (`(`, `\1`, `(?=x)`)→`ErrBadPattern` via `errors.Is`, `buildPattern` `(?i)`/`(?m)`. [spec: Config validation]
+- [x] 1.4 Create `replace_test.go` (table-driven, `-race`): single match, `$1`, `${name}`, chaining, no-match→`changed=false`, empty replacement deletes, net no-op. [spec: Ordered chained rules; Edge-case behavior]
+
+## Phase 2: Plugin behavior
+
+- [ ] 2.1 Create `plugin.go`: `Plugin{registry,logger}`, `New(*adapter.Registry,*slog.Logger)`, descriptor methods — `SupportedStages=[pre_request,pre_response]`, `MandatoryStages=[]`, `SupportedModes=[Enforce,Observe]`, `SupportedProtocols=[ProtocolLLM]`, `MutatesRequestBody/ResponseBody=true`, `MutatesMetadata=false`, `ValidateConfig`. [spec: Descriptor & stage registration; Modes]
+- [ ] 2.2 In `plugin.go` add `Execute` dispatch by stage+`target` (`passThrough` no-op on mismatch) + `executeRequest` (rewrite `System`+all `Messages[].Content`, `Result{RequestBody}`) + `rewriteRequest`. [spec: Request-leg rewrite; Provider-agnostic behavior]
+- [ ] 2.3 In `plugin.go` add `executeResponse` (streaming pass-through guard, rewrite `CanonicalResponse.Content`, `Result{Body,StopUpstream:true}`) + `rewriteResponse`. [spec: Response-leg rewrite]
+- [ ] 2.4 Create `data.go`: `Data` struct + `setExtras` via `in.Event.SetExtras`; wire `decision` (`rewritten`/`observed`/`no_match`) and `SetDecisionFromOutcome`. [spec: Modes]
+- [ ] 2.5 Create `plugin_test.go` (`-race`, real `adapter.NewRegistry()`): descriptor values, stage/target no-op both ways, request leg rewrite, response leg `Body`+`StopUpstream`, observe no-mutate, streaming pass-through, no-match extras, cross-provider (OpenAI+Anthropic), nil guards. [spec: all Requirement scenarios]
+
+## Phase 3: Wiring + catalog
+
+- [ ] 3.1 `pkg/container/modules/plugins.go`: add `regexreplace` import + `regexreplace.New(p.Adapters, p.Logger)` in the catalog slice. [spec: Descriptor & stage registration]
+- [ ] 3.2 `pkg/app/plugins/catalog_metadata.go`: add `pluginCatalogMeta["regex_replace"]`, group `groupGuardrails`, `target` enum (required, `enumOptions("request","response")`) + `rules` array of objects {pattern (required), replacement, case_insensitive, multiline}. [spec: Descriptor & stage registration]
+- [ ] 3.3 `pkg/app/plugins/catalog_test.go`: add dedicated `TestRegexReplaceSchema` reading `pluginCatalogMeta["regex_replace"]` (mirror `TestAzureContentSafetySchema`). Do NOT add to `builtinSlugs`/`registerBuiltins`. [spec: Descriptor & stage registration]
+
+## Phase 4: Functional test + docs
+
+- [ ] 4.1 Create `tests/functional/plugin_regex_replace_test.go`: request-side asserts `up.LastBody()` shows rewrite; response-side asserts client raw body rewritten; use `setupPolicyRoute`/`policyPlugin`/`proxyRequest`/`newJSONUpstream`. [spec: Non-functional; Request/Response-leg rewrite]
+- [ ] 4.2 `docs/policies.json`: add a `regex_replace` policy entry mirroring existing plugin docs (target + rules). [spec: Descriptor & stage registration]
+- [ ] 4.3 `postman/TrustGate.postman_collection.json`: add a `regex_replace` policy example mirroring existing plugin requests. [spec: Descriptor & stage registration]
+- [ ] 4.4 Run `go test -race ./...` + confirm no code comments in production files; `go vet`/`golangci-lint` clean. [spec: Non-functional coverage gate]

--- a/pkg/app/plugins/catalog_metadata.go
+++ b/pkg/app/plugins/catalog_metadata.go
@@ -1373,4 +1373,62 @@ var pluginCatalogMeta = map[string]catalogMeta{
 			},
 		},
 	},
+	"regex_replace": {
+		name:        "Regex Replace",
+		group:       groupGuardrails,
+		description: "Rewrite text with RE2 regular expressions on one leg: the request prompt or the LLM response. Rules apply in declaration order and chain, so each rule sees the previous rule's output. Response rewrites short-circuit later pre-response plugins, so order a response-side instance last in its chain. Streaming responses pass through untouched.",
+		schema: SettingsSchema{
+			Fields: []Field{
+				{
+					Key:         "target",
+					Label:       "Target",
+					Type:        FieldTypeEnum,
+					Description: "Which leg to rewrite. A single instance rewrites the request prompt or the LLM response, not both.",
+					Required:    true,
+					Enum:        enumOptions("request", "response"),
+				},
+				{
+					Key:         "rules",
+					Label:       "Rules",
+					Type:        FieldTypeArray,
+					Description: "Ordered replacement rules. Each rule's output feeds the next.",
+					Required:    true,
+					Item: &Field{
+						Key:   "rule",
+						Label: "Rule",
+						Type:  FieldTypeObject,
+						Fields: []Field{
+							{
+								Key:         "pattern",
+								Label:       "Pattern",
+								Type:        FieldTypeString,
+								Description: "RE2 regular expression. Backreferences and lookaround are not supported.",
+								Required:    true,
+							},
+							{
+								Key:         "replacement",
+								Label:       "Replacement",
+								Type:        FieldTypeString,
+								Description: "Replacement text. Use $1 or ${name} to reference capture groups. Empty removes the match.",
+							},
+							{
+								Key:         "case_insensitive",
+								Label:       "Case Insensitive",
+								Type:        FieldTypeBoolean,
+								Description: "Match without regard to letter case ((?i)).",
+								Default:     false,
+							},
+							{
+								Key:         "multiline",
+								Label:       "Multiline",
+								Type:        FieldTypeBoolean,
+								Description: "^ and $ match at line boundaries ((?m)).",
+								Default:     false,
+							},
+						},
+					},
+				},
+			},
+		},
+	},
 }

--- a/pkg/app/plugins/catalog_test.go
+++ b/pkg/app/plugins/catalog_test.go
@@ -536,6 +536,53 @@ func TestAzureContentSafetySchema(t *testing.T) {
 	assert.False(t, message.Required)
 }
 
+func TestRegexReplaceSchema(t *testing.T) {
+	meta, ok := pluginCatalogMeta["regex_replace"]
+	require.True(t, ok)
+	assert.Equal(t, "Regex Replace", meta.name)
+	assert.Equal(t, groupGuardrails, meta.group)
+
+	fields := meta.schema.Fields
+
+	target, ok := fieldByKey(fields, "target")
+	require.True(t, ok)
+	assert.Equal(t, FieldTypeEnum, target.Type)
+	assert.True(t, target.Required)
+	assert.Equal(t, []string{"request", "response"}, enumValues(target.Enum))
+	assert.Equal(t, []string{"Request", "Response"}, enumLabels(target.Enum))
+
+	rules, ok := fieldByKey(fields, "rules")
+	require.True(t, ok)
+	assert.Equal(t, FieldTypeArray, rules.Type)
+	assert.True(t, rules.Required)
+	require.NotNil(t, rules.Item)
+	assert.Equal(t, FieldTypeObject, rules.Item.Type)
+	for _, k := range []string{"pattern", "replacement", "case_insensitive", "multiline"} {
+		_, ok := fieldByKey(rules.Item.Fields, k)
+		assert.Truef(t, ok, "rules item missing %q", k)
+	}
+
+	pattern, ok := fieldByKey(rules.Item.Fields, "pattern")
+	require.True(t, ok)
+	assert.Equal(t, FieldTypeString, pattern.Type)
+	assert.True(t, pattern.Required)
+
+	replacement, ok := fieldByKey(rules.Item.Fields, "replacement")
+	require.True(t, ok)
+	assert.Equal(t, FieldTypeString, replacement.Type)
+	assert.False(t, replacement.Required)
+
+	caseInsensitive, ok := fieldByKey(rules.Item.Fields, "case_insensitive")
+	require.True(t, ok)
+	assert.Equal(t, FieldTypeBoolean, caseInsensitive.Type)
+	assert.False(t, caseInsensitive.Required)
+
+	multiline, ok := fieldByKey(rules.Item.Fields, "multiline")
+	require.True(t, ok)
+	assert.Equal(t, FieldTypeBoolean, multiline.Type)
+	assert.False(t, multiline.Required)
+}
+
 func TestSemanticCacheSchema(t *testing.T) {
 	meta, ok := pluginCatalogMeta["semantic_cache"]
 	require.True(t, ok)

--- a/pkg/container/modules/plugins.go
+++ b/pkg/container/modules/plugins.go
@@ -35,6 +35,7 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/infra/plugins/pertoolratelimit"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/plugins/prompttemplate"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/plugins/ratelimit"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/plugins/regexreplace"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/plugins/requestsize"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/plugins/semanticcache"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/plugins/tokenratelimit"
@@ -108,6 +109,7 @@ func newPluginRegistry(p pluginParams) (appplugins.Registry, error) {
 		openaimoderation.New(p.Adapters, p.Cfg.OpenAIModeration.BaseURL, p.Cfg.OpenAIModeration.Timeout, p.Logger),
 		azurecontentsafety.New(p.Adapters, p.Logger),
 		bedrockguardrail.New(p.Adapters, p.Logger),
+		regexreplace.New(p.Adapters, p.Logger),
 	}
 	for _, plugin := range catalog {
 		if err := reg.Register(plugin); err != nil {

--- a/pkg/infra/plugins/regexreplace/config.go
+++ b/pkg/infra/plugins/regexreplace/config.go
@@ -1,0 +1,121 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package regexreplace
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/plugins/pluginutil"
+)
+
+const PluginName = "regex_replace"
+
+const (
+	targetRequest  = "request"
+	targetResponse = "response"
+)
+
+var (
+	ErrNoRules       = errors.New("regex_replace: at least one rule is required")
+	ErrInvalidTarget = errors.New("regex_replace: target must be one of request, response")
+	ErrEmptyPattern  = errors.New("regex_replace: rule pattern must not be empty")
+	ErrBadPattern    = errors.New("regex_replace: invalid regular expression")
+)
+
+type Rule struct {
+	Pattern         string `mapstructure:"pattern"`
+	Replacement     string `mapstructure:"replacement"`
+	CaseInsensitive bool   `mapstructure:"case_insensitive"`
+	Multiline       bool   `mapstructure:"multiline"`
+}
+
+type Settings struct {
+	Target string `mapstructure:"target"`
+	Rules  []Rule `mapstructure:"rules"`
+
+	compiled []compiledRule
+}
+
+type compiledRule struct {
+	re          *regexp.Regexp
+	replacement string
+}
+
+func parseConfig(settings map[string]any) (Settings, error) {
+	cfg, err := pluginutil.Parse[Settings](settings)
+	if err != nil {
+		return Settings{}, err
+	}
+	if err := cfg.validate(); err != nil {
+		return Settings{}, err
+	}
+	if err := cfg.compile(); err != nil {
+		return Settings{}, err
+	}
+	return cfg, nil
+}
+
+func (s *Settings) validate() error {
+	switch s.Target {
+	case targetRequest, targetResponse:
+	default:
+		return fmt.Errorf("%w: got %q", ErrInvalidTarget, s.Target)
+	}
+	if len(s.Rules) == 0 {
+		return ErrNoRules
+	}
+	for i, r := range s.Rules {
+		if strings.TrimSpace(r.Pattern) == "" {
+			return fmt.Errorf("%w: rule %d", ErrEmptyPattern, i)
+		}
+	}
+	return nil
+}
+
+func (s *Settings) compile() error {
+	compiled := make([]compiledRule, 0, len(s.Rules))
+	for i, r := range s.Rules {
+		re, err := regexp.Compile(buildPattern(r))
+		if err != nil {
+			return fmt.Errorf("%w: rule %d: %w", ErrBadPattern, i, err)
+		}
+		compiled = append(compiled, compiledRule{re: re, replacement: r.Replacement})
+	}
+	s.compiled = compiled
+	return nil
+}
+
+func buildPattern(r Rule) string {
+	var b strings.Builder
+	if r.CaseInsensitive {
+		b.WriteString("(?i)")
+	}
+	if r.Multiline {
+		b.WriteString("(?m)")
+	}
+	b.WriteString(r.Pattern)
+	return b.String()
+}
+
+func (s Settings) isRequestLeg() bool {
+	return s.Target == targetRequest
+}
+
+func (s Settings) isResponseLeg() bool {
+	return s.Target == targetResponse
+}

--- a/pkg/infra/plugins/regexreplace/config_test.go
+++ b/pkg/infra/plugins/regexreplace/config_test.go
@@ -1,0 +1,166 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package regexreplace
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseConfigValid(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		settings map[string]any
+		wantLen  int
+	}{
+		{
+			name: "single request rule",
+			settings: map[string]any{
+				"target": "request",
+				"rules": []any{
+					map[string]any{"pattern": "foo", "replacement": "bar"},
+				},
+			},
+			wantLen: 1,
+		},
+		{
+			name: "many response rules with flags",
+			settings: map[string]any{
+				"target": "response",
+				"rules": []any{
+					map[string]any{"pattern": "foo", "replacement": "bar", "case_insensitive": true},
+					map[string]any{"pattern": "^baz$", "replacement": "qux", "multiline": true},
+				},
+			},
+			wantLen: 2,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg, err := parseConfig(tt.settings)
+			require.NoError(t, err)
+			assert.Len(t, cfg.compiled, tt.wantLen)
+		})
+	}
+}
+
+func TestParseConfigErrors(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		settings map[string]any
+		wantErr  error
+	}{
+		{
+			name: "missing target",
+			settings: map[string]any{
+				"rules": []any{map[string]any{"pattern": "foo", "replacement": "bar"}},
+			},
+			wantErr: ErrInvalidTarget,
+		},
+		{
+			name: "unknown target",
+			settings: map[string]any{
+				"target": "both",
+				"rules":  []any{map[string]any{"pattern": "foo", "replacement": "bar"}},
+			},
+			wantErr: ErrInvalidTarget,
+		},
+		{
+			name:     "empty rules",
+			settings: map[string]any{"target": "request", "rules": []any{}},
+			wantErr:  ErrNoRules,
+		},
+		{
+			name: "empty pattern",
+			settings: map[string]any{
+				"target": "request",
+				"rules":  []any{map[string]any{"pattern": "  ", "replacement": "bar"}},
+			},
+			wantErr: ErrEmptyPattern,
+		},
+		{
+			name: "invalid group",
+			settings: map[string]any{
+				"target": "request",
+				"rules":  []any{map[string]any{"pattern": "(", "replacement": "x"}},
+			},
+			wantErr: ErrBadPattern,
+		},
+		{
+			name: "backreference rejected",
+			settings: map[string]any{
+				"target": "request",
+				"rules":  []any{map[string]any{"pattern": `\1`, "replacement": "x"}},
+			},
+			wantErr: ErrBadPattern,
+		},
+		{
+			name: "lookahead rejected",
+			settings: map[string]any{
+				"target": "request",
+				"rules":  []any{map[string]any{"pattern": "(?=x)", "replacement": "y"}},
+			},
+			wantErr: ErrBadPattern,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := parseConfig(tt.settings)
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, tt.wantErr))
+		})
+	}
+}
+
+func TestBuildPattern(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		rule Rule
+		want string
+	}{
+		{name: "plain", rule: Rule{Pattern: "foo"}, want: "foo"},
+		{name: "case insensitive", rule: Rule{Pattern: "foo", CaseInsensitive: true}, want: "(?i)foo"},
+		{name: "multiline", rule: Rule{Pattern: "^foo$", Multiline: true}, want: "(?m)^foo$"},
+		{name: "both flags", rule: Rule{Pattern: "foo", CaseInsensitive: true, Multiline: true}, want: "(?i)(?m)foo"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, buildPattern(tt.rule))
+		})
+	}
+}
+
+func TestSettingsLegHelpers(t *testing.T) {
+	t.Parallel()
+	req := Settings{Target: targetRequest}
+	assert.True(t, req.isRequestLeg())
+	assert.False(t, req.isResponseLeg())
+
+	resp := Settings{Target: targetResponse}
+	assert.True(t, resp.isResponseLeg())
+	assert.False(t, resp.isRequestLeg())
+}

--- a/pkg/infra/plugins/regexreplace/data.go
+++ b/pkg/infra/plugins/regexreplace/data.go
@@ -1,0 +1,39 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package regexreplace
+
+import "github.com/NeuralTrust/TrustGate/pkg/infra/metrics"
+
+const (
+	decisionRewritten = "rewritten"
+	decisionObserved  = "observed"
+	decisionNoMatch   = "no_match"
+)
+
+type Data struct {
+	Target       string `json:"target,omitempty"`
+	Stage        string `json:"stage,omitempty"`
+	Mode         string `json:"mode,omitempty"`
+	Decision     string `json:"decision,omitempty"`
+	RulesMatched int    `json:"rules_matched,omitempty"`
+	Changed      bool   `json:"changed,omitempty"`
+}
+
+func setExtras(event *metrics.EventContext, data *Data) {
+	if event == nil || data == nil {
+		return
+	}
+	event.SetExtras(data)
+}

--- a/pkg/infra/plugins/regexreplace/data.go
+++ b/pkg/infra/plugins/regexreplace/data.go
@@ -23,12 +23,11 @@ const (
 )
 
 type Data struct {
-	Target       string `json:"target,omitempty"`
-	Stage        string `json:"stage,omitempty"`
-	Mode         string `json:"mode,omitempty"`
-	Decision     string `json:"decision,omitempty"`
-	RulesMatched int    `json:"rules_matched,omitempty"`
-	Changed      bool   `json:"changed,omitempty"`
+	Target   string `json:"target,omitempty"`
+	Stage    string `json:"stage,omitempty"`
+	Mode     string `json:"mode,omitempty"`
+	Decision string `json:"decision,omitempty"`
+	Changed  bool   `json:"changed,omitempty"`
 }
 
 func setExtras(event *metrics.EventContext, data *Data) {

--- a/pkg/infra/plugins/regexreplace/plugin.go
+++ b/pkg/infra/plugins/regexreplace/plugin.go
@@ -1,0 +1,176 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package regexreplace
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	appplugins "github.com/NeuralTrust/TrustGate/pkg/app/plugins"
+	"github.com/NeuralTrust/TrustGate/pkg/domain/policy"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/adapter"
+)
+
+var _ appplugins.Plugin = (*Plugin)(nil)
+
+type Plugin struct {
+	registry *adapter.Registry
+	logger   *slog.Logger
+}
+
+func New(registry *adapter.Registry, logger *slog.Logger) *Plugin {
+	return &Plugin{registry: registry, logger: logger}
+}
+
+func (p *Plugin) Name() string { return PluginName }
+
+func (p *Plugin) MandatoryStages() []policy.Stage {
+	return []policy.Stage{}
+}
+
+func (p *Plugin) SupportedStages() []policy.Stage {
+	return []policy.Stage{policy.StagePreRequest, policy.StagePreResponse}
+}
+
+func (p *Plugin) SupportedModes() []policy.Mode {
+	return []policy.Mode{policy.ModeEnforce, policy.ModeObserve}
+}
+
+func (p *Plugin) SupportedProtocols() []appplugins.Protocol {
+	return []appplugins.Protocol{appplugins.ProtocolLLM}
+}
+
+func (p *Plugin) MutatesRequestBody() bool { return true }
+
+func (p *Plugin) MutatesResponseBody() bool { return true }
+
+func (p *Plugin) MutatesMetadata() bool { return false }
+
+func (p *Plugin) ValidateConfig(settings map[string]any) error {
+	if _, err := parseConfig(settings); err != nil {
+		return fmt.Errorf("regex_replace: %w", err)
+	}
+	return nil
+}
+
+func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplugins.Result, error) {
+	cfg, err := parseConfig(in.Config.Settings)
+	if err != nil {
+		return nil, fmt.Errorf("regex_replace: %w", err)
+	}
+	switch in.Stage {
+	case policy.StagePreRequest:
+		if !cfg.isRequestLeg() {
+			return passThrough(), nil
+		}
+		return p.executeRequest(ctx, in, cfg)
+	case policy.StagePreResponse:
+		if !cfg.isResponseLeg() {
+			return passThrough(), nil
+		}
+		return p.executeResponse(ctx, in, cfg)
+	default:
+		return passThrough(), nil
+	}
+}
+
+func (p *Plugin) executeRequest(ctx context.Context, in appplugins.ExecInput, cfg Settings) (*appplugins.Result, error) {
+	if in.Request == nil || len(in.Request.Body) == 0 || in.Request.Provider == "" || p.registry == nil {
+		return passThrough(), nil
+	}
+	format, err := adapter.ResolveAgentFormat(in.Request.Provider, in.Request.SourceFormat, nil)
+	if err != nil {
+		p.debug(ctx, "resolve request format failed", slog.Any("error", err))
+		return passThrough(), nil
+	}
+	creq, err := p.registry.DecodeRequestFor(in.Request.Body, format)
+	if err != nil || creq == nil {
+		p.debug(ctx, "decode request failed", slog.Any("error", err))
+		return passThrough(), nil
+	}
+	body, changed, err := rewriteRequest(p.registry, format, creq, cfg.compiled)
+	if err != nil {
+		p.debug(ctx, "rewrite request failed", slog.Any("error", err))
+		return passThrough(), nil
+	}
+	return p.decide(in, cfg, changed, body, false), nil
+}
+
+func (p *Plugin) executeResponse(ctx context.Context, in appplugins.ExecInput, cfg Settings) (*appplugins.Result, error) {
+	if in.Request == nil || in.Response == nil || p.registry == nil {
+		return passThrough(), nil
+	}
+	if in.Request.Provider == "" || len(in.Response.Body) == 0 {
+		return passThrough(), nil
+	}
+	if in.Response.Streaming {
+		return passThrough(), nil
+	}
+	format, err := adapter.ResolveAgentFormat(in.Request.Provider, in.Request.SourceFormat, nil)
+	if err != nil {
+		p.debug(ctx, "resolve response format failed", slog.Any("error", err))
+		return passThrough(), nil
+	}
+	cresp, err := p.registry.DecodeResponseFor(in.Response.Body, format)
+	if err != nil || cresp == nil {
+		p.debug(ctx, "decode response failed", slog.Any("error", err))
+		return passThrough(), nil
+	}
+	body, changed, err := rewriteResponse(p.registry, format, cresp, cfg.compiled)
+	if err != nil {
+		p.debug(ctx, "rewrite response failed", slog.Any("error", err))
+		return passThrough(), nil
+	}
+	return p.decide(in, cfg, changed, body, true), nil
+}
+
+func (p *Plugin) decide(in appplugins.ExecInput, cfg Settings, changed bool, body []byte, isResponse bool) *appplugins.Result {
+	data := &Data{
+		Target:  cfg.Target,
+		Stage:   string(in.Stage),
+		Mode:    string(in.Mode),
+		Changed: changed,
+	}
+	if !changed {
+		data.Decision = decisionNoMatch
+		setExtras(in.Event, data)
+		return passThrough()
+	}
+	if !appplugins.Blocks(in.Mode) {
+		data.Decision = decisionObserved
+		setExtras(in.Event, data)
+		return passThrough()
+	}
+	data.Decision = decisionRewritten
+	setExtras(in.Event, data)
+	appplugins.SetDecisionFromOutcome(in.Event, decisionRewritten)
+	if isResponse {
+		return &appplugins.Result{StatusCode: http.StatusOK, Body: body, StopUpstream: true}
+	}
+	return &appplugins.Result{StatusCode: http.StatusOK, RequestBody: body}
+}
+
+func (p *Plugin) debug(ctx context.Context, msg string, attrs ...any) {
+	if p.logger == nil {
+		return
+	}
+	p.logger.DebugContext(ctx, msg, attrs...)
+}
+
+func passThrough() *appplugins.Result {
+	return &appplugins.Result{StatusCode: http.StatusOK}
+}

--- a/pkg/infra/plugins/regexreplace/plugin.go
+++ b/pkg/infra/plugins/regexreplace/plugin.go
@@ -159,9 +159,16 @@ func (p *Plugin) decide(in appplugins.ExecInput, cfg Settings, changed bool, bod
 	setExtras(in.Event, data)
 	appplugins.SetDecisionFromOutcome(in.Event, decisionRewritten)
 	if isResponse {
-		return &appplugins.Result{StatusCode: http.StatusOK, Body: body, StopUpstream: true}
+		return &appplugins.Result{StatusCode: responseStatus(in), Body: body, StopUpstream: true}
 	}
 	return &appplugins.Result{StatusCode: http.StatusOK, RequestBody: body}
+}
+
+func responseStatus(in appplugins.ExecInput) int {
+	if in.Response != nil && in.Response.StatusCode != 0 {
+		return in.Response.StatusCode
+	}
+	return http.StatusOK
 }
 
 func (p *Plugin) debug(ctx context.Context, msg string, attrs ...any) {

--- a/pkg/infra/plugins/regexreplace/plugin_test.go
+++ b/pkg/infra/plugins/regexreplace/plugin_test.go
@@ -399,7 +399,7 @@ func TestExecuteGuardPassThroughs(t *testing.T) {
 func TestRequestRewritePreservesNonTextFields(t *testing.T) {
 	t.Parallel()
 	p := New(adapter.NewRegistry(), nil)
-	body := []byte(`{"model":"gpt-4o","temperature":0.7,"tools":[{"type":"function","function":{"name":"get_weather","description":"d","parameters":{"type":"object"}}}],"messages":[{"role":"user","content":"my secret code"}]}`)
+	body := []byte(`{"model":"gpt-4o","temperature":0.7,"top_p":0.9,"stop":["END"],"seed":42,"tools":[{"type":"function","function":{"name":"get_weather","description":"d","parameters":{"type":"object"}}}],"messages":[{"role":"user","content":"my secret code"}]}`)
 	set := settings(targetRequest, maskRule("secret", "[REDACTED]"))
 	event, _ := newEvent()
 	in := execInput(policy.StagePreRequest, policy.ModeEnforce, set, reqCtx(openAIProvider, openAIProvider, body), nil, event)
@@ -411,13 +411,16 @@ func TestRequestRewritePreservesNonTextFields(t *testing.T) {
 	if res == nil || len(res.RequestBody) == 0 {
 		t.Fatalf("expected rewritten request body, got %+v", res)
 	}
-	for _, want := range []string{"gpt-4o", "temperature", "get_weather", "[REDACTED]"} {
+	for _, want := range []string{"gpt-4o", "temperature", "top_p", "stop", "get_weather", "[REDACTED]"} {
 		if !bytes.Contains(res.RequestBody, []byte(want)) {
-			t.Fatalf("rewritten body missing %q: %s", want, res.RequestBody)
+			t.Fatalf("rewritten body missing modeled field %q: %s", want, res.RequestBody)
 		}
 	}
 	if bytes.Contains(res.RequestBody, []byte("my secret code")) {
 		t.Fatalf("rewritten body still contains original secret: %s", res.RequestBody)
+	}
+	if bytes.Contains(res.RequestBody, []byte("seed")) {
+		t.Fatalf("canonical re-encode is expected to drop unmodeled fields; seed unexpectedly survived: %s", res.RequestBody)
 	}
 }
 

--- a/pkg/infra/plugins/regexreplace/plugin_test.go
+++ b/pkg/infra/plugins/regexreplace/plugin_test.go
@@ -1,0 +1,470 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package regexreplace
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"testing"
+
+	appplugins "github.com/NeuralTrust/TrustGate/pkg/app/plugins"
+	"github.com/NeuralTrust/TrustGate/pkg/domain/policy"
+	infracontext "github.com/NeuralTrust/TrustGate/pkg/infra/context"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/adapter"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/trace"
+)
+
+const (
+	openAIProvider    = "openai"
+	anthropicProvider = "anthropic"
+)
+
+func maskRule(pattern, replacement string) map[string]any {
+	return map[string]any{"pattern": pattern, "replacement": replacement}
+}
+
+func settings(target string, rules ...map[string]any) map[string]any {
+	return map[string]any{"target": target, "rules": rules}
+}
+
+func reqCtx(provider, source string, body []byte) *infracontext.RequestContext {
+	return &infracontext.RequestContext{Provider: provider, SourceFormat: source, Body: body}
+}
+
+func respCtx(body []byte, streaming bool) *infracontext.ResponseContext {
+	return &infracontext.ResponseContext{Body: body, Streaming: streaming}
+}
+
+func newEvent() (*metrics.EventContext, *trace.Span) {
+	tr := trace.New("", trace.Metadata{})
+	span := tr.StartSpan(trace.SpanPlugin, PluginName)
+	return metrics.NewEventContext(span), span
+}
+
+func execInput(stage policy.Stage, mode policy.Mode, set map[string]any, req *infracontext.RequestContext, resp *infracontext.ResponseContext, event *metrics.EventContext) appplugins.ExecInput {
+	return appplugins.ExecInput{
+		Stage:    stage,
+		Mode:     mode,
+		Config:   policy.PluginConfig{Settings: set},
+		Request:  req,
+		Response: resp,
+		Event:    event,
+	}
+}
+
+func openAIRequest(system, user string) []byte {
+	return []byte(`{"model":"gpt-4o","messages":[{"role":"system","content":"` + system + `"},{"role":"user","content":"` + user + `"}]}`)
+}
+
+func anthropicRequest(system, user string) []byte {
+	return []byte(`{"model":"claude-3","system":"` + system + `","messages":[{"role":"user","content":"` + user + `"}],"max_tokens":100}`)
+}
+
+func openAIResponse(content string) []byte {
+	return []byte(`{"id":"r1","model":"gpt-4o","choices":[{"message":{"role":"assistant","content":"` + content + `"},"finish_reason":"stop"}]}`)
+}
+
+func anthropicResponse(content string) []byte {
+	return []byte(`{"id":"msg_1","type":"message","role":"assistant","model":"claude","content":[{"type":"text","text":"` + content + `"}],"stop_reason":"end_turn","usage":{"input_tokens":30,"output_tokens":15}}`)
+}
+
+func assertPassThrough(t *testing.T, res *appplugins.Result, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if res == nil || res.StatusCode != http.StatusOK || res.StopUpstream || res.Body != nil || res.RequestBody != nil {
+		t.Fatalf("expected pass-through, got %+v", res)
+	}
+}
+
+func extras(t *testing.T, span *trace.Span) *Data {
+	t.Helper()
+	if span.Plugin == nil {
+		t.Fatal("expected plugin span attrs")
+	}
+	data, ok := span.Plugin.Extras.(*Data)
+	if !ok {
+		t.Fatalf("expected *Data extras, got %T", span.Plugin.Extras)
+	}
+	return data
+}
+
+func TestDescriptor(t *testing.T) {
+	t.Parallel()
+	p := New(adapter.NewRegistry(), nil)
+
+	if p.Name() != PluginName {
+		t.Fatalf("Name = %q, want %q", p.Name(), PluginName)
+	}
+	if len(p.MandatoryStages()) != 0 {
+		t.Fatalf("MandatoryStages = %v, want empty", p.MandatoryStages())
+	}
+	stages := p.SupportedStages()
+	if len(stages) != 2 || stages[0] != policy.StagePreRequest || stages[1] != policy.StagePreResponse {
+		t.Fatalf("SupportedStages = %v", stages)
+	}
+	modes := p.SupportedModes()
+	if len(modes) != 2 || modes[0] != policy.ModeEnforce || modes[1] != policy.ModeObserve {
+		t.Fatalf("SupportedModes = %v", modes)
+	}
+	protocols := p.SupportedProtocols()
+	if len(protocols) != 1 || protocols[0] != appplugins.ProtocolLLM {
+		t.Fatalf("SupportedProtocols = %v", protocols)
+	}
+	if !p.MutatesRequestBody() || !p.MutatesResponseBody() {
+		t.Fatal("MutatesRequestBody and MutatesResponseBody must be true")
+	}
+	if p.MutatesMetadata() {
+		t.Fatal("MutatesMetadata must be false")
+	}
+}
+
+func TestValidateConfigRejectsInvalid(t *testing.T) {
+	t.Parallel()
+	p := New(adapter.NewRegistry(), nil)
+	if err := p.ValidateConfig(settings("both", maskRule("a", "b"))); err == nil {
+		t.Fatal("expected error for invalid target")
+	}
+	if err := p.ValidateConfig(settings(targetRequest, maskRule("a", "b"))); err != nil {
+		t.Fatalf("expected valid config, got %v", err)
+	}
+}
+
+func TestStageTargetNoOp(t *testing.T) {
+	t.Parallel()
+	p := New(adapter.NewRegistry(), nil)
+
+	tests := []struct {
+		name  string
+		stage policy.Stage
+		set   map[string]any
+		req   *infracontext.RequestContext
+		resp  *infracontext.ResponseContext
+	}{
+		{
+			name:  "request target on pre_response",
+			stage: policy.StagePreResponse,
+			set:   settings(targetRequest, maskRule("world", "earth")),
+			req:   reqCtx(openAIProvider, openAIProvider, openAIRequest("be safe", "hello world")),
+			resp:  respCtx(openAIResponse("hello world"), false),
+		},
+		{
+			name:  "response target on pre_request",
+			stage: policy.StagePreRequest,
+			set:   settings(targetResponse, maskRule("world", "earth")),
+			req:   reqCtx(openAIProvider, openAIProvider, openAIRequest("be safe", "hello world")),
+			resp:  nil,
+		},
+		{
+			name:  "unsupported stage",
+			stage: policy.StagePostResponse,
+			set:   settings(targetRequest, maskRule("world", "earth")),
+			req:   reqCtx(openAIProvider, openAIProvider, openAIRequest("be safe", "hello world")),
+			resp:  respCtx(openAIResponse("hello world"), false),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			event, span := newEvent()
+			in := execInput(tt.stage, policy.ModeEnforce, tt.set, tt.req, tt.resp, event)
+			res, err := p.Execute(context.Background(), in)
+			assertPassThrough(t, res, err)
+			if span.Plugin != nil && span.Plugin.Extras != nil {
+				t.Fatalf("expected no telemetry on stage/target no-op, got %+v", span.Plugin.Extras)
+			}
+		})
+	}
+}
+
+func TestRequestLegRewrite(t *testing.T) {
+	t.Parallel()
+	p := New(adapter.NewRegistry(), nil)
+	set := settings(targetRequest, maskRule("secret", "[REDACTED]"))
+	event, span := newEvent()
+	in := execInput(policy.StagePreRequest, policy.ModeEnforce, set, reqCtx(openAIProvider, openAIProvider, openAIRequest("keep secret", "my secret code")), nil, event)
+
+	res, err := p.Execute(context.Background(), in)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if res == nil || res.StatusCode != http.StatusOK || res.StopUpstream || len(res.RequestBody) == 0 || res.Body != nil {
+		t.Fatalf("expected request rewrite result, got %+v", res)
+	}
+	creq, err := adapter.NewRegistry().DecodeRequestFor(res.RequestBody, adapter.FormatOpenAI)
+	if err != nil {
+		t.Fatalf("decode rewritten request: %v", err)
+	}
+	if creq.System != "keep [REDACTED]" {
+		t.Fatalf("system = %q, want %q", creq.System, "keep [REDACTED]")
+	}
+	if got := creq.Messages[len(creq.Messages)-1].Content; got != "my [REDACTED] code" {
+		t.Fatalf("user content = %q, want %q", got, "my [REDACTED] code")
+	}
+	if d := extras(t, span); d.Decision != decisionRewritten || !d.Changed {
+		t.Fatalf("extras = %+v, want rewritten+changed", d)
+	}
+}
+
+func TestResponseLegRewrite(t *testing.T) {
+	t.Parallel()
+	p := New(adapter.NewRegistry(), nil)
+	set := settings(targetResponse, maskRule("answer", "solution"))
+	event, span := newEvent()
+	in := execInput(policy.StagePreResponse, policy.ModeEnforce, set, reqCtx(openAIProvider, openAIProvider, openAIRequest("be safe", "question")), respCtx(openAIResponse("the answer"), false), event)
+
+	res, err := p.Execute(context.Background(), in)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if res == nil || res.StatusCode != http.StatusOK || !res.StopUpstream || len(res.Body) == 0 || res.RequestBody != nil {
+		t.Fatalf("expected response rewrite with StopUpstream, got %+v", res)
+	}
+	cresp, err := adapter.NewRegistry().DecodeResponseFor(res.Body, adapter.FormatOpenAI)
+	if err != nil {
+		t.Fatalf("decode rewritten response: %v", err)
+	}
+	if cresp.Content != "the solution" {
+		t.Fatalf("content = %q, want %q", cresp.Content, "the solution")
+	}
+	if d := extras(t, span); d.Decision != decisionRewritten {
+		t.Fatalf("decision = %q, want %q", d.Decision, decisionRewritten)
+	}
+}
+
+func TestObserveModeDoesNotMutate(t *testing.T) {
+	t.Parallel()
+	p := New(adapter.NewRegistry(), nil)
+
+	t.Run("request", func(t *testing.T) {
+		t.Parallel()
+		set := settings(targetRequest, maskRule("secret", "[REDACTED]"))
+		event, span := newEvent()
+		in := execInput(policy.StagePreRequest, policy.ModeObserve, set, reqCtx(openAIProvider, openAIProvider, openAIRequest("be safe", "my secret")), nil, event)
+		res, err := p.Execute(context.Background(), in)
+		assertPassThrough(t, res, err)
+		if d := extras(t, span); d.Decision != decisionObserved || !d.Changed {
+			t.Fatalf("extras = %+v, want observed+changed", d)
+		}
+	})
+
+	t.Run("response", func(t *testing.T) {
+		t.Parallel()
+		set := settings(targetResponse, maskRule("answer", "solution"))
+		event, span := newEvent()
+		in := execInput(policy.StagePreResponse, policy.ModeObserve, set, reqCtx(openAIProvider, openAIProvider, openAIRequest("be safe", "q")), respCtx(openAIResponse("the answer"), false), event)
+		res, err := p.Execute(context.Background(), in)
+		assertPassThrough(t, res, err)
+		if d := extras(t, span); d.Decision != decisionObserved {
+			t.Fatalf("decision = %q, want %q", d.Decision, decisionObserved)
+		}
+	})
+}
+
+func TestStreamingResponsePassThrough(t *testing.T) {
+	t.Parallel()
+	p := New(adapter.NewRegistry(), nil)
+	set := settings(targetResponse, maskRule("answer", "solution"))
+	event, span := newEvent()
+	in := execInput(policy.StagePreResponse, policy.ModeEnforce, set, reqCtx(openAIProvider, openAIProvider, openAIRequest("be safe", "q")), respCtx(openAIResponse("the answer"), true), event)
+
+	res, err := p.Execute(context.Background(), in)
+	assertPassThrough(t, res, err)
+	if span.Plugin != nil && span.Plugin.Extras != nil {
+		t.Fatalf("expected no telemetry on streaming pass-through, got %+v", span.Plugin.Extras)
+	}
+}
+
+func TestNoMatchNoMutation(t *testing.T) {
+	t.Parallel()
+	p := New(adapter.NewRegistry(), nil)
+	set := settings(targetRequest, maskRule("absent", "x"))
+	event, span := newEvent()
+	in := execInput(policy.StagePreRequest, policy.ModeEnforce, set, reqCtx(openAIProvider, openAIProvider, openAIRequest("be safe", "hello world")), nil, event)
+
+	res, err := p.Execute(context.Background(), in)
+	assertPassThrough(t, res, err)
+	d := extras(t, span)
+	if d.Decision != decisionNoMatch || d.Changed {
+		t.Fatalf("extras = %+v, want no_match and changed=false", d)
+	}
+}
+
+func TestCrossProviderRewrite(t *testing.T) {
+	t.Parallel()
+	p := New(adapter.NewRegistry(), nil)
+
+	tests := []struct {
+		name     string
+		provider string
+		format   adapter.Format
+		body     []byte
+	}{
+		{"openai", openAIProvider, adapter.FormatOpenAI, openAIRequest("keep secret", "my secret")},
+		{"anthropic", anthropicProvider, adapter.FormatAnthropic, anthropicRequest("keep secret", "my secret")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			set := settings(targetRequest, maskRule("secret", "[REDACTED]"))
+			event, _ := newEvent()
+			in := execInput(policy.StagePreRequest, policy.ModeEnforce, set, reqCtx(tt.provider, tt.provider, tt.body), nil, event)
+			res, err := p.Execute(context.Background(), in)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if res == nil || len(res.RequestBody) == 0 {
+				t.Fatalf("expected rewritten request body, got %+v", res)
+			}
+			creq, err := adapter.NewRegistry().DecodeRequestFor(res.RequestBody, tt.format)
+			if err != nil {
+				t.Fatalf("decode rewritten request: %v", err)
+			}
+			if creq.System != "keep [REDACTED]" {
+				t.Fatalf("system = %q, want %q", creq.System, "keep [REDACTED]")
+			}
+			if got := creq.Messages[len(creq.Messages)-1].Content; got != "my [REDACTED]" {
+				t.Fatalf("user content = %q, want %q", got, "my [REDACTED]")
+			}
+		})
+	}
+}
+
+func TestCrossProviderResponseRewrite(t *testing.T) {
+	t.Parallel()
+	p := New(adapter.NewRegistry(), nil)
+	set := settings(targetResponse, maskRule("answer", "solution"))
+	event, _ := newEvent()
+	in := execInput(policy.StagePreResponse, policy.ModeEnforce, set, reqCtx(anthropicProvider, anthropicProvider, anthropicRequest("be safe", "q")), respCtx(anthropicResponse("the answer"), false), event)
+
+	res, err := p.Execute(context.Background(), in)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if res == nil || !res.StopUpstream || len(res.Body) == 0 {
+		t.Fatalf("expected anthropic response rewrite, got %+v", res)
+	}
+	cresp, err := adapter.NewRegistry().DecodeResponseFor(res.Body, adapter.FormatAnthropic)
+	if err != nil {
+		t.Fatalf("decode rewritten response: %v", err)
+	}
+	if cresp.Content != "the solution" {
+		t.Fatalf("content = %q, want %q", cresp.Content, "the solution")
+	}
+}
+
+func TestExecuteGuardPassThroughs(t *testing.T) {
+	t.Parallel()
+	p := New(adapter.NewRegistry(), nil)
+
+	tests := []struct {
+		name  string
+		stage policy.Stage
+		set   map[string]any
+		req   *infracontext.RequestContext
+		resp  *infracontext.ResponseContext
+	}{
+		{"nil request", policy.StagePreRequest, settings(targetRequest, maskRule("a", "b")), nil, nil},
+		{"empty request body", policy.StagePreRequest, settings(targetRequest, maskRule("a", "b")), reqCtx(openAIProvider, openAIProvider, nil), nil},
+		{"empty provider request", policy.StagePreRequest, settings(targetRequest, maskRule("a", "b")), reqCtx("", "", openAIRequest("s", "u")), nil},
+		{"nil response", policy.StagePreResponse, settings(targetResponse, maskRule("a", "b")), reqCtx(openAIProvider, openAIProvider, openAIRequest("s", "u")), nil},
+		{"empty response body", policy.StagePreResponse, settings(targetResponse, maskRule("a", "b")), reqCtx(openAIProvider, openAIProvider, openAIRequest("s", "u")), respCtx(nil, false)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			event, _ := newEvent()
+			in := execInput(tt.stage, policy.ModeEnforce, tt.set, tt.req, tt.resp, event)
+			res, err := p.Execute(context.Background(), in)
+			assertPassThrough(t, res, err)
+		})
+	}
+}
+
+func TestRequestRewritePreservesNonTextFields(t *testing.T) {
+	t.Parallel()
+	p := New(adapter.NewRegistry(), nil)
+	body := []byte(`{"model":"gpt-4o","temperature":0.7,"tools":[{"type":"function","function":{"name":"get_weather","description":"d","parameters":{"type":"object"}}}],"messages":[{"role":"user","content":"my secret code"}]}`)
+	set := settings(targetRequest, maskRule("secret", "[REDACTED]"))
+	event, _ := newEvent()
+	in := execInput(policy.StagePreRequest, policy.ModeEnforce, set, reqCtx(openAIProvider, openAIProvider, body), nil, event)
+
+	res, err := p.Execute(context.Background(), in)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if res == nil || len(res.RequestBody) == 0 {
+		t.Fatalf("expected rewritten request body, got %+v", res)
+	}
+	for _, want := range []string{"gpt-4o", "temperature", "get_weather", "[REDACTED]"} {
+		if !bytes.Contains(res.RequestBody, []byte(want)) {
+			t.Fatalf("rewritten body missing %q: %s", want, res.RequestBody)
+		}
+	}
+	if bytes.Contains(res.RequestBody, []byte("my secret code")) {
+		t.Fatalf("rewritten body still contains original secret: %s", res.RequestBody)
+	}
+}
+
+func TestExecuteDoesNotMutateInputBodyInPlace(t *testing.T) {
+	t.Parallel()
+	p := New(adapter.NewRegistry(), nil)
+
+	t.Run("request", func(t *testing.T) {
+		t.Parallel()
+		original := openAIRequest("keep secret", "my secret code")
+		snapshot := append([]byte(nil), original...)
+		event, _ := newEvent()
+		req := reqCtx(openAIProvider, openAIProvider, original)
+		in := execInput(policy.StagePreRequest, policy.ModeEnforce, settings(targetRequest, maskRule("secret", "[REDACTED]")), req, nil, event)
+		if _, err := p.Execute(context.Background(), in); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if !bytes.Equal(req.Body, snapshot) {
+			t.Fatalf("request body mutated in place: %s", req.Body)
+		}
+	})
+
+	t.Run("response", func(t *testing.T) {
+		t.Parallel()
+		original := openAIResponse("the answer")
+		snapshot := append([]byte(nil), original...)
+		event, _ := newEvent()
+		resp := respCtx(original, false)
+		in := execInput(policy.StagePreResponse, policy.ModeEnforce, settings(targetResponse, maskRule("answer", "solution")), reqCtx(openAIProvider, openAIProvider, openAIRequest("s", "u")), resp, event)
+		if _, err := p.Execute(context.Background(), in); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if !bytes.Equal(resp.Body, snapshot) {
+			t.Fatalf("response body mutated in place: %s", resp.Body)
+		}
+	})
+}
+
+func TestExecuteInvalidConfigErrors(t *testing.T) {
+	t.Parallel()
+	p := New(adapter.NewRegistry(), nil)
+	in := execInput(policy.StagePreRequest, policy.ModeEnforce, settings("both", maskRule("a", "b")), reqCtx(openAIProvider, openAIProvider, openAIRequest("s", "u")), nil, nil)
+	res, err := p.Execute(context.Background(), in)
+	if err == nil {
+		t.Fatal("expected error on invalid config")
+	}
+	if res != nil {
+		t.Fatalf("expected nil result on invalid config, got %+v", res)
+	}
+}

--- a/pkg/infra/plugins/regexreplace/replace.go
+++ b/pkg/infra/plugins/regexreplace/replace.go
@@ -1,0 +1,23 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package regexreplace
+
+func applyRules(rules []compiledRule, input string) (string, bool) {
+	out := input
+	for _, r := range rules {
+		out = r.re.ReplaceAllString(out, r.replacement)
+	}
+	return out, out != input
+}

--- a/pkg/infra/plugins/regexreplace/replace.go
+++ b/pkg/infra/plugins/regexreplace/replace.go
@@ -14,10 +14,60 @@
 
 package regexreplace
 
+import "github.com/NeuralTrust/TrustGate/pkg/infra/providers/adapter"
+
 func applyRules(rules []compiledRule, input string) (string, bool) {
 	out := input
 	for _, r := range rules {
 		out = r.re.ReplaceAllString(out, r.replacement)
 	}
 	return out, out != input
+}
+
+func rewriteRequest(reg *adapter.Registry, format adapter.Format, creq *adapter.CanonicalRequest, rules []compiledRule) ([]byte, bool, error) {
+	adp, err := reg.GetAdapter(format)
+	if err != nil {
+		return nil, false, err
+	}
+	changed := false
+	if creq.System != "" {
+		if out, did := applyRules(rules, creq.System); did {
+			creq.System = out
+			changed = true
+		}
+	}
+	for i := range creq.Messages {
+		if creq.Messages[i].Content == "" {
+			continue
+		}
+		if out, did := applyRules(rules, creq.Messages[i].Content); did {
+			creq.Messages[i].Content = out
+			changed = true
+		}
+	}
+	if !changed {
+		return nil, false, nil
+	}
+	body, err := adp.EncodeRequest(creq)
+	if err != nil {
+		return nil, false, err
+	}
+	return body, true, nil
+}
+
+func rewriteResponse(reg *adapter.Registry, format adapter.Format, cresp *adapter.CanonicalResponse, rules []compiledRule) ([]byte, bool, error) {
+	adp, err := reg.GetAdapter(format)
+	if err != nil {
+		return nil, false, err
+	}
+	out, changed := applyRules(rules, cresp.Content)
+	if !changed {
+		return nil, false, nil
+	}
+	cresp.Content = out
+	body, err := adp.EncodeResponse(cresp)
+	if err != nil {
+		return nil, false, err
+	}
+	return body, true, nil
 }

--- a/pkg/infra/plugins/regexreplace/replace_test.go
+++ b/pkg/infra/plugins/regexreplace/replace_test.go
@@ -1,0 +1,138 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package regexreplace
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mustCompile(t *testing.T, rules ...Rule) []compiledRule {
+	t.Helper()
+	out := make([]compiledRule, 0, len(rules))
+	for _, r := range rules {
+		re, err := regexp.Compile(buildPattern(r))
+		require.NoError(t, err)
+		out = append(out, compiledRule{re: re, replacement: r.Replacement})
+	}
+	return out
+}
+
+func TestApplyRules(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		rules       []Rule
+		input       string
+		want        string
+		wantChanged bool
+	}{
+		{
+			name:        "single match",
+			rules:       []Rule{{Pattern: "foo", Replacement: "bar"}},
+			input:       "foo baz",
+			want:        "bar baz",
+			wantChanged: true,
+		},
+		{
+			name:        "capture group",
+			rules:       []Rule{{Pattern: `(\w+)@example\.com`, Replacement: "$1@masked"}},
+			input:       "alice@example.com",
+			want:        "alice@masked",
+			wantChanged: true,
+		},
+		{
+			name:        "named group",
+			rules:       []Rule{{Pattern: `(?P<name>\w+)@example\.com`, Replacement: "${name}@masked"}},
+			input:       "bob@example.com",
+			want:        "bob@masked",
+			wantChanged: true,
+		},
+		{
+			name: "chaining",
+			rules: []Rule{
+				{Pattern: "a", Replacement: "b"},
+				{Pattern: "b", Replacement: "c"},
+			},
+			input:       "a",
+			want:        "c",
+			wantChanged: true,
+		},
+		{
+			name:        "no match",
+			rules:       []Rule{{Pattern: "zzz", Replacement: "x"}},
+			input:       "foo bar",
+			want:        "foo bar",
+			wantChanged: false,
+		},
+		{
+			name:        "empty replacement deletes",
+			rules:       []Rule{{Pattern: `\d+`, Replacement: ""}},
+			input:       "abc123def",
+			want:        "abcdef",
+			wantChanged: true,
+		},
+		{
+			name:        "case insensitive flag matches",
+			rules:       []Rule{{Pattern: "foo", Replacement: "bar", CaseInsensitive: true}},
+			input:       "FOO baz",
+			want:        "bar baz",
+			wantChanged: true,
+		},
+		{
+			name:        "case insensitive off does not match",
+			rules:       []Rule{{Pattern: "foo", Replacement: "bar"}},
+			input:       "FOO baz",
+			want:        "FOO baz",
+			wantChanged: false,
+		},
+		{
+			name:        "multiline flag anchors each line",
+			rules:       []Rule{{Pattern: "^foo$", Replacement: "bar", Multiline: true}},
+			input:       "x\nfoo\ny",
+			want:        "x\nbar\ny",
+			wantChanged: true,
+		},
+		{
+			name:        "multiline off does not anchor inner line",
+			rules:       []Rule{{Pattern: "^foo$", Replacement: "bar"}},
+			input:       "x\nfoo\ny",
+			want:        "x\nfoo\ny",
+			wantChanged: false,
+		},
+		{
+			name: "net no-op",
+			rules: []Rule{
+				{Pattern: "a", Replacement: "b"},
+				{Pattern: "b", Replacement: "a"},
+			},
+			input:       "a",
+			want:        "a",
+			wantChanged: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, changed := applyRules(mustCompile(t, tt.rules...), tt.input)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantChanged, changed)
+		})
+	}
+}

--- a/postman/TrustGate.postman_collection.json
+++ b/postman/TrustGate.postman_collection.json
@@ -1055,6 +1055,34 @@
           }
         },
         {
+          "name": "Create Policy (regex_replace)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"regex-replace-request-{{$guid}}\",\n  \"slug\": \"regex_replace\",\n  \"enabled\": true,\n  \"priority\": 0,\n  \"parallel\": false,\n  \"stages\": [\n    \"pre_request\"\n  ],\n  \"settings\": {\n    \"target\": \"request\",\n    \"rules\": [\n      {\n        \"pattern\": \"(?i)password\\\\s*[:=]\\\\s*\\\\S+\",\n        \"replacement\": \"password: [REDACTED]\"\n      }\n    ]\n  }\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/gateways/{{gateway_id}}/policies",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "v1",
+                "gateways",
+                "{{gateway_id}}",
+                "policies"
+              ]
+            }
+          }
+        },
+        {
           "name": "List Policies",
           "request": {
             "method": "GET",

--- a/tests/functional/plugin_regex_replace_test.go
+++ b/tests/functional/plugin_regex_replace_test.go
@@ -1,0 +1,68 @@
+//go:build functional
+
+package functional_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func regexReplaceSettings(target string, rules []map[string]any) map[string]any {
+	return map[string]any{
+		"target": target,
+		"rules":  rules,
+	}
+}
+
+func regexReplacePolicy(settings map[string]any, stages ...string) map[string]any {
+	entry := policyPlugin("regex_replace", settings)
+	entry["stages"] = stages
+	return entry
+}
+
+func regexReplaceChatRequest(content string) map[string]any {
+	return map[string]any{
+		"model":    "gpt-4o-mini",
+		"messages": []map[string]string{{"role": "user", "content": content}},
+	}
+}
+
+func TestPluginE2E_RegexReplace_RequestLeg(t *testing.T) {
+	defer Track(t, "PluginRegexReplace")()
+
+	up := newJSONUpstream(t, "regex-request-served")
+	settings := regexReplaceSettings("request", []map[string]any{
+		{"pattern": "secret", "replacement": "[REDACTED]"},
+	})
+	apiKey, path := setupPolicyRoute(t, up, regexReplacePolicy(settings, "pre_request"))
+
+	status, _, raw := proxyRequest(t, http.MethodPost, apiKey, path, nil,
+		mustJSON(t, regexReplaceChatRequest("my secret token is 12345")),
+	)
+
+	assert.Equal(t, http.StatusOK, status, "body: %s", raw)
+	assert.GreaterOrEqual(t, up.Hits(), 1, "a rewritten request is still forwarded")
+	assert.Contains(t, string(up.LastBody()), "[REDACTED]", "the masked text must reach the upstream")
+	assert.NotContains(t, string(up.LastBody()), "secret", "the raw text must not reach the upstream")
+}
+
+func TestPluginE2E_RegexReplace_ResponseLeg(t *testing.T) {
+	defer Track(t, "PluginRegexReplace")()
+
+	up := newJSONUpstream(t, "the answer is 42")
+	settings := regexReplaceSettings("response", []map[string]any{
+		{"pattern": "answer", "replacement": "solution"},
+	})
+	apiKey, path := setupPolicyRoute(t, up, regexReplacePolicy(settings, "pre_response"))
+
+	status, _, raw := proxyRequest(t, http.MethodPost, apiKey, path, nil,
+		mustJSON(t, regexReplaceChatRequest("what is the answer?")),
+	)
+
+	assert.Equal(t, http.StatusOK, status, "body: %s", raw)
+	assert.Equal(t, 1, up.Hits(), "the response rewrite must not trigger a second upstream call")
+	assert.Contains(t, string(raw), "solution", "the client must see the rewritten response text")
+	assert.NotContains(t, string(raw), "answer", "the original response text must not reach the client")
+}


### PR DESCRIPTION
## Summary
- New `regex_replace` plugin under `pkg/infra/plugins/regexreplace/`: applies configured regex rules to a single leg per instance — the request prompt (`pre_request`) XOR the LLM response (`pre_response`).
- Registered in the plugin catalog (`Guardrails` group) and wired via DI (`pkg/container/modules/plugins.go`).
- Fail-open behavior on undecodable bodies (mirrors `bedrock_guardrail`); config errors surface at validation.
- Preserves the upstream response status code on response-leg rewrites instead of forcing 200.
- Unit + functional test coverage, Postman entry, and `docs/policies.json` metadata.

## Linear
RUN-993 — https://linear.app/neuraltrust/issue/RUN-993/featplugins-regex-replace-plugin

## Known limitation
On a match, the leg is re-encoded from the canonical model, so provider-specific fields not represented in the canonical model (e.g. `seed`, `user`, `presence_penalty`, `logit_bias`) are dropped. No-match traffic forwards original bytes untouched. Documented in the design doc and locked by `TestRequestRewritePreservesNonTextFields`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/infra/plugins/regexreplace/... ./pkg/app/plugins/...`
- [ ] Functional test `tests/functional/plugin_regex_replace_test.go` in CI

Made with [Cursor](https://cursor.com)