### PR TITLE
fix(ratelimit): close review follow-ups for caps and MCP

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -201,7 +201,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Creates a new gateway. The slug is optional: when omitted the server generates a unique random slug. If provided it must be a lowercase DNS label and unique.",
+                "description": "Creates a new gateway. The slug is optional: when omitted the server generates a unique random slug. If provided it must be a lowercase DNS label and unique. Tenant JWTs may not send entitlements (422); only platform admins may stamp tier. With RATE_LIMIT_ENABLED, create returns 409 when the tenant is already at MaxInstances for the effective tier.",
                 "consumes": [
                     "application/json"
                 ],
@@ -244,6 +244,12 @@ const docTemplate = `{
                     },
                     "409": {
                         "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
                         "schema": {
                             "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                         }
@@ -2910,7 +2916,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Updates an existing gateway.",
+                "description": "Updates an existing gateway. Tenant JWTs may not send entitlements (422). Platform tier downgrades that would leave the tenant over the new MaxInstances return 409 — delete excess gateways first.",
                 "consumes": [
                     "application/json"
                 ],
@@ -2967,6 +2973,12 @@ const docTemplate = `{
                     },
                     "409": {
                         "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
                         "schema": {
                             "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                         }
@@ -4347,6 +4359,14 @@ const docTemplate = `{
                 "domain": {
                     "type": "string"
                 },
+                "entitlements": {
+                    "description": "Entitlements.Tier is optional; only platform admins may set it. Tenant callers sending\nentitlements receive 422. When omitted the gateway defaults to free (or inherits sibling tier).",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_domain_gateway.Entitlements"
+                        }
+                    ]
+                },
                 "metadata": {
                     "type": "object",
                     "additionalProperties": {
@@ -4363,6 +4383,10 @@ const docTemplate = `{
                 },
                 "telemetry": {
                     "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_domain_telemetry.Telemetry"
+                },
+                "tenant_id": {
+                    "description": "TenantID is optional ownership for platform (empty JWT) create-for-tenant; tenant JWTs must match or omit it.",
+                    "type": "string"
                 }
             }
         },
@@ -4374,6 +4398,14 @@ const docTemplate = `{
                 },
                 "domain": {
                     "type": "string"
+                },
+                "entitlements": {
+                    "description": "Entitlements.Tier is optional; only platform admins may set it (tenant callers get 422).\nWhen omitted the gateway's tier is left unchanged. Downgrading when the tenant already\nhas more gateways than the new tier's MaxInstances returns 409 — delete excess first.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_domain_gateway.Entitlements"
+                        }
+                    ]
                 },
                 "metadata": {
                     "type": "object",
@@ -4417,6 +4449,9 @@ const docTemplate = `{
                 },
                 "domain": {
                     "type": "string"
+                },
+                "entitlements": {
+                    "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_domain_gateway.Entitlements"
                 },
                 "hosts": {
                     "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_gateway_response.GatewayHosts"
@@ -5970,6 +6005,14 @@ const docTemplate = `{
                 "type": "array",
                 "items": {
                     "type": "integer"
+                }
+            }
+        },
+        "github_com_NeuralTrust_TrustGate_pkg_domain_gateway.Entitlements": {
+            "type": "object",
+            "properties": {
+                "tier": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -226,7 +226,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Creates a new gateway. The slug is optional: when omitted the server generates a unique random slug. If provided it must be a lowercase DNS label and unique.",
+                "description": "Creates a new gateway. The slug is optional: when omitted the server generates a unique random slug. If provided it must be a lowercase DNS label and unique. Tenant JWTs may not send entitlements (422); only platform admins may stamp tier. With RATE_LIMIT_ENABLED, create returns 409 when the tenant is already at MaxInstances for the effective tier.",
                 "tags": [
                     "gateways"
                 ],
@@ -275,6 +275,16 @@
                     },
                     "409": {
                         "description": "Conflict",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -3635,7 +3645,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Updates an existing gateway.",
+                "description": "Updates an existing gateway. Tenant JWTs may not send entitlements (422). Platform tier downgrades that would leave the tenant over the new MaxInstances return 409 — delete excess gateways first.",
                 "tags": [
                     "gateways"
                 ],
@@ -3706,6 +3716,16 @@
                     },
                     "409": {
                         "description": "Conflict",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -5179,6 +5199,14 @@
                     "domain": {
                         "type": "string"
                     },
+                    "entitlements": {
+                        "description": "Entitlements.Tier is optional; only platform admins may set it. Tenant callers sending\nentitlements receive 422. When omitted the gateway defaults to free (or inherits sibling tier).",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_domain_gateway.Entitlements"
+                            }
+                        ]
+                    },
                     "metadata": {
                         "type": "object",
                         "additionalProperties": {
@@ -5195,6 +5223,10 @@
                     },
                     "telemetry": {
                         "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_domain_telemetry.Telemetry"
+                    },
+                    "tenant_id": {
+                        "description": "TenantID is optional ownership for platform (empty JWT) create-for-tenant; tenant JWTs must match or omit it.",
+                        "type": "string"
                     }
                 }
             },
@@ -5206,6 +5238,14 @@
                     },
                     "domain": {
                         "type": "string"
+                    },
+                    "entitlements": {
+                        "description": "Entitlements.Tier is optional; only platform admins may set it (tenant callers get 422).\nWhen omitted the gateway's tier is left unchanged. Downgrading when the tenant already\nhas more gateways than the new tier's MaxInstances returns 409 — delete excess first.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_domain_gateway.Entitlements"
+                            }
+                        ]
                     },
                     "metadata": {
                         "type": "object",
@@ -5249,6 +5289,9 @@
                     },
                     "domain": {
                         "type": "string"
+                    },
+                    "entitlements": {
+                        "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_domain_gateway.Entitlements"
                     },
                     "hosts": {
                         "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_gateway_response.GatewayHosts"
@@ -6802,6 +6845,14 @@
                     "type": "array",
                     "items": {
                         "type": "integer"
+                    }
+                }
+            },
+            "github_com_NeuralTrust_TrustGate_pkg_domain_gateway.Entitlements": {
+                "type": "object",
+                "properties": {
+                    "tier": {
+                        "type": "string"
                     }
                 }
             },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -194,7 +194,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Creates a new gateway. The slug is optional: when omitted the server generates a unique random slug. If provided it must be a lowercase DNS label and unique.",
+                "description": "Creates a new gateway. The slug is optional: when omitted the server generates a unique random slug. If provided it must be a lowercase DNS label and unique. Tenant JWTs may not send entitlements (422); only platform admins may stamp tier. With RATE_LIMIT_ENABLED, create returns 409 when the tenant is already at MaxInstances for the effective tier.",
                 "consumes": [
                     "application/json"
                 ],
@@ -237,6 +237,12 @@
                     },
                     "409": {
                         "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
                         "schema": {
                             "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                         }
@@ -2903,7 +2909,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Updates an existing gateway.",
+                "description": "Updates an existing gateway. Tenant JWTs may not send entitlements (422). Platform tier downgrades that would leave the tenant over the new MaxInstances return 409 — delete excess gateways first.",
                 "consumes": [
                     "application/json"
                 ],
@@ -2960,6 +2966,12 @@
                     },
                     "409": {
                         "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
                         "schema": {
                             "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                         }
@@ -4340,6 +4352,14 @@
                 "domain": {
                     "type": "string"
                 },
+                "entitlements": {
+                    "description": "Entitlements.Tier is optional; only platform admins may set it. Tenant callers sending\nentitlements receive 422. When omitted the gateway defaults to free (or inherits sibling tier).",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_domain_gateway.Entitlements"
+                        }
+                    ]
+                },
                 "metadata": {
                     "type": "object",
                     "additionalProperties": {
@@ -4356,6 +4376,10 @@
                 },
                 "telemetry": {
                     "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_domain_telemetry.Telemetry"
+                },
+                "tenant_id": {
+                    "description": "TenantID is optional ownership for platform (empty JWT) create-for-tenant; tenant JWTs must match or omit it.",
+                    "type": "string"
                 }
             }
         },
@@ -4367,6 +4391,14 @@
                 },
                 "domain": {
                     "type": "string"
+                },
+                "entitlements": {
+                    "description": "Entitlements.Tier is optional; only platform admins may set it (tenant callers get 422).\nWhen omitted the gateway's tier is left unchanged. Downgrading when the tenant already\nhas more gateways than the new tier's MaxInstances returns 409 — delete excess first.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_domain_gateway.Entitlements"
+                        }
+                    ]
                 },
                 "metadata": {
                     "type": "object",
@@ -4410,6 +4442,9 @@
                 },
                 "domain": {
                     "type": "string"
+                },
+                "entitlements": {
+                    "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_domain_gateway.Entitlements"
                 },
                 "hosts": {
                     "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_gateway_response.GatewayHosts"
@@ -5963,6 +5998,14 @@
                 "type": "array",
                 "items": {
                     "type": "integer"
+                }
+            }
+        },
+        "github_com_NeuralTrust_TrustGate_pkg_domain_gateway.Entitlements": {
+            "type": "object",
+            "properties": {
+                "tier": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -689,6 +689,12 @@ definitions:
         $ref: '#/definitions/github_com_NeuralTrust_TrustGate_pkg_domain_gateway.ClientTLSConfig'
       domain:
         type: string
+      entitlements:
+        allOf:
+        - $ref: '#/definitions/github_com_NeuralTrust_TrustGate_pkg_domain_gateway.Entitlements'
+        description: |-
+          Entitlements.Tier is optional; only platform admins may set it. Tenant callers sending
+          entitlements receive 422. When omitted the gateway defaults to free (or inherits sibling tier).
       metadata:
         additionalProperties:
           type: string
@@ -702,6 +708,10 @@ definitions:
         type: string
       telemetry:
         $ref: '#/definitions/github_com_NeuralTrust_TrustGate_pkg_domain_telemetry.Telemetry'
+      tenant_id:
+        description: TenantID is optional ownership for platform (empty JWT) create-for-tenant;
+          tenant JWTs must match or omit it.
+        type: string
     type: object
   github_com_NeuralTrust_TrustGate_pkg_api_handler_http_gateway_request.UpdateGatewayRequest:
     properties:
@@ -709,6 +719,13 @@ definitions:
         $ref: '#/definitions/github_com_NeuralTrust_TrustGate_pkg_domain_gateway.ClientTLSConfig'
       domain:
         type: string
+      entitlements:
+        allOf:
+        - $ref: '#/definitions/github_com_NeuralTrust_TrustGate_pkg_domain_gateway.Entitlements'
+        description: |-
+          Entitlements.Tier is optional; only platform admins may set it (tenant callers get 422).
+          When omitted the gateway's tier is left unchanged. Downgrading when the tenant already
+          has more gateways than the new tier's MaxInstances returns 409 — delete excess first.
       metadata:
         additionalProperties:
           type: string
@@ -737,6 +754,8 @@ definitions:
         type: string
       domain:
         type: string
+      entitlements:
+        $ref: '#/definitions/github_com_NeuralTrust_TrustGate_pkg_domain_gateway.Entitlements'
       hosts:
         $ref: '#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_gateway_response.GatewayHosts'
       id:
@@ -1812,6 +1831,11 @@ definitions:
         type: integer
       type: array
     type: object
+  github_com_NeuralTrust_TrustGate_pkg_domain_gateway.Entitlements:
+    properties:
+      tier:
+        type: string
+    type: object
   github_com_NeuralTrust_TrustGate_pkg_domain_gateway.SessionConfig:
     properties:
       body_param_name:
@@ -2350,7 +2374,9 @@ paths:
       - application/json
       description: 'Creates a new gateway. The slug is optional: when omitted the
         server generates a unique random slug. If provided it must be a lowercase
-        DNS label and unique.'
+        DNS label and unique. Tenant JWTs may not send entitlements (422); only platform
+        admins may stamp tier. With RATE_LIMIT_ENABLED, create returns 409 when the
+        tenant is already at MaxInstances for the effective tier.'
       parameters:
       - description: Gateway to create
         in: body
@@ -2375,6 +2401,10 @@ paths:
             $ref: '#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody'
         "409":
           description: Conflict
+          schema:
+            $ref: '#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody'
+        "422":
+          description: Unprocessable Entity
           schema:
             $ref: '#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody'
       security:
@@ -4178,7 +4208,9 @@ paths:
     put:
       consumes:
       - application/json
-      description: Updates an existing gateway.
+      description: Updates an existing gateway. Tenant JWTs may not send entitlements
+        (422). Platform tier downgrades that would leave the tenant over the new MaxInstances
+        return 409 — delete excess gateways first.
       parameters:
       - description: Gateway id
         format: uuid
@@ -4213,6 +4245,10 @@ paths:
             $ref: '#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody'
         "409":
           description: Conflict
+          schema:
+            $ref: '#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody'
+        "422":
+          description: Unprocessable Entity
           schema:
             $ref: '#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody'
       security:

--- a/pkg/api/handler/http/gateway/create_gateway_handler.go
+++ b/pkg/api/handler/http/gateway/create_gateway_handler.go
@@ -40,7 +40,7 @@ func NewCreateGatewayHandler(creator appgateway.Creator, baseDomain, mcpBaseDoma
 
 // Handle godoc
 // @Summary      Create a gateway
-// @Description  Creates a new gateway. The slug is optional: when omitted the server generates a unique random slug. If provided it must be a lowercase DNS label and unique.
+// @Description  Creates a new gateway. The slug is optional: when omitted the server generates a unique random slug. If provided it must be a lowercase DNS label and unique. Tenant JWTs may not send entitlements (422); only platform admins may stamp tier. With RATE_LIMIT_ENABLED, create returns 409 when the tenant is already at MaxInstances for the effective tier.
 // @Tags         gateways
 // @Accept       json
 // @Produce      json
@@ -50,6 +50,7 @@ func NewCreateGatewayHandler(creator appgateway.Creator, baseDomain, mcpBaseDoma
 // @Failure      400      {object}  httpio.ErrorBody
 // @Failure      401      {object}  httpio.ErrorBody
 // @Failure      409      {object}  httpio.ErrorBody
+// @Failure      422      {object}  httpio.ErrorBody
 // @Router       /v1/gateways [post]
 func (h *CreateGatewayHandler) Handle(c *fiber.Ctx) error {
 	var req request.CreateGatewayRequest

--- a/pkg/api/handler/http/gateway/request/create_gateway_request.go
+++ b/pkg/api/handler/http/gateway/request/create_gateway_request.go
@@ -33,7 +33,8 @@ type CreateGatewayRequest struct {
 	Telemetry       *telemetry.Telemetry   `json:"telemetry,omitempty"`
 	ClientTLSConfig domain.ClientTLSConfig `json:"client_tls,omitempty"`
 	SessionConfig   *domain.SessionConfig  `json:"session_config,omitempty"`
-	// Entitlements.Tier is optional; when omitted the gateway defaults to the free tier.
+	// Entitlements.Tier is optional; only platform admins may set it. Tenant callers sending
+	// entitlements receive 422. When omitted the gateway defaults to free (or inherits sibling tier).
 	Entitlements *domain.Entitlements `json:"entitlements,omitempty"`
 }
 

--- a/pkg/api/handler/http/gateway/request/update_gateway_request.go
+++ b/pkg/api/handler/http/gateway/request/update_gateway_request.go
@@ -31,7 +31,9 @@ type UpdateGatewayRequest struct {
 	Telemetry       *telemetry.Telemetry    `json:"telemetry,omitempty"`
 	ClientTLSConfig *domain.ClientTLSConfig `json:"client_tls,omitempty"`
 	SessionConfig   *domain.SessionConfig   `json:"session_config,omitempty"`
-	// Entitlements.Tier is optional; when omitted the gateway's tier is left unchanged.
+	// Entitlements.Tier is optional; only platform admins may set it (tenant callers get 422).
+	// When omitted the gateway's tier is left unchanged. Downgrading when the tenant already
+	// has more gateways than the new tier's MaxInstances returns 409 — delete excess first.
 	Entitlements *domain.Entitlements `json:"entitlements,omitempty"`
 }
 

--- a/pkg/api/handler/http/gateway/update_gateway_handler.go
+++ b/pkg/api/handler/http/gateway/update_gateway_handler.go
@@ -40,7 +40,7 @@ func NewUpdateGatewayHandler(updater appgateway.Updater, finder appgateway.Finde
 
 // Handle godoc
 // @Summary      Update a gateway
-// @Description  Updates an existing gateway.
+// @Description  Updates an existing gateway. Tenant JWTs may not send entitlements (422). Platform tier downgrades that would leave the tenant over the new MaxInstances return 409 — delete excess gateways first.
 // @Tags         gateways
 // @Accept       json
 // @Produce      json
@@ -52,6 +52,7 @@ func NewUpdateGatewayHandler(updater appgateway.Updater, finder appgateway.Finde
 // @Failure      401      {object}  httpio.ErrorBody
 // @Failure      404      {object}  httpio.ErrorBody
 // @Failure      409      {object}  httpio.ErrorBody
+// @Failure      422      {object}  httpio.ErrorBody
 // @Router       /v1/gateways/{id} [put]
 func (h *UpdateGatewayHandler) Handle(c *fiber.Ctx) error {
 	id, err := httpio.ParseUUIDParam[ids.GatewayKind](c, "id")
@@ -83,7 +84,8 @@ func (h *UpdateGatewayHandler) Handle(c *fiber.Ctx) error {
 		Slug:            req.Slug,
 		Status:          req.Status,
 		Domain:          req.Domain,
-		TenantID:        tenantIDFromContext(c),
+		TenantID:        caller,
+		PlatformAdmin:   caller == "",
 		Metadata:        req.Metadata,
 		Telemetry:       req.Telemetry,
 		ClientTLSConfig: req.ClientTLSConfig,

--- a/pkg/api/handler/http/mcp/mcp_handler.go
+++ b/pkg/api/handler/http/mcp/mcp_handler.go
@@ -22,6 +22,7 @@ import (
 	appconsumer "github.com/NeuralTrust/TrustGate/pkg/app/consumer"
 	"github.com/NeuralTrust/TrustGate/pkg/app/identity/sts"
 	appmcp "github.com/NeuralTrust/TrustGate/pkg/app/mcp"
+	ratelimitapp "github.com/NeuralTrust/TrustGate/pkg/app/ratelimit"
 	consumerdomain "github.com/NeuralTrust/TrustGate/pkg/domain/consumer"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
 	infracontext "github.com/NeuralTrust/TrustGate/pkg/infra/context"
@@ -224,6 +225,8 @@ func writeAppError(c *fiber.Ctx, id json.RawMessage, err error) error {
 		return writeRPCError(c, id, codeResourceNotFound, err.Error())
 	case errors.Is(err, appmcp.ErrNoMCPRegistries):
 		return writeRPCError(c, id, codeInvalidRequest, err.Error())
+	case errors.Is(err, ratelimitapp.ErrUnavailable):
+		return writeRPCError(c, id, int(appmcp.CodeUnavailable), err.Error())
 	default:
 		return writeRPCError(c, id, codeInternalError, err.Error())
 	}

--- a/pkg/api/handler/http/mcp/rpc_dispatcher.go
+++ b/pkg/api/handler/http/mcp/rpc_dispatcher.go
@@ -138,6 +138,12 @@ func (g *RPCGateway) checkRateLimit(ctx context.Context, rc *appconsumer.Routabl
 			HTTPHeaders: exceeded.Headers(),
 		}
 	}
+	if errors.Is(err, ratelimitapp.ErrUnavailable) {
+		return &appmcp.RPCError{
+			Code:    appmcp.CodeUnavailable,
+			Message: err.Error(),
+		}
+	}
 	return err
 }
 

--- a/pkg/api/handler/http/mcp/rpc_dispatcher_test.go
+++ b/pkg/api/handler/http/mcp/rpc_dispatcher_test.go
@@ -333,7 +333,7 @@ func TestRPCGateway_PromptsGet_GatewayPlanExceeded_ReturnsRPCError(t *testing.T)
 	composer.AssertNotCalled(t, "GetPrompt", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
-func TestRPCGateway_ToolsCall_GatewayPlanUnavailable_PropagatesError(t *testing.T) {
+func TestRPCGateway_ToolsCall_GatewayPlanUnavailable_ReturnsRPCError(t *testing.T) {
 	t.Parallel()
 	composer := mocks.NewComposer(t)
 	limiter := ratelimitmocks.NewChecker(t)
@@ -346,6 +346,8 @@ func TestRPCGateway_ToolsCall_GatewayPlanUnavailable_PropagatesError(t *testing.
 	res, err := g.Dispatch(context.Background(), rc, "tools/call", json.RawMessage(`{"name":"echo"}`))
 
 	assert.Nil(t, res)
-	require.True(t, errors.Is(err, ratelimitapp.ErrUnavailable))
+	var rpcErr *appmcp.RPCError
+	require.True(t, errors.As(err, &rpcErr), "want *appmcp.RPCError, got %v", err)
+	assert.Equal(t, appmcp.CodeUnavailable, rpcErr.Code)
 	composer.AssertNotCalled(t, "CallTool", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }

--- a/pkg/app/gateway/creator.go
+++ b/pkg/app/gateway/creator.go
@@ -17,11 +17,13 @@ package gateway
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 
 	"github.com/NeuralTrust/TrustGate/pkg/app/configsyncport"
 	appmetrics "github.com/NeuralTrust/TrustGate/pkg/app/metrics"
+	commonerrors "github.com/NeuralTrust/TrustGate/pkg/common/errors"
 	domain "github.com/NeuralTrust/TrustGate/pkg/domain/gateway"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ratelimit"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/telemetry"
@@ -98,6 +100,9 @@ func (c *creator) Create(ctx context.Context, in CreateInput) (*domain.Gateway, 
 		g.SessionConfig = domain.DefaultSessionConfig()
 	}
 	// Platform admins (empty JWT tenant / PlatformAdmin) may set entitlements; tenant callers cannot.
+	if in.Entitlements != nil && !(in.PlatformAdmin || in.TenantID == "") {
+		return nil, fmt.Errorf("entitlements may only be set by platform admins: %w", commonerrors.ErrValidation)
+	}
 	if in.Entitlements != nil && (in.PlatformAdmin || in.TenantID == "") {
 		g.Entitlements = *in.Entitlements
 	}

--- a/pkg/app/gateway/creator.go
+++ b/pkg/app/gateway/creator.go
@@ -100,7 +100,7 @@ func (c *creator) Create(ctx context.Context, in CreateInput) (*domain.Gateway, 
 		g.SessionConfig = domain.DefaultSessionConfig()
 	}
 	// Platform admins (empty JWT tenant / PlatformAdmin) may set entitlements; tenant callers cannot.
-	if in.Entitlements != nil && !(in.PlatformAdmin || in.TenantID == "") {
+	if in.Entitlements != nil && !in.PlatformAdmin && in.TenantID != "" {
 		return nil, fmt.Errorf("entitlements may only be set by platform admins: %w", commonerrors.ErrValidation)
 	}
 	if in.Entitlements != nil && (in.PlatformAdmin || in.TenantID == "") {

--- a/pkg/app/gateway/creator_test.go
+++ b/pkg/app/gateway/creator_test.go
@@ -410,26 +410,20 @@ func TestCreator_Create_RateLimitDisabled_PassesUnlimitedCap(t *testing.T) {
 	}
 }
 
-func TestCreator_Create_IgnoresClientEntitlementsWhenTenantSet(t *testing.T) {
+func TestCreator_Create_RejectsClientEntitlementsWhenTenantSet(t *testing.T) {
 	t.Parallel()
 	repo := repomocks.NewRepository(t)
-	expectNoSiblingGateways(repo, "acme")
-	// Tenant-scoped caller cannot upgrade its own tier; cap stays at the free-tier 1.
-	repo.EXPECT().SaveWithTenantCap(mock.Anything, mock.Anything, "acme", 1).Return(nil).Once()
 
 	creator := appgateway.NewCreator(repo, newCacheManager(), nil, newTestLogger(), nil, true)
 
 	entitlements := domain.Entitlements{Tier: "enterprise"}
-	g, err := creator.Create(context.Background(), appgateway.CreateInput{
+	_, err := creator.Create(context.Background(), appgateway.CreateInput{
 		Slug:         "prod",
 		TenantID:     "acme",
 		Entitlements: &entitlements,
 	})
-	if err != nil {
-		t.Fatalf("Create error: %v", err)
-	}
-	if g.Entitlements.Tier != domain.TierFree {
-		t.Fatalf("tenant-set entitlements must be ignored: got %q, want free", g.Entitlements.Tier)
+	if !errors.Is(err, commonerrors.ErrValidation) {
+		t.Fatalf("expected ErrValidation rejecting tenant entitlements, got %v", err)
 	}
 }
 

--- a/pkg/app/gateway/updater.go
+++ b/pkg/app/gateway/updater.go
@@ -118,7 +118,7 @@ func (u *updater) Update(ctx context.Context, in UpdateInput) (*domain.Gateway, 
 	if in.SessionConfig != nil {
 		g.SessionConfig = in.SessionConfig
 	}
-	if in.Entitlements != nil && !(in.PlatformAdmin || in.TenantID == "") {
+	if in.Entitlements != nil && !in.PlatformAdmin && in.TenantID != "" {
 		return nil, fmt.Errorf("entitlements may only be set by platform admins: %w", commonerrors.ErrValidation)
 	}
 	if in.Entitlements != nil && (in.PlatformAdmin || in.TenantID == "") {

--- a/pkg/app/gateway/updater.go
+++ b/pkg/app/gateway/updater.go
@@ -1,26 +1,14 @@
-// Copyright 2026 NeuralTrust
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package gateway
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"time"
 
 	"github.com/NeuralTrust/TrustGate/pkg/app/configsyncport"
 	appmetrics "github.com/NeuralTrust/TrustGate/pkg/app/metrics"
+	commonerrors "github.com/NeuralTrust/TrustGate/pkg/common/errors"
 	domain "github.com/NeuralTrust/TrustGate/pkg/domain/gateway"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ratelimit"
@@ -34,6 +22,8 @@ type UpdateInput struct {
 	Status          *string
 	Domain          *string
 	TenantID        string
+	// PlatformAdmin is true when the JWT has no tenant claim (may set entitlements).
+	PlatformAdmin   bool
 	Metadata        map[string]string
 	Telemetry       *telemetry.Telemetry
 	ClientTLSConfig *domain.ClientTLSConfig
@@ -114,18 +104,29 @@ func (u *updater) Update(ctx context.Context, in UpdateInput) (*domain.Gateway, 
 	if in.SessionConfig != nil {
 		g.SessionConfig = in.SessionConfig
 	}
-	// Only platform admins (empty caller tenant) may change entitlements.
-	if in.Entitlements != nil && in.TenantID == "" {
+	if in.Entitlements != nil && !(in.PlatformAdmin || in.TenantID == "") {
+		return nil, fmt.Errorf("entitlements may only be set by platform admins: %w", commonerrors.ErrValidation)
+	}
+	if in.Entitlements != nil && (in.PlatformAdmin || in.TenantID == "") {
 		g.Entitlements = *in.Entitlements
 	}
 	g.UpdatedAt = time.Now().UTC()
 	if err := g.Validate(); err != nil {
 		return nil, err
 	}
-	if err := u.enforceInstanceCap(ctx, tenantID, old.Entitlements, g.Entitlements); err != nil {
-		return nil, err
+	maxInstances := 0
+	if u.rateLimitEnabled && tenantID != "" && old.Entitlements.Tier != g.Entitlements.Tier {
+		limits, ok := ratelimit.LimitsFor(g.Entitlements.Tier)
+		if ok && limits.HasInstanceCap() {
+			maxInstances = limits.MaxInstances
+		}
 	}
-	if err := u.repo.Update(ctx, g); err != nil {
+	if maxInstances > 0 {
+		err = u.repo.UpdateWithTenantCap(ctx, g, tenantID, maxInstances)
+	} else {
+		err = u.repo.Update(ctx, g)
+	}
+	if err != nil {
 		return nil, err
 	}
 	deleteGatewayCache(u.memoryCache, &old)
@@ -135,24 +136,4 @@ func (u *updater) Update(ctx context.Context, in UpdateInput) (*domain.Gateway, 
 		u.signaler.Signal(ctx)
 	}
 	return g, nil
-}
-
-// enforceInstanceCap rejects a tier change that would leave the tenant over the new tier's instance cap.
-// The count includes the current gateway, so N gateways under a cap of N is allowed and N under N-1 rejects.
-func (u *updater) enforceInstanceCap(ctx context.Context, tenantID string, oldEnt, newEnt domain.Entitlements) error {
-	if !u.rateLimitEnabled || tenantID == "" || oldEnt.Tier == newEnt.Tier {
-		return nil
-	}
-	limits, ok := ratelimit.LimitsFor(newEnt.Tier)
-	if !ok || !limits.HasInstanceCap() {
-		return nil
-	}
-	count, err := u.repo.CountByTenantID(ctx, tenantID)
-	if err != nil {
-		return err
-	}
-	if count > limits.MaxInstances {
-		return ratelimit.ErrInstanceLimit
-	}
-	return nil
 }

--- a/pkg/app/gateway/updater.go
+++ b/pkg/app/gateway/updater.go
@@ -1,3 +1,17 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package gateway
 
 import (
@@ -17,11 +31,11 @@ import (
 )
 
 type UpdateInput struct {
-	ID              ids.GatewayID
-	Slug            *string
-	Status          *string
-	Domain          *string
-	TenantID        string
+	ID       ids.GatewayID
+	Slug     *string
+	Status   *string
+	Domain   *string
+	TenantID string
 	// PlatformAdmin is true when the JWT has no tenant claim (may set entitlements).
 	PlatformAdmin   bool
 	Metadata        map[string]string

--- a/pkg/app/gateway/updater_test.go
+++ b/pkg/app/gateway/updater_test.go
@@ -302,7 +302,7 @@ func TestUpdater_Update_PreservesEntitlementsWhenOmitted(t *testing.T) {
 	}
 }
 
-func TestUpdater_Update_IgnoresEntitlementsForTenantCaller(t *testing.T) {
+func TestUpdater_Update_RejectsEntitlementsForTenantCaller(t *testing.T) {
 	t.Parallel()
 	repo := repomocks.NewRepository(t)
 	id := ids.New[ids.GatewayKind]()
@@ -311,28 +311,19 @@ func TestUpdater_Update_IgnoresEntitlementsForTenantCaller(t *testing.T) {
 	existing.Metadata = map[string]string{domain.MetadataTenantIDKey: "acme"}
 
 	repo.EXPECT().FindByID(mock.Anything, id).Return(existing, nil).Once()
-	repo.EXPECT().
-		Update(mock.Anything, mock.MatchedBy(func(g *domain.Gateway) bool {
-			return g.Entitlements.Tier == domain.TierFree
-		})).
-		Return(nil).
-		Once()
 
 	updater := appgateway.NewUpdater(repo, newCacheManager(), cachetest.NoopPublisher(), nil, newTestLogger(), nil, false)
-	got, err := updater.Update(context.Background(), appgateway.UpdateInput{
+	_, err := updater.Update(context.Background(), appgateway.UpdateInput{
 		ID:           id,
 		TenantID:     "acme",
 		Entitlements: &domain.Entitlements{Tier: "enterprise"},
 	})
-	if err != nil {
-		t.Fatalf("Update error: %v", err)
-	}
-	if got.Entitlements.Tier != domain.TierFree {
-		t.Fatalf("tenant caller must not change entitlements: got %q, want free", got.Entitlements.Tier)
+	if !errors.Is(err, commonerrors.ErrValidation) {
+		t.Fatalf("expected ErrValidation rejecting tenant entitlements, got %v", err)
 	}
 }
 
-func TestUpdater_Update_AllowsEntitlementsForTenantCallerWhenMutable(t *testing.T) {
+func TestUpdater_Update_AllowsEntitlementsForPlatformAdmin(t *testing.T) {
 	t.Parallel()
 	repo := repomocks.NewRepository(t)
 	id := ids.New[ids.GatewayKind]()
@@ -350,9 +341,10 @@ func TestUpdater_Update_AllowsEntitlementsForTenantCallerWhenMutable(t *testing.
 
 	updater := appgateway.NewUpdater(repo, newCacheManager(), cachetest.NoopPublisher(), nil, newTestLogger(), nil, false)
 	got, err := updater.Update(context.Background(), appgateway.UpdateInput{
-		ID:           id,
-		TenantID:     "",
-		Entitlements: &domain.Entitlements{Tier: "standard"},
+		ID:            id,
+		TenantID:      "",
+		PlatformAdmin: true,
+		Entitlements:  &domain.Entitlements{Tier: "standard"},
 	})
 	if err != nil {
 		t.Fatalf("Update error: %v", err)
@@ -372,12 +364,18 @@ func TestUpdater_Update_RejectsTierChangeOverInstanceCap(t *testing.T) {
 	existing.Entitlements = domain.Entitlements{Tier: "enterprise"}
 
 	repo.EXPECT().FindByID(mock.Anything, id).Return(existing, nil).Once()
-	repo.EXPECT().CountByTenantID(mock.Anything, "acme").Return(2, nil).Once()
+	repo.EXPECT().
+		UpdateWithTenantCap(mock.Anything, mock.MatchedBy(func(g *domain.Gateway) bool {
+			return g.Entitlements.Tier == "free"
+		}), "acme", 1).
+		Return(ratelimit.ErrInstanceLimit).
+		Once()
 
 	updater := appgateway.NewUpdater(repo, newCacheManager(), cachetest.NoopPublisher(), nil, newTestLogger(), nil, true)
 	_, err := updater.Update(context.Background(), appgateway.UpdateInput{
-		ID:           id,
-		Entitlements: &domain.Entitlements{Tier: "free"},
+		ID:            id,
+		PlatformAdmin: true,
+		Entitlements:  &domain.Entitlements{Tier: "free"},
 	})
 	if !errors.Is(err, ratelimit.ErrInstanceLimit) {
 		t.Fatalf("expected ErrInstanceLimit downgrading over the cap, got %v", err)
@@ -397,18 +395,18 @@ func TestUpdater_Update_AllowsTierChangeWithinInstanceCap(t *testing.T) {
 	existing.Entitlements = domain.Entitlements{Tier: "enterprise"}
 
 	repo.EXPECT().FindByID(mock.Anything, id).Return(existing, nil).Once()
-	repo.EXPECT().CountByTenantID(mock.Anything, "acme").Return(1, nil).Once()
 	repo.EXPECT().
-		Update(mock.Anything, mock.MatchedBy(func(g *domain.Gateway) bool {
+		UpdateWithTenantCap(mock.Anything, mock.MatchedBy(func(g *domain.Gateway) bool {
 			return g.Entitlements.Tier == "free"
-		})).
+		}), "acme", 1).
 		Return(nil).
 		Once()
 
 	updater := appgateway.NewUpdater(repo, newCacheManager(), cachetest.NoopPublisher(), nil, newTestLogger(), nil, true)
 	got, err := updater.Update(context.Background(), appgateway.UpdateInput{
-		ID:           id,
-		Entitlements: &domain.Entitlements{Tier: "free"},
+		ID:            id,
+		PlatformAdmin: true,
+		Entitlements:  &domain.Entitlements{Tier: "free"},
 	})
 	if err != nil {
 		t.Fatalf("Update error: %v", err)

--- a/pkg/app/mcp/plugin_runner.go
+++ b/pkg/app/mcp/plugin_runner.go
@@ -37,6 +37,10 @@ const codePolicyBlocked int64 = -32001
 // that return HTTP 429 (e.g. per_tool_rate_limiter) keep codePolicyBlocked (-32001).
 const CodeRateLimited int64 = -32004
 
+// CodeUnavailable is returned when gateway plan entitlements cannot be resolved
+// (unknown/empty tier). Aligns with HTTP 503 on the proxy path.
+const CodeUnavailable int64 = -32005
+
 const trustGuardRateLimitedType = "trustguard_rate_limited"
 
 const (

--- a/pkg/app/ratelimit/checker.go
+++ b/pkg/app/ratelimit/checker.go
@@ -29,7 +29,7 @@ const (
 	ReasonQuota = "quota"
 )
 
-// ErrUnavailable means the gateway has no usable tier (HTTP 503 / MCP internal error).
+// ErrUnavailable means the gateway has no usable tier (HTTP 503 / JSON-RPC -32005).
 var ErrUnavailable = errors.New("rate limit entitlements unavailable")
 
 // Exceeded is returned when a plan limit is hit (HTTP 429 / JSON-RPC -32004).

--- a/pkg/domain/gateway/mocks/gateway_repository_mock.go
+++ b/pkg/domain/gateway/mocks/gateway_repository_mock.go
@@ -513,6 +513,55 @@ func (_c *Repository_Update_Call) RunAndReturn(run func(context.Context, *gatewa
 	return _c
 }
 
+// UpdateWithTenantCap provides a mock function with given fields: ctx, g, tenantID, maxInstances
+func (_m *Repository) UpdateWithTenantCap(ctx context.Context, g *gateway.Gateway, tenantID string, maxInstances int) error {
+	ret := _m.Called(ctx, g, tenantID, maxInstances)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateWithTenantCap")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *gateway.Gateway, string, int) error); ok {
+		r0 = rf(ctx, g, tenantID, maxInstances)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Repository_UpdateWithTenantCap_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateWithTenantCap'
+type Repository_UpdateWithTenantCap_Call struct {
+	*mock.Call
+}
+
+// UpdateWithTenantCap is a helper method to define mock.On call
+//   - ctx context.Context
+//   - g *gateway.Gateway
+//   - tenantID string
+//   - maxInstances int
+func (_e *Repository_Expecter) UpdateWithTenantCap(ctx interface{}, g interface{}, tenantID interface{}, maxInstances interface{}) *Repository_UpdateWithTenantCap_Call {
+	return &Repository_UpdateWithTenantCap_Call{Call: _e.mock.On("UpdateWithTenantCap", ctx, g, tenantID, maxInstances)}
+}
+
+func (_c *Repository_UpdateWithTenantCap_Call) Run(run func(ctx context.Context, g *gateway.Gateway, tenantID string, maxInstances int)) *Repository_UpdateWithTenantCap_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*gateway.Gateway), args[2].(string), args[3].(int))
+	})
+	return _c
+}
+
+func (_c *Repository_UpdateWithTenantCap_Call) Return(_a0 error) *Repository_UpdateWithTenantCap_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Repository_UpdateWithTenantCap_Call) RunAndReturn(run func(context.Context, *gateway.Gateway, string, int) error) *Repository_UpdateWithTenantCap_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewRepository creates a new instance of Repository. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewRepository(t interface {

--- a/pkg/domain/gateway/repository.go
+++ b/pkg/domain/gateway/repository.go
@@ -40,4 +40,6 @@ type Repository interface {
 	CountByTenantID(ctx context.Context, tenantID string) (int, error)
 	// SaveWithTenantCap atomically enforces maxInstances for tenantID before inserting g; maxInstances <= 0 means unlimited.
 	SaveWithTenantCap(ctx context.Context, g *Gateway, tenantID string, maxInstances int) error
+	// UpdateWithTenantCap updates g under the same tenant advisory lock used by SaveWithTenantCap when maxInstances > 0.
+	UpdateWithTenantCap(ctx context.Context, g *Gateway, tenantID string, maxInstances int) error
 }

--- a/pkg/domain/ratelimit/errors.go
+++ b/pkg/domain/ratelimit/errors.go
@@ -21,4 +21,6 @@ import (
 )
 
 // ErrInstanceLimit is returned when a tenant already has the tier's max instances.
+// On tier downgrade this means the tenant still has more gateways than the new
+// tier allows — delete excess gateways (or keep them on a higher tier) before lowering the plan.
 var ErrInstanceLimit = fmt.Errorf("ratelimit: instance limit reached: %w", commonerrors.ErrConflict)

--- a/pkg/infra/repository/gateway/repository.go
+++ b/pkg/infra/repository/gateway/repository.go
@@ -177,6 +177,70 @@ func (r *Repository) Update(ctx context.Context, g *domain.Gateway) error {
 	})
 }
 
+// UpdateWithTenantCap serializes the count-then-update behind the same tenant advisory lock as SaveWithTenantCap.
+func (r *Repository) UpdateWithTenantCap(ctx context.Context, g *domain.Gateway, tenantID string, maxInstances int) error {
+	if g == nil {
+		return errors.New("gateway repository: nil gateway")
+	}
+	if tenantID == "" || maxInstances <= 0 {
+		return r.Update(ctx, g)
+	}
+	metadataBytes, err := marshalJSON(g.Metadata)
+	if err != nil {
+		return fmt.Errorf("gateway repository: marshal metadata: %w", err)
+	}
+	telemetryBytes, err := marshalJSON(g.Telemetry)
+	if err != nil {
+		return fmt.Errorf("gateway repository: marshal telemetry: %w", err)
+	}
+	clientTLSBytes, err := marshalJSON(g.ClientTLSConfig)
+	if err != nil {
+		return fmt.Errorf("gateway repository: marshal client_tls: %w", err)
+	}
+	sessionBytes, err := marshalJSON(g.SessionConfig)
+	if err != nil {
+		return fmt.Errorf("gateway repository: marshal session_config: %w", err)
+	}
+	entitlementsBytes, err := marshalJSON(g.Entitlements)
+	if err != nil {
+		return fmt.Errorf("gateway repository: marshal entitlements: %w", err)
+	}
+	const query = `
+		UPDATE gateways
+		   SET slug           = $2,
+		       status         = $3,
+		       domain         = $4,
+		       metadata       = $5,
+		       telemetry      = $6,
+		       client_tls     = $7,
+		       session_config = $8,
+		       entitlements   = $9,
+		       updated_at     = $10
+		 WHERE id = $1`
+	return r.withMarkedTx(ctx, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtext($1))`, tenantID); err != nil {
+			return fmt.Errorf("gateway repository: acquire tenant lock: %w", err)
+		}
+		var count int
+		if err := tx.QueryRow(ctx, `SELECT COUNT(*) FROM gateways WHERE metadata->>'tenant_id' = $1`, tenantID).Scan(&count); err != nil {
+			return fmt.Errorf("gateway repository: count by tenant: %w", err)
+		}
+		if count > maxInstances {
+			return ratelimit.ErrInstanceLimit
+		}
+		cmd, err := tx.Exec(ctx, query,
+			g.ID, g.Slug, g.Status, g.Domain, metadataBytes, telemetryBytes, clientTLSBytes, sessionBytes, entitlementsBytes, g.UpdatedAt,
+		)
+		if err != nil {
+			return mapPgError(err)
+		}
+		if cmd.RowsAffected() == 0 {
+			return domain.ErrNotFound
+		}
+		return nil
+	})
+}
+
 // cascadeDeleteStatements removes every resource that belongs to the gateway
 // before the gateway row itself. The order respects the ON DELETE RESTRICT
 // foreign keys on the junction tables (consumer_auth.auth_id,

--- a/pkg/runtimeconfig/snapshot/adapters/gateway_repository.go
+++ b/pkg/runtimeconfig/snapshot/adapters/gateway_repository.go
@@ -79,6 +79,10 @@ func (r *gatewayRepository) Update(_ context.Context, _ *domain.Gateway) error {
 	return configsync.ErrReadOnly
 }
 
+func (r *gatewayRepository) UpdateWithTenantCap(_ context.Context, _ *domain.Gateway, _ string, _ int) error {
+	return configsync.ErrReadOnly
+}
+
 func (r *gatewayRepository) Delete(_ context.Context, _ ids.GatewayID) error {
 	return configsync.ErrReadOnly
 }

--- a/postman/TrustGate.postman_collection.json
+++ b/postman/TrustGate.postman_collection.json
@@ -481,7 +481,45 @@
                 "gateways"
               ]
             },
-            "description": "Optional `slug` (lowercase DNS label): when omitted the server generates a unique random slug. The slug identifies the gateway on the proxy plane: `X-AG-Gateway-Slug` header (GATEWAY_DISCOVERY_MODE=header, default) or `{slug}.<GATEWAY_BASE_DOMAIN>` host (subdomain mode)."
+            "description": "Optional slug (lowercase DNS label); omitted \u2192 server generates. Tenant JWT must not send entitlements (422). Platform may stamp entitlements.tier and body tenant_id (create-for-tenant). With RATE_LIMIT_ENABLED, 409 at MaxInstances; free create inherits highest sibling tier."
+          }
+        },
+        {
+          "name": "Create Gateway with entitlements (tenant \u2192 422)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('tenant cannot stamp entitlements', function () { pm.response.to.have.status(422); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"slug\": \"team-a-ent-{{$randomInt}}\",\n  \"entitlements\": {\"tier\": \"standard\"}\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/gateways",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "v1",
+                "gateways"
+              ]
+            },
+            "description": "Tenant JWT must not send entitlements; only platform admins may stamp tier. Expect 422 when using a tenant-scoped admin token."
           }
         },
         {
@@ -558,7 +596,8 @@
                 "gateways",
                 "{{gateway_id}}"
               ]
-            }
+            },
+            "description": "Update gateway fields. Tenant JWT + entitlements \u2192 422. Platform tier downgrade when count > new MaxInstances \u2192 409 (delete excess first)."
           }
         },
         {


### PR DESCRIPTION
## Summary
- Reject tenant JWT `entitlements` with **422** (no silent ignore).
- Enforce `MaxInstances` on tier update under the same tenant `pg_advisory_xact_lock` as create (`UpdateWithTenantCap`).
- Map plan `ErrUnavailable` to MCP JSON-RPC **-32005** (aligned with proxy HTTP 503).
- Document delete-before-downgrade in API/request comments.

Follow-up to #237 review suggestions.

## Test plan
- [x] `go test ./pkg/app/gateway/ ./pkg/api/handler/http/gateway/ ./pkg/api/handler/http/mcp/ ./pkg/domain/ratelimit/ ./pkg/infra/repository/gateway/`
- [ ] Tenant create/update with `entitlements` → 422
- [ ] Platform downgrade over cap → 409; delete then downgrade → 200
- [ ] MCP tools/call with unknown tier → `-32005`