### PR TITLE
ci: notify dataplane-bundle on release

### DIFF
--- a/.github/workflows/notify-bundle.yml
+++ b/.github/workflows/notify-bundle.yml
@@ -1,0 +1,22 @@
+# On every published release, poke dataplane-bundle so the combined DataPlane
+# image is rebuilt with this new TrustGate tag.
+# Uses the existing GH_TOKEN PAT (must have write access to the same org's
+# NeuralTrust/dataplane-bundle repo, which repository_dispatch requires).
+
+name: Notify dataplane-bundle
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger bundle rebuild
+        run: |
+          curl -sf -X POST \
+            -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/NeuralTrust/dataplane-bundle/dispatches \
+            -d '{"event_type":"trustgate-released","client_payload":{"tag":"${{ github.event.release.tag_name }}"}}'


### PR DESCRIPTION
## Summary
Adds a workflow that fires a `repository_dispatch` to `NeuralTrust/dataplane-bundle` on every published release, so the combined DataPlane image (TrustGate proxy + DataAgent) is rebuilt with the new TrustGate tag.

- Trigger: `release: published` (i.e. after a merge to `main` produces an auto-release).
- Reuses the existing `GH_TOKEN` PAT (must have write access to the bundle repo for the dispatch).
- Effective once merged to `main` (release-triggered workflows run from the default branch).

## Test plan
- [ ] Merge to develop → main
- [ ] Publish a release and confirm the bundle build is triggered

Made with [Cursor](https://cursor.com)