### PR TITLE
feat(configsync): verify config-sync tokens with HS256 shared secret

### DIFF
--- a/k8s/base/secrets.env.example
+++ b/k8s/base/secrets.env.example
@@ -33,13 +33,14 @@
 #   CONFIG_SYNC_LKG_KEY - AES-256 key that encrypts the on-disk last-known-good
 #                         snapshot on the data planes. Must be base64 that decodes to
 #                         exactly 32 bytes, e.g. `openssl rand -base64 32`.
-#   CONFIG_SYNC_JWT_PUBLIC_KEY - only for CONFIG_SYNC_AUTH_MODE=composite|signed. PKIX PEM
-#                         public key (EdDSA/ES256/RS256) that verifies the per-tenant config-sync
-#                         JWTs minted by DataCore for external (hybrid) data planes. Add it to the
-#                         agentgateway .env blob (newlines escaped so godotenv parses one line, or
-#                         base64-encoded PEM). Non-secret issuer/audience go in overlays/*/config.env
+#   CONFIG_SYNC_JWT_SECRET - only for CONFIG_SYNC_AUTH_MODE=composite|signed. The HS256 shared
+#                         secret that verifies the per-tenant config-sync JWTs minted by DataCore
+#                         for external (hybrid) data planes; it is the same secret DataCore signs
+#                         with (CONFIG_SYNC_SIGNING_SECRET). Add it to the agentgateway .env blob.
+#                         Non-secret issuer/audience go in overlays/*/config.env
 #                         (CONFIG_SYNC_JWT_ISSUER/CONFIG_SYNC_JWT_AUDIENCE). Leave unset while
-#                         CONFIG_SYNC_AUTH_MODE=shared.
+#                         CONFIG_SYNC_AUTH_MODE=shared. CONFIG_SYNC_JWT_SECRET_PREVIOUS optionally
+#                         holds the prior secret accepted during rotation.
 #
 # DB-less config-sync gRPC TLS (prod only — the channel carries registry credentials,
 # so it must not be plaintext in a deployed environment). These are PEM files, mounted

--- a/k8s/overlays/dev/config.env
+++ b/k8s/overlays/dev/config.env
@@ -42,16 +42,16 @@ CONFIG_SYNC_POLL_INTERVAL=5m
 #                       tenant partition (gateways filtered by metadata.tenant_id) -- while the
 #                       shared token keeps serving the global snapshot to the in-cluster fleet.
 #   signed             : JWT-only, no shared token (not used by the SaaS control plane).
-# composite/signed require the three CONFIG_SYNC_JWT_* below (asymmetric EdDSA/ES256/RS256; the
-# PEM public key is a secret in the GCP .env blob, issuer/audience are non-secret config). They
-# fail closed if unset. JWKS is not yet supported.
+# composite/signed require the three CONFIG_SYNC_JWT_* below (HS256 shared secret; the secret
+# lives in the GCP .env blob, issuer/audience are non-secret config). They fail closed if unset.
 CONFIG_SYNC_AUTH_MODE=shared
-# Flip to composite once DataCore mints per-tenant signed JWTs: (1) add CONFIG_SYNC_JWT_PUBLIC_KEY
-# to the agentgateway secret blob, (2) uncomment the issuer/audience below to match DataCore's
-# tokens, (3) set CONFIG_SYNC_AUTH_MODE=composite.
+# Flip to composite once DataCore mints per-tenant signed JWTs: (1) add CONFIG_SYNC_JWT_SECRET
+# (the shared HS256 secret DataCore signs with) to the agentgateway secret blob, (2) uncomment the
+# issuer/audience below to match DataCore's tokens, (3) set CONFIG_SYNC_AUTH_MODE=composite.
 # CONFIG_SYNC_JWT_ISSUER=datacore
 # CONFIG_SYNC_JWT_AUDIENCE=trustgate-config-sync
-# CONFIG_SYNC_JWT_PUBLIC_KEY -> secret (agentgateway .env blob in GCP), never set here
+# CONFIG_SYNC_JWT_SECRET -> secret (agentgateway .env blob in GCP), never set here
+# CONFIG_SYNC_JWT_SECRET_PREVIOUS -> optional prior secret accepted during rotation
 # Telemetry: default exporters loaded from a YAML mounted via ConfigMap; both
 # metadata and raw classes ship to the ClickStack OTel Collector over OTLP/HTTP.
 # WithEndpointURL takes the path verbatim, so the endpoint must include /v1/logs.

--- a/k8s/overlays/prod/config.env
+++ b/k8s/overlays/prod/config.env
@@ -40,16 +40,16 @@ CONFIG_SYNC_POLL_INTERVAL=5m
 #                       tenant partition (gateways filtered by metadata.tenant_id) -- while the
 #                       shared token keeps serving the global snapshot to the in-cluster fleet.
 #   signed             : JWT-only, no shared token (not used by the SaaS control plane).
-# composite/signed require the three CONFIG_SYNC_JWT_* below (asymmetric EdDSA/ES256/RS256; the
-# PEM public key is a secret in the GCP .env blob, issuer/audience are non-secret config). They
-# fail closed if unset. JWKS is not yet supported.
+# composite/signed require the three CONFIG_SYNC_JWT_* below (HS256 shared secret; the secret
+# lives in the GCP .env blob, issuer/audience are non-secret config). They fail closed if unset.
 CONFIG_SYNC_AUTH_MODE=shared
-# Flip to composite once DataCore mints per-tenant signed JWTs: (1) add CONFIG_SYNC_JWT_PUBLIC_KEY
-# to the agentgateway secret blob, (2) uncomment the issuer/audience below to match DataCore's
-# tokens, (3) set CONFIG_SYNC_AUTH_MODE=composite.
+# Flip to composite once DataCore mints per-tenant signed JWTs: (1) add CONFIG_SYNC_JWT_SECRET
+# (the shared HS256 secret DataCore signs with) to the agentgateway secret blob, (2) uncomment the
+# issuer/audience below to match DataCore's tokens, (3) set CONFIG_SYNC_AUTH_MODE=composite.
 # CONFIG_SYNC_JWT_ISSUER=datacore
 # CONFIG_SYNC_JWT_AUDIENCE=trustgate-config-sync
-# CONFIG_SYNC_JWT_PUBLIC_KEY -> secret (agentgateway .env blob in GCP), never set here
+# CONFIG_SYNC_JWT_SECRET -> secret (agentgateway .env blob in GCP), never set here
+# CONFIG_SYNC_JWT_SECRET_PREVIOUS -> optional prior secret accepted during rotation
 # Telemetry: default exporters loaded from a YAML mounted via ConfigMap; both
 # metadata and raw classes ship to the ClickStack OTel Collector over OTLP/HTTP.
 # WithEndpointURL takes the path verbatim, so the endpoint must include /v1/logs.

--- a/pkg/app/proxy/provider.go
+++ b/pkg/app/proxy/provider.go
@@ -274,13 +274,16 @@ func (p *providerInvoker) prepare(
 
 	body = injectPreviousResponseID(body, targetFormat, req.PreviousResponseID)
 
-	sentModel, _ := adapter.ExtractModel(body)
+	sentModel := resolveSentModel(body, req)
 
 	return &preparedInvocation{
 		client: client,
 		cfg: &providers.Config{
-			Options:     bk.ProviderOptions(),
-			Credentials: providers.CredentialsFromTargetAuth(bk.Auth()),
+			Options:       bk.ProviderOptions(),
+			Credentials:   providers.CredentialsFromTargetAuth(bk.Auth()),
+			Model:         sentModel,
+			DefaultModel:  req.DefaultModel,
+			AllowedModels: req.AllowedModels,
 		},
 		body:         body,
 		sentModel:    sentModel,
@@ -289,6 +292,18 @@ func (p *providerInvoker) prepare(
 		crossFormat:  crossFormat,
 		capability:   capability,
 	}, nil
+}
+
+// Bedrock/Vertex strip the model from the adapted body (it travels out of band),
+// so fall back to the post-routing request body and then the binding default.
+func resolveSentModel(body []byte, req *infracontext.RequestContext) string {
+	if m, err := adapter.ExtractModel(body); err == nil && m != "" {
+		return m
+	}
+	if m, err := adapter.ExtractModel(req.Body); err == nil && m != "" {
+		return m
+	}
+	return req.DefaultModel
 }
 
 func capabilityFromRequest(req *infracontext.RequestContext) string {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -164,10 +164,14 @@ type ConfigSyncConfig struct {
 	Token            string // #nosec G117 -- config struct field, not a hardcoded credential
 	// TokenPrevious is the prior bearer accepted alongside Token so a token can be
 	// rotated without a window where in-flight data planes fail to authenticate.
-	TokenPrevious     string // #nosec G117 -- config struct field, not a hardcoded credential
-	AuthMode          string
-	JWTPublicKey      string // #nosec G117 -- config struct field, not a hardcoded credential
-	JWTJWKSURL        string
+	TokenPrevious string // #nosec G117 -- config struct field, not a hardcoded credential
+	AuthMode      string
+	// JWTSecret is the HS256 shared secret used to verify config-sync credentials
+	// minted by DataCore. JWTSecretPrevious is the prior secret accepted alongside
+	// it so the secret can be rotated without a window where data planes fail to
+	// authenticate.
+	JWTSecret         string // #nosec G117 -- config struct field, not a hardcoded credential
+	JWTSecretPrevious string // #nosec G117 -- config struct field, not a hardcoded credential
 	JWTIssuer         string
 	JWTAudience       string
 	LKGPath           string
@@ -651,8 +655,8 @@ func getConfigSyncConfig() ConfigSyncConfig {
 		Token:                getEnv("CONFIG_SYNC_TOKEN", ""),
 		TokenPrevious:        getEnv("CONFIG_SYNC_TOKEN_PREVIOUS", ""),
 		AuthMode:             normalizeConfigSyncAuthMode(getEnv("CONFIG_SYNC_AUTH_MODE", ConfigSyncAuthModeShared)),
-		JWTPublicKey:         getEnv("CONFIG_SYNC_JWT_PUBLIC_KEY", ""),
-		JWTJWKSURL:           getEnv("CONFIG_SYNC_JWT_JWKS_URL", ""),
+		JWTSecret:            getEnv("CONFIG_SYNC_JWT_SECRET", ""),
+		JWTSecretPrevious:    getEnv("CONFIG_SYNC_JWT_SECRET_PREVIOUS", ""),
 		JWTIssuer:            getEnv("CONFIG_SYNC_JWT_ISSUER", ""),
 		JWTAudience:          getEnv("CONFIG_SYNC_JWT_AUDIENCE", ""),
 		LKGPath:              getEnv("CONFIG_SYNC_LKG_PATH", defaultConfigSyncLKGPath),
@@ -823,11 +827,8 @@ func (cs ConfigSyncConfig) validateAuthMode() error {
 }
 
 func (cs ConfigSyncConfig) validateSignedJWTParams() error {
-	if cs.JWTPublicKey == "" {
-		if cs.JWTJWKSURL != "" {
-			return fmt.Errorf("%w: CONFIG_SYNC_AUTH_MODE=%s with JWKS is not yet supported; set CONFIG_SYNC_JWT_PUBLIC_KEY", errors.ErrInvalidConfig, cs.AuthMode)
-		}
-		return fmt.Errorf("%w: CONFIG_SYNC_AUTH_MODE=%s requires CONFIG_SYNC_JWT_PUBLIC_KEY", errors.ErrInvalidConfig, cs.AuthMode)
+	if cs.JWTSecret == "" {
+		return fmt.Errorf("%w: CONFIG_SYNC_AUTH_MODE=%s requires CONFIG_SYNC_JWT_SECRET", errors.ErrInvalidConfig, cs.AuthMode)
 	}
 	if cs.JWTIssuer == "" || cs.JWTAudience == "" {
 		return fmt.Errorf("%w: CONFIG_SYNC_AUTH_MODE=%s requires CONFIG_SYNC_JWT_ISSUER and CONFIG_SYNC_JWT_AUDIENCE", errors.ErrInvalidConfig, cs.AuthMode)

--- a/pkg/config/configsync_auth_test.go
+++ b/pkg/config/configsync_auth_test.go
@@ -29,12 +29,11 @@ func TestConfigSyncValidateAuthMode(t *testing.T) {
 	}{
 		{name: "shared default", cfg: ConfigSyncConfig{AuthMode: ConfigSyncAuthModeShared}, wantErr: false},
 		{name: "unknown mode", cfg: ConfigSyncConfig{AuthMode: "magic"}, wantErr: true},
-		{name: "signed without key", cfg: ConfigSyncConfig{AuthMode: ConfigSyncAuthModeSigned, JWTIssuer: "i", JWTAudience: "a"}, wantErr: true},
-		{name: "signed jwks only", cfg: ConfigSyncConfig{AuthMode: ConfigSyncAuthModeSigned, JWTJWKSURL: "https://x/jwks", JWTIssuer: "i", JWTAudience: "a"}, wantErr: true},
-		{name: "signed without iss/aud", cfg: ConfigSyncConfig{AuthMode: ConfigSyncAuthModeSigned, JWTPublicKey: "pem"}, wantErr: true},
-		{name: "signed complete", cfg: ConfigSyncConfig{AuthMode: ConfigSyncAuthModeSigned, JWTPublicKey: "pem", JWTIssuer: "i", JWTAudience: "a"}, wantErr: false},
-		{name: "composite complete", cfg: ConfigSyncConfig{AuthMode: ConfigSyncAuthModeComposite, Token: "t", JWTPublicKey: "pem", JWTIssuer: "i", JWTAudience: "a"}, wantErr: false},
-		{name: "composite without token", cfg: ConfigSyncConfig{AuthMode: ConfigSyncAuthModeComposite, JWTPublicKey: "pem", JWTIssuer: "i", JWTAudience: "a"}, wantErr: true},
+		{name: "signed without secret", cfg: ConfigSyncConfig{AuthMode: ConfigSyncAuthModeSigned, JWTIssuer: "i", JWTAudience: "a"}, wantErr: true},
+		{name: "signed without iss/aud", cfg: ConfigSyncConfig{AuthMode: ConfigSyncAuthModeSigned, JWTSecret: "sec"}, wantErr: true},
+		{name: "signed complete", cfg: ConfigSyncConfig{AuthMode: ConfigSyncAuthModeSigned, JWTSecret: "sec", JWTIssuer: "i", JWTAudience: "a"}, wantErr: false},
+		{name: "composite complete", cfg: ConfigSyncConfig{AuthMode: ConfigSyncAuthModeComposite, Token: "t", JWTSecret: "sec", JWTIssuer: "i", JWTAudience: "a"}, wantErr: false},
+		{name: "composite without token", cfg: ConfigSyncConfig{AuthMode: ConfigSyncAuthModeComposite, JWTSecret: "sec", JWTIssuer: "i", JWTAudience: "a"}, wantErr: true},
 		{name: "composite without jwt", cfg: ConfigSyncConfig{AuthMode: ConfigSyncAuthModeComposite, Token: "t"}, wantErr: true},
 	}
 	for _, tc := range cases {

--- a/pkg/infra/configsync/grpc/authenticator.go
+++ b/pkg/infra/configsync/grpc/authenticator.go
@@ -17,16 +17,13 @@ package grpc
 import (
 	"crypto/sha256"
 	"crypto/subtle"
-	"crypto/x509"
-	"encoding/pem"
 	"errors"
-	"fmt"
 
 	"github.com/NeuralTrust/TrustGate/pkg/config"
 	"github.com/golang-jwt/jwt/v5"
 )
 
-var signedTokenAlgorithms = []string{"EdDSA", "ES256", "RS256"}
+var signedTokenAlgorithms = []string{"HS256"}
 
 var (
 	errAuthNotConfigured = errors.New("config-sync auth is not configured")
@@ -74,16 +71,16 @@ func (s *sharedAuthenticator) authenticate(bearer string) (string, error) {
 
 type jwtAuthenticator struct {
 	parser  *jwt.Parser
-	keyfunc jwt.Keyfunc
+	secrets [][]byte
 }
 
 func newJWTAuthenticator(cfg config.ConfigSyncConfig) (*jwtAuthenticator, error) {
-	if cfg.JWTPublicKey == "" {
-		return nil, errors.New("config-sync signed mode requires a JWT public key")
+	if cfg.JWTSecret == "" {
+		return nil, errors.New("config-sync signed mode requires a JWT shared secret")
 	}
-	key, err := parsePKIXPublicKeyPEM(cfg.JWTPublicKey)
-	if err != nil {
-		return nil, fmt.Errorf("parse config-sync JWT public key: %w", err)
+	secrets := [][]byte{[]byte(cfg.JWTSecret)}
+	if cfg.JWTSecretPrevious != "" {
+		secrets = append(secrets, []byte(cfg.JWTSecretPrevious))
 	}
 	opts := []jwt.ParserOption{
 		jwt.WithValidMethods(signedTokenAlgorithms),
@@ -97,7 +94,7 @@ func newJWTAuthenticator(cfg config.ConfigSyncConfig) (*jwtAuthenticator, error)
 	}
 	return &jwtAuthenticator{
 		parser:  jwt.NewParser(opts...),
-		keyfunc: func(*jwt.Token) (any, error) { return key, nil },
+		secrets: secrets,
 	}, nil
 }
 
@@ -105,15 +102,18 @@ func (j *jwtAuthenticator) authenticate(bearer string) (string, error) {
 	if bearer == "" {
 		return "", errUnauthenticated
 	}
-	claims := jwt.MapClaims{}
-	if _, err := j.parser.ParseWithClaims(bearer, claims, j.keyfunc); err != nil {
-		return "", errUnauthenticated
+	for _, secret := range j.secrets {
+		claims := jwt.MapClaims{}
+		if _, err := j.parser.ParseWithClaims(bearer, claims, func(*jwt.Token) (any, error) { return secret, nil }); err != nil {
+			continue
+		}
+		scope, ok := claims["scope"].(string)
+		if !ok || scope == "" {
+			return "", errUnauthenticated
+		}
+		return scope, nil
 	}
-	scope, ok := claims["scope"].(string)
-	if !ok || scope == "" {
-		return "", errUnauthenticated
-	}
-	return scope, nil
+	return "", errUnauthenticated
 }
 
 // compositeAuthenticator accepts either a signed per-tenant JWT (external data
@@ -140,16 +140,4 @@ func (c *compositeAuthenticator) authenticate(bearer string) (string, error) {
 		return scope, nil
 	}
 	return c.shared.authenticate(bearer)
-}
-
-func parsePKIXPublicKeyPEM(pemStr string) (any, error) {
-	block, _ := pem.Decode([]byte(pemStr))
-	if block == nil {
-		return nil, errors.New("no PEM block found")
-	}
-	key, err := x509.ParsePKIXPublicKey(block.Bytes)
-	if err != nil {
-		return nil, err
-	}
-	return key, nil
 }

--- a/pkg/infra/configsync/grpc/authenticator_test.go
+++ b/pkg/infra/configsync/grpc/authenticator_test.go
@@ -15,9 +15,6 @@
 package grpc
 
 import (
-	"crypto/ed25519"
-	"crypto/x509"
-	"encoding/pem"
 	"testing"
 	"time"
 
@@ -28,29 +25,21 @@ import (
 const (
 	testIssuer   = "datacore"
 	testAudience = "trustgate-config-sync"
+	testSecret   = "config-sync-shared-secret"
+	otherSecret  = "a-different-secret"
 )
 
-func newSignedTestConfig(t *testing.T) (config.ConfigSyncConfig, ed25519.PrivateKey) {
+func newSignedTestConfig(t *testing.T) config.ConfigSyncConfig {
 	t.Helper()
-	pub, priv, err := ed25519.GenerateKey(nil)
-	if err != nil {
-		t.Fatalf("generate key: %v", err)
+	return config.ConfigSyncConfig{
+		AuthMode:    config.ConfigSyncAuthModeSigned,
+		JWTSecret:   testSecret,
+		JWTIssuer:   testIssuer,
+		JWTAudience: testAudience,
 	}
-	der, err := x509.MarshalPKIXPublicKey(pub)
-	if err != nil {
-		t.Fatalf("marshal public key: %v", err)
-	}
-	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})
-	cfg := config.ConfigSyncConfig{
-		AuthMode:     config.ConfigSyncAuthModeSigned,
-		JWTPublicKey: string(pemBytes),
-		JWTIssuer:    testIssuer,
-		JWTAudience:  testAudience,
-	}
-	return cfg, priv
 }
 
-func mint(t *testing.T, priv ed25519.PrivateKey, method jwt.SigningMethod, claims jwt.MapClaims) string {
+func mint(t *testing.T, secret string, method jwt.SigningMethod, claims jwt.MapClaims) string {
 	t.Helper()
 	token := jwt.NewWithClaims(method, claims)
 	var (
@@ -60,7 +49,7 @@ func mint(t *testing.T, priv ed25519.PrivateKey, method jwt.SigningMethod, claim
 	if method == jwt.SigningMethodNone {
 		signed, err = token.SignedString(jwt.UnsafeAllowNoneSignatureType)
 	} else {
-		signed, err = token.SignedString(priv)
+		signed, err = token.SignedString([]byte(secret))
 	}
 	if err != nil {
 		t.Fatalf("sign token: %v", err)
@@ -78,12 +67,11 @@ func validClaims() jwt.MapClaims {
 }
 
 func TestJWTAuthenticator_ValidTokenExtractsScope(t *testing.T) {
-	cfg, priv := newSignedTestConfig(t)
-	auth, err := newJWTAuthenticator(cfg)
+	auth, err := newJWTAuthenticator(newSignedTestConfig(t))
 	if err != nil {
 		t.Fatalf("newJWTAuthenticator: %v", err)
 	}
-	scope, err := auth.authenticate(mint(t, priv, jwt.SigningMethodEdDSA, validClaims()))
+	scope, err := auth.authenticate(mint(t, testSecret, jwt.SigningMethodHS256, validClaims()))
 	if err != nil {
 		t.Fatalf("authenticate: %v", err)
 	}
@@ -92,35 +80,52 @@ func TestJWTAuthenticator_ValidTokenExtractsScope(t *testing.T) {
 	}
 }
 
-func TestJWTAuthenticator_Rejects(t *testing.T) {
-	cfg, priv := newSignedTestConfig(t)
+func TestJWTAuthenticator_RotationAcceptsPreviousSecret(t *testing.T) {
+	cfg := newSignedTestConfig(t)
+	cfg.JWTSecret = "new-secret"
+	cfg.JWTSecretPrevious = testSecret
 	auth, err := newJWTAuthenticator(cfg)
 	if err != nil {
 		t.Fatalf("newJWTAuthenticator: %v", err)
 	}
-	_, otherPriv, _ := ed25519.GenerateKey(nil)
+	for _, secret := range []string{"new-secret", testSecret} {
+		scope, err := auth.authenticate(mint(t, secret, jwt.SigningMethodHS256, validClaims()))
+		if err != nil {
+			t.Fatalf("authenticate with %q: %v", secret, err)
+		}
+		if scope != "org_1" {
+			t.Fatalf("scope = %q, want org_1", scope)
+		}
+	}
+}
+
+func TestJWTAuthenticator_Rejects(t *testing.T) {
+	auth, err := newJWTAuthenticator(newSignedTestConfig(t))
+	if err != nil {
+		t.Fatalf("newJWTAuthenticator: %v", err)
+	}
 
 	cases := map[string]string{
 		"empty":         "",
 		"garbage":       "not-a-jwt",
-		"alg_none":      mint(t, priv, jwt.SigningMethodNone, validClaims()),
-		"bad_signature": mint(t, otherPriv, jwt.SigningMethodEdDSA, validClaims()),
-		"expired": mint(t, priv, jwt.SigningMethodEdDSA, jwt.MapClaims{
+		"alg_none":      mint(t, testSecret, jwt.SigningMethodNone, validClaims()),
+		"bad_signature": mint(t, otherSecret, jwt.SigningMethodHS256, validClaims()),
+		"expired": mint(t, testSecret, jwt.SigningMethodHS256, jwt.MapClaims{
 			"iss": testIssuer, "aud": testAudience, "scope": "org_1",
 			"exp": time.Now().Add(-time.Hour).Unix(),
 		}),
-		"no_exp": mint(t, priv, jwt.SigningMethodEdDSA, jwt.MapClaims{
+		"no_exp": mint(t, testSecret, jwt.SigningMethodHS256, jwt.MapClaims{
 			"iss": testIssuer, "aud": testAudience, "scope": "org_1",
 		}),
-		"wrong_issuer": mint(t, priv, jwt.SigningMethodEdDSA, jwt.MapClaims{
+		"wrong_issuer": mint(t, testSecret, jwt.SigningMethodHS256, jwt.MapClaims{
 			"iss": "evil", "aud": testAudience, "scope": "org_1",
 			"exp": time.Now().Add(time.Hour).Unix(),
 		}),
-		"wrong_audience": mint(t, priv, jwt.SigningMethodEdDSA, jwt.MapClaims{
+		"wrong_audience": mint(t, testSecret, jwt.SigningMethodHS256, jwt.MapClaims{
 			"iss": testIssuer, "aud": "other", "scope": "org_1",
 			"exp": time.Now().Add(time.Hour).Unix(),
 		}),
-		"missing_scope": mint(t, priv, jwt.SigningMethodEdDSA, jwt.MapClaims{
+		"missing_scope": mint(t, testSecret, jwt.SigningMethodHS256, jwt.MapClaims{
 			"iss": testIssuer, "aud": testAudience,
 			"exp": time.Now().Add(time.Hour).Unix(),
 		}),
@@ -155,7 +160,7 @@ func TestSharedAuthenticator(t *testing.T) {
 }
 
 func TestCompositeAuthenticator(t *testing.T) {
-	cfg, priv := newSignedTestConfig(t)
+	cfg := newSignedTestConfig(t)
 	cfg.AuthMode = config.ConfigSyncAuthModeComposite
 	cfg.Token = "shared-tok"
 	cfg.TokenPrevious = "old-tok"
@@ -164,7 +169,7 @@ func TestCompositeAuthenticator(t *testing.T) {
 		t.Fatalf("newCompositeAuthenticator: %v", err)
 	}
 
-	scope, err := auth.authenticate(mint(t, priv, jwt.SigningMethodEdDSA, validClaims()))
+	scope, err := auth.authenticate(mint(t, testSecret, jwt.SigningMethodHS256, validClaims()))
 	if err != nil {
 		t.Fatalf("jwt authenticate: %v", err)
 	}
@@ -182,13 +187,12 @@ func TestCompositeAuthenticator(t *testing.T) {
 		}
 	}
 
-	_, otherPriv, _ := ed25519.GenerateKey(nil)
 	for name, bearer := range map[string]string{
 		"empty":         "",
 		"garbage":       "not-a-jwt",
 		"wrong_token":   "nope",
-		"bad_signature": mint(t, otherPriv, jwt.SigningMethodEdDSA, validClaims()),
-		"expired": mint(t, priv, jwt.SigningMethodEdDSA, jwt.MapClaims{
+		"bad_signature": mint(t, otherSecret, jwt.SigningMethodHS256, validClaims()),
+		"expired": mint(t, testSecret, jwt.SigningMethodHS256, jwt.MapClaims{
 			"iss": testIssuer, "aud": testAudience, "scope": "org_1",
 			"exp": time.Now().Add(-time.Hour).Unix(),
 		}),
@@ -202,7 +206,7 @@ func TestCompositeAuthenticator(t *testing.T) {
 }
 
 func TestNewAuthInterceptor_Composite(t *testing.T) {
-	cfg, _ := newSignedTestConfig(t)
+	cfg := newSignedTestConfig(t)
 	cfg.AuthMode = config.ConfigSyncAuthModeComposite
 	cfg.Token = "shared-tok"
 	interceptor, err := NewAuthInterceptor(&config.Config{ConfigSync: cfg}, discardLogger())
@@ -214,14 +218,13 @@ func TestNewAuthInterceptor_Composite(t *testing.T) {
 	}
 }
 
-func TestNewAuthInterceptor_SignedRequiresValidKey(t *testing.T) {
+func TestNewAuthInterceptor_SignedRequiresSecret(t *testing.T) {
 	_, err := NewAuthInterceptor(&config.Config{ConfigSync: config.ConfigSyncConfig{
-		AuthMode:     config.ConfigSyncAuthModeSigned,
-		JWTPublicKey: "-----BEGIN PUBLIC KEY-----\nnot-base64\n-----END PUBLIC KEY-----",
-		JWTIssuer:    testIssuer,
-		JWTAudience:  testAudience,
+		AuthMode:    config.ConfigSyncAuthModeSigned,
+		JWTIssuer:   testIssuer,
+		JWTAudience: testAudience,
 	}}, discardLogger())
 	if err == nil {
-		t.Fatal("expected error for malformed public key")
+		t.Fatal("expected error when signed mode has no shared secret")
 	}
 }

--- a/pkg/infra/providers/bedrock/client.go
+++ b/pkg/infra/providers/bedrock/client.go
@@ -57,7 +57,7 @@ func (c *client) Completions(
 	cfg *providers.Config,
 	reqBody []byte,
 ) ([]byte, error) {
-	model := c.resolveModel(reqBody, cfg.DefaultModel)
+	model := c.resolveModel(reqBody, cfg)
 	if model == "" {
 		return nil, fmt.Errorf("model is required")
 	}
@@ -89,7 +89,7 @@ func (c *client) CompletionsStream(
 	cfg *providers.Config,
 	reqBody []byte,
 ) (iter.Seq2[[]byte, error], error) {
-	model := c.resolveModel(reqBody, cfg.DefaultModel)
+	model := c.resolveModel(reqBody, cfg)
 	if model == "" {
 		return nil, fmt.Errorf("model is required")
 	}
@@ -327,19 +327,20 @@ func stripBedrockFields(body []byte) []byte {
 	return out
 }
 
-// resolveModel extracts the model from the request body. Falls back to
-// defaultModel when the body doesn't contain a model field. Strips a leading
-// region prefix (e.g. "eu.") so the value passed to InvokeModel is the standard
-// Bedrock model ID.
-func (c *client) resolveModel(reqBody []byte, defaultModel string) string {
+// Cross-format adaptation strips the model from the body (Bedrock resolves it
+// from the InvokeModel path), so it falls back to cfg. The "eu." region prefix
+// is trimmed to the standard Bedrock model ID.
+func (c *client) resolveModel(reqBody []byte, cfg *providers.Config) string {
 	if modelID, err := extractBedrockModelID(reqBody); err == nil && modelID != "" {
 		return modelID
 	}
-	m := defaultModel
 	if extracted, err := adapter.ExtractModel(reqBody); err == nil && extracted != "" {
-		m = extracted
+		return bedrockModelID(extracted)
 	}
-	return bedrockModelID(m)
+	if cfg.Model != "" {
+		return bedrockModelID(cfg.Model)
+	}
+	return bedrockModelID(cfg.DefaultModel)
 }
 
 func extractBedrockModelID(body []byte) (string, error) {

--- a/pkg/infra/providers/bedrock/client_test.go
+++ b/pkg/infra/providers/bedrock/client_test.go
@@ -82,17 +82,22 @@ func TestResolveModel(t *testing.T) {
 	c := &client{}
 
 	t.Run("uses exact modelId before default model", func(t *testing.T) {
-		model := c.resolveModel([]byte(`{"modelId":"eu.amazon.nova-micro-v1:0","messages":[]}`), "anthropic.claude-sonnet-4-20250514-v1:0")
+		model := c.resolveModel([]byte(`{"modelId":"eu.amazon.nova-micro-v1:0","messages":[]}`), &providers.Config{DefaultModel: "anthropic.claude-sonnet-4-20250514-v1:0"})
 		assert.Equal(t, "eu.amazon.nova-micro-v1:0", model)
 	})
 
+	t.Run("falls back to config model", func(t *testing.T) {
+		model := c.resolveModel([]byte(`{"messages":[]}`), &providers.Config{Model: "openai.gpt-oss-120b"})
+		assert.Equal(t, "openai.gpt-oss-120b", model)
+	})
+
 	t.Run("falls back to default model", func(t *testing.T) {
-		model := c.resolveModel([]byte(`{"messages":[]}`), "anthropic.claude-sonnet-4-20250514-v1:0")
+		model := c.resolveModel([]byte(`{"messages":[]}`), &providers.Config{DefaultModel: "anthropic.claude-sonnet-4-20250514-v1:0"})
 		assert.Equal(t, "anthropic.claude-sonnet-4-20250514-v1:0", model)
 	})
 
 	t.Run("no model returns empty", func(t *testing.T) {
-		assert.Equal(t, "", c.resolveModel([]byte(`{}`), ""))
+		assert.Equal(t, "", c.resolveModel([]byte(`{}`), &providers.Config{}))
 	})
 }
 


### PR DESCRIPTION
## Summary
Switches the TrustGate config-sync authenticator from asymmetric PKIX verification to HS256 with a shared secret. Part of the unified HS256 shared-secret auth across the stack (DataCore issues, control planes verify locally).

- `WithValidMethods(["HS256"])` + `WithExpirationRequired`; strict iss/aud
- Shared secret with current + previous for rotation
- Replaces `CONFIG_SYNC_JWT_PUBLIC_KEY` with `CONFIG_SYNC_JWT_SECRET` (+ `_PREVIOUS`) in config, validation, overlays and secrets example

## Commits included
- `feat(configsync): verify config-sync tokens with HS256 shared secret` (this change)
- `fix(bedrock): resolve model from gateway config when body is stripped` (pre-existing on this branch)

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/infra/configsync/grpc/... ./pkg/config/...`
- [ ] Deploy verifier before switching DataCore to HS256 (compatibility window)

Made with [Cursor](https://cursor.com)