### PR TITLE
fix(bedrock): preserve session token for static and assume-role auth

### DIFF
--- a/frontend/src/lib/auth-catalog.ts
+++ b/frontend/src/lib/auth-catalog.ts
@@ -82,6 +82,7 @@ export function fallbackAuthOptions(providerCode: string): CatalogAuthTypeOption
             { key: "region", label: "Region", type: "string", required: true },
             { key: "access_key_id", label: "Access Key ID", type: "string", required: true },
             { key: "secret_access_key", label: "Secret Access Key", type: "string", required: true, secret: true },
+            { key: "session_token", label: "Session Token", type: "string", secret: true },
             { key: "role", label: "Role ARN", type: "string", required: true },
             { key: "use_role", label: "Assume Role", type: "boolean", required: true, default: true },
           ],

--- a/pkg/app/catalog/provider_auth.go
+++ b/pkg/app/catalog/provider_auth.go
@@ -182,6 +182,13 @@ var (
 		Required:    true,
 		Secret:      true,
 	}
+	awsSessionTokenField = AuthField{
+		Key:         "session_token",
+		Label:       "Session Token",
+		Type:        AuthFieldTypeString,
+		Description: "Temporary session token for STS credentials.",
+		Secret:      true,
+	}
 
 	awsAuthOptions = []AuthTypeOption{
 		{
@@ -192,13 +199,7 @@ var (
 				awsRegionField,
 				awsAccessKeyField,
 				awsSecretKeyField,
-				{
-					Key:         "session_token",
-					Label:       "Session Token",
-					Type:        AuthFieldTypeString,
-					Description: "Temporary session token for STS credentials.",
-					Secret:      true,
-				},
+				awsSessionTokenField,
 			},
 		},
 		{
@@ -209,6 +210,7 @@ var (
 				awsRegionField,
 				awsAccessKeyField,
 				awsSecretKeyField,
+				awsSessionTokenField,
 				{
 					Key:         "role",
 					Label:       "Role ARN",

--- a/pkg/app/catalog/provider_auth_test.go
+++ b/pkg/app/catalog/provider_auth_test.go
@@ -89,6 +89,9 @@ func TestProviderAuthOptions_BedrockVariants(t *testing.T) {
 	if fieldRequired(accessKey.Fields, "use_role") {
 		t.Fatalf("access_key variant must not require use_role: %+v", accessKey.Fields)
 	}
+	if !fieldPresent(accessKey.Fields, "session_token") {
+		t.Fatalf("access_key missing session_token: %+v", accessKey.Fields)
+	}
 
 	assumeRole := variants["assume_role"]
 	for _, key := range []string{"region", "access_key_id", "secret_access_key", "role", "use_role"} {
@@ -98,6 +101,12 @@ func TestProviderAuthOptions_BedrockVariants(t *testing.T) {
 	}
 	if defaultVal, ok := fieldDefault(assumeRole.Fields, "use_role"); !ok || defaultVal != true {
 		t.Fatalf("use_role default = %#v, want true", defaultVal)
+	}
+	if !fieldPresent(assumeRole.Fields, "session_token") {
+		t.Fatalf("assume_role missing session_token: %+v", assumeRole.Fields)
+	}
+	if fieldRequired(assumeRole.Fields, "session_token") {
+		t.Fatalf("assume_role must not require session_token: %+v", assumeRole.Fields)
 	}
 }
 

--- a/pkg/infra/bedrock/client.go
+++ b/pkg/infra/bedrock/client.go
@@ -96,7 +96,7 @@ func (c *client) BuildClient(
 	}
 
 	if useRole && roleARN != "" {
-		creds, err := assumeRole(ctx, accessKey, secretKey, roleARN, region, sessionName)
+		creds, err := assumeRole(ctx, accessKey, secretKey, sessionToken, roleARN, region, sessionName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to assume role: %v", err)
 		}
@@ -137,8 +137,8 @@ func loadAWSConfig(ctx context.Context, accessKey, secretKey, sessionToken, regi
 	)
 }
 
-func assumeRole(ctx context.Context, accessKey, secretKey, roleARN, region, sessionName string) (*types.Credentials, error) {
-	baseCfg, err := loadAWSConfig(ctx, accessKey, secretKey, "", region)
+func assumeRole(ctx context.Context, accessKey, secretKey, sessionToken, roleARN, region, sessionName string) (*types.Credentials, error) {
+	baseCfg, err := loadAWSConfig(ctx, accessKey, secretKey, sessionToken, region)
 	if err != nil {
 		return nil, fmt.Errorf("unable to load base AWS config: %w", err)
 	}

--- a/pkg/infra/providers/bedrock/client.go
+++ b/pkg/infra/providers/bedrock/client.go
@@ -261,15 +261,17 @@ func buildAwsConfig(ctx context.Context, credentials providers.Credentials) (aws
 	accessKey := credentials.AwsBedrock.AccessKey
 	secretKey := credentials.AwsBedrock.SecretKey
 
+	sessionToken := credentials.AwsBedrock.SessionToken
+
 	if credentials.AwsBedrock.UseRole && credentials.AwsBedrock.RoleARN != "" {
-		creds, err := assumeRole(ctx, accessKey, secretKey, credentials.AwsBedrock.RoleARN, region)
+		creds, err := assumeRole(ctx, accessKey, secretKey, sessionToken, credentials.AwsBedrock.RoleARN, region)
 		if err != nil {
 			return aws.Config{}, err
 		}
 		return loadAWSConfig(ctx, *creds.AccessKeyId, *creds.SecretAccessKey, *creds.SessionToken, region)
 	}
 
-	return loadAWSConfig(ctx, accessKey, secretKey, "", region)
+	return loadAWSConfig(ctx, accessKey, secretKey, sessionToken, region)
 }
 
 func loadAWSConfig(ctx context.Context, accessKey, secretKey, sessionToken, region string) (aws.Config, error) {
@@ -287,8 +289,8 @@ func loadAWSConfig(ctx context.Context, accessKey, secretKey, sessionToken, regi
 	)
 }
 
-func assumeRole(ctx context.Context, accessKey, secretKey, roleARN, region string, sessionName ...string) (*stsTypes.Credentials, error) {
-	baseCfg, err := loadAWSConfig(ctx, accessKey, secretKey, "", region)
+func assumeRole(ctx context.Context, accessKey, secretKey, sessionToken, roleARN, region string, sessionName ...string) (*stsTypes.Credentials, error) {
+	baseCfg, err := loadAWSConfig(ctx, accessKey, secretKey, sessionToken, region)
 	if err != nil {
 		return nil, fmt.Errorf("unable to load base AWS config: %w", err)
 	}

--- a/pkg/infra/providers/bedrock/client_test.go
+++ b/pkg/infra/providers/bedrock/client_test.go
@@ -137,3 +137,20 @@ func TestCompletions_MissingModel(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "model is required")
 }
+
+func TestBuildAwsConfig_PreservesSessionTokenWhenUseRoleDisabled(t *testing.T) {
+	cfg, err := buildAwsConfig(context.Background(), providers.Credentials{
+		AwsBedrock: &providers.AwsBedrock{
+			Region:       "eu-west-1",
+			AccessKey:    "ASIATEST",
+			SecretKey:    "secret",
+			SessionToken: "session-token",
+			UseRole:      false,
+		},
+	})
+	require.NoError(t, err)
+
+	creds, err := cfg.Credentials.Retrieve(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "session-token", creds.SessionToken)
+}


### PR DESCRIPTION
## Summary
- Pass AWS session tokens through Bedrock `buildAwsConfig` when `use_role` is disabled (fixes ASIA/STS keys failing or hanging on registry test-connection).
- Forward base session credentials into `AssumeRole` when role assumption is enabled.
- Add optional `session_token` to the Bedrock `assume_role` provider catalog variant (API + TrustGate console fallback catalog).

## Test plan
- [x] `go test ./pkg/infra/providers/bedrock/... ./pkg/app/catalog/... ./pkg/infra/bedrock/...`
- [ ] Manual: Registry → AWS Bedrock → Assume role → toggle OFF → fill ASIA key + session token → Test connection returns success or explicit AWS error (not stuck)