### PR TITLE
fix(mcp): default consumer fail_mode to open

### DIFF
--- a/pkg/app/mcp/composer.go
+++ b/pkg/app/mcp/composer.go
@@ -17,6 +17,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/url"
@@ -153,6 +154,10 @@ func (c *composer) compose(ctx context.Context, rc *appconsumer.RoutableConsumer
 		if err != nil {
 			if ctx.Err() != nil {
 				return nil, ctx.Err()
+			}
+			var consentErr *ConsentRequiredError
+			if errors.As(err, &consentErr) {
+				return nil, err
 			}
 			if !failOpen {
 				return nil, fmt.Errorf("%w: registry %q: %w", ErrUpstreamUnavailable, reg.Name, err)

--- a/pkg/app/mcp/composer.go
+++ b/pkg/app/mcp/composer.go
@@ -143,7 +143,7 @@ func (c *composer) compose(ctx context.Context, rc *appconsumer.RoutableConsumer
 	if len(registries) == 0 {
 		return nil, ErrNoMCPRegistries
 	}
-	failOpen := rc.Consumer.FailMode() == consumerdomain.FailModeOpen
+	failOpen := rc.Consumer.FailMode() != consumerdomain.FailModeClosed
 	toolkit := rc.Consumer.Toolkit()
 
 	var candidates []binding

--- a/pkg/app/mcp/composer_test.go
+++ b/pkg/app/mcp/composer_test.go
@@ -103,6 +103,14 @@ func (f *fakeDialer) Connect(_ context.Context, target Target) (Upstream, error)
 	return up, nil
 }
 
+type fakeCreds struct {
+	err error
+}
+
+func (f *fakeCreds) Apply(context.Context, *appconsumer.RoutableConsumer, *registrydomain.Registry, *Target) error {
+	return f.err
+}
+
 func mcpRegistry(t *testing.T, name, url string) *registrydomain.Registry {
 	t.Helper()
 	reg, err := registrydomain.NewMCPRegistry(
@@ -277,6 +285,23 @@ func TestComposer_FailMode(t *testing.T) {
 			t.Fatalf("tools = %v, want [alive]", names)
 		}
 	})
+}
+
+func TestComposer_ConsentRequiredBypassesFailOpen(t *testing.T) {
+	t.Parallel()
+	regA := mcpRegistry(t, "coda", "https://a.example.com/mcp")
+	dialer := &fakeDialer{upstreams: map[string]*fakeUpstream{
+		"https://a.example.com/mcp": {tools: tools("x")},
+	}}
+	creds := &fakeCreds{err: &ConsentRequiredError{Provider: "coda", Ticket: "tk", Path: "/p/mcp"}}
+	c := NewComposer(dialer, creds, newMapCache(), slog.New(slog.DiscardHandler))
+
+	consumer := &consumerdomain.Consumer{Type: consumerdomain.TypeMCP, MCP: &consumerdomain.MCPPolicy{FailMode: consumerdomain.FailModeOpen}}
+	_, err := c.ListTools(context.Background(), routable(consumer, regA))
+	var consentErr *ConsentRequiredError
+	if !errors.As(err, &consentErr) {
+		t.Fatalf("error = %v, want ConsentRequiredError to propagate even in fail-open", err)
+	}
 }
 
 func TestComposer_CallTool_RoutesToOwningUpstream(t *testing.T) {

--- a/pkg/app/mcp/discovery.go
+++ b/pkg/app/mcp/discovery.go
@@ -43,7 +43,7 @@ func federate[T any](
 	if len(registries) == 0 {
 		return nil, ErrNoMCPRegistries
 	}
-	failOpen := rc.Consumer.FailMode() == consumerdomain.FailModeOpen
+	failOpen := rc.Consumer.FailMode() != consumerdomain.FailModeClosed
 
 	var out []T
 	reachable := 0

--- a/pkg/app/mcp/discovery.go
+++ b/pkg/app/mcp/discovery.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 
 	appconsumer "github.com/NeuralTrust/TrustGate/pkg/app/consumer"
@@ -52,6 +53,10 @@ func federate[T any](
 		if err != nil {
 			if ctx.Err() != nil {
 				return nil, ctx.Err()
+			}
+			var consentErr *ConsentRequiredError
+			if errors.As(err, &consentErr) {
+				return nil, err
 			}
 			if !failOpen {
 				return nil, fmt.Errorf("%w: registry %q: %w", ErrUpstreamUnavailable, reg.Name, err)

--- a/pkg/domain/consumer/consumer_type_validation_test.go
+++ b/pkg/domain/consumer/consumer_type_validation_test.go
@@ -25,14 +25,14 @@ func mcpParams() CreateParams {
 	return p
 }
 
-func TestConsumer_MCP_DefaultsFailModeClosed(t *testing.T) {
+func TestConsumer_MCP_DefaultsFailModeOpen(t *testing.T) {
 	t.Parallel()
 	c, err := New(mcpParams())
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	if c.FailMode() != FailModeClosed {
-		t.Fatalf("FailMode = %q, want %q", c.FailMode(), FailModeClosed)
+	if c.FailMode() != FailModeOpen {
+		t.Fatalf("FailMode = %q, want %q", c.FailMode(), FailModeOpen)
 	}
 }
 

--- a/pkg/domain/consumer/mcp_policy.go
+++ b/pkg/domain/consumer/mcp_policy.go
@@ -23,7 +23,7 @@ type MCPPolicy struct {
 
 func (p *MCPPolicy) Validate(known map[ids.RegistryID]struct{}) error {
 	if p.FailMode == "" {
-		p.FailMode = FailModeClosed
+		p.FailMode = FailModeOpen
 	}
 	if err := p.FailMode.Validate(); err != nil {
 		return err

--- a/pkg/domain/consumer/toolkit_test.go
+++ b/pkg/domain/consumer/toolkit_test.go
@@ -154,8 +154,8 @@ func TestConsumer_Validate_ToolkitAndFailMode(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if c.FailMode() != FailModeClosed {
-			t.Fatalf("FailMode = %q, want default closed", c.FailMode())
+		if c.FailMode() != FailModeOpen {
+			t.Fatalf("FailMode = %q, want default open", c.FailMode())
 		}
 	})
 


### PR DESCRIPTION
## Summary
Make MCP tool discovery resilient by default while preserving the connect/consent UX.

1. **Default `fail_mode` to open.** `MCPPolicy.Validate` defaults an unset `fail_mode` to `open` (was `closed`); the composer and federated discovery treat an unset value as open too. Only an explicit `"closed"` propagates upstream errors. A single unreachable/empty registry no longer breaks the whole `tools/list`.
2. **Consent-required always surfaces.** A registry needing user consent (no stored credential) returns `ConsentRequiredError` during discovery. That is an actionable auth prompt, not an outage, so it now propagates regardless of `fail_mode` in both the composer and federated discovery. Previously, fail-open swallowed it and the client got a generic `-32603 no upstream reachable` instead of the `-32003` connect prompt.

## Motivation
- With `fail_mode: closed`, one failing registry (e.g. Coda) made the whole `tools/list` fail — the client saw **no tools at all** even when other registries (e.g. Linear) were healthy.
- Naive open-by-default would have hidden the consent prompt for registries that just need connecting; item 2 fixes that.

## Notes
- Existing consumers keep their **persisted** `fail_mode`. Consumers stored as `closed` must be flipped via `PUT /v1/gateways/{gateway_id}/consumers/{id}` with `{"fail_mode":"open"}`.
- Explicit `fail_mode: "closed"` behavior is unchanged (errors still propagate).
- `open` only helps when there are multiple registries and at least one is reachable; a single failing registry still yields an error (or, now, a consent prompt).

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/domain/consumer/... ./pkg/app/mcp/...`
- [x] New test: `ConsentRequiredError` propagates even under fail-open
- [x] Updated domain tests to assert the open default