### PR TITLE
fix(configsync): propagate snapshot recompile across admin replicas

### DIFF
--- a/pkg/container/modules/cache_events.go
+++ b/pkg/container/modules/cache_events.go
@@ -54,6 +54,7 @@ type CacheEventListenerParams struct {
 	Listener         cache.EventListener
 	GatewayDataSub   cache.EventSubscriber[event.InvalidateGatewayDataEvent]
 	RegistryCacheSub cache.EventSubscriber[event.InvalidateRegistryCacheEvent]
+	SnapshotDirtySub cache.EventSubscriber[event.SnapshotDirtyEvent] `optional:"true"`
 }
 
 // StartCacheEventListener registers the cache invalidation subscribers and
@@ -62,6 +63,9 @@ type CacheEventListenerParams struct {
 func StartCacheEventListener(ctx context.Context, p CacheEventListenerParams) {
 	cache.RegisterEventSubscriber(p.Listener, p.GatewayDataSub)
 	cache.RegisterEventSubscriber(p.Listener, p.RegistryCacheSub)
+	if p.SnapshotDirtySub != nil {
+		cache.RegisterEventSubscriber(p.Listener, p.SnapshotDirtySub)
+	}
 
 	go p.Listener.Listen(ctx, channel.GatewayEventsChannel)
 	p.Logger.Info(bootlog.CacheListenerStarted, slog.String("channel", string(channel.GatewayEventsChannel)))

--- a/pkg/container/modules/control_config_sync.go
+++ b/pkg/container/modules/control_config_sync.go
@@ -30,6 +30,8 @@ import (
 	policydomain "github.com/NeuralTrust/TrustGate/pkg/domain/policy"
 	registrydomain "github.com/NeuralTrust/TrustGate/pkg/domain/registry"
 	roledomain "github.com/NeuralTrust/TrustGate/pkg/domain/role"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/cache"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/cache/subscriber"
 	infrasnapshot "github.com/NeuralTrust/TrustGate/pkg/infra/configsnapshot"
 	snapshotpb "github.com/NeuralTrust/TrustGate/pkg/infra/configsnapshot/proto"
 	configsyncgrpc "github.com/NeuralTrust/TrustGate/pkg/infra/configsync/grpc"
@@ -140,7 +142,15 @@ func ControlConfigSync(c *container.Container) error {
 	}); err != nil {
 		return err
 	}
-	return c.Provide(func(p *appsnapshot.SnapshotVersionPublisher) configsyncport.SnapshotSignaler {
-		return p
-	})
+	if err := c.Provide(func(p *appsnapshot.SnapshotVersionPublisher, publisher cache.EventPublisher, logger *slog.Logger) configsyncport.SnapshotSignaler {
+		return infrasnapshot.NewDistributedSignaler(p, publisher, logger)
+	}); err != nil {
+		return err
+	}
+	if err := c.Provide(func(d *appsnapshot.Dispatcher) subscriber.SnapshotSignaler {
+		return d
+	}); err != nil {
+		return err
+	}
+	return c.Provide(subscriber.NewSnapshotDirtyEventSubscriber)
 }

--- a/pkg/infra/cache/event/events.go
+++ b/pkg/infra/cache/event/events.go
@@ -24,12 +24,14 @@ var (
 	DeleteGatewayCacheEventType      = "DeleteGatewayCacheEvent"
 	InvalidateGatewayDataEventType   = "InvalidateGatewayDataEvent"
 	InvalidateRegistryCacheEventType = "InvalidateRegistryCacheEvent"
+	SnapshotDirtyEventType           = "SnapshotDirtyEvent"
 )
 
 var Registry = map[string]reflect.Type{
 	DeleteGatewayCacheEventType:      reflect.TypeOf(DeleteGatewayCacheEvent{}),
 	InvalidateGatewayDataEventType:   reflect.TypeOf(InvalidateGatewayDataEvent{}),
 	InvalidateRegistryCacheEventType: reflect.TypeOf(InvalidateRegistryCacheEvent{}),
+	SnapshotDirtyEventType:           reflect.TypeOf(SnapshotDirtyEvent{}),
 }
 
 func GetEventsRegistry() map[string]reflect.Type {

--- a/pkg/infra/cache/event/snapshot_dirty_event.go
+++ b/pkg/infra/cache/event/snapshot_dirty_event.go
@@ -1,0 +1,26 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package event
+
+// SnapshotDirtyEvent signals that config feeding the runtime snapshot changed on
+// one admin replica, so every admin replica must recompile and push a new
+// snapshot version to its connected data planes. Version broadcast is in-process
+// per admin pod, so without this cross-pod nudge a replica that did not handle
+// the write would only converge on its periodic backstop timer.
+type SnapshotDirtyEvent struct{}
+
+func (e SnapshotDirtyEvent) Type() string {
+	return SnapshotDirtyEventType
+}

--- a/pkg/infra/cache/subscriber/snapshot_dirty_event_subscriber.go
+++ b/pkg/infra/cache/subscriber/snapshot_dirty_event_subscriber.go
@@ -1,0 +1,49 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package subscriber
+
+import (
+	"context"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/cache"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/cache/event"
+)
+
+// SnapshotSignaler triggers a local recompile-and-broadcast of the runtime
+// config snapshot. It is satisfied by the config-sync dispatcher.
+type SnapshotSignaler interface {
+	Signal()
+}
+
+var _ cache.EventSubscriber[event.SnapshotDirtyEvent] = (*SnapshotDirtyEventSubscriber)(nil)
+
+// SnapshotDirtyEventSubscriber recompiles the local snapshot when a peer admin
+// replica reports a config change, so every replica pushes the new version to
+// its own connected data planes without waiting for the backstop timer.
+type SnapshotDirtyEventSubscriber struct {
+	signaler SnapshotSignaler
+}
+
+func NewSnapshotDirtyEventSubscriber(signaler SnapshotSignaler) cache.EventSubscriber[event.SnapshotDirtyEvent] {
+	return &SnapshotDirtyEventSubscriber{signaler: signaler}
+}
+
+func (s *SnapshotDirtyEventSubscriber) OnEvent(_ context.Context, _ event.SnapshotDirtyEvent) error {
+	if s.signaler == nil {
+		return nil
+	}
+	s.signaler.Signal()
+	return nil
+}

--- a/pkg/infra/cache/subscriber/snapshot_dirty_event_subscriber_test.go
+++ b/pkg/infra/cache/subscriber/snapshot_dirty_event_subscriber_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package subscriber_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/cache/event"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/cache/subscriber"
+)
+
+type countingSignaler struct {
+	calls int
+}
+
+func (c *countingSignaler) Signal() {
+	c.calls++
+}
+
+func TestSnapshotDirtyEventSubscriber_OnEvent_SignalsLocalRecompile(t *testing.T) {
+	t.Parallel()
+	signaler := &countingSignaler{}
+	sub := subscriber.NewSnapshotDirtyEventSubscriber(signaler)
+
+	if err := sub.OnEvent(context.Background(), event.SnapshotDirtyEvent{}); err != nil {
+		t.Fatalf("OnEvent error: %v", err)
+	}
+
+	if signaler.calls != 1 {
+		t.Fatalf("expected local recompile to be signalled once, got %d", signaler.calls)
+	}
+}
+
+func TestSnapshotDirtyEventSubscriber_OnEvent_NilSignalerIsNoOp(t *testing.T) {
+	t.Parallel()
+	sub := subscriber.NewSnapshotDirtyEventSubscriber(nil)
+
+	if err := sub.OnEvent(context.Background(), event.SnapshotDirtyEvent{}); err != nil {
+		t.Fatalf("OnEvent with nil signaler must not error: %v", err)
+	}
+}

--- a/pkg/infra/configsnapshot/distributed_signaler.go
+++ b/pkg/infra/configsnapshot/distributed_signaler.go
@@ -1,0 +1,58 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configsnapshot
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/cache"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/cache/event"
+)
+
+// LocalSignaler triggers a recompile-and-broadcast on the current process.
+type LocalSignaler interface {
+	Signal(ctx context.Context)
+}
+
+// DistributedSignaler recompiles the snapshot on the local admin process and
+// fans the same nudge out to every other admin replica over the Redis event bus.
+//
+// Version broadcast to data planes is in-process per admin pod: a write handled
+// by replica A only reaches the data planes streaming from A. Publishing a
+// SnapshotDirtyEvent makes replica B recompile and push to its own data planes
+// immediately, instead of leaving them stale until B's periodic backstop fires.
+type DistributedSignaler struct {
+	local     LocalSignaler
+	publisher cache.EventPublisher
+	logger    *slog.Logger
+}
+
+func NewDistributedSignaler(local LocalSignaler, publisher cache.EventPublisher, logger *slog.Logger) *DistributedSignaler {
+	return &DistributedSignaler{local: local, publisher: publisher, logger: logger}
+}
+
+func (s *DistributedSignaler) Signal(ctx context.Context) {
+	if s.local != nil {
+		s.local.Signal(ctx)
+	}
+	if s.publisher == nil {
+		return
+	}
+	if err := s.publisher.Publish(ctx, event.SnapshotDirtyEvent{}); err != nil {
+		s.logger.Warn("configsnapshot: failed to publish snapshot dirty event to peers",
+			slog.String("error", err.Error()))
+	}
+}

--- a/pkg/infra/configsnapshot/distributed_signaler_test.go
+++ b/pkg/infra/configsnapshot/distributed_signaler_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configsnapshot_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/cache/event"
+	infrasnapshot "github.com/NeuralTrust/TrustGate/pkg/infra/configsnapshot"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+type recordingLocal struct {
+	calls int
+}
+
+func (r *recordingLocal) Signal(_ context.Context) {
+	r.calls++
+}
+
+type recordingPublisher struct {
+	published []string
+	err       error
+}
+
+func (p *recordingPublisher) Publish(_ context.Context, ev event.Event) error {
+	p.published = append(p.published, ev.Type())
+	return p.err
+}
+
+func TestDistributedSignaler_Signal_RecompilesLocallyAndFansOut(t *testing.T) {
+	t.Parallel()
+	local := &recordingLocal{}
+	publisher := &recordingPublisher{}
+	signaler := infrasnapshot.NewDistributedSignaler(local, publisher, discardLogger())
+
+	signaler.Signal(context.Background())
+
+	if local.calls != 1 {
+		t.Fatalf("expected local recompile once, got %d", local.calls)
+	}
+	if len(publisher.published) != 1 || publisher.published[0] != event.SnapshotDirtyEventType {
+		t.Fatalf("expected one SnapshotDirtyEvent published to peers, got %v", publisher.published)
+	}
+}
+
+func TestDistributedSignaler_Signal_LocalRecompileSurvivesPublishError(t *testing.T) {
+	t.Parallel()
+	local := &recordingLocal{}
+	publisher := &recordingPublisher{err: errors.New("redis down")}
+	signaler := infrasnapshot.NewDistributedSignaler(local, publisher, discardLogger())
+
+	signaler.Signal(context.Background())
+
+	if local.calls != 1 {
+		t.Fatalf("local recompile must run even when peer fan-out fails, got %d calls", local.calls)
+	}
+}
+
+func TestDistributedSignaler_Signal_NilPublisherStillRecompilesLocally(t *testing.T) {
+	t.Parallel()
+	local := &recordingLocal{}
+	signaler := infrasnapshot.NewDistributedSignaler(local, nil, discardLogger())
+
+	signaler.Signal(context.Background())
+
+	if local.calls != 1 {
+		t.Fatalf("expected local recompile once, got %d", local.calls)
+	}
+}


### PR DESCRIPTION
## Summary

Config snapshot version broadcast is **in-process per admin pod**: when a registry/consumer write lands on admin replica A, only the data planes streaming from A get the new snapshot pushed. Data planes connected to replica B keep serving stale config until B's periodic backstop timer (~5 min) fires. With 2 admin replicas this shows up as intermittent, delayed propagation of MCP registry changes.

This wraps the local snapshot signaler in a `DistributedSignaler` that, in addition to recompiling locally, publishes a `SnapshotDirtyEvent` on the existing Redis event bus. Every admin replica's cache listener receives it and triggers its own recompile-and-broadcast, so all data planes converge in seconds.

## What changes

- `infra/cache/event`: new `SnapshotDirtyEvent` (empty struct) + registry entry.
- `infra/cache/subscriber`: `SnapshotDirtyEventSubscriber` calls the local dispatcher `Signal()` on receipt.
- `infra/configsnapshot`: `DistributedSignaler` = local signaler + Redis publish. Local recompile always runs even if the publish fails (logged).
- `container/modules`: `SnapshotSignaler` is now the `DistributedSignaler`; the dirty subscriber is registered in the cache listener (optional, so the dbless data plane graph is unaffected).

## What this does NOT change

- The streaming model (still 1 data plane ↔ 1 admin pod).
- Failover / reconnection — that is already handled by the gRPC `Hello` + version-diff on reconnect, independent of Redis.
- No config travels over Redis; only a "recompile now" nudge. The snapshot itself still transfers over gRPC.

## Notes

- Requires Redis pub/sub to be enabled for cross-pod delivery; the 5-min backstop remains the safety net if Redis is unavailable.
- Same fix applied to TrustGuard.

## Test plan

- [x] `go build ./...`, `go vet`
- [x] Unit tests for subscriber and `DistributedSignaler`
- [x] DI smoke test (`pkg/container`) green
- [ ] Manual: change registries on an MCP consumer with 2 admin replicas and confirm data planes on both replicas converge without waiting for the backstop

Made with [Cursor](https://cursor.com)