### PR TITLE
fix(ratelimit): close MCP metering and TrustGuard 503 gaps

### DIFF
--- a/pkg/api/handler/http/mcp/mcp_handler.go
+++ b/pkg/api/handler/http/mcp/mcp_handler.go
@@ -190,7 +190,7 @@ func writeAppError(c *fiber.Ctx, id json.RawMessage, err error) error {
 	switch {
 	case errors.As(err, &rpcErr):
 		applyRPCErrorHeaders(c, rpcErr)
-		return writeJSON(c, rpcResponse{
+		return writeJSONStatus(c, httpStatusForRPCCode(rpcErr.Code), rpcResponse{
 			JSONRPC: "2.0",
 			ID:      normalizeID(id),
 			Error:   &rpcError{Code: int(rpcErr.Code), Message: rpcErr.Message, Data: rpcErr.Data},
@@ -226,7 +226,11 @@ func writeAppError(c *fiber.Ctx, id json.RawMessage, err error) error {
 	case errors.Is(err, appmcp.ErrNoMCPRegistries):
 		return writeRPCError(c, id, codeInvalidRequest, err.Error())
 	case errors.Is(err, ratelimitapp.ErrUnavailable):
-		return writeRPCError(c, id, int(appmcp.CodeUnavailable), err.Error())
+		return writeJSONStatus(c, fiber.StatusServiceUnavailable, rpcResponse{
+			JSONRPC: "2.0",
+			ID:      normalizeID(id),
+			Error:   &rpcError{Code: int(appmcp.CodeUnavailable), Message: err.Error()},
+		})
 	default:
 		return writeRPCError(c, id, codeInternalError, err.Error())
 	}
@@ -257,7 +261,22 @@ func writeRPCError(c *fiber.Ctx, id json.RawMessage, code int, message string) e
 }
 
 func writeJSON(c *fiber.Ctx, body any) error {
-	return c.Status(fiber.StatusOK).JSON(body)
+	return writeJSONStatus(c, fiber.StatusOK, body)
+}
+
+func writeJSONStatus(c *fiber.Ctx, status int, body any) error {
+	return c.Status(status).JSON(body)
+}
+
+func httpStatusForRPCCode(code int64) int {
+	switch code {
+	case appmcp.CodeRateLimited:
+		return fiber.StatusTooManyRequests
+	case appmcp.CodeUnavailable:
+		return fiber.StatusServiceUnavailable
+	default:
+		return fiber.StatusOK
+	}
 }
 
 func applyRPCErrorHeaders(c *fiber.Ctx, err *appmcp.RPCError) {

--- a/pkg/api/handler/http/mcp/rpc_dispatcher.go
+++ b/pkg/api/handler/http/mcp/rpc_dispatcher.go
@@ -150,6 +150,9 @@ func (g *RPCGateway) checkRateLimit(ctx context.Context, rc *appconsumer.Routabl
 func (g *RPCGateway) dispatch(ctx context.Context, rc *appconsumer.RoutableConsumer, method string, params json.RawMessage) (any, error) {
 	switch method {
 	case "tools/list":
+		if err := g.checkRateLimit(ctx, rc); err != nil {
+			return nil, err
+		}
 		tools, err := g.composer.ListTools(ctx, rc)
 		if err != nil {
 			return nil, err
@@ -181,6 +184,9 @@ func (g *RPCGateway) dispatch(ctx context.Context, rc *appconsumer.RoutableConsu
 		}
 		return result, nil
 	case "resources/list":
+		if err := g.checkRateLimit(ctx, rc); err != nil {
+			return nil, err
+		}
 		resources, err := g.composer.ListResources(ctx, rc)
 		if err != nil {
 			return nil, err
@@ -190,6 +196,9 @@ func (g *RPCGateway) dispatch(ctx context.Context, rc *appconsumer.RoutableConsu
 		}
 		return map[string]any{"resources": resources}, nil
 	case "resources/templates/list":
+		if err := g.checkRateLimit(ctx, rc); err != nil {
+			return nil, err
+		}
 		templates, err := g.composer.ListResourceTemplates(ctx, rc)
 		if err != nil {
 			return nil, err
@@ -210,6 +219,9 @@ func (g *RPCGateway) dispatch(ctx context.Context, rc *appconsumer.RoutableConsu
 		}
 		return g.composer.ReadResource(ctx, rc, p.URI)
 	case "prompts/list":
+		if err := g.checkRateLimit(ctx, rc); err != nil {
+			return nil, err
+		}
 		prompts, err := g.composer.ListPrompts(ctx, rc)
 		if err != nil {
 			return nil, err

--- a/pkg/api/handler/http/mcp/rpc_dispatcher_test.go
+++ b/pkg/api/handler/http/mcp/rpc_dispatcher_test.go
@@ -245,7 +245,7 @@ func TestHandler_ToolsCall_RateLimitPropagatesHeaders(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+	require.Equal(t, fiber.StatusTooManyRequests, resp.StatusCode)
 	require.Equal(t, "30", resp.Header.Get("Retry-After"))
 	require.Equal(t, "quota", resp.Header.Get("X-RateLimit-Reason"))
 	require.Equal(t, "10000", resp.Header.Get("X-RateLimit-Limit"))
@@ -255,6 +255,30 @@ func TestHandler_ToolsCall_RateLimitPropagatesHeaders(t *testing.T) {
 	rpcErr := body["error"].(map[string]any)
 	require.Equal(t, float64(-32004), rpcErr["code"])
 	composer.AssertNotCalled(t, "CallTool", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestRPCGateway_ToolsList_GatewayPlanExceeded_ReturnsRPCError(t *testing.T) {
+	t.Parallel()
+	composer := mocks.NewComposer(t)
+	limiter := ratelimitmocks.NewChecker(t)
+	limiter.EXPECT().Check(mock.Anything, mock.Anything).Return(&ratelimitapp.Exceeded{
+		Reason:     ratelimitapp.ReasonBurst,
+		Limit:      60,
+		Remaining:  0,
+		RetryAfter: 5 * time.Second,
+	}).Once()
+
+	g := mcphttp.NewRPCGateway(composer, noopRunner(), limiter)
+	rc := &appconsumer.RoutableConsumer{
+		Consumer: &consumerdomain.Consumer{Type: consumerdomain.TypeMCP, GatewayID: ids.New[ids.GatewayKind]()},
+	}
+	res, err := g.Dispatch(context.Background(), rc, "tools/list", nil)
+
+	assert.Nil(t, res)
+	var rpcErr *appmcp.RPCError
+	require.True(t, errors.As(err, &rpcErr), "want *appmcp.RPCError, got %v", err)
+	assert.Equal(t, appmcp.CodeRateLimited, rpcErr.Code)
+	composer.AssertNotCalled(t, "ListTools", mock.Anything, mock.Anything)
 }
 
 func TestRPCGateway_ToolsCall_GatewayPlanExceeded_ReturnsRPCErrorWithHeaders(t *testing.T) {

--- a/pkg/app/mcp/plugin_runner.go
+++ b/pkg/app/mcp/plugin_runner.go
@@ -38,10 +38,11 @@ const codePolicyBlocked int64 = -32001
 const CodeRateLimited int64 = -32004
 
 // CodeUnavailable is returned when gateway plan entitlements cannot be resolved
-// (unknown/empty tier). Aligns with HTTP 503 on the proxy path.
+// (unknown tier) or TrustGuard evaluate returns 503. Aligns with HTTP 503 on the proxy path.
 const CodeUnavailable int64 = -32005
 
 const trustGuardRateLimitedType = "trustguard_rate_limited"
+const trustGuardUnavailableType = "trustguard_unavailable"
 
 const (
 	directionInput  = "input"
@@ -203,6 +204,9 @@ func blockToRPCError(pe *appplugins.PluginError) *RPCError {
 	// Only TrustGuard plan-limit 429 maps to -32004; policy rate limiters stay -32001.
 	if pe != nil && pe.StatusCode == http.StatusTooManyRequests && pe.Type == trustGuardRateLimitedType {
 		code = CodeRateLimited
+	}
+	if pe != nil && pe.StatusCode == http.StatusServiceUnavailable && pe.Type == trustGuardUnavailableType {
+		code = CodeUnavailable
 	}
 	var headers map[string][]string
 	if pe != nil && len(pe.Headers) > 0 {

--- a/pkg/app/mcp/plugin_runner_test.go
+++ b/pkg/app/mcp/plugin_runner_test.go
@@ -103,6 +103,17 @@ func TestPluginRunner_PreRequest(t *testing.T) {
 			wantRPCData: `{"error":"rate limit exceeded","reason":"burst"}`,
 		},
 		{
+			name: "trustguard entitlements unavailable via plugin error",
+			execErr: &appplugins.PluginError{
+				StatusCode: 503,
+				Type:       "trustguard_unavailable",
+				Message:    "rate limit entitlements unavailable",
+				Body:       []byte(`{"error":"rate limit entitlements unavailable"}`),
+			},
+			wantRPCCode: CodeUnavailable,
+			wantRPCData: `{"error":"rate limit entitlements unavailable"}`,
+		},
+		{
 			name: "policy rate limit 429 stays policy-blocked",
 			execErr: &appplugins.PluginError{
 				StatusCode: 429,

--- a/pkg/infra/plugins/trustguard/client.go
+++ b/pkg/infra/plugins/trustguard/client.go
@@ -51,6 +51,16 @@ func (e *rateLimitedError) Error() string {
 	return "trustguard: rate limit exceeded"
 }
 
+// entitlementsUnavailableError is returned when TrustGuard evaluate cannot
+// resolve plan entitlements (HTTP 503). Must not fail-open.
+type entitlementsUnavailableError struct {
+	body []byte
+}
+
+func (e *entitlementsUnavailableError) Error() string {
+	return "trustguard: rate limit entitlements unavailable"
+}
+
 type client struct {
 	http *http.Client
 }
@@ -94,6 +104,9 @@ func (c *client) Guard(ctx context.Context, baseURL, token, traceID string, body
 			headers: copyRateLimitHeaders(res.Header),
 			body:    append([]byte(nil), raw...),
 		}
+	}
+	if res.StatusCode == http.StatusServiceUnavailable {
+		return nil, &entitlementsUnavailableError{body: append([]byte(nil), raw...)}
 	}
 	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusMultipleChoices {
 		return nil, fmt.Errorf("trustguard: unexpected status %d", res.StatusCode)

--- a/pkg/infra/plugins/trustguard/client_test.go
+++ b/pkg/infra/plugins/trustguard/client_test.go
@@ -194,6 +194,25 @@ func TestGuardUnauthorizedReturnsSentinel(t *testing.T) {
 	}
 }
 
+func TestGuardUnavailableReturnsTypedError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = io.WriteString(w, `{"error":"rate limit entitlements unavailable"}`)
+	}))
+	defer srv.Close()
+
+	c := newClient(time.Second)
+	_, err := c.Guard(context.Background(), srv.URL, "k", "", sampleRequest())
+	var unavailable *entitlementsUnavailableError
+	if !errors.As(err, &unavailable) {
+		t.Fatalf("err = %v, want *entitlementsUnavailableError", err)
+	}
+	if !bytes.Contains(unavailable.body, []byte(`entitlements unavailable`)) {
+		t.Fatalf("body = %s", unavailable.body)
+	}
+}
+
 func TestGuardRateLimitedReturnsTypedError(t *testing.T) {
 	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/infra/plugins/trustguard/plugin.go
+++ b/pkg/infra/plugins/trustguard/plugin.go
@@ -228,6 +228,11 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 			setExtras(in.Event, guardData{Direction: direction, Decision: decisionBlocked})
 			return nil, rateLimitError(limited)
 		}
+		var unavailable *entitlementsUnavailableError
+		if errors.As(err, &unavailable) {
+			setExtras(in.Event, guardData{Direction: direction, Decision: decisionBlocked})
+			return nil, unavailableError(unavailable)
+		}
 		p.warn(ctx, "trustguard call failed, failing open",
 			slog.String("plugin", PluginName),
 			slog.String("stage", string(in.Stage)),

--- a/pkg/infra/plugins/trustguard/plugin_test.go
+++ b/pkg/infra/plugins/trustguard/plugin_test.go
@@ -332,6 +332,27 @@ func TestExecuteRateLimitDoesNotFailOpen(t *testing.T) {
 	}
 }
 
+func TestExecuteUnavailableDoesNotFailOpen(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{status: http.StatusServiceUnavailable}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	in := execInput(policy.StagePreRequest, policy.ModeObserve, settings(""), requestContext(), nil)
+	_, err := p.Execute(context.Background(), in)
+	pe, ok := appplugins.AsPluginError(err)
+	if !ok {
+		t.Fatalf("entitlements unavailable must not fail-open, got %v", err)
+	}
+	if pe.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", pe.StatusCode)
+	}
+	if pe.Type != typeUnavailable {
+		t.Fatalf("type = %q, want %q", pe.Type, typeUnavailable)
+	}
+}
+
 func TestExecuteServerErrorStillFailsOpen(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/infra/plugins/trustguard/reject.go
+++ b/pkg/infra/plugins/trustguard/reject.go
@@ -23,9 +23,11 @@ import (
 
 const typeBlocked = "trustguard_blocked"
 const typeRateLimited = "trustguard_rate_limited"
+const typeUnavailable = "trustguard_unavailable"
 
 const blockMessage = "request blocked due to a policy infraction"
 const rateLimitMessage = "rate limit exceeded"
+const unavailableMessage = "rate limit entitlements unavailable"
 
 func blockError(resp *GuardResponse) *appplugins.PluginError {
 	return &appplugins.PluginError{
@@ -46,6 +48,19 @@ func rateLimitError(err *rateLimitedError) *appplugins.PluginError {
 		Type:       typeRateLimited,
 		Message:    rateLimitMessage,
 		Headers:    err.headers,
+		Body:       body,
+	}
+}
+
+func unavailableError(err *entitlementsUnavailableError) *appplugins.PluginError {
+	body := []byte(`{"error":"rate limit entitlements unavailable"}`)
+	if err != nil && len(err.body) > 0 {
+		body = err.body
+	}
+	return &appplugins.PluginError{
+		StatusCode: http.StatusServiceUnavailable,
+		Type:       typeUnavailable,
+		Message:    unavailableMessage,
 		Body:       body,
 	}
 }


### PR DESCRIPTION
## Summary
- Apply gateway plan rate limits to MCP discovery (`tools/list`, `resources/list`, `resources/templates/list`, `prompts/list`), not only call/read/get.
- JSON-RPC plan errors use HTTP **429** (`-32004`) / **503** (`-32005`) so status-only clients see throttle/unavailable.
- TrustGuard evaluate **503** (entitlements unavailable) no longer fail-opens in the plugin; maps to plugin/RPC unavailable like direct Guard clients.

## Out of scope
- `RATE_LIMIT_ENABLED` stays off in k8s (not activated yet).

## Test plan
- [x] `go test ./pkg/infra/plugins/trustguard/ ./pkg/api/handler/http/mcp/ ./pkg/app/mcp/`
- [ ] Manual: with `RATE_LIMIT_ENABLED=true`, flood `tools/list` → 429 + headers