### PR TITLE
fix(bedrock): resolve model from gateway config when body is stripped

### DIFF
--- a/pkg/app/proxy/provider.go
+++ b/pkg/app/proxy/provider.go
@@ -274,13 +274,16 @@ func (p *providerInvoker) prepare(
 
 	body = injectPreviousResponseID(body, targetFormat, req.PreviousResponseID)
 
-	sentModel, _ := adapter.ExtractModel(body)
+	sentModel := resolveSentModel(body, req)
 
 	return &preparedInvocation{
 		client: client,
 		cfg: &providers.Config{
-			Options:     bk.ProviderOptions(),
-			Credentials: providers.CredentialsFromTargetAuth(bk.Auth()),
+			Options:       bk.ProviderOptions(),
+			Credentials:   providers.CredentialsFromTargetAuth(bk.Auth()),
+			Model:         sentModel,
+			DefaultModel:  req.DefaultModel,
+			AllowedModels: req.AllowedModels,
 		},
 		body:         body,
 		sentModel:    sentModel,
@@ -289,6 +292,18 @@ func (p *providerInvoker) prepare(
 		crossFormat:  crossFormat,
 		capability:   capability,
 	}, nil
+}
+
+// Bedrock/Vertex strip the model from the adapted body (it travels out of band),
+// so fall back to the post-routing request body and then the binding default.
+func resolveSentModel(body []byte, req *infracontext.RequestContext) string {
+	if m, err := adapter.ExtractModel(body); err == nil && m != "" {
+		return m
+	}
+	if m, err := adapter.ExtractModel(req.Body); err == nil && m != "" {
+		return m
+	}
+	return req.DefaultModel
 }
 
 func capabilityFromRequest(req *infracontext.RequestContext) string {

--- a/pkg/infra/providers/bedrock/client.go
+++ b/pkg/infra/providers/bedrock/client.go
@@ -57,7 +57,7 @@ func (c *client) Completions(
 	cfg *providers.Config,
 	reqBody []byte,
 ) ([]byte, error) {
-	model := c.resolveModel(reqBody, cfg.DefaultModel)
+	model := c.resolveModel(reqBody, cfg)
 	if model == "" {
 		return nil, fmt.Errorf("model is required")
 	}
@@ -89,7 +89,7 @@ func (c *client) CompletionsStream(
 	cfg *providers.Config,
 	reqBody []byte,
 ) (iter.Seq2[[]byte, error], error) {
-	model := c.resolveModel(reqBody, cfg.DefaultModel)
+	model := c.resolveModel(reqBody, cfg)
 	if model == "" {
 		return nil, fmt.Errorf("model is required")
 	}
@@ -327,19 +327,20 @@ func stripBedrockFields(body []byte) []byte {
 	return out
 }
 
-// resolveModel extracts the model from the request body. Falls back to
-// defaultModel when the body doesn't contain a model field. Strips a leading
-// region prefix (e.g. "eu.") so the value passed to InvokeModel is the standard
-// Bedrock model ID.
-func (c *client) resolveModel(reqBody []byte, defaultModel string) string {
+// Cross-format adaptation strips the model from the body (Bedrock resolves it
+// from the InvokeModel path), so it falls back to cfg. The "eu." region prefix
+// is trimmed to the standard Bedrock model ID.
+func (c *client) resolveModel(reqBody []byte, cfg *providers.Config) string {
 	if modelID, err := extractBedrockModelID(reqBody); err == nil && modelID != "" {
 		return modelID
 	}
-	m := defaultModel
 	if extracted, err := adapter.ExtractModel(reqBody); err == nil && extracted != "" {
-		m = extracted
+		return bedrockModelID(extracted)
 	}
-	return bedrockModelID(m)
+	if cfg.Model != "" {
+		return bedrockModelID(cfg.Model)
+	}
+	return bedrockModelID(cfg.DefaultModel)
 }
 
 func extractBedrockModelID(body []byte) (string, error) {

--- a/pkg/infra/providers/bedrock/client_test.go
+++ b/pkg/infra/providers/bedrock/client_test.go
@@ -82,17 +82,22 @@ func TestResolveModel(t *testing.T) {
 	c := &client{}
 
 	t.Run("uses exact modelId before default model", func(t *testing.T) {
-		model := c.resolveModel([]byte(`{"modelId":"eu.amazon.nova-micro-v1:0","messages":[]}`), "anthropic.claude-sonnet-4-20250514-v1:0")
+		model := c.resolveModel([]byte(`{"modelId":"eu.amazon.nova-micro-v1:0","messages":[]}`), &providers.Config{DefaultModel: "anthropic.claude-sonnet-4-20250514-v1:0"})
 		assert.Equal(t, "eu.amazon.nova-micro-v1:0", model)
 	})
 
+	t.Run("falls back to config model", func(t *testing.T) {
+		model := c.resolveModel([]byte(`{"messages":[]}`), &providers.Config{Model: "openai.gpt-oss-120b"})
+		assert.Equal(t, "openai.gpt-oss-120b", model)
+	})
+
 	t.Run("falls back to default model", func(t *testing.T) {
-		model := c.resolveModel([]byte(`{"messages":[]}`), "anthropic.claude-sonnet-4-20250514-v1:0")
+		model := c.resolveModel([]byte(`{"messages":[]}`), &providers.Config{DefaultModel: "anthropic.claude-sonnet-4-20250514-v1:0"})
 		assert.Equal(t, "anthropic.claude-sonnet-4-20250514-v1:0", model)
 	})
 
 	t.Run("no model returns empty", func(t *testing.T) {
-		assert.Equal(t, "", c.resolveModel([]byte(`{}`), ""))
+		assert.Equal(t, "", c.resolveModel([]byte(`{}`), &providers.Config{}))
 	})
 }
 


### PR DESCRIPTION
## Summary
- Pass the resolved model through `providers.Config` in the proxy invoker so Bedrock can resolve `ModelId` after cross-format adaptation strips `model` from the request body.
- Fall back to the post-routing request body and binding `default_model` when the adapted body no longer carries the model.
- Add Bedrock client test coverage for the `cfg.Model` fallback path.

## Context
Bedrock chat completions failed with `model is required` even when clients sent `"model"` in the OpenAI-style payload, because the Bedrock adapter intentionally removes `model` from the body (InvokeModel uses the path). The provider config previously only carried credentials/options.

## Test plan
- [x] `go test ./pkg/infra/providers/bedrock/... ./pkg/app/proxy/...`
- [ ] Retry `POST /v1/chat/completions` against a Bedrock registry with `"model": "openai.gpt-oss-120b"` and confirm the gateway no longer returns `backend_error` for missing model


Made with [Cursor](https://cursor.com)