### PR TITLE
feat(configsync): scope config sync per gateway instance

### DIFF
--- a/pkg/app/configsnapshot/compiler.go
+++ b/pkg/app/configsnapshot/compiler.go
@@ -80,7 +80,7 @@ func (c *Compiler) CompileFor(ctx context.Context, scope string) (*readmodel.Sna
 	data := readmodel.Data{}
 	var skipped, considered int
 	for i := range gateways {
-		if scope != "" && gateways[i].TenantID() != scope {
+		if scope != "" && gateways[i].ID.String() != scope {
 			continue
 		}
 		considered++
@@ -136,7 +136,7 @@ func (c *Compiler) CompileAll(ctx context.Context) (*readmodel.Snapshot, map[str
 			return nil, nil, err
 		}
 		appendGatewayData(&global, gateways[i], gwData)
-		if scope := gateways[i].TenantID(); scope != "" {
+		if scope := gateways[i].ID.String(); scope != "" {
 			bucket, ok := buckets[scope]
 			if !ok {
 				bucket = &readmodel.Data{}

--- a/pkg/app/configsnapshot/dispatcher.go
+++ b/pkg/app/configsnapshot/dispatcher.go
@@ -70,8 +70,9 @@ type Dispatcher struct {
 	maxRows     int
 	trigger     chan struct{}
 
-	mu        sync.Mutex
-	published string
+	mu              sync.Mutex
+	publishedGlobal string
+	publishedScoped map[string]string
 }
 
 // NewDispatcher builds the control-plane snapshot dispatcher.
@@ -113,8 +114,9 @@ func NewDispatcher(
 		debounce:    debounce,
 		backstop:    backstop,
 		retention:   retention,
-		maxRows:     maxRows,
-		trigger:     make(chan struct{}, 1),
+		maxRows:         maxRows,
+		trigger:         make(chan struct{}, 1),
+		publishedScoped: make(map[string]string),
 	}
 }
 
@@ -209,15 +211,30 @@ func (d *Dispatcher) dispatch(ctx context.Context) error {
 		return err
 	}
 
+	// The global snapshot is derived from every gateway plus the shared catalog, so
+	// any change bumps the global version; that makes it a safe outer gate for the
+	// scoped diff below. A change to one gateway bumps only the global version and
+	// that gateway's scoped version, so only that scope's pods are notified.
 	d.mu.Lock()
-	if version != d.published {
+	if version != d.publishedGlobal {
 		if scoped != nil {
 			d.holder.SetPartitioned(raw, version, scoped)
 		} else {
 			d.holder.Set(raw, version)
 		}
-		d.broadcaster.Broadcast(version)
-		d.published = version
+		d.broadcaster.BroadcastScope("", version)
+		d.publishedGlobal = version
+		for scope, snap := range scoped {
+			if d.publishedScoped[scope] != snap.Version {
+				d.broadcaster.BroadcastScope(scope, snap.Version)
+				d.publishedScoped[scope] = snap.Version
+			}
+		}
+		for scope := range d.publishedScoped {
+			if _, ok := scoped[scope]; !ok {
+				delete(d.publishedScoped, scope)
+			}
+		}
 	}
 	d.mu.Unlock()
 

--- a/pkg/app/configsnapshot/dispatcher_test.go
+++ b/pkg/app/configsnapshot/dispatcher_test.go
@@ -70,6 +70,7 @@ func newDispatchCompiler(gateways appsnapshot.GatewayReader) *appsnapshot.Compil
 type fakeBroadcaster struct {
 	mu       sync.Mutex
 	versions []string
+	scoped   map[string][]string
 }
 
 func (b *fakeBroadcaster) Broadcast(version string) {
@@ -78,11 +79,32 @@ func (b *fakeBroadcaster) Broadcast(version string) {
 	b.versions = append(b.versions, version)
 }
 
+func (b *fakeBroadcaster) BroadcastScope(scope, version string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if scope == "" {
+		b.versions = append(b.versions, version)
+		return
+	}
+	if b.scoped == nil {
+		b.scoped = map[string][]string{}
+	}
+	b.scoped[scope] = append(b.scoped[scope], version)
+}
+
 func (b *fakeBroadcaster) broadcasted() []string {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	out := make([]string, len(b.versions))
 	copy(out, b.versions)
+	return out
+}
+
+func (b *fakeBroadcaster) scopedBroadcasted(scope string) []string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]string, len(b.scoped[scope]))
+	copy(out, b.scoped[scope])
 	return out
 }
 
@@ -241,6 +263,32 @@ func TestDispatch_ChangedDataBroadcastsNewVersion(t *testing.T) {
 	}
 	if versions[0] == versions[1] {
 		t.Fatalf("changed data must produce a distinct version, got %v", versions)
+	}
+}
+
+func TestDispatch_ScopedBroadcastOnlyWakesChangedInstance(t *testing.T) {
+	t.Parallel()
+	gwA := mustGatewayID(t, "11111111-1111-1111-1111-111111111111")
+	gwB := mustGatewayID(t, "22222222-2222-2222-2222-222222222222")
+	gateways := &settableGateways{items: []*gatewaydomain.Gateway{{ID: gwA}}}
+	holder := appsnapshot.NewHolder()
+	broadcaster := &fakeBroadcaster{}
+	outbox := &fakeOutbox{}
+	d := appsnapshot.NewDispatcher(newDispatchCompiler(gateways), infrasnapshot.NewCodec(), holder, broadcaster, outbox, nil, appsnapshot.DispatcherConfig{})
+
+	if err := d.Dispatch(context.Background()); err != nil {
+		t.Fatalf("first dispatch: %v", err)
+	}
+	gateways.set([]*gatewaydomain.Gateway{{ID: gwA}, {ID: gwB}})
+	if err := d.Dispatch(context.Background()); err != nil {
+		t.Fatalf("second dispatch: %v", err)
+	}
+
+	if got := broadcaster.scopedBroadcasted(gwA.String()); len(got) != 1 {
+		t.Fatalf("adding gwB must not wake gwA's pods; gwA scoped broadcasts = %v", got)
+	}
+	if got := broadcaster.scopedBroadcasted(gwB.String()); len(got) != 1 {
+		t.Fatalf("the new gwB scope must be notified exactly once, got %v", got)
 	}
 }
 

--- a/pkg/app/configsnapshot/scope_test.go
+++ b/pkg/app/configsnapshot/scope_test.go
@@ -70,7 +70,7 @@ func TestCompilerCompileForIsolatesScope(t *testing.T) {
 
 	compiler := twoTenantCompiler(t, acme, globex, acmeConsumer, globexConsumer)
 
-	snap, err := compiler.CompileFor(context.Background(), "acme")
+	snap, err := compiler.CompileFor(context.Background(), acme.String())
 	if err != nil {
 		t.Fatalf("compile for acme: %v", err)
 	}
@@ -104,7 +104,7 @@ func TestCompilerCompileAllPartitionsAndIsolates(t *testing.T) {
 	if len(scoped) != 2 {
 		t.Fatalf("expected 2 scopes, got %d", len(scoped))
 	}
-	acmeSnap, ok := scoped["acme"]
+	acmeSnap, ok := scoped[acme.String()]
 	if !ok {
 		t.Fatal("missing acme scope")
 	}
@@ -119,7 +119,7 @@ func TestCompilerCompileAllPartitionsAndIsolates(t *testing.T) {
 	if len(acmeSnap.Data().Providers) != 1 {
 		t.Fatalf("expected shared catalog in acme scope, got %d", len(acmeSnap.Data().Providers))
 	}
-	globexSnap := scoped["globex"]
+	globexSnap := scoped[globex.String()]
 	if gws := globexSnap.Data().Gateways; len(gws) != 1 || gws[0].ID != globex {
 		t.Fatalf("globex scope leaked other gateways: %+v", gws)
 	}
@@ -164,7 +164,7 @@ func TestCompileForIsolatesEveryChildObjectType(t *testing.T) {
 		nil,
 	)
 
-	snap, err := compiler.CompileFor(context.Background(), "acme")
+	snap, err := compiler.CompileFor(context.Background(), acme.String())
 	if err != nil {
 		t.Fatalf("compile for acme: %v", err)
 	}

--- a/pkg/app/configsyncport/port.go
+++ b/pkg/app/configsyncport/port.go
@@ -27,7 +27,13 @@ type SnapshotSignaler interface {
 // gRPC hub implements it; the dispatcher depends only on this port so the app layer
 // never imports gRPC.
 type VersionBroadcaster interface {
+	// Broadcast delivers version to every connected data plane.
 	Broadcast(version string)
+	// BroadcastScope delivers version only to connections registered under scope,
+	// so a change to one instance wakes only that instance's pods. An empty scope
+	// targets the in-cluster shared/composite data planes that serve the global
+	// snapshot.
+	BroadcastScope(scope, version string)
 }
 
 // OutboxRepository is the change-marker outbox as seen by the dispatcher: read the

--- a/pkg/infra/configsync/grpc/authenticator.go
+++ b/pkg/infra/configsync/grpc/authenticator.go
@@ -107,8 +107,8 @@ func (j *jwtAuthenticator) authenticate(bearer string) (string, error) {
 		if _, err := j.parser.ParseWithClaims(bearer, claims, func(*jwt.Token) (any, error) { return secret, nil }); err != nil {
 			continue
 		}
-		scope, ok := claims["scope"].(string)
-		if !ok || scope == "" {
+		scope := instanceScope(claims)
+		if scope == "" {
 			return "", errUnauthenticated
 		}
 		return scope, nil
@@ -116,12 +116,16 @@ func (j *jwtAuthenticator) authenticate(bearer string) (string, error) {
 	return "", errUnauthenticated
 }
 
-// compositeAuthenticator accepts either a signed per-tenant JWT (external data
-// planes → scoped snapshot) or the shared bearer token (in-cluster data plane →
-// global snapshot). The JWT is verified first; only a bearer that fails JWT
-// verification is compared against the shared token in constant time. This lets a
-// single control plane serve an internal shared fleet and external per-tenant
-// data planes at once, without the shared secret ever leaving the cluster.
+func instanceScope(claims jwt.MapClaims) string {
+	if instanceID, ok := claims["instance_id"].(string); ok && instanceID != "" {
+		return instanceID
+	}
+	if scope, ok := claims["scope"].(string); ok {
+		return scope
+	}
+	return ""
+}
+
 type compositeAuthenticator struct {
 	jwt    *jwtAuthenticator
 	shared *sharedAuthenticator

--- a/pkg/infra/configsync/grpc/hub.go
+++ b/pkg/infra/configsync/grpc/hub.go
@@ -83,6 +83,21 @@ func (h *Hub) Broadcast(version string) {
 	}
 }
 
+// BroadcastScope delivers version only to connections registered under scope,
+// coalescing to the newest version per connection and never blocking. Multiple
+// pods sharing one instance scope all receive the notice; other scopes are left
+// undisturbed. An empty scope targets the in-cluster shared/composite data
+// planes that serve the global snapshot.
+func (h *Hub) BroadcastScope(scope, version string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for conn := range h.conns {
+		if conn.scope == scope {
+			conn.enqueue(version)
+		}
+	}
+}
+
 // ConnectionCount reports the number of registered data-plane streams.
 func (h *Hub) ConnectionCount() int {
 	h.mu.Lock()


### PR DESCRIPTION
## Context

Part of the hybrid residency instance-centric refactor (project RUN, epic RUN-817). The config-sync scope moves from tenant to `instance_id` (gateway_id), so each data plane pulls the config of a single gateway.

## Changes

- Authenticator reads the `instance_id` claim (fallback to `scope` for pre-rename tokens).
- Compiler/holder partition snapshots by `gateway.ID`.
- `VersionBroadcaster.BroadcastScope` + dispatcher track global and per-scope versions, so a change wakes only the affected gateway's pods (no thundering herd across all data planes).

## Test plan

- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./...` (configsnapshot, configsync) green

## Rollout

Config-sync verifier secret (`CONFIG_SYNC_JWT_SECRET`) must equal DataCore `CONFIG_SYNC_SIGNING_SECRET`; align `iss`/`aud`.

Made with [Cursor](https://cursor.com)