### PR TITLE
fix: redact credentials in telemetry exports and logs

### DIFF
--- a/pkg/api/middleware/access_log.go
+++ b/pkg/api/middleware/access_log.go
@@ -19,6 +19,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/NeuralTrust/TrustGate/pkg/infra/logredact"
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/requestid"
 )
@@ -68,7 +69,7 @@ func (m *AccessLogMiddleware) Middleware() fiber.Handler {
 			if errors.As(err, &fe) {
 				status = fe.Code
 			}
-			attrs = append(attrs, slog.String("error", err.Error()))
+			attrs = append(attrs, slog.String("error", logredact.RedactLogString(err.Error())))
 		}
 		m.logger.Info("http access", append([]any{slog.Int("status", status)}, attrs...)...)
 		return err

--- a/pkg/app/metrics/builder.go
+++ b/pkg/app/metrics/builder.go
@@ -179,7 +179,7 @@ func (b *Builder) foldPluginSpans(requestTrace *trace.RequestTrace) ([]events.Po
 			Flagged:    flagged,
 			Score:      attrs.Score,
 			ScoreLabel: attrs.ScoreLabel,
-			Extras:     attrs.Extras,
+			Extras:     events.SanitizeExtras(attrs.Extras),
 		})
 	}
 	return chain, pluginsMs, anyFlagged, security

--- a/pkg/infra/logger/credential_redact_handler.go
+++ b/pkg/infra/logger/credential_redact_handler.go
@@ -1,0 +1,83 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logger
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/logredact"
+)
+
+// CredentialRedactHandler redacts credential-shaped substrings from slog records.
+type CredentialRedactHandler struct {
+	handler slog.Handler
+}
+
+// NewCredentialRedactHandler wraps h so messages and string attrs are scrubbed.
+func NewCredentialRedactHandler(h slog.Handler) *CredentialRedactHandler {
+	return &CredentialRedactHandler{handler: h}
+}
+
+func (h *CredentialRedactHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.handler.Enabled(ctx, level)
+}
+
+func (h *CredentialRedactHandler) Handle(ctx context.Context, r slog.Record) error {
+	r.Message = logredact.RedactLogString(r.Message)
+	cloned := slog.Record{
+		Time:    r.Time,
+		Level:   r.Level,
+		Message: r.Message,
+		PC:      r.PC,
+	}
+	r.Attrs(func(a slog.Attr) bool {
+		cloned.AddAttrs(redactAttr(a))
+		return true
+	})
+	return h.handler.Handle(ctx, cloned)
+}
+
+func (h *CredentialRedactHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	redacted := make([]slog.Attr, len(attrs))
+	for i, a := range attrs {
+		redacted[i] = redactAttr(a)
+	}
+	return NewCredentialRedactHandler(h.handler.WithAttrs(redacted))
+}
+
+func (h *CredentialRedactHandler) WithGroup(name string) slog.Handler {
+	return NewCredentialRedactHandler(h.handler.WithGroup(name))
+}
+
+func redactAttr(a slog.Attr) slog.Attr {
+	switch a.Value.Kind() {
+	case slog.KindAny:
+		if err, ok := a.Value.Any().(error); ok && err != nil {
+			return slog.String(a.Key, logredact.RedactLogString(err.Error()))
+		}
+		return a
+	case slog.KindString:
+		return slog.String(a.Key, logredact.RedactLogString(a.Value.String()))
+	case slog.KindGroup:
+		g := a.Value.Group()
+		for i := range g {
+			g[i] = redactAttr(g[i])
+		}
+		return slog.Attr{Key: a.Key, Value: slog.GroupValue(g...)}
+	default:
+		return a
+	}
+}

--- a/pkg/infra/logger/credential_redact_handler_test.go
+++ b/pkg/infra/logger/credential_redact_handler_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logger
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestCredentialRedactHandler_ScrubsAnyErrorAttrs(t *testing.T) {
+	var buf bytes.Buffer
+	base := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})
+	log := slog.New(NewCredentialRedactHandler(base))
+
+	log.Error("request failed", slog.Any("error", errors.New("Authorization: Bearer sk-live-secret")))
+
+	out := buf.String()
+	if strings.Contains(out, "sk-live-secret") {
+		t.Fatalf("secret leaked in log output: %s", out)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &obj); err != nil {
+		t.Fatalf("invalid json log: %v", err)
+	}
+	errVal, _ := obj["error"].(string)
+	if !strings.Contains(errVal, "[REDACTED]") {
+		t.Fatalf("error attr not redacted: %q", errVal)
+	}
+}
+
+func TestCredentialRedactHandler_PreservesNonErrorAnyAttrs(t *testing.T) {
+	var buf bytes.Buffer
+	base := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})
+	log := slog.New(NewCredentialRedactHandler(base))
+
+	log.Info("status", slog.Any("count", 42), slog.Any("error", nil))
+
+	out := buf.String()
+	if !strings.Contains(out, `"count":42`) {
+		t.Fatalf("non-error Any attr altered: %s", out)
+	}
+}
+
+func TestCredentialRedactHandler_EnabledDelegates(t *testing.T) {
+	h := NewCredentialRedactHandler(slog.NewTextHandler(ioDiscard{}, &slog.HandlerOptions{Level: slog.LevelError}))
+	if !h.Enabled(context.Background(), slog.LevelError) {
+		t.Fatal("expected handler to be enabled at error level")
+	}
+}
+
+type ioDiscard struct{}
+
+func (ioDiscard) Write(p []byte) (int, error) { return len(p), nil }

--- a/pkg/infra/logger/logger.go
+++ b/pkg/infra/logger/logger.go
@@ -181,7 +181,7 @@ func NewLoggerWithFormat(level slog.Level, format LogFormat, fileEnabled bool) *
 		consoleBaseHandler = slog.NewJSONHandler(os.Stdout, handlerOpts)
 	}
 
-	consoleHandler := NewSourceFilterHandler(consoleBaseHandler)
+	consoleHandler := NewSourceFilterHandler(NewCredentialRedactHandler(consoleBaseHandler))
 
 	if !fileEnabled {
 		return slog.New(consoleHandler)
@@ -206,5 +206,5 @@ func createFileHandler(opts *slog.HandlerOptions) (slog.Handler, error) {
 		return nil, err
 	}
 	jsonHandler := slog.NewJSONHandler(logFile, opts)
-	return NewSourceFilterHandler(jsonHandler), nil
+	return NewSourceFilterHandler(NewCredentialRedactHandler(jsonHandler)), nil
 }

--- a/pkg/infra/logredact/redact.go
+++ b/pkg/infra/logredact/redact.go
@@ -1,0 +1,56 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logredact
+
+import (
+	"regexp"
+	"strings"
+)
+
+const placeholder = "[REDACTED]"
+
+var (
+	bearerPattern   = regexp.MustCompile(`(?i)\bbearer\s+\S+`)
+	basicPattern    = regexp.MustCompile(`(?i)\bbasic\s+\S+`)
+	headerPattern   = regexp.MustCompile(`(?i)\b(?:authorization|x-[\w-]*-api-key|api-key)\s*:\s*\S+`)
+	jsonCredPattern = regexp.MustCompile(`(?i)"(?:api_key|apikey|token|secret|authorization|access_token|client_secret|private_key)"\s*:\s*"[^"]*"`)
+	skKeyPattern    = regexp.MustCompile(`\bsk-[A-Za-z0-9_-]{8,}\b`)
+	tgkKeyPattern   = regexp.MustCompile(`\btgk_[A-Za-z0-9_-]{8,}\b`)
+)
+
+// RedactLogString scrubs credential-shaped substrings from unstructured log text.
+func RedactLogString(s string) string {
+	if s == "" {
+		return s
+	}
+	out := bearerPattern.ReplaceAllString(s, "Bearer "+placeholder)
+	out = basicPattern.ReplaceAllString(out, "Basic "+placeholder)
+	out = headerPattern.ReplaceAllStringFunc(out, func(match string) string {
+		if idx := strings.Index(match, ":"); idx >= 0 {
+			return match[:idx+1] + " " + placeholder
+		}
+		return placeholder
+	})
+	out = jsonCredPattern.ReplaceAllStringFunc(out, func(match string) string {
+		if idx := strings.Index(match, ":"); idx >= 0 {
+			key := strings.TrimSpace(match[:idx+1])
+			return key + " \"" + placeholder + "\""
+		}
+		return match
+	})
+	out = skKeyPattern.ReplaceAllString(out, placeholder)
+	out = tgkKeyPattern.ReplaceAllString(out, placeholder)
+	return out
+}

--- a/pkg/infra/logredact/redact_test.go
+++ b/pkg/infra/logredact/redact_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logredact
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRedactLogString_BearerAndHeaders(t *testing.T) {
+	in := "upstream failed: Authorization: Bearer sk-live-secret X-TG-API-Key: tgk_abc123"
+	got := RedactLogString(in)
+	if strings.Contains(got, "sk-live-secret") || strings.Contains(got, "tgk_abc123") {
+		t.Fatalf("secrets leaked: %q", got)
+	}
+	if !strings.Contains(got, placeholder) {
+		t.Fatalf("expected placeholder in %q", got)
+	}
+}
+
+func TestRedactLogString_JSONInline(t *testing.T) {
+	in := `decode failed body={"api_key":"sk-secret","model":"gpt-4o"}`
+	got := RedactLogString(in)
+	if strings.Contains(got, "sk-secret") {
+		t.Fatalf("json credential leaked: %q", got)
+	}
+}
+
+func TestRedactLogString_PreservesSafeText(t *testing.T) {
+	in := "collector not found for gateway_id=abc"
+	if got := RedactLogString(in); got != in {
+		t.Fatalf("safe text altered: %q", got)
+	}
+}

--- a/pkg/infra/metrics/events/sanitize.go
+++ b/pkg/infra/metrics/events/sanitize.go
@@ -17,7 +17,6 @@ package events
 import (
 	"bytes"
 	"encoding/json"
-	"io"
 	"mime"
 	"mime/multipart"
 	"strings"
@@ -27,45 +26,75 @@ const (
 	multipartPlaceholder = `{"_multipart": true}`
 	truncatedSuffix      = "...[truncated]"
 
-	// maxSanitizedBodyBytes caps the body representation stored in an event so a
-	// large payload cannot produce an oversized Kafka message or blow up memory.
 	maxSanitizedBodyBytes = 64 * 1024
-	// maxMultipartFieldValueBytes caps the captured value of a multipart form field.
 	maxMultipartFieldValueBytes = 256
 
 	redactedValue = "[REDACTED]"
+
+	bearerRedacted = "Bearer " + redactedValue
+	basicRedacted  = "Basic " + redactedValue
 )
 
-// sensitiveHeaders are stored lower-cased; their values are never exported to a
-// telemetry exporter to avoid leaking credentials/PII into the metrics topic.
+var credentialBodyKeys = map[string]struct{}{
+	"password":       {},
+	"passwd":           {},
+	"secret":           {},
+	"token":            {},
+	"api_key":          {},
+	"apikey":           {},
+	"authorization":    {},
+	"credential":       {},
+	"access_token":     {},
+	"refresh_token":    {},
+	"client_secret":    {},
+	"private_key":      {},
+}
+
 var sensitiveHeaders = map[string]struct{}{
 	"authorization":         {},
 	"proxy-authorization":   {},
+	"www-authenticate":      {},
+	"authentication":        {},
 	"cookie":                {},
 	"set-cookie":            {},
 	"x-api-key":             {},
+	"api-key":               {},
+	"x-tg-api-key":          {},
 	"x-ag-api-key":          {},
 	"x-ag-playground-token": {},
-	"api-key":               {},
 	"x-auth-token":          {},
 	"x-access-token":        {},
 	"x-amz-security-token":  {},
+	"x-amz-credential":      {},
+	"x-goog-api-key":        {},
+	"x-csrf-token":          {},
+	"x-xsrf-token":          {},
 }
 
 // SanitizeBody returns a loggable representation of a request/response body.
-// Multipart payloads are reduced to their field names and file metadata so raw
-// file contents never reach an exporter, and oversized bodies are truncated to
-// maxSanitizedBodyBytes.
 func SanitizeBody(body []byte, headers map[string][]string) string {
 	return sanitizeBody(body, headers, maxSanitizedBodyBytes)
 }
 
-// SanitizeBodyFull behaves like SanitizeBody but never truncates by size, so the
-// full body is preserved (e.g. complete streamed responses). Multipart payloads
-// are still reduced to field/file metadata so raw file contents never reach an
-// exporter.
+// SanitizeBodyFull behaves like SanitizeBody but never truncates by size.
 func SanitizeBodyFull(body []byte, headers map[string][]string) string {
 	return sanitizeBody(body, headers, 0)
+}
+
+// SanitizeExtras redacts credential-shaped keys from plugin extras before export.
+func SanitizeExtras(extras any) any {
+	if extras == nil {
+		return nil
+	}
+	raw, err := json.Marshal(extras)
+	if err != nil {
+		return nil
+	}
+	var generic any
+	if err := json.Unmarshal(raw, &generic); err != nil {
+		return nil
+	}
+	return stripCredentialBodyValue(generic)
 }
 
 func sanitizeBody(body []byte, headers map[string][]string, maxBytes int) string {
@@ -75,11 +104,17 @@ func sanitizeBody(body []byte, headers map[string][]string, maxBytes int) string
 
 	contentType := lookupHeader(headers, "Content-Type")
 	if contentType == "" {
+		if stripped, ok := tryStripJSONCredentials(body); ok {
+			return capBody(stripped, maxBytes)
+		}
 		return capBody(body, maxBytes)
 	}
 
 	mediaType, params, err := mime.ParseMediaType(contentType)
 	if err != nil {
+		if stripped, ok := tryStripJSONCredentials(body); ok {
+			return capBody(stripped, maxBytes)
+		}
 		return capBody(body, maxBytes)
 	}
 
@@ -87,19 +122,146 @@ func sanitizeBody(body []byte, headers map[string][]string, maxBytes int) string
 		return extractMultipartFileNames(body, params["boundary"])
 	}
 
+	if isJSONMediaType(mediaType) {
+		return capBody(stripCredentialJSONBody(body), maxBytes)
+	}
+
 	return capBody(body, maxBytes)
 }
 
-// RedactHeaders returns a copy of headers with the values of sensitive headers
-// replaced by a redaction marker. The original map is never mutated.
+func isJSONMediaType(mediaType string) bool {
+	return mediaType == "application/json" || strings.HasSuffix(mediaType, "+json")
+}
+
+func tryStripJSONCredentials(body []byte) ([]byte, bool) {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 {
+		return nil, false
+	}
+	switch trimmed[0] {
+	case '{', '[':
+	default:
+		return nil, false
+	}
+	return stripCredentialJSONBody(trimmed), true
+}
+
+func stripCredentialJSONBody(body []byte) []byte {
+	if len(body) == 0 {
+		return body
+	}
+	var generic any
+	if err := json.Unmarshal(body, &generic); err != nil {
+		return body
+	}
+	if !containsCredentialKeys(generic) {
+		return body
+	}
+	stripped := stripCredentialBodyValue(generic)
+	out, err := json.Marshal(stripped)
+	if err != nil {
+		return body
+	}
+	return out
+}
+
+func containsCredentialKeys(v any) bool {
+	switch t := v.(type) {
+	case map[string]any:
+		for key, val := range t {
+			if isCredentialBodyKey(key) {
+				return true
+			}
+			if containsCredentialKeys(val) {
+				return true
+			}
+		}
+	case []any:
+		for _, val := range t {
+			if containsCredentialKeys(val) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func stripCredentialBodyValue(v any) any {
+	switch t := v.(type) {
+	case map[string]any:
+		for key, val := range t {
+			if isCredentialBodyKey(key) {
+				t[key] = stripCredentialBodyLeaf(val)
+			} else {
+				t[key] = stripCredentialBodyValue(val)
+			}
+		}
+		return t
+	case []any:
+		for i := range t {
+			t[i] = stripCredentialBodyValue(t[i])
+		}
+		return t
+	default:
+		return v
+	}
+}
+
+func stripCredentialBodyLeaf(v any) any {
+	switch t := v.(type) {
+	case string:
+		return redactedValue
+	case []any:
+		for i := range t {
+			t[i] = stripCredentialBodyLeaf(t[i])
+		}
+		return t
+	case map[string]any:
+		return stripCredentialBodyValue(t)
+	default:
+		return v
+	}
+}
+
+func isCredentialBodyKey(key string) bool {
+	lower := strings.ToLower(strings.TrimSpace(key))
+	if _, ok := credentialBodyKeys[lower]; ok {
+		return true
+	}
+	switch {
+	case lower == "apikey":
+		return true
+	case strings.HasSuffix(lower, "_api_key"):
+		return true
+	case strings.HasSuffix(lower, "-api-key"):
+		return true
+	case strings.HasSuffix(lower, "_apikey"):
+		return true
+	}
+	return false
+}
+
+func isSensitiveHeader(key string) bool {
+	lower := strings.ToLower(key)
+	if _, ok := sensitiveHeaders[lower]; ok {
+		return true
+	}
+	return strings.HasSuffix(lower, "-api-key") || lower == "apikey"
+}
+
+// RedactHeaders returns a copy of headers with sensitive values replaced.
 func RedactHeaders(headers map[string][]string) map[string][]string {
 	if headers == nil {
 		return nil
 	}
 	out := make(map[string][]string, len(headers))
 	for key, values := range headers {
-		if _, sensitive := sensitiveHeaders[strings.ToLower(key)]; sensitive {
-			out[key] = []string{redactedValue}
+		if isSensitiveHeader(key) {
+			redacted := make([]string, len(values))
+			for i, v := range values {
+				redacted[i] = redactCredentialHeaderValue(key, v)
+			}
+			out[key] = redacted
 			continue
 		}
 		out[key] = values
@@ -107,8 +269,21 @@ func RedactHeaders(headers map[string][]string) map[string][]string {
 	return out
 }
 
-// capBody truncates body to maxBytes, appending a marker. A non-positive maxBytes
-// disables truncation and returns the full body.
+func redactCredentialHeaderValue(headerKey, value string) string {
+	switch strings.ToLower(headerKey) {
+	case "authorization", "proxy-authorization":
+		trimmed := strings.TrimSpace(value)
+		lower := strings.ToLower(trimmed)
+		if strings.HasPrefix(lower, "bearer ") {
+			return bearerRedacted
+		}
+		if strings.HasPrefix(lower, "basic ") {
+			return basicRedacted
+		}
+	}
+	return redactedValue
+}
+
 func capBody(body []byte, maxBytes int) string {
 	if maxBytes <= 0 || len(body) <= maxBytes {
 		return string(body)
@@ -139,10 +314,7 @@ func extractMultipartFileNames(body []byte, boundary string) string {
 				"filename": filename,
 			}
 		} else if fieldname != "" {
-			value, _ := io.ReadAll(io.LimitReader(part, maxMultipartFieldValueBytes+1))
-			if len(value) > 0 {
-				result[fieldname] = capMultipartValue(value)
-			}
+			result[fieldname] = redactedValue
 		}
 		_ = part.Close()
 	}
@@ -157,13 +329,6 @@ func extractMultipartFileNames(body []byte, boundary string) string {
 	}
 
 	return string(jsonBytes)
-}
-
-func capMultipartValue(value []byte) string {
-	if len(value) > maxMultipartFieldValueBytes {
-		return string(value[:maxMultipartFieldValueBytes]) + truncatedSuffix
-	}
-	return string(value)
 }
 
 func lookupHeader(headers map[string][]string, name string) string {

--- a/pkg/infra/metrics/events/sanitize_test.go
+++ b/pkg/infra/metrics/events/sanitize_test.go
@@ -15,6 +15,7 @@
 package events_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics/events"
@@ -25,19 +26,63 @@ func TestRedactHeaders_RedactsSensitiveHeaders(t *testing.T) {
 	headers := map[string][]string{
 		"Authorization":         {"Bearer secret"},
 		"X-AG-Api-Key":          {"super-secret-key"},
+		"X-TG-Api-Key":          {"tgk_gateway_secret"},
 		"X-AG-Playground-Token": {"eyJhbGciOiJIUzI1NiJ9.playground.jwt"},
 		"Content-Type":          {"application/json"},
 	}
 
 	out := events.RedactHeaders(headers)
 
-	assert.Equal(t, []string{"[REDACTED]"}, out["Authorization"])
+	assert.Equal(t, []string{"Bearer [REDACTED]"}, out["Authorization"])
 	assert.Equal(t, []string{"[REDACTED]"}, out["X-AG-Api-Key"])
-	assert.Equal(t, []string{"[REDACTED]"}, out["X-AG-Playground-Token"],
-		"playground token must never reach a telemetry exporter or the trace store")
+	assert.Equal(t, []string{"[REDACTED]"}, out["X-TG-Api-Key"])
+	assert.Equal(t, []string{"[REDACTED]"}, out["X-AG-Playground-Token"])
 	assert.Equal(t, []string{"application/json"}, out["Content-Type"])
 }
 
 func TestRedactHeaders_NilReturnsNil(t *testing.T) {
 	assert.Nil(t, events.RedactHeaders(nil))
+}
+
+func TestRedactHeaders_RedactsProviderAPIKeySuffix(t *testing.T) {
+	out := events.RedactHeaders(map[string][]string{
+		"X-OpenAI-Api-Key": {"sk-live"},
+	})
+	assert.Equal(t, []string{"[REDACTED]"}, out["X-OpenAI-Api-Key"])
+}
+
+func TestSanitizeBody_HidesJSONCredentialKeys(t *testing.T) {
+	body := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"api_key":"sk-secret"}`)
+	got := events.SanitizeBody(body, map[string][]string{"Content-Type": {"application/json"}})
+
+	assert.NotContains(t, got, "sk-secret")
+	assert.Contains(t, got, "[REDACTED]")
+	assert.Contains(t, got, "gpt-4o")
+}
+
+func TestSanitizeBody_HidesJSONCredentialsWithoutContentType(t *testing.T) {
+	body := []byte(`{"openai_api_key":"sk-secret","input":"hello"}`)
+	got := events.SanitizeBody(body, nil)
+
+	assert.NotContains(t, got, "sk-secret")
+	assert.Contains(t, got, "[REDACTED]")
+	assert.Contains(t, got, "hello")
+}
+
+func TestSanitizeExtras_RedactsCredentialKeys(t *testing.T) {
+	out, ok := events.SanitizeExtras(map[string]any{
+		"findings_count": 2,
+		"api_key":        "sk-leak",
+		"matched":        []any{map[string]any{"type": "pii"}},
+	}).(map[string]any)
+	assert.True(t, ok)
+	assert.Equal(t, float64(2), out["findings_count"])
+	assert.Equal(t, "[REDACTED]", out["api_key"])
+	assert.NotNil(t, out["matched"])
+}
+
+func TestSanitizeBody_PreservesPlainTextWithoutCredentials(t *testing.T) {
+	got := events.SanitizeBody([]byte("plain user text"), map[string][]string{"Content-Type": {"text/plain"}})
+	assert.Equal(t, "plain user text", got)
+	assert.False(t, strings.Contains(got, "[REDACTED]"))
 }

--- a/pkg/infra/trace/span.go
+++ b/pkg/infra/trace/span.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/NeuralTrust/TrustGate/pkg/infra/logredact"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/adapter"
 	"github.com/google/uuid"
 )
@@ -158,7 +159,7 @@ func (s *Span) StatusCode() int {
 func (s *Span) SetError(msg string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.errMsg = msg
+	s.errMsg = logredact.RedactLogString(msg)
 }
 
 func (s *Span) Error() string {


### PR DESCRIPTION
## Summary
- Redact gateway API key headers and Bearer/Basic auth in telemetry events
- Strip JSON credential keys from LLM request/response bodies and plugin extras before export
- Add operational log redaction via `CredentialRedactHandler` (including `slog.Any("error", err)`) and span/access-log error scrubbing

## Test plan
- [x] `go test ./pkg/infra/logger/... ./pkg/infra/logredact/... ./pkg/infra/metrics/events/... ./pkg/app/metrics/... ./pkg/infra/trace/... ./pkg/api/middleware/...`
- [ ] Smoke proxy request and confirm exported metadata/raw events have redacted headers and bodies

## Notes
- Does not retroactively clean historical telemetry data
- Plain-text non-JSON bodies intentionally out of scope