### PR TITLE
fix: omit empty password from IAM Postgres DSN

### DIFF
--- a/pkg/infra/database/connection.go
+++ b/pkg/infra/database/connection.go
@@ -63,10 +63,19 @@ func buildPoolConfig(ctx context.Context, cfg *config.DatabaseConfig) (*pgxpool.
 	if cfg.Login == "aws" {
 		password = ""
 	}
+	// Omit empty password= from the DSN. pgx keyword parsing treats
+	// `password= dbname=foo` as Password="dbname=foo" and Database="", so IAM
+	// (empty password) would drop the database name and fall back to the username.
 	dsn := fmt.Sprintf(
-		"host=%s port=%d user=%s password=%s dbname=%s sslmode=%s",
-		cfg.Host, cfg.Port, cfg.User, password, cfg.Name, cfg.SSLMode,
+		"host=%s port=%d user=%s dbname=%s sslmode=%s",
+		cfg.Host, cfg.Port, cfg.User, cfg.Name, cfg.SSLMode,
 	)
+	if password != "" {
+		dsn = fmt.Sprintf(
+			"host=%s port=%d user=%s password=%s dbname=%s sslmode=%s",
+			cfg.Host, cfg.Port, cfg.User, password, cfg.Name, cfg.SSLMode,
+		)
+	}
 	if cfg.SSLRootCert != "" {
 		dsn += " sslrootcert=" + cfg.SSLRootCert
 	}

--- a/pkg/infra/database/connection_iam_dsn_test.go
+++ b/pkg/infra/database/connection_iam_dsn_test.go
@@ -1,3 +1,17 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package database
 
 import (
@@ -11,6 +25,7 @@ import (
 // Empty password= in a keyword DSN makes pgx swallow dbname as the password.
 // IAM auth must omit the password key entirely so Database stays set.
 func TestBuildPoolConfig_IAMOmitsEmptyPassword(t *testing.T) {
+	t.Setenv("AWS_REGION", "us-east-1")
 	cfg := &config.DatabaseConfig{
 		Login:    "aws",
 		Host:     "db.example.com",

--- a/pkg/infra/database/connection_iam_dsn_test.go
+++ b/pkg/infra/database/connection_iam_dsn_test.go
@@ -1,0 +1,30 @@
+package database
+
+import (
+	"context"
+	"testing"
+
+	"github.com/NeuralTrust/TrustGate/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+// Empty password= in a keyword DSN makes pgx swallow dbname as the password.
+// IAM auth must omit the password key entirely so Database stays set.
+func TestBuildPoolConfig_IAMOmitsEmptyPassword(t *testing.T) {
+	cfg := &config.DatabaseConfig{
+		Login:    "aws",
+		Host:     "db.example.com",
+		Port:     5432,
+		User:     "agentgateway_iam",
+		Password: "",
+		Name:     "agentgateway",
+		SSLMode:  "require",
+		MaxConns: 1,
+		MinConns: 0,
+	}
+	poolCfg, err := buildPoolConfig(context.Background(), cfg)
+	require.NoError(t, err)
+	require.Equal(t, "agentgateway", poolCfg.ConnConfig.Database)
+	require.Equal(t, "agentgateway_iam", poolCfg.ConnConfig.User)
+	require.Empty(t, poolCfg.ConnConfig.Password)
+}


### PR DESCRIPTION
## Summary
- When using AWS IAM DB auth (`login=aws`), the DSN used `password=` with an empty value. pgx keyword parsing then treated `dbname=…` as the password and left Database empty.
- Omit the `password` key entirely when the password is empty, and add a regression test.

## Test plan
- [x] `go test ./pkg/infra/database/ -run TestBuildPoolConfig_IAMOmitsEmptyPassword`
- [ ] Confirm IAM-authenticated pods connect with the expected database name