### PR TITLE
feat: align embedded admin dashboard with current API

### DIFF
--- a/docker-compose.api.yaml
+++ b/docker-compose.api.yaml
@@ -21,13 +21,10 @@ x-server-common: &server-common
   environment:
     DB_HOST: postgres
     REDIS_HOST: redis
-    KAFKA_BROKERS: kafka:9092
   depends_on:
     postgres:
       condition: service_healthy
     redis:
-      condition: service_healthy
-    kafka:
       condition: service_healthy
   restart: unless-stopped
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,53 +27,5 @@ services:
       timeout: 3s
       retries: 5
 
-  # Confluent Kafka + Zookeeper, version pinned to match TrustGate.
-  zookeeper:
-    image: confluentinc/cp-zookeeper:7.6.0
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-      KAFKA_OPTS: "-Dzookeeper.4lw.commands.whitelist=srvr,ruok,stat"
-    ports:
-      - "2181:2181"
-    volumes:
-      - zk_data:/var/lib/zookeeper/data
-      - zk_logs:/var/lib/zookeeper/log
-    healthcheck:
-      test: ["CMD-SHELL", "echo ruok | nc -w 2 localhost 2181 | grep imok"]
-      interval: 10s
-      timeout: 5s
-      retries: 10
-
-  kafka:
-    image: confluentinc/cp-kafka:7.6.0
-    hostname: kafka
-    depends_on:
-      zookeeper:
-        condition: service_healthy
-    ports:
-      - "9092:9092"
-      - "29092:29092"
-    environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:29092
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,PLAINTEXT_HOST://0.0.0.0:29092
-      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
-      KAFKA_NUM_PARTITIONS: 3
-    volumes:
-      - kafka_data:/var/lib/kafka/data
-    healthcheck:
-      test: ["CMD-SHELL", "kafka-broker-api-versions --bootstrap-server localhost:9092 >/dev/null 2>&1"]
-      interval: 10s
-      timeout: 5s
-      retries: 15
-
 volumes:
   postgres_data:
-  kafka_data:
-  zk_data:
-  zk_logs:

--- a/frontend/src/app/dashboard/roles/page.tsx
+++ b/frontend/src/app/dashboard/roles/page.tsx
@@ -1,0 +1,5 @@
+import { RolesView } from "@/components/entities/roles-view";
+
+export default function RolesPage() {
+  return <RolesView />;
+}

--- a/frontend/src/components/entities/auth-view.tsx
+++ b/frontend/src/components/entities/auth-view.tsx
@@ -207,15 +207,31 @@ function AuthFormDialog({
   const { toast } = useToast();
   const isEdit = auth !== null;
 
+  const o2 = auth?.config.oauth2;
+  const oidc = auth?.config.oidc;
+
   const [name, setName] = useState(auth?.name ?? "");
   const [type, setType] = useState<AuthType>(auth?.type ?? "api_key");
   const [enabled, setEnabled] = useState(auth?.enabled ?? true);
 
-  const [issuer, setIssuer] = useState(auth?.config.oauth2?.issuer ?? "");
-  const [jwksUrl, setJwksUrl] = useState(auth?.config.oauth2?.jwks_url ?? "");
-  const [introspectionUrl, setIntrospectionUrl] = useState(auth?.config.oauth2?.introspection_url ?? "");
-  const [audiences, setAudiences] = useState((auth?.config.oauth2?.audiences ?? []).join(", "));
-  const [scopes, setScopes] = useState((auth?.config.oauth2?.required_scopes ?? []).join(", "));
+  const [issuer, setIssuer] = useState(o2?.issuer ?? oidc?.issuer ?? "");
+  const [audiences, setAudiences] = useState((o2?.audiences ?? oidc?.audiences ?? []).join(", "));
+  const [scopes, setScopes] = useState((o2?.required_scopes ?? oidc?.required_scopes ?? []).join(", "));
+  const [algorithms, setAlgorithms] = useState(
+    (o2?.allowed_algorithms ?? oidc?.allowed_algorithms ?? []).join(", "),
+  );
+  const [subjectClaim, setSubjectClaim] = useState(o2?.subject_claim ?? oidc?.subject_claim ?? "");
+  const [jwksUrl, setJwksUrl] = useState(o2?.jwks_url ?? oidc?.jwks_url ?? "");
+
+  const [introspectionUrl, setIntrospectionUrl] = useState(o2?.introspection_url ?? "");
+  const [sessionMode, setSessionMode] = useState(o2?.session_mode ?? false);
+  const [userinfoUrl, setUserinfoUrl] = useState(o2?.userinfo_url ?? "");
+  const [authorizeUrl, setAuthorizeUrl] = useState(o2?.authorize_url ?? "");
+  const [tokenUrl, setTokenUrl] = useState(o2?.token_url ?? "");
+  const [clientId, setClientId] = useState(o2?.client_id ?? "");
+  const [clientSecret, setClientSecret] = useState("");
+
+  const [publicKeys, setPublicKeys] = useState((oidc?.public_keys ?? []).join("\n\n"));
 
   const [caCert, setCaCert] = useState(auth?.config.mtls?.ca_cert ?? "");
   const [commonNames, setCommonNames] = useState((auth?.config.mtls?.allowed_common_names ?? []).join(", "));
@@ -223,6 +239,8 @@ function AuthFormDialog({
   const [submitting, setSubmitting] = useState(false);
 
   const splitList = (v: string) => v.split(",").map((s) => s.trim()).filter(Boolean);
+  const splitPems = (v: string) =>
+    v.split(/(?=-----BEGIN)/).map((s) => s.trim()).filter(Boolean);
 
   async function submit() {
     if (!name.trim()) {
@@ -234,13 +252,32 @@ function AuthFormDialog({
     if (type === "api_key") {
       body.config = {};
     } else if (type === "oauth2") {
+      const oauth2: Record<string, unknown> = {
+        issuer,
+        audiences: splitList(audiences),
+        jwks_url: jwksUrl || undefined,
+        introspection_url: introspectionUrl || undefined,
+        userinfo_url: userinfoUrl || undefined,
+        authorize_url: authorizeUrl || undefined,
+        token_url: tokenUrl || undefined,
+        client_id: clientId || undefined,
+        subject_claim: subjectClaim || undefined,
+        required_scopes: splitList(scopes),
+        allowed_algorithms: splitList(algorithms),
+        session_mode: sessionMode,
+      };
+      if (clientSecret) oauth2.client_secret = clientSecret;
+      body.config = { oauth2 };
+    } else if (type === "oidc") {
       body.config = {
-        oauth2: {
+        oidc: {
           issuer,
-          jwks_url: jwksUrl || undefined,
-          introspection_url: introspectionUrl || undefined,
           audiences: splitList(audiences),
+          jwks_url: jwksUrl || undefined,
+          public_keys: splitPems(publicKeys),
           required_scopes: splitList(scopes),
+          allowed_algorithms: splitList(algorithms),
+          subject_claim: subjectClaim || undefined,
         },
       };
     } else {
@@ -291,6 +328,7 @@ function AuthFormDialog({
               >
                 <option value="api_key">API key</option>
                 <option value="oauth2">OAuth2</option>
+                <option value="oidc">OIDC</option>
                 <option value="mtls">mTLS</option>
               </Select>
             </Field>
@@ -325,6 +363,87 @@ function AuthFormDialog({
                   </Field>
                   <Field label="Required scopes" hint="comma-separated">
                     <Input value={scopes} onChange={(e) => setScopes(e.target.value)} />
+                  </Field>
+                </Grid2>
+                <Grid2>
+                  <Field label="Allowed algorithms" hint="comma-separated">
+                    <Input value={algorithms} onChange={(e) => setAlgorithms(e.target.value)} placeholder="RS256" />
+                  </Field>
+                  <Field label="Subject claim" hint="optional">
+                    <Input value={subjectClaim} onChange={(e) => setSubjectClaim(e.target.value)} placeholder="sub" />
+                  </Field>
+                </Grid2>
+                <SwitchRow
+                  label="Session mode"
+                  description="Use the authorization-code flow with server-managed sessions."
+                  checked={sessionMode}
+                  onCheckedChange={setSessionMode}
+                />
+                {sessionMode && (
+                  <>
+                    <Grid2>
+                      <Field label="Authorize URL">
+                        <Input value={authorizeUrl} onChange={(e) => setAuthorizeUrl(e.target.value)} />
+                      </Field>
+                      <Field label="Token URL">
+                        <Input value={tokenUrl} onChange={(e) => setTokenUrl(e.target.value)} />
+                      </Field>
+                    </Grid2>
+                    <Field label="UserInfo URL" hint="optional">
+                      <Input value={userinfoUrl} onChange={(e) => setUserinfoUrl(e.target.value)} />
+                    </Field>
+                    <Grid2>
+                      <Field label="Client ID">
+                        <Input value={clientId} onChange={(e) => setClientId(e.target.value)} />
+                      </Field>
+                      <Field label="Client secret" hint={isEdit ? "blank keeps current" : undefined}>
+                        <Input
+                          type="password"
+                          value={clientSecret}
+                          onChange={(e) => setClientSecret(e.target.value)}
+                        />
+                      </Field>
+                    </Grid2>
+                  </>
+                )}
+              </Section>
+            </>
+          )}
+
+          {type === "oidc" && (
+            <>
+              <Divider />
+              <Section title="OIDC">
+                <Field label="Issuer">
+                  <Input value={issuer} onChange={(e) => setIssuer(e.target.value)} placeholder="https://issuer.example.com" />
+                </Field>
+                <Grid2>
+                  <Field label="Audiences" hint="comma-separated">
+                    <Input value={audiences} onChange={(e) => setAudiences(e.target.value)} />
+                  </Field>
+                  <Field label="Required scopes" hint="comma-separated">
+                    <Input value={scopes} onChange={(e) => setScopes(e.target.value)} />
+                  </Field>
+                </Grid2>
+                <Field label="JWKS URL" hint="or provide public keys below">
+                  <Input value={jwksUrl} onChange={(e) => setJwksUrl(e.target.value)} />
+                </Field>
+                <Field label="Public keys (PEM)" hint="one or more, or use JWKS">
+                  <textarea
+                    value={publicKeys}
+                    onChange={(e) => setPublicKeys(e.target.value)}
+                    rows={5}
+                    spellCheck={false}
+                    className="w-full bg-surface-2 border border-border rounded-(--radius) px-3 py-2 text-[12px] font-mono text-fg placeholder:text-faint outline-none focus:border-accent/70 focus:ring-2 focus:ring-accent/20"
+                    placeholder="-----BEGIN PUBLIC KEY-----"
+                  />
+                </Field>
+                <Grid2>
+                  <Field label="Allowed algorithms" hint="comma-separated, no HMAC">
+                    <Input value={algorithms} onChange={(e) => setAlgorithms(e.target.value)} placeholder="RS256, ES256" />
+                  </Field>
+                  <Field label="Subject claim" hint="optional">
+                    <Input value={subjectClaim} onChange={(e) => setSubjectClaim(e.target.value)} placeholder="sub" />
                   </Field>
                 </Grid2>
               </Section>

--- a/frontend/src/components/entities/consumer-detail.tsx
+++ b/frontend/src/components/entities/consumer-detail.tsx
@@ -2,25 +2,31 @@
 
 import { useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Check, Server, KeyRound, ShieldCheck, ArrowUp, ArrowDown, X } from "lucide-react";
+import { Check, Server, KeyRound, ShieldCheck, ArrowUp, ArrowDown, X, UsersRound } from "lucide-react";
 import { api, gatewayScope } from "@/lib/admin-client";
 import { useActiveGatewayId } from "@/components/layout/gateway-context";
 import { useList, useInvalidate, errorMessage } from "@/lib/hooks";
 import { useToast } from "@/components/ui/toast";
-import { Dialog, DialogContent, DialogHeader, DialogBody, DialogFooter, DialogClose } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogHeader, DialogBody } from "@/components/ui/dialog";
 import { Tabs, TabsList, TabTrigger, TabContent } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { Field, Input, Select } from "@/components/ui/field";
 import { Grid2 } from "@/components/ui/form-bits";
 import { PageLoader, Badge } from "@/components/ui/misc";
 import { cn } from "@/lib/cn";
-import type { Consumer, Registry, Auth, Policy, Algorithm } from "@/lib/types";
+import {
+  ModelPolicyEditor,
+  buildModelPolicies,
+  modelPolicyStateFrom,
+} from "./model-policy-editor";
+import type { Consumer, Registry, Auth, Policy, Role, Algorithm, ModelPolicy, RoutingMode } from "@/lib/types";
 
 const TRIGGERS = ["http_5xx", "http_429", "timeout", "provider_error", "plugin_rejection"];
 
 // Routing "strategy" is a UI-level concept layered over the backend's
-// (algorithm + fallback) model: "single"/"fallback" need no distribution
-// config, while the distribution strategies map onto load-balancing algorithms.
+// (lb_config + fallback) model: "single"/"fallback" keep load balancing
+// disabled, while the distribution strategies enable lb_config with the mapped
+// algorithm.
 type Strategy =
   | "single"
   | "fallback"
@@ -31,23 +37,28 @@ type Strategy =
   | "semantic";
 
 const STRATEGY_META: Record<Strategy, { label: string; hint: string }> = {
-  single: { label: "Single target", hint: "Route every request to the attached provider." },
+  single: { label: "Single target", hint: "Route every request to the attached registry." },
   fallback: {
     label: "Fallback",
     hint: "Try providers in declared order; on failure, route to the next. Order matters.",
   },
-  "round-robin": { label: "Round robin", hint: "Even rotation across the attached providers." },
+  "round-robin": { label: "Round robin", hint: "Even rotation across the attached registries." },
   weighted: {
     label: "Weighted",
-    hint: "Distribute requests across providers by configurable per-provider weights.",
+    hint: "Distribute requests across registries by configurable per-registry weights.",
   },
   "least-connections": {
     label: "Least connections",
-    hint: "Prefer the provider with the fewest in-flight requests.",
+    hint: "Prefer the registry with the fewest in-flight requests.",
   },
-  random: { label: "Random", hint: "Pick an attached provider at random." },
+  random: { label: "Random", hint: "Pick an attached registry at random." },
   semantic: { label: "Semantic", hint: "Route by embedding similarity (requires an embedding model)." },
 };
+
+// A strategy that enables lb_config (anything other than single/fallback).
+function isLoadBalanced(s: Strategy): boolean {
+  return s !== "single" && s !== "fallback";
+}
 
 function algorithmFor(s: Strategy): Algorithm {
   switch (s) {
@@ -68,7 +79,8 @@ function algorithmFor(s: Strategy): Algorithm {
 
 function strategyOf(c: Consumer): Strategy {
   if (c.fallback?.enabled) return "fallback";
-  switch (c.algorithm) {
+  if (!c.lb_config?.enabled) return "single";
+  switch (c.lb_config.algorithm) {
     case "weighted-round-robin":
       return "weighted";
     case "least-connections":
@@ -102,7 +114,7 @@ export function ConsumerDetail({
       <DialogContent size="xl">
         <DialogHeader
           title={consumer ? consumer.name : "Consumer"}
-          description={consumer?.path}
+          description={consumer ? `/${consumer.slug}` : undefined}
         />
         {isLoading || !consumer ? (
           <DialogBody>
@@ -146,16 +158,28 @@ function useConsumerInvalidate(consumerId: string) {
 }
 
 function BindingsTab({ consumer }: { consumer: Consumer }) {
+  const roleBased = consumer.routing_mode === "role_based";
   return (
     <div className="flex flex-col gap-6">
-      <BindingSection
-        consumer={consumer}
-        kind="registries"
-        title="Registries"
-        icon={<Server className="h-4 w-4" />}
-        boundIds={consumer.registries.map((r) => r.id)}
-        useItems={() => useList<Registry>("registries")}
-      />
+      {roleBased ? (
+        <BindingSection
+          consumer={consumer}
+          kind="roles"
+          title="Roles"
+          icon={<UsersRound className="h-4 w-4" />}
+          boundIds={consumer.role_ids}
+          useItems={() => useList<Role>("roles")}
+        />
+      ) : (
+        <BindingSection
+          consumer={consumer}
+          kind="registries"
+          title="Registries"
+          icon={<Server className="h-4 w-4" />}
+          boundIds={consumer.registry_ids}
+          useItems={() => useList<Registry>("registries")}
+        />
+      )}
       <BindingSection
         consumer={consumer}
         kind="auths"
@@ -194,7 +218,7 @@ function BindingSection<T extends NamedEntity>({
   isPolicyBound,
 }: {
   consumer: Consumer;
-  kind: "registries" | "auths" | "policies";
+  kind: "registries" | "roles" | "auths" | "policies";
   title: string;
   icon: React.ReactNode;
   boundIds: string[];
@@ -275,24 +299,40 @@ function BindingSection<T extends NamedEntity>({
   );
 }
 
+// Model policies (registry_id → allowed/default) are required for every member
+// of an enabled lb_config pool. This merges the consumer's existing policies
+// with a bare entry for any attached registry that lacks one, so enabling load
+// balancing never fails validation.
+function poolModelPolicies(consumer: Consumer, attached: Registry[]): ModelPolicy[] {
+  const existing = new Map((consumer.model_policies ?? []).map((p) => [p.registry_id, p]));
+  return attached.map((r) => {
+    const current = existing.get(r.id);
+    const policy: ModelPolicy = { registry_id: r.id };
+    if (current?.allowed && current.allowed.length > 0) policy.allowed = current.allowed;
+    if (current?.default) policy.default = current.default;
+    return policy;
+  });
+}
+
 function RoutingTab({ consumer, onClose }: { consumer: Consumer; onClose: () => void }) {
   const gatewayId = useActiveGatewayId();
   const invalidate = useConsumerInvalidate(consumer.id);
   const { toast } = useToast();
   const { data: registries } = useList<Registry>("registries");
 
-  const attached = (registries ?? []).filter((r) => consumer.registries.some((b) => b.id === r.id));
+  const attached = (registries ?? []).filter((r) => consumer.registry_ids.includes(r.id));
 
+  const emb = consumer.lb_config?.embedding_config;
+  const [mode, setMode] = useState<RoutingMode>(consumer.routing_mode);
   const [strategy, setStrategy] = useState<Strategy>(strategyOf(consumer));
-  const [embProvider, setEmbProvider] = useState(consumer.embedding_config?.provider ?? "");
-  const [embModel, setEmbModel] = useState(consumer.embedding_config?.model ?? "");
+  const [embProvider, setEmbProvider] = useState(emb?.provider ?? "");
+  const [embModel, setEmbModel] = useState(emb?.model ?? "");
   const [embKey, setEmbKey] = useState("");
   // Only user edits live in state; the displayed value falls back to the
-  // consumer's configured weight, then the registry's own default. This keeps
-  // the inputs correct regardless of when the registries query resolves.
+  // consumer's configured weight, then a default of 1.
   const [weights, setWeights] = useState<Record<string, string>>(() => {
     const init: Record<string, string> = {};
-    for (const w of consumer.weights ?? []) init[w.registry_id] = String(w.weight);
+    for (const w of consumer.registry_weights ?? []) init[w.registry_id] = String(w.weight);
     return init;
   });
   const fb = consumer.fallback;
@@ -300,19 +340,19 @@ function RoutingTab({ consumer, onClose }: { consumer: Consumer; onClose: () => 
   const [chain, setChain] = useState<string[]>(fb?.chain ?? []);
   const [maxAttempts, setMaxAttempts] = useState(String(fb?.budget?.max_attempts ?? 3));
   const [maxLatency, setMaxLatency] = useState(String(fb?.budget?.max_total_latency_ms ?? 5000));
-  const [maxCost, setMaxCost] = useState(String(fb?.budget?.max_cost_usd ?? 0));
   const [saving, setSaving] = useState(false);
 
   const meta = STRATEGY_META[strategy];
-  // Existing semantic consumers keep the option available even though it is not
-  // offered by default in the catalog-driven design.
-  const showSemantic = consumer.algorithm === "semantic" || strategy === "semantic";
+  const showSemantic = consumer.lb_config?.algorithm === "semantic" || strategy === "semantic";
 
   function displayWeight(r: Registry): string {
-    return weights[r.id] ?? String(r.weight ?? 1);
+    return weights[r.id] ?? String(weightFromConsumer(r.id) ?? 1);
+  }
+  function weightFromConsumer(registryId: string): number | undefined {
+    return (consumer.registry_weights ?? []).find((w) => w.registry_id === registryId)?.weight;
   }
   function weightOf(r: Registry): number {
-    return Math.min(100, Math.max(0, Math.round(Number(displayWeight(r)) || 0)));
+    return Math.min(100, Math.max(1, Math.round(Number(displayWeight(r)) || 1)));
   }
   const totalWeight = attached.reduce((sum, r) => sum + weightOf(r), 0);
 
@@ -343,42 +383,66 @@ function RoutingTab({ consumer, onClose }: { consumer: Consumer; onClose: () => 
   const chainable = attached.filter((r) => !chain.includes(r.id));
 
   async function save() {
-    const body = consumerBaseBody(consumer);
-    body.algorithm = algorithmFor(strategy);
+    const base = `${gatewayScope(gatewayId)}/consumers/${consumer.id}`;
 
-    if (strategy === "semantic") {
-      if (!embProvider.trim() || !embModel.trim() || !embKey.trim()) {
-        toast({
-          variant: "error",
-          title: "Embedding model required",
-          description: "Semantic routing needs an embedding provider, model and API key.",
-        });
-        return;
+    if (mode === "role_based") {
+      setSaving(true);
+      try {
+        await api.put(base, { routing_mode: "role_based" });
+        toast({ variant: "success", title: "Switched to role-based routing" });
+        invalidate();
+        onClose();
+      } catch (err) {
+        toast({ variant: "error", title: "Save failed", description: errorMessage(err) });
+      } finally {
+        setSaving(false);
       }
-      body.embedding_config = {
-        provider: embProvider.trim(),
-        model: embModel.trim(),
-        auth: { api_key: embKey.trim() },
-      };
+      return;
     }
 
-    if (strategy === "weighted") {
+    const body: Record<string, unknown> = { routing_mode: "inline" };
+
+    if (isLoadBalanced(strategy)) {
       if (attached.length === 0) {
-        toast({ variant: "error", title: "Attach at least one provider first (Bindings tab)." });
+        toast({ variant: "error", title: "Attach at least one registry first (Bindings tab)." });
         return;
       }
-      if (totalWeight === 0) {
-        toast({ variant: "error", title: "Set a weight above zero for at least one provider." });
-        return;
-      }
-      body.weights = attached.map((r) => ({ registry_id: r.id, weight: weightOf(r) }));
-    }
+      const lb: Record<string, unknown> = {
+        enabled: true,
+        algorithm: algorithmFor(strategy),
+        members: attached.map((r) => ({ registry_id: r.id })),
+      };
 
-    if (strategy === "fallback") {
-      if (chainResolved.length === 0) {
-        toast({ variant: "error", title: "Add at least one provider to the fallback order." });
+      if (strategy === "semantic") {
+        if (!embProvider.trim() || !embModel.trim()) {
+          toast({
+            variant: "error",
+            title: "Embedding model required",
+            description: "Semantic routing needs an embedding provider and model.",
+          });
+          return;
+        }
+        lb.embedding_config = {
+          provider: embProvider.trim(),
+          model: embModel.trim(),
+          ...(embKey.trim() ? { auth: { api_key: embKey.trim() } } : {}),
+        };
+      }
+
+      if (strategy === "weighted" && totalWeight === 0) {
+        toast({ variant: "error", title: "Set a weight above zero for at least one registry." });
         return;
       }
+
+      body.lb_config = lb;
+      body.fallback = { enabled: false };
+      body.model_policies = poolModelPolicies(consumer, attached);
+    } else if (strategy === "fallback") {
+      if (chainResolved.length === 0) {
+        toast({ variant: "error", title: "Add at least one registry to the fallback order." });
+        return;
+      }
+      body.lb_config = { enabled: false };
       body.fallback = {
         enabled: true,
         triggers,
@@ -386,16 +450,23 @@ function RoutingTab({ consumer, onClose }: { consumer: Consumer; onClose: () => 
         budget: {
           max_attempts: Number(maxAttempts) || 1,
           max_total_latency_ms: Number(maxLatency) || 0,
-          max_cost_usd: Number(maxCost) || 0,
         },
       };
     } else {
+      body.lb_config = { enabled: false };
       body.fallback = { enabled: false };
     }
 
     setSaving(true);
     try {
-      await api.put(`${gatewayScope(gatewayId)}/consumers/${consumer.id}`, body);
+      // Weights are stored per registry association, not on the consumer body,
+      // so they are updated through the (idempotent) attach endpoint.
+      if (strategy === "weighted") {
+        for (const r of attached) {
+          await api.post(`${base}/registries/${r.id}`, { weight: weightOf(r) });
+        }
+      }
+      await api.put(base, body);
       toast({ variant: "success", title: "Routing saved" });
       invalidate();
       onClose();
@@ -408,6 +479,23 @@ function RoutingTab({ consumer, onClose }: { consumer: Consumer; onClose: () => 
 
   return (
     <div className="flex flex-col gap-4">
+      <Field label="Access mode">
+        <Select value={mode} onChange={(e) => setMode(e.target.value as RoutingMode)}>
+          <option value="inline">Inline (registries)</option>
+          <option value="role_based">Role-based (identity)</option>
+        </Select>
+      </Field>
+
+      {mode === "role_based" && (
+        <div className="rounded-(--radius) border border-border bg-surface-2/30 p-3.5 text-[12px] text-muted">
+          Routing is governed by the roles bound in the <span className="text-fg">Bindings</span> tab.
+          A role-based consumer needs a single OIDC or OAuth2 auth and at least one role; each role
+          carries its own registries and model policies.
+        </div>
+      )}
+
+      {mode === "inline" && (
+        <>
       <Field label="Strategy">
         <Select value={strategy} onChange={(e) => setStrategy(e.target.value as Strategy)}>
           <optgroup label="Without distribution">
@@ -427,9 +515,9 @@ function RoutingTab({ consumer, onClose }: { consumer: Consumer; onClose: () => 
 
       {strategy === "weighted" && (
         <div className="flex flex-col gap-2">
-          <p className="text-[13px] font-medium text-fg">Providers</p>
+          <p className="text-[13px] font-medium text-fg">Registries</p>
           {attached.length === 0 ? (
-            <p className="text-[12px] text-faint">Attach providers first (Bindings tab).</p>
+            <p className="text-[12px] text-faint">Attach registries first (Bindings tab).</p>
           ) : (
             <div className="flex flex-col gap-1.5">
               {attached.map((r) => {
@@ -444,7 +532,7 @@ function RoutingTab({ consumer, onClose }: { consumer: Consumer; onClose: () => 
                     </span>
                     <Input
                       type="number"
-                      min={0}
+                      min={1}
                       max={100}
                       value={displayWeight(r)}
                       onChange={(e) => setWeights((prev) => ({ ...prev, [r.id]: e.target.value }))}
@@ -465,7 +553,7 @@ function RoutingTab({ consumer, onClose }: { consumer: Consumer; onClose: () => 
           <div className="flex flex-col gap-2">
             <p className="text-[13px] font-medium text-fg">Provider order</p>
             {attached.length === 0 ? (
-              <p className="text-[12px] text-faint">Attach providers first (Bindings tab).</p>
+              <p className="text-[12px] text-faint">Attach registries first (Bindings tab).</p>
             ) : (
               <>
                 <div className="flex flex-col gap-1.5">
@@ -515,7 +603,7 @@ function RoutingTab({ consumer, onClose }: { consumer: Consumer; onClose: () => 
                       e.target.value = "";
                     }}
                   >
-                    <option value="">Add a provider…</option>
+                    <option value="">Add a registry…</option>
                     {chainable.map((r) => (
                       <option key={r.id} value={r.id}>
                         {r.name} ({r.provider})
@@ -558,9 +646,6 @@ function RoutingTab({ consumer, onClose }: { consumer: Consumer; onClose: () => 
                 <Input type="number" min={0} value={maxLatency} onChange={(e) => setMaxLatency(e.target.value)} />
               </Field>
             </Grid2>
-            <Field label="Max cost (USD)">
-              <Input type="number" min={0} step="0.01" value={maxCost} onChange={(e) => setMaxCost(e.target.value)} />
-            </Field>
           </div>
         </>
       )}
@@ -576,10 +661,12 @@ function RoutingTab({ consumer, onClose }: { consumer: Consumer; onClose: () => 
               <Input value={embModel} onChange={(e) => setEmbModel(e.target.value)} placeholder="text-embedding-3-small" />
             </Field>
           </Grid2>
-          <Field label="API key" hint="re-enter to update">
+          <Field label="API key" hint="leave blank to keep the current key">
             <Input type="password" value={embKey} onChange={(e) => setEmbKey(e.target.value)} placeholder="sk-..." />
           </Field>
         </div>
+      )}
+        </>
       )}
 
       <div className="flex justify-end pt-2">
@@ -591,69 +678,31 @@ function RoutingTab({ consumer, onClose }: { consumer: Consumer; onClose: () => 
   );
 }
 
-function consumerBaseBody(consumer: Consumer): Record<string, unknown> {
-  return {
-    name: consumer.name,
-    path: consumer.path,
-    type: consumer.type,
-    algorithm: consumer.algorithm,
-    active: consumer.active,
-    ...(consumer.headers ? { headers: consumer.headers } : {}),
-  };
-}
-
 function ModelPoliciesTab({ consumer, onClose }: { consumer: Consumer; onClose: () => void }) {
   const gatewayId = useActiveGatewayId();
   const invalidate = useConsumerInvalidate(consumer.id);
   const { toast } = useToast();
   const { data: registries } = useList<Registry>("registries");
 
-  const attached = (registries ?? []).filter((r) => consumer.registries.some((b) => b.id === r.id));
+  const attached = (registries ?? []).filter((r) => consumer.registry_ids.includes(r.id));
 
-  const initial: Record<string, { allowed: string; default: string }> = {};
-  for (const binding of consumer.registries) {
-    if (!binding.model_policies) continue;
-    initial[binding.id] = {
-      allowed: (binding.model_policies.allowed ?? []).join(", "),
-      default: binding.model_policies.default ?? "",
-    };
-  }
-  const [state, setState] = useState(initial);
+  const [state, setState] = useState(() => modelPolicyStateFrom(consumer.model_policies));
   const [saving, setSaving] = useState(false);
 
-  function update(registryId: string, key: "allowed" | "default", value: string) {
-    setState((prev) => ({
-      ...prev,
-      [registryId]: { allowed: "", default: "", ...prev[registryId], [key]: value },
-    }));
-  }
-
   async function save() {
-    const registryBindings = attached.map((r) => {
-      const entry = state[r.id];
-      const allowed = entry ? entry.allowed.split(",").map((s) => s.trim()).filter(Boolean) : [];
-      if (allowed.length === 0 && !entry?.default) return { id: r.id };
-      return { id: r.id, model_policies: { allowed, default: entry?.default || undefined } };
-    });
-
-    const body = consumerBaseBody(consumer);
-    if (consumer.fallback) {
-      body.fallback = {
-        enabled: consumer.fallback.enabled,
-        triggers: consumer.fallback.triggers,
-        chain: consumer.fallback.chain,
-        budget: {
-          max_attempts: consumer.fallback.budget.max_attempts,
-          max_total_latency_ms: consumer.fallback.budget.max_total_latency_ms,
-          max_cost_usd: consumer.fallback.budget.max_cost_usd,
-        },
-      };
+    const policies = buildModelPolicies(attached, state);
+    // An enabled lb_config requires a model policy for every pool member; keep
+    // those covered with a bare entry so saving allowlists never breaks routing.
+    if (consumer.lb_config?.enabled) {
+      const covered = new Set(policies.map((p) => p.registry_id));
+      for (const member of consumer.lb_config.members ?? []) {
+        if (!covered.has(member.registry_id)) policies.push({ registry_id: member.registry_id });
+      }
     }
-    body.registries = registryBindings;
 
     setSaving(true);
     try {
-      await api.put(`${gatewayScope(gatewayId)}/consumers/${consumer.id}`, body);
+      await api.put(`${gatewayScope(gatewayId)}/consumers/${consumer.id}`, { model_policies: policies });
       toast({ variant: "success", title: "Model policies saved" });
       invalidate();
       onClose();
@@ -674,25 +723,7 @@ function ModelPoliciesTab({ consumer, onClose }: { consumer: Consumer; onClose: 
 
   return (
     <div className="flex flex-col gap-4">
-      {attached.map((r) => (
-        <div key={r.id} className="rounded-(--radius) border border-border bg-surface-2/30 p-3.5 flex flex-col gap-3">
-          <p className="text-[13px] font-medium text-fg">{r.name}</p>
-          <Field label="Allowed models" hint="comma-separated, empty = all">
-            <Input
-              value={state[r.id]?.allowed ?? ""}
-              onChange={(e) => update(r.id, "allowed", e.target.value)}
-              placeholder="gpt-4o, gpt-4o-mini"
-            />
-          </Field>
-          <Field label="Default model" hint="optional">
-            <Input
-              value={state[r.id]?.default ?? ""}
-              onChange={(e) => update(r.id, "default", e.target.value)}
-              placeholder="gpt-4o"
-            />
-          </Field>
-        </div>
-      ))}
+      <ModelPolicyEditor registries={attached} state={state} onChange={setState} />
       <div className="flex justify-end pt-2">
         <Button variant="primary" onClick={save} loading={saving}>
           Save model policies

--- a/frontend/src/components/entities/consumers-view.tsx
+++ b/frontend/src/components/entities/consumers-view.tsx
@@ -32,14 +32,13 @@ const PROTOCOLS: { value: ConsumerType; label: string }[] = [
   { value: "A2A", label: "A2A" },
 ];
 
-// The consumer name doubles as its route slug: the proxy path is derived from
-// the slugified name so each consumer exposes a unique endpoint.
-function slugify(value: string): string {
-  return value
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
+// The proxy route slug is generated server-side on creation; the UI surfaces it
+// but does not derive it from the name.
+function routingLabel(c: Consumer): string {
+  if (c.routing_mode === "role_based") return "role-based";
+  if (c.fallback?.enabled) return "fallback";
+  if (c.lb_config?.enabled) return c.lb_config.algorithm ?? "round-robin";
+  return "single";
 }
 
 export function ConsumersView() {
@@ -52,7 +51,7 @@ export function ConsumersView() {
   return (
     <div>
       <PageHeader
-        description="Consumers are routed endpoints. Each binds a path to registries, auth credentials and policies."
+        description="Consumers are routed endpoints. Each exposes a slug-based route backed by registries, auth credentials and policies."
         action={
           <Button variant="primary" onClick={create.onOpen}>
             <Plus className="h-4 w-4" />
@@ -79,9 +78,9 @@ export function ConsumersView() {
         <Table>
           <THead>
             <TH>Name</TH>
-            <TH>Path</TH>
+            <TH>Slug</TH>
             <TH>Type</TH>
-            <TH>Algorithm</TH>
+            <TH>Routing</TH>
             <TH>Bindings</TH>
             <TH>Status</TH>
             <TH className="text-right pr-4">Actions</TH>
@@ -93,17 +92,17 @@ export function ConsumersView() {
                   <span className="font-medium text-fg">{c.name}</span>
                 </TD>
                 <TD>
-                  <Mono>{c.path}</Mono>
+                  <Mono>{c.slug}</Mono>
                 </TD>
                 <TD>
                   <Badge>{c.type}</Badge>
                 </TD>
                 <TD>
-                  <span className="text-muted text-[12px]">{c.algorithm}</span>
+                  <span className="text-muted text-[12px]">{routingLabel(c)}</span>
                 </TD>
                 <TD>
                   <span className="text-[12px] text-muted">
-                    {c.registries.length}r · {c.auth_ids.length}a
+                    {c.registry_ids.length}r · {c.auth_ids.length}a
                   </span>
                 </TD>
                 <TD>
@@ -204,18 +203,14 @@ function CreateConsumerDialog({
   const [authName, setAuthName] = useState("");
   const [submitting, setSubmitting] = useState(false);
 
-  const slug = slugify(name);
-
   async function submit() {
-    if (!slug) {
+    if (!name.trim()) {
       toast({ variant: "error", title: "Name is required" });
       return;
     }
     const body: Record<string, unknown> = {
       name: name.trim(),
-      path: `/${slug}`,
       type,
-      algorithm: "round-robin",
     };
 
     setSubmitting(true);
@@ -262,7 +257,7 @@ function CreateConsumerDialog({
             <Label>Name</Label>
             <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="chat-prod" />
             <p className="text-[12px] text-muted">
-              Route <Mono>{slug ? `/${slug}` : "/…"}</Mono> — derived from the name.
+              A unique route slug is generated automatically on creation.
             </p>
           </div>
 

--- a/frontend/src/components/entities/model-policy-editor.tsx
+++ b/frontend/src/components/entities/model-policy-editor.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useState } from "react";
+import { Plus, X } from "lucide-react";
+import { useModelsCatalog } from "@/lib/hooks";
+import { Button } from "@/components/ui/button";
+import { Field, Input, Select } from "@/components/ui/field";
+import { cn } from "@/lib/cn";
+import type { ModelPolicy, Registry } from "@/lib/types";
+
+export interface ModelPolicyState {
+  allowed: string[];
+  default: string;
+}
+
+// buildModelPolicies turns the per-registry editor state into the array the
+// admin API expects, dropping registries with no allowlist and no default
+// (which the backend reads as "allow all models").
+export function buildModelPolicies(
+  registries: Registry[],
+  state: Record<string, ModelPolicyState>,
+): ModelPolicy[] {
+  const out: ModelPolicy[] = [];
+  for (const r of registries) {
+    const entry = state[r.id];
+    const allowed = entry?.allowed ?? [];
+    const def = entry?.default?.trim() ?? "";
+    if (allowed.length === 0 && !def) continue;
+    const policy: ModelPolicy = { registry_id: r.id };
+    if (allowed.length > 0) policy.allowed = allowed;
+    if (def) policy.default = def;
+    out.push(policy);
+  }
+  return out;
+}
+
+export function modelPolicyStateFrom(policies: ModelPolicy[] | undefined): Record<string, ModelPolicyState> {
+  const state: Record<string, ModelPolicyState> = {};
+  for (const p of policies ?? []) {
+    state[p.registry_id] = { allowed: p.allowed ?? [], default: p.default ?? "" };
+  }
+  return state;
+}
+
+export function ModelPolicyEditor({
+  registries,
+  state,
+  onChange,
+}: {
+  registries: Registry[];
+  state: Record<string, ModelPolicyState>;
+  onChange: (state: Record<string, ModelPolicyState>) => void;
+}) {
+  function update(registryId: string, next: ModelPolicyState) {
+    onChange({ ...state, [registryId]: next });
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {registries.map((r) => (
+        <ModelPolicyRow
+          key={r.id}
+          registry={r}
+          value={state[r.id] ?? { allowed: [], default: "" }}
+          onChange={(next) => update(r.id, next)}
+        />
+      ))}
+    </div>
+  );
+}
+
+function ModelPolicyRow({
+  registry,
+  value,
+  onChange,
+}: {
+  registry: Registry;
+  value: ModelPolicyState;
+  onChange: (value: ModelPolicyState) => void;
+}) {
+  const { data: models } = useModelsCatalog(registry.provider);
+  const [custom, setCustom] = useState("");
+
+  const catalogSlugs = (models ?? []).map((m) => m.slug);
+  const extraSlugs = value.allowed.filter((a) => !catalogSlugs.includes(a));
+  const options = [...catalogSlugs, ...extraSlugs];
+
+  function toggle(slug: string) {
+    const allowed = value.allowed.includes(slug)
+      ? value.allowed.filter((x) => x !== slug)
+      : [...value.allowed, slug];
+    const nextDefault = value.default && !allowed.includes(value.default) ? "" : value.default;
+    onChange({ allowed, default: nextDefault });
+  }
+
+  function addCustom() {
+    const slug = custom.trim();
+    if (!slug || value.allowed.includes(slug)) {
+      setCustom("");
+      return;
+    }
+    onChange({ ...value, allowed: [...value.allowed, slug] });
+    setCustom("");
+  }
+
+  return (
+    <div className="rounded-(--radius) border border-border bg-surface-2/30 p-3.5 flex flex-col gap-3">
+      <p className="text-[13px] font-medium text-fg">
+        {registry.name} <span className="text-faint">({registry.provider})</span>
+      </p>
+
+      <Field label="Allowed models" hint="none selected = all models">
+        {options.length > 0 ? (
+          <div className="flex flex-wrap gap-1.5">
+            {options.map((slug) => {
+              const active = value.allowed.includes(slug);
+              return (
+                <button
+                  key={slug}
+                  type="button"
+                  onClick={() => toggle(slug)}
+                  className={cn(
+                    "inline-flex items-center gap-1 rounded-full border px-2.5 h-7 text-[12px] transition-colors",
+                    active
+                      ? "border-accent/50 bg-accent/10 text-fg"
+                      : "border-border text-muted hover:text-fg",
+                  )}
+                >
+                  {slug}
+                  {active && <X className="h-3 w-3" />}
+                </button>
+              );
+            })}
+          </div>
+        ) : (
+          <p className="text-[12px] text-faint">No catalog models for this provider — add them manually below.</p>
+        )}
+      </Field>
+
+      <div className="flex items-center gap-2">
+        <Input
+          value={custom}
+          onChange={(e) => setCustom(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && (e.preventDefault(), addCustom())}
+          placeholder="add a model slug…"
+          className="flex-1"
+        />
+        <Button variant="ghost" size="sm" onClick={addCustom}>
+          <Plus className="h-4 w-4" />
+          Add
+        </Button>
+      </div>
+
+      <Field label="Default model" hint="optional, must be allowed">
+        <Select
+          value={value.default}
+          onChange={(e) => onChange({ ...value, default: e.target.value })}
+          disabled={value.allowed.length === 0}
+        >
+          <option value="">No default</option>
+          {value.allowed.map((slug) => (
+            <option key={slug} value={slug}>
+              {slug}
+            </option>
+          ))}
+        </Select>
+      </Field>
+    </div>
+  );
+}

--- a/frontend/src/components/entities/playground-view.tsx
+++ b/frontend/src/components/entities/playground-view.tsx
@@ -67,7 +67,7 @@ export function PlaygroundView() {
     setResponse("");
     setErrorText(null);
     try {
-      const res = await fetch(`/api/playground${selected.path}`, {
+      const res = await fetch(`/api/playground/${selected.slug}/v1/chat/completions`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
@@ -121,7 +121,7 @@ export function PlaygroundView() {
             </Field>
             {selected && (
               <p className="text-[12px] text-muted -mt-1">
-                Route <Mono>POST {selected.path}</Mono>
+                Route <Mono>POST /{selected.slug}/v1/chat/completions</Mono>
               </p>
             )}
 

--- a/frontend/src/components/entities/policies-view.tsx
+++ b/frontend/src/components/entities/policies-view.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { Plus, Pencil, Trash2, ShieldCheck, Globe } from "lucide-react";
 import { api, gatewayScope } from "@/lib/admin-client";
 import { useActiveGatewayId } from "@/components/layout/gateway-context";
-import { useList, useInvalidate, errorMessage } from "@/lib/hooks";
+import { useList, useInvalidate, usePolicyCatalog, errorMessage } from "@/lib/hooks";
 import { useToast } from "@/components/ui/toast";
 import { PageHeader, ConfirmDialog, useDisclosure } from "@/components/ui/page";
 import { Button } from "@/components/ui/button";
@@ -22,9 +22,9 @@ import { Field, Input, Select, Label } from "@/components/ui/field";
 import { Section, SwitchRow, Grid2, Divider } from "@/components/ui/form-bits";
 import { JsonEditor } from "@/components/ui/json-editor";
 import { cn } from "@/lib/cn";
-import type { Policy, PolicyStage } from "@/lib/types";
+import type { Policy, PolicyStage, PolicyCatalogEntry } from "@/lib/types";
 
-const KNOWN_SLUGS = [
+const FALLBACK_SLUGS = [
   "rate_limiter",
   "token_rate_limiter",
   "request_size_limiter",
@@ -220,10 +220,15 @@ function PolicyFormDialog({
   const gatewayId = useActiveGatewayId();
   const invalidate = useInvalidate();
   const { toast } = useToast();
+  const { data: catalogGroups } = usePolicyCatalog();
   const isEdit = policy !== null;
 
+  const entries: PolicyCatalogEntry[] = (catalogGroups ?? []).flatMap((g) => g.items);
+  const slugOptions = entries.length > 0 ? entries.map((e) => e.slug) : FALLBACK_SLUGS;
+
   const [name, setName] = useState(policy?.name ?? "");
-  const [slug, setSlug] = useState(policy?.slug ?? KNOWN_SLUGS[0]!);
+  const [slug, setSlug] = useState(policy?.slug ?? slugOptions[0]!);
+  const [mode, setMode] = useState(policy?.mode ?? "");
   const [enabled, setEnabled] = useState(policy?.enabled ?? true);
   const [parallel, setParallel] = useState(policy?.parallel ?? false);
   const [priority, setPriority] = useState(String(policy?.priority ?? 0));
@@ -233,6 +238,22 @@ function PolicyFormDialog({
   );
   const [settingsValid, setSettingsValid] = useState(true);
   const [submitting, setSubmitting] = useState(false);
+
+  const entry = entries.find((e) => e.slug === slug);
+  const supportedModes = entry?.supported_modes ?? [];
+  const settingsFields = entry?.settings_schema?.fields ?? [];
+
+  function selectSlug(next: string) {
+    setSlug(next);
+    const catalogEntry = entries.find((e) => e.slug === next);
+    if (!catalogEntry) return;
+    if (catalogEntry.mandatory_stages.length > 0) {
+      setStages(catalogEntry.mandatory_stages);
+    } else if (catalogEntry.supported_stages.length > 0) {
+      setStages([catalogEntry.supported_stages[0]!]);
+    }
+    setMode(catalogEntry.default_mode || "");
+  }
 
   function toggleStage(stage: PolicyStage) {
     setStages((prev) =>
@@ -258,14 +279,20 @@ function PolicyFormDialog({
       return;
     }
 
+    // Mandatory stages must always be present regardless of the toggles.
+    const finalStages = entry
+      ? Array.from(new Set([...entry.mandatory_stages, ...stages]))
+      : stages;
+
     const body: Record<string, unknown> = {
       name: name.trim(),
       slug: slug.trim(),
       enabled,
       parallel,
       priority: Number(priority) || 0,
-      stages,
+      stages: finalStages,
     };
+    if (mode.trim()) body.mode = mode.trim();
     if (parsedSettings) body.settings = parsedSettings;
 
     setSubmitting(true);
@@ -300,24 +327,56 @@ function PolicyFormDialog({
               <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="global-rate-limit" />
             </Field>
             <Field label="Plugin">
-              <Select value={slug} onChange={(e) => setSlug(e.target.value)}>
-                {KNOWN_SLUGS.map((s) => (
-                  <option key={s} value={s}>
-                    {s}
-                  </option>
-                ))}
-              </Select>
+              {catalogGroups && catalogGroups.length > 0 ? (
+                <Select value={slug} onChange={(e) => selectSlug(e.target.value)} disabled={isEdit}>
+                  {catalogGroups.map((group) => (
+                    <optgroup key={group.type} label={group.type}>
+                      {group.items.map((it) => (
+                        <option key={it.slug} value={it.slug}>
+                          {it.name}
+                        </option>
+                      ))}
+                    </optgroup>
+                  ))}
+                </Select>
+              ) : (
+                <Select value={slug} onChange={(e) => selectSlug(e.target.value)} disabled={isEdit}>
+                  {slugOptions.map((s) => (
+                    <option key={s} value={s}>
+                      {s}
+                    </option>
+                  ))}
+                </Select>
+              )}
             </Field>
           </Grid2>
+
+          {entry?.description && <p className="text-[12px] text-muted -mt-2">{entry.description}</p>}
 
           <Grid2>
             <Field label="Priority" hint="lower runs first">
               <Input type="number" value={priority} onChange={(e) => setPriority(e.target.value)} />
             </Field>
-            <div className="flex flex-col gap-2 justify-end">
-              <SwitchRow label="Enabled" checked={enabled} onCheckedChange={setEnabled} />
-            </div>
+            {supportedModes.length > 0 ? (
+              <Field label="Mode">
+                <Select value={mode} onChange={(e) => setMode(e.target.value)}>
+                  {supportedModes.map((m) => (
+                    <option key={m} value={m}>
+                      {m}
+                    </option>
+                  ))}
+                </Select>
+              </Field>
+            ) : (
+              <div className="flex flex-col gap-2 justify-end">
+                <SwitchRow label="Enabled" checked={enabled} onCheckedChange={setEnabled} />
+              </div>
+            )}
           </Grid2>
+
+          {supportedModes.length > 0 && (
+            <SwitchRow label="Enabled" checked={enabled} onCheckedChange={setEnabled} />
+          )}
 
           <SwitchRow
             label="Parallel"
@@ -353,6 +412,20 @@ function PolicyFormDialog({
           <Divider />
 
           <Section title="Settings" description="Plugin-specific configuration as JSON.">
+            {settingsFields.length > 0 && (
+              <div className="rounded-(--radius) border border-border bg-surface-2/30 px-3 py-2.5 flex flex-col gap-1">
+                <p className="text-[11px] font-medium uppercase tracking-wider text-faint">Available fields</p>
+                <ul className="flex flex-col gap-0.5">
+                  {settingsFields.map((f) => (
+                    <li key={f.key} className="text-[12px] text-muted">
+                      <code className="text-accent">{f.key}</code>
+                      <span className="text-faint"> · {f.type}{f.required ? " · required" : ""}</span>
+                      {f.description ? <span className="text-faint"> — {f.description}</span> : null}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
             <JsonEditor value={settings} onChange={setSettings} onValidityChange={setSettingsValid} rows={9} />
           </Section>
         </DialogBody>

--- a/frontend/src/components/entities/registries-view.tsx
+++ b/frontend/src/components/entities/registries-view.tsx
@@ -359,7 +359,6 @@ function RegistryFormDialog({
     const body: Record<string, unknown> = {
       name,
       provider,
-      weight: 1,
       auth: buildTargetAuth(selectedOption, fieldValues),
     };
     if (provider === PROVIDER_OPTIONS_PROVIDER) {

--- a/frontend/src/components/entities/roles-view.tsx
+++ b/frontend/src/components/entities/roles-view.tsx
@@ -1,0 +1,524 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Plus, Pencil, Trash2, UsersRound, Settings2, Check, Server, X } from "lucide-react";
+import { api, gatewayScope } from "@/lib/admin-client";
+import { useActiveGatewayId } from "@/components/layout/gateway-context";
+import { useList, useInvalidate, errorMessage } from "@/lib/hooks";
+import { useToast } from "@/components/ui/toast";
+import { PageHeader, ConfirmDialog, useDisclosure } from "@/components/ui/page";
+import { Button } from "@/components/ui/button";
+import { Table, THead, TBody, TH, TR, TD } from "@/components/ui/table";
+import { Badge, EmptyState, PageLoader } from "@/components/ui/misc";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogBody,
+  DialogFooter,
+  DialogClose,
+} from "@/components/ui/dialog";
+import { Tabs, TabsList, TabTrigger, TabContent } from "@/components/ui/tabs";
+import { Field, Input, Select, Label } from "@/components/ui/field";
+import { Grid2, SwitchRow, Divider } from "@/components/ui/form-bits";
+import { cn } from "@/lib/cn";
+import {
+  ModelPolicyEditor,
+  buildModelPolicies,
+  modelPolicyStateFrom,
+  type ModelPolicyState,
+} from "./model-policy-editor";
+import type { Role, Registry, OidcMapping, OidcClaim, OidcClaimOp } from "@/lib/types";
+
+const CLAIM_OPS: { value: OidcClaimOp; label: string }[] = [
+  { value: "equals", label: "equals" },
+  { value: "contains_any", label: "contains any" },
+  { value: "contains_all", label: "contains all" },
+];
+
+export function RolesView() {
+  const { data: roles, isLoading } = useList<Role>("roles");
+  const form = useDisclosure();
+  const [editing, setEditing] = useState<Role | null>(null);
+  const [detail, setDetail] = useState<Role | null>(null);
+  const [toDelete, setToDelete] = useState<Role | null>(null);
+
+  return (
+    <div>
+      <PageHeader
+        description="Roles power role-based routing. A role maps OIDC/OAuth2 identity claims to a set of registries and model policies."
+        action={
+          <Button
+            variant="primary"
+            onClick={() => {
+              setEditing(null);
+              form.onOpen();
+            }}
+          >
+            <Plus className="h-4 w-4" />
+            New role
+          </Button>
+        }
+      />
+
+      {isLoading ? (
+        <PageLoader />
+      ) : !roles || roles.length === 0 ? (
+        <EmptyState
+          icon={<UsersRound className="h-5 w-5" />}
+          title="No roles yet"
+          description="Create a role to route identity-authenticated consumers by their claims."
+        />
+      ) : (
+        <Table>
+          <THead>
+            <TH>Name</TH>
+            <TH>OIDC mapping</TH>
+            <TH>Registries</TH>
+            <TH className="text-right pr-4">Actions</TH>
+          </THead>
+          <TBody>
+            {roles.map((r) => (
+              <TR key={r.id}>
+                <TD>
+                  <span className="font-medium text-fg">{r.name}</span>
+                </TD>
+                <TD>
+                  {r.oidc_mapping ? (
+                    <span className="text-[12px] text-muted">
+                      match {r.oidc_mapping.match} · {r.oidc_mapping.claims.length} claim
+                      {r.oidc_mapping.claims.length === 1 ? "" : "s"}
+                    </span>
+                  ) : (
+                    <span className="text-faint">—</span>
+                  )}
+                </TD>
+                <TD>
+                  <span className="text-[12px] text-muted">{r.registry_ids.length}</span>
+                </TD>
+                <TD className="text-right pr-4">
+                  <div className="inline-flex gap-1">
+                    <Button variant="ghost" size="icon" onClick={() => setDetail(r)} aria-label="Configure">
+                      <Settings2 className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => {
+                        setEditing(r);
+                        form.onOpen();
+                      }}
+                      aria-label="Edit"
+                    >
+                      <Pencil className="h-4 w-4" />
+                    </Button>
+                    <Button variant="ghost" size="icon" onClick={() => setToDelete(r)} aria-label="Delete">
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </TD>
+              </TR>
+            ))}
+          </TBody>
+        </Table>
+      )}
+
+      {form.open && <RoleFormDialog open={form.open} onOpenChange={form.setOpen} role={editing} />}
+      {detail && (
+        <RoleDetail roleId={detail.id} open={detail !== null} onOpenChange={(v) => !v && setDetail(null)} />
+      )}
+      <DeleteRoleDialog role={toDelete} onClose={() => setToDelete(null)} />
+    </div>
+  );
+}
+
+function DeleteRoleDialog({ role, onClose }: { role: Role | null; onClose: () => void }) {
+  const gatewayId = useActiveGatewayId();
+  const invalidate = useInvalidate();
+  const { toast } = useToast();
+  const [loading, setLoading] = useState(false);
+
+  async function confirm() {
+    if (!role) return;
+    setLoading(true);
+    try {
+      await api.del(`${gatewayScope(gatewayId)}/roles/${role.id}`);
+      toast({ variant: "success", title: "Role deleted", description: role.name });
+      void invalidate("roles");
+      onClose();
+    } catch (err) {
+      toast({ variant: "error", title: "Could not delete", description: errorMessage(err) });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <ConfirmDialog
+      open={role !== null}
+      onOpenChange={(v) => !v && onClose()}
+      title="Delete role"
+      description={`"${role?.name}" will be permanently removed and detached from all consumers.`}
+      onConfirm={confirm}
+      loading={loading}
+    />
+  );
+}
+
+function emptyClaim(): OidcClaim {
+  return { path: "", op: "equals", values: [] };
+}
+
+function RoleFormDialog({
+  open,
+  onOpenChange,
+  role,
+}: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  role: Role | null;
+}) {
+  const gatewayId = useActiveGatewayId();
+  const invalidate = useInvalidate();
+  const { toast } = useToast();
+  const isEdit = role !== null;
+
+  const [name, setName] = useState(role?.name ?? "");
+  const [mappingEnabled, setMappingEnabled] = useState(role?.oidc_mapping != null);
+  const [match, setMatch] = useState<OidcMapping["match"]>(role?.oidc_mapping?.match ?? "any");
+  const [claims, setClaims] = useState<{ path: string; op: OidcClaimOp; values: string }[]>(
+    (role?.oidc_mapping?.claims ?? [emptyClaim()]).map((c) => ({
+      path: c.path,
+      op: c.op,
+      values: c.values.join(", "),
+    })),
+  );
+  const [submitting, setSubmitting] = useState(false);
+
+  const splitList = (v: string) => v.split(",").map((s) => s.trim()).filter(Boolean);
+
+  function updateClaim(i: number, patch: Partial<{ path: string; op: OidcClaimOp; values: string }>) {
+    setClaims((prev) => prev.map((c, idx) => (idx === i ? { ...c, ...patch } : c)));
+  }
+
+  function buildMapping(): OidcMapping | null | string {
+    if (!mappingEnabled) return null;
+    const built: OidcClaim[] = [];
+    for (const c of claims) {
+      const path = c.path.trim();
+      const values = splitList(c.values);
+      if (!path && values.length === 0) continue;
+      if (!path) return "Every claim needs a path.";
+      if (values.length === 0) return `Claim "${path}" needs at least one value.`;
+      built.push({ path, op: c.op, values });
+    }
+    if (built.length === 0) return "Add at least one claim, or disable OIDC mapping.";
+    return { match, claims: built };
+  }
+
+  async function submit() {
+    if (!name.trim()) {
+      toast({ variant: "error", title: "Name is required" });
+      return;
+    }
+    const mapping = buildMapping();
+    if (typeof mapping === "string") {
+      toast({ variant: "error", title: mapping });
+      return;
+    }
+
+    const body: Record<string, unknown> = { name: name.trim() };
+    if (mapping) body.oidc_mapping = mapping;
+    else if (isEdit) body.oidc_mapping = null;
+
+    setSubmitting(true);
+    try {
+      const base = `${gatewayScope(gatewayId)}/roles`;
+      if (isEdit) {
+        await api.put(`${base}/${role.id}`, body);
+      } else {
+        await api.post(base, body);
+      }
+      toast({ variant: "success", title: isEdit ? "Role updated" : "Role created", description: name });
+      void invalidate("roles");
+      onOpenChange(false);
+    } catch (err) {
+      toast({ variant: "error", title: "Save failed", description: errorMessage(err) });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent size="lg">
+        <DialogHeader
+          title={isEdit ? "Edit role" : "New role"}
+          description="Bind registries and model policies from the role's configuration panel after creating it."
+        />
+        <DialogBody className="flex flex-col gap-5">
+          <Field label="Name">
+            <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="premium-users" />
+          </Field>
+
+          <Divider />
+
+          <SwitchRow
+            label="OIDC claim mapping"
+            description="Assign this role automatically when an identity token matches the claims below."
+            checked={mappingEnabled}
+            onCheckedChange={setMappingEnabled}
+          />
+
+          {mappingEnabled && (
+            <div className="flex flex-col gap-3">
+              <Field label="Match">
+                <Select value={match} onChange={(e) => setMatch(e.target.value as OidcMapping["match"])}>
+                  <option value="any">Any claim matches</option>
+                  <option value="all">All claims match</option>
+                </Select>
+              </Field>
+
+              <div className="flex flex-col gap-2">
+                <Label>Claims</Label>
+                {claims.map((c, i) => (
+                  <div key={i} className="rounded-(--radius) border border-border bg-surface-2/30 p-3 flex flex-col gap-2.5">
+                    <Grid2>
+                      <Field label="Path">
+                        <Input
+                          value={c.path}
+                          onChange={(e) => updateClaim(i, { path: e.target.value })}
+                          placeholder="realm_access.roles"
+                        />
+                      </Field>
+                      <Field label="Operator">
+                        <Select value={c.op} onChange={(e) => updateClaim(i, { op: e.target.value as OidcClaimOp })}>
+                          {CLAIM_OPS.map((o) => (
+                            <option key={o.value} value={o.value}>
+                              {o.label}
+                            </option>
+                          ))}
+                        </Select>
+                      </Field>
+                    </Grid2>
+                    <div className="flex items-end gap-2">
+                      <Field label="Values" hint="comma-separated" className="flex-1">
+                        <Input
+                          value={c.values}
+                          onChange={(e) => updateClaim(i, { values: e.target.value })}
+                          placeholder="admin, premium"
+                        />
+                      </Field>
+                      {claims.length > 1 && (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => setClaims((prev) => prev.filter((_, idx) => idx !== i))}
+                          aria-label="Remove claim"
+                        >
+                          <X className="h-4 w-4" />
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+                ))}
+                <div>
+                  <Button variant="ghost" size="sm" onClick={() => setClaims((prev) => [...prev, { path: "", op: "equals", values: "" }])}>
+                    <Plus className="h-4 w-4" />
+                    Add claim
+                  </Button>
+                </div>
+              </div>
+            </div>
+          )}
+        </DialogBody>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="ghost">Cancel</Button>
+          </DialogClose>
+          <Button variant="primary" onClick={submit} loading={submitting}>
+            {isEdit ? "Save changes" : "Create role"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function RoleDetail({
+  roleId,
+  open,
+  onOpenChange,
+}: {
+  roleId: string;
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+}) {
+  const gatewayId = useActiveGatewayId();
+  const { data: role, isLoading } = useQuery({
+    queryKey: ["role", gatewayId, roleId],
+    queryFn: () => api.get<Role>(`${gatewayScope(gatewayId)}/roles/${roleId}`),
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent size="xl">
+        <DialogHeader title={role ? role.name : "Role"} description="Registries and model policies" />
+        {isLoading || !role ? (
+          <DialogBody>
+            <PageLoader />
+          </DialogBody>
+        ) : (
+          <Tabs defaultValue="registries">
+            <div className="px-6 pt-3">
+              <TabsList>
+                <TabTrigger value="registries">Registries</TabTrigger>
+                <TabTrigger value="models">Model policies</TabTrigger>
+              </TabsList>
+            </div>
+            <DialogBody className="min-h-[340px]">
+              <TabContent value="registries">
+                <RoleRegistriesTab role={role} />
+              </TabContent>
+              <TabContent value="models">
+                <RoleModelPoliciesTab role={role} onClose={() => onOpenChange(false)} />
+              </TabContent>
+            </DialogBody>
+          </Tabs>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function useRoleInvalidate(roleId: string) {
+  const qc = useQueryClient();
+  const gatewayId = useActiveGatewayId();
+  const invalidate = useInvalidate();
+  return () => {
+    void qc.invalidateQueries({ queryKey: ["role", gatewayId, roleId] });
+    void invalidate("roles");
+  };
+}
+
+function RoleRegistriesTab({ role }: { role: Role }) {
+  const gatewayId = useActiveGatewayId();
+  const invalidate = useRoleInvalidate(role.id);
+  const { toast } = useToast();
+  const { data: registries, isLoading } = useList<Registry>("registries");
+  const [pending, setPending] = useState<string | null>(null);
+
+  const bound = new Set(role.registry_ids);
+
+  async function toggle(registry: Registry, isBound: boolean) {
+    setPending(registry.id);
+    const url = `${gatewayScope(gatewayId)}/roles/${role.id}/registries/${registry.id}`;
+    try {
+      if (isBound) await api.del(url);
+      else await api.post(url);
+      invalidate();
+    } catch (err) {
+      toast({ variant: "error", title: "Could not update binding", description: errorMessage(err) });
+    } finally {
+      setPending(null);
+    }
+  }
+
+  if (isLoading) return <p className="text-[13px] text-muted">Loading…</p>;
+  if (!registries || registries.length === 0) {
+    return <p className="text-[13px] text-faint">No registries available in this gateway.</p>;
+  }
+
+  return (
+    <section className="flex flex-col gap-2.5">
+      <div className="flex items-center gap-2 text-[13px] font-semibold text-fg">
+        <span className="text-accent">
+          <Server className="h-4 w-4" />
+        </span>
+        Registries
+      </div>
+      <div className="flex flex-col gap-1.5">
+        {registries.map((registry) => {
+          const isBound = bound.has(registry.id);
+          return (
+            <button
+              key={registry.id}
+              type="button"
+              disabled={pending === registry.id}
+              onClick={() => toggle(registry, isBound)}
+              className={cn(
+                "flex items-center justify-between gap-3 rounded-(--radius) border px-3.5 h-11 text-left transition-colors disabled:opacity-50",
+                isBound
+                  ? "border-accent/40 bg-accent/8"
+                  : "border-border bg-surface-2/30 hover:border-border-strong",
+              )}
+            >
+              <div className="flex items-center gap-2.5 min-w-0">
+                <span
+                  className={cn(
+                    "flex h-4.5 w-4.5 items-center justify-center rounded border shrink-0",
+                    isBound ? "bg-accent border-accent text-bg" : "border-border-strong text-transparent",
+                  )}
+                >
+                  <Check className="h-3 w-3" />
+                </span>
+                <span className="text-[13px] text-fg truncate">
+                  {registry.name} <span className="text-faint">({registry.provider})</span>
+                </span>
+              </div>
+              <span className="text-[12px] text-faint shrink-0">{isBound ? "Attached" : "Attach"}</span>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function RoleModelPoliciesTab({ role, onClose }: { role: Role; onClose: () => void }) {
+  const gatewayId = useActiveGatewayId();
+  const invalidate = useRoleInvalidate(role.id);
+  const { toast } = useToast();
+  const { data: registries } = useList<Registry>("registries");
+
+  const attached = (registries ?? []).filter((r) => role.registry_ids.includes(r.id));
+  const [state, setState] = useState<Record<string, ModelPolicyState>>(() =>
+    modelPolicyStateFrom(role.model_policies),
+  );
+  const [saving, setSaving] = useState(false);
+
+  async function save() {
+    const policies = buildModelPolicies(attached, state);
+    setSaving(true);
+    try {
+      await api.put(`${gatewayScope(gatewayId)}/roles/${role.id}`, { model_policies: policies });
+      toast({ variant: "success", title: "Model policies saved" });
+      invalidate();
+      onClose();
+    } catch (err) {
+      toast({ variant: "error", title: "Save failed", description: errorMessage(err) });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (attached.length === 0) {
+    return (
+      <p className="text-[13px] text-faint py-8 text-center">
+        Attach registries first (Registries tab) to configure per-model allowlists.
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <ModelPolicyEditor registries={attached} state={state} onChange={setState} />
+      <div className="flex justify-end pt-2">
+        <Button variant="primary" onClick={save} loading={saving}>
+          Save model policies
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/layout/gateway-switcher.tsx
+++ b/frontend/src/components/layout/gateway-switcher.tsx
@@ -3,14 +3,17 @@
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
-import { Check, ChevronsUpDown, Plus, Layers } from "lucide-react";
+import { Check, ChevronsUpDown, Plus, Layers, Settings2, Trash2 } from "lucide-react";
 import { setActiveGateway } from "@/app/actions";
 import { api } from "@/lib/admin-client";
 import { useGateway } from "./gateway-context";
 import { useToast } from "@/components/ui/toast";
 import { Dialog, DialogContent, DialogHeader, DialogBody, DialogFooter, DialogClose } from "@/components/ui/dialog";
-import { Field, Input } from "@/components/ui/field";
+import { ConfirmDialog } from "@/components/ui/page";
+import { Field, Input, Select } from "@/components/ui/field";
+import { SwitchRow, Divider, Section } from "@/components/ui/form-bits";
 import { Button } from "@/components/ui/button";
+import { errorMessage } from "@/lib/hooks";
 import type { Gateway } from "@/lib/types";
 import { cn } from "@/lib/cn";
 
@@ -19,6 +22,8 @@ export function GatewaySwitcher() {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [createOpen, setCreateOpen] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
 
   function switchTo(id: string) {
     if (id === active.id) return;
@@ -74,6 +79,18 @@ export function GatewaySwitcher() {
             <DropdownMenu.Item
               onSelect={(e) => {
                 e.preventDefault();
+                setSettingsOpen(true);
+              }}
+              className="flex items-center gap-2 rounded-(--radius-sm) px-2 py-1.5 text-[13px] text-muted outline-none data-[highlighted]:bg-surface-2 data-[highlighted]:text-fg cursor-pointer"
+            >
+              <span className="flex h-4 w-4 items-center justify-center">
+                <Settings2 className="h-3.5 w-3.5" />
+              </span>
+              Gateway settings
+            </DropdownMenu.Item>
+            <DropdownMenu.Item
+              onSelect={(e) => {
+                e.preventDefault();
                 setCreateOpen(true);
               }}
               className="flex items-center gap-2 rounded-(--radius-sm) px-2 py-1.5 text-[13px] text-muted outline-none data-[highlighted]:bg-surface-2 data-[highlighted]:text-fg cursor-pointer"
@@ -83,12 +100,184 @@ export function GatewaySwitcher() {
               </span>
               Create gateway
             </DropdownMenu.Item>
+            <DropdownMenu.Separator className="my-1.5 h-px bg-border" />
+            <DropdownMenu.Item
+              disabled={gateways.length <= 1}
+              onSelect={(e) => {
+                e.preventDefault();
+                setDeleteOpen(true);
+              }}
+              className="flex items-center gap-2 rounded-(--radius-sm) px-2 py-1.5 text-[13px] text-danger outline-none data-[highlighted]:bg-surface-2 cursor-pointer data-[disabled]:opacity-40 data-[disabled]:cursor-not-allowed"
+            >
+              <span className="flex h-4 w-4 items-center justify-center">
+                <Trash2 className="h-3.5 w-3.5" />
+              </span>
+              Delete gateway
+            </DropdownMenu.Item>
           </DropdownMenu.Content>
         </DropdownMenu.Portal>
       </DropdownMenu.Root>
 
       <CreateGatewayDialog open={createOpen} onOpenChange={setCreateOpen} />
+      {settingsOpen && (
+        <GatewaySettingsDialog gateway={active} open={settingsOpen} onOpenChange={setSettingsOpen} />
+      )}
+      <DeleteGatewayDialog
+        gateway={active}
+        canDelete={gateways.length > 1}
+        open={deleteOpen}
+        onOpenChange={setDeleteOpen}
+        onDeleted={() => {
+          const next = gateways.find((g) => g.id !== active.id);
+          startTransition(async () => {
+            if (next) await setActiveGateway(next.id);
+            router.refresh();
+          });
+        }}
+      />
     </>
+  );
+}
+
+function GatewaySettingsDialog({
+  gateway,
+  open,
+  onOpenChange,
+}: {
+  gateway: Gateway;
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+}) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [slug, setSlug] = useState(gateway.slug);
+  const [status, setStatus] = useState(gateway.status || "active");
+  const [domain, setDomain] = useState(gateway.domain ?? "");
+  const [sessionEnabled, setSessionEnabled] = useState(gateway.session_config?.enabled ?? false);
+  const [headerName, setHeaderName] = useState(gateway.session_config?.header_name ?? "");
+  const [bodyParam, setBodyParam] = useState(gateway.session_config?.body_param_name ?? "");
+  const [submitting, setSubmitting] = useState(false);
+
+  async function submit() {
+    if (!slug.trim()) {
+      toast({ variant: "error", title: "Slug is required" });
+      return;
+    }
+    const body: Record<string, unknown> = {
+      slug: slug.trim(),
+      status,
+      session_config: {
+        enabled: sessionEnabled,
+        header_name: headerName.trim() || undefined,
+        body_param_name: bodyParam.trim() || undefined,
+      },
+    };
+    if (domain.trim()) body.domain = domain.trim();
+
+    setSubmitting(true);
+    try {
+      await api.put(`/v1/gateways/${gateway.id}`, body);
+      toast({ variant: "success", title: "Gateway updated", description: slug.trim() });
+      onOpenChange(false);
+      router.refresh();
+    } catch (err) {
+      toast({ variant: "error", title: "Could not update gateway", description: errorMessage(err) });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent size="lg">
+        <DialogHeader title="Gateway settings" description={`Proxy host: ${gateway.hosts?.proxy ?? "—"}`} />
+        <DialogBody className="flex flex-col gap-5">
+          <Field label="Slug">
+            <Input value={slug} onChange={(e) => setSlug(e.target.value)} placeholder="staging-gateway" />
+          </Field>
+          <Field label="Status">
+            <Select value={status} onChange={(e) => setStatus(e.target.value)}>
+              <option value="active">active</option>
+              <option value="inactive">inactive</option>
+            </Select>
+          </Field>
+          <Field label="Custom domain" hint="optional">
+            <Input value={domain} onChange={(e) => setDomain(e.target.value)} placeholder="gateway.example.com" />
+          </Field>
+
+          <Divider />
+
+          <Section title="Session">
+            <SwitchRow label="Enabled" checked={sessionEnabled} onCheckedChange={setSessionEnabled} />
+            {sessionEnabled && (
+              <>
+                <Field label="Header name" hint="optional">
+                  <Input value={headerName} onChange={(e) => setHeaderName(e.target.value)} placeholder="X-Session-Id" />
+                </Field>
+                <Field label="Body param name" hint="optional">
+                  <Input value={bodyParam} onChange={(e) => setBodyParam(e.target.value)} placeholder="session_id" />
+                </Field>
+              </>
+            )}
+          </Section>
+        </DialogBody>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="ghost">Cancel</Button>
+          </DialogClose>
+          <Button variant="primary" onClick={submit} loading={submitting}>
+            Save changes
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function DeleteGatewayDialog({
+  gateway,
+  canDelete,
+  open,
+  onOpenChange,
+  onDeleted,
+}: {
+  gateway: Gateway;
+  canDelete: boolean;
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  onDeleted: () => void;
+}) {
+  const { toast } = useToast();
+  const [loading, setLoading] = useState(false);
+
+  async function confirm() {
+    if (!canDelete) {
+      toast({ variant: "error", title: "Cannot delete the last gateway" });
+      onOpenChange(false);
+      return;
+    }
+    setLoading(true);
+    try {
+      await api.del(`/v1/gateways/${gateway.id}`);
+      toast({ variant: "success", title: "Gateway deleted", description: gateway.slug });
+      onOpenChange(false);
+      onDeleted();
+    } catch (err) {
+      toast({ variant: "error", title: "Could not delete gateway", description: errorMessage(err) });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <ConfirmDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Delete gateway"
+      description={`"${gateway.slug}" and all of its registries, consumers, roles, policies and auths will be permanently removed.`}
+      onConfirm={confirm}
+      loading={loading}
+    />
   );
 }
 

--- a/frontend/src/components/layout/logo.tsx
+++ b/frontend/src/components/layout/logo.tsx
@@ -2,17 +2,30 @@ import { cn } from "@/lib/cn";
 
 export function LogoMark({ className }: { className?: string }) {
   return (
-    <svg viewBox="0 0 32 32" fill="none" className={cn("h-7 w-7", className)} aria-hidden>
-      <rect x="1" y="1" width="30" height="30" rx="8" fill="#0e0e11" stroke="#2e2e36" />
-      <path
-        d="M16 7 L24 11.5 V20.5 L16 25 L8 20.5 V11.5 Z"
-        stroke="#7c7cff"
-        strokeWidth="1.6"
-        strokeLinejoin="round"
-        fill="rgba(124,124,255,0.08)"
-      />
-      <circle cx="16" cy="16" r="2.4" fill="#7c7cff" />
-    </svg>
+    <span className={cn("inline-flex h-7 w-7 overflow-hidden rounded-[7px]", className)}>
+      <svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" className="h-full w-full">
+        <g clipPath="url(#ntClip)">
+          <path fill="url(#ntGrad)" d="M32 0H0v32h32z" />
+          <path
+            fill="#fff"
+            d="M18.092 20.06a.67.67 0 0 1-.55.3.7.7 0 0 1-.565-.286l-2.704-3.814-1.45 2.103 2.197 3.098a3.08 3.08 0 0 0 2.51 1.297h.038a3.06 3.06 0 0 0 2.502-1.342l8.02-11.477h-2.926z"
+          />
+          <path
+            fill="#fff"
+            d="M14.292 11.518a.63.63 0 0 1 .552.286l2.652 3.74 1.449-2.103-2.145-3.024a3.08 3.08 0 0 0-2.509-1.297h-.039a3.06 3.06 0 0 0-2.506 1.35L3.925 21.85l-.085.123h2.91l6.98-10.155a.68.68 0 0 1 .562-.3"
+          />
+        </g>
+        <defs>
+          <linearGradient id="ntGrad" x1="30.667" x2="6.667" y1="0" y2="32" gradientUnits="userSpaceOnUse">
+            <stop stopColor="#03AFFF" />
+            <stop offset="1" stopColor="#9B29FF" />
+          </linearGradient>
+          <clipPath id="ntClip">
+            <path fill="#fff" d="M0 0h32v32H0z" />
+          </clipPath>
+        </defs>
+      </svg>
+    </span>
   );
 }
 
@@ -20,9 +33,7 @@ export function Logo({ className }: { className?: string }) {
   return (
     <div className={cn("flex items-center gap-2.5", className)}>
       <LogoMark className="h-7 w-7" />
-      <span className="text-[15px] font-semibold tracking-tight text-fg">
-        TrustGate
-      </span>
+      <span className="text-[15px] font-semibold tracking-tight text-fg">NeuralTrust</span>
     </div>
   );
 }

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -2,13 +2,14 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Server, Users, KeyRound, ShieldCheck, FlaskConical } from "lucide-react";
+import { Server, Users, UsersRound, KeyRound, ShieldCheck, FlaskConical } from "lucide-react";
 import { Logo } from "./logo";
 import { cn } from "@/lib/cn";
 
 const nav = [
   { href: "/dashboard/consumers", label: "Consumers", icon: Users },
   { href: "/dashboard/registries", label: "Registry", icon: Server },
+  { href: "/dashboard/roles", label: "Roles", icon: UsersRound },
   { href: "/dashboard/policies", label: "Policies", icon: ShieldCheck },
   { href: "/dashboard/auth", label: "Auth", icon: KeyRound },
   { href: "/dashboard/playground", label: "Playground", icon: FlaskConical },

--- a/frontend/src/lib/hooks.ts
+++ b/frontend/src/lib/hooks.ts
@@ -5,7 +5,14 @@ import { api, gatewayScope } from "@/lib/admin-client";
 import { useActiveGatewayId } from "@/components/layout/gateway-context";
 import { useToast } from "@/components/ui/toast";
 import { AdminApiError } from "@/lib/admin-client";
-import type { ListResponse, MCPServer, MCPServersResponse } from "@/lib/types";
+import type {
+  ListResponse,
+  MCPServer,
+  MCPServersResponse,
+  Model,
+  PolicyCatalog,
+  PolicyCatalogGroup,
+} from "@/lib/types";
 
 export function useList<T>(resource: string) {
   const gatewayId = useActiveGatewayId();
@@ -23,6 +30,28 @@ export function useCatalogQuery<T>(key: string, path: string, enabled = true) {
     queryFn: () => api.get<ListResponse<T>>(path),
     select: (data) => data.items ?? [],
     enabled,
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function usePolicyCatalog() {
+  return useQuery({
+    queryKey: ["policies-catalog"],
+    queryFn: () => api.get<PolicyCatalog>("/v1/policies-catalog"),
+    select: (data): PolicyCatalogGroup[] => data.groups ?? [],
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function useModelsCatalog(providerCode?: string) {
+  return useQuery({
+    queryKey: ["models-catalog", providerCode ?? "all"],
+    queryFn: () =>
+      api.get<ListResponse<Model>>(
+        `/v1/models-catalog${providerCode ? `?provider=${encodeURIComponent(providerCode)}` : ""}`,
+      ),
+    select: (data): Model[] => data.items ?? [],
+    enabled: providerCode !== "",
     staleTime: 5 * 60 * 1000,
   });
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -10,10 +10,21 @@ export interface ApiError {
   message?: string;
 }
 
+export interface GatewayHosts {
+  proxy?: string;
+  mcp?: string;
+}
+
 export interface Gateway {
   id: string;
   slug: string;
   status: string;
+  version?: string;
+  domain?: string;
+  hosts?: GatewayHosts | null;
+  metadata?: Record<string, string> | null;
+  telemetry?: Record<string, unknown> | null;
+  client_tls?: Record<string, unknown> | null;
   session_config?: SessionConfig | null;
   created_at: string;
   updated_at: string;
@@ -123,7 +134,7 @@ export interface Registry {
   provider: string;
   provider_options?: Record<string, unknown>;
   description?: string;
-  weight?: number;
+  enabled?: boolean;
   auth?: TargetAuth | null;
   health_checks?: HealthChecks | null;
   mcp_target?: MCPTarget | null;
@@ -132,6 +143,7 @@ export interface Registry {
 }
 
 export type ConsumerType = "LLM" | "MCP" | "A2A";
+export type RoutingMode = "inline" | "role_based";
 export type Algorithm =
   | "round-robin"
   | "random"
@@ -139,15 +151,56 @@ export type Algorithm =
   | "least-connections"
   | "semantic";
 
+export interface EmbeddingAuth {
+  api_key?: string;
+  header_name?: string;
+  header_value?: string;
+  param_name?: string;
+  param_value?: string;
+  param_location?: string;
+}
+
 export interface EmbeddingConfig {
   provider: string;
   model: string;
+  auth?: EmbeddingAuth | null;
+}
+
+export interface LBPoolMember {
+  registry_id: string;
+  models?: string[];
+}
+
+export interface LBConfig {
+  enabled: boolean;
+  algorithm?: Algorithm;
+  pool_alias?: string;
+  members?: LBPoolMember[];
+  embedding_config?: EmbeddingConfig | null;
+}
+
+export interface RegistryWeight {
+  registry_id: string;
+  weight: number;
+}
+
+export interface ModelPolicy {
+  registry_id: string;
+  allowed?: string[];
+  default?: string;
+}
+
+export interface ToolkitEntry {
+  registry_id: string;
+  tool?: string;
+  prompt?: string;
+  resource?: string;
+  expose_as?: string;
 }
 
 export interface FallbackBudget {
   max_attempts: number;
   max_total_latency_ms?: number;
-  max_cost_usd?: number;
 }
 
 export interface Fallback {
@@ -157,40 +210,29 @@ export interface Fallback {
   chain: string[];
 }
 
-export interface ModelPolicy {
-  allowed?: string[];
-  default?: string;
-}
-
-export interface RegistryBinding {
-  id: string;
-  model_policies?: ModelPolicy | null;
-}
-
-export interface ConsumerWeight {
-  registry_id: string;
-  weight: number;
-}
-
 export interface Consumer {
   id: string;
   gateway_id: string;
   name: string;
   type: ConsumerType;
-  path: string;
-  algorithm: Algorithm;
-  embedding_config?: EmbeddingConfig | null;
+  slug: string;
+  routing_mode: RoutingMode;
+  lb_config?: LBConfig | null;
   headers?: Record<string, string>;
   active: boolean;
-  registries: RegistryBinding[];
+  registry_ids: string[];
+  registry_weights?: RegistryWeight[];
+  role_ids: string[];
   auth_ids: string[];
   fallback?: Fallback | null;
-  weights?: ConsumerWeight[];
+  model_policies?: ModelPolicy[];
+  toolkit?: ToolkitEntry[];
+  fail_mode?: string;
   created_at: string;
   updated_at: string;
 }
 
-export type AuthType = "api_key" | "oauth2" | "mtls";
+export type AuthType = "api_key" | "oauth2" | "oidc" | "mtls";
 
 export interface OAuth2Config {
   issuer: string;
@@ -201,6 +243,21 @@ export interface OAuth2Config {
   client_secret?: string;
   required_scopes?: string[];
   allowed_algorithms?: string[];
+  session_mode?: boolean;
+  userinfo_url?: string;
+  subject_claim?: string;
+  authorize_url?: string;
+  token_url?: string;
+}
+
+export interface OidcConfig {
+  issuer: string;
+  audiences?: string[];
+  jwks_url?: string;
+  public_keys?: string[];
+  required_scopes?: string[];
+  allowed_algorithms?: string[];
+  subject_claim?: string;
 }
 
 export interface MtlsConfig {
@@ -212,7 +269,13 @@ export interface MtlsConfig {
 
 export interface AuthConfig {
   oauth2?: OAuth2Config;
+  oidc?: OidcConfig;
   mtls?: MtlsConfig;
+}
+
+// Auth types that can drive role-based (identity-provider) consumer routing.
+export function isIdentityProviderAuth(type: AuthType): boolean {
+  return type === "oauth2" || type === "oidc";
 }
 
 export interface Auth {
@@ -227,7 +290,53 @@ export interface Auth {
   updated_at: string;
 }
 
+export type OidcMatch = "any" | "all";
+export type OidcClaimOp = "equals" | "contains_any" | "contains_all";
+
+export interface OidcClaim {
+  path: string;
+  op: OidcClaimOp;
+  values: string[];
+}
+
+export interface OidcMapping {
+  match: OidcMatch;
+  claims: OidcClaim[];
+}
+
+export interface RoleModelPolicy {
+  registry_id: string;
+  allowed?: string[];
+  default?: string;
+}
+
+export interface RoleToolkitEntry {
+  registry_id: string;
+  tool?: string;
+  prompt?: string;
+  resource?: string;
+  expose_as?: string;
+}
+
+export interface RoleMcpPolicies {
+  toolkit?: RoleToolkitEntry[];
+  fail_mode?: string;
+}
+
+export interface Role {
+  id: string;
+  gateway_id: string;
+  name: string;
+  model_policies?: RoleModelPolicy[];
+  mcp_policies?: RoleMcpPolicies | null;
+  oidc_mapping?: OidcMapping | null;
+  registry_ids: string[];
+  created_at: string;
+  updated_at: string;
+}
+
 export type PolicyStage = "pre_request" | "post_request" | "pre_response" | "post_response";
+export type PolicyMode = "enforce" | "throttle" | "observe";
 
 export interface Policy {
   id: string;
@@ -235,14 +344,56 @@ export interface Policy {
   consumer_ids?: string[];
   name: string;
   slug: string;
+  description?: string;
   enabled: boolean;
   global: boolean;
   priority: number;
   parallel?: boolean;
+  mode?: string;
   settings?: Record<string, unknown>;
   stages?: PolicyStage[];
   created_at: string;
   updated_at: string;
+}
+
+export interface PolicyCatalogEnumOption {
+  value: string;
+  label: string;
+}
+
+export interface PolicyCatalogField {
+  key: string;
+  label: string;
+  type: "string" | "integer" | "number" | "boolean" | "duration" | "enum" | "object" | "array" | "map";
+  description?: string;
+  required?: boolean;
+  default?: unknown;
+  enum?: PolicyCatalogEnumOption[];
+  fields?: PolicyCatalogField[];
+  item?: Record<string, unknown>;
+  key_options?: string[];
+  value?: Record<string, unknown>;
+}
+
+export interface PolicyCatalogEntry {
+  slug: string;
+  name: string;
+  description?: string;
+  mandatory_stages: PolicyStage[];
+  supported_stages: PolicyStage[];
+  supported_modes: PolicyMode[];
+  supported_protocols: string[];
+  default_mode: string;
+  settings_schema?: { fields?: PolicyCatalogField[] } | null;
+}
+
+export interface PolicyCatalogGroup {
+  type: string;
+  items: PolicyCatalogEntry[];
+}
+
+export interface PolicyCatalog {
+  groups: PolicyCatalogGroup[];
 }
 
 export type AuthFieldType = "string" | "boolean";
@@ -290,9 +441,18 @@ export interface Model {
   id: string;
   provider_id: string;
   slug: string;
+  external_id?: string;
   display_name?: string;
   context_window?: number;
+  max_output?: number;
+  input_price?: string;
+  output_price?: string;
+  capabilities?: Record<string, unknown>;
   enabled: boolean;
+  source?: string;
+  release_date?: string;
+  input_modalities?: string[];
+  output_modalities?: string[];
 }
 
 export type MCPAuthHint = "none" | "static" | "oauth";


### PR DESCRIPTION
## Summary

Update the embedded admin dashboard (`frontend/`) to match the current TrustGate admin API and add the previously missing surface.

- **Roles + role-based routing**: new Roles page (create/edit with OIDC claim mapping, registry bindings, per-registry model policies). Consumer detail gains an inline vs `role_based` access-mode switch with role bindings.
- **Dynamic catalogs**: policy plugin picker from `/v1/policies-catalog` (groups, stages, mode, settings schema); model pickers from `/v1/models-catalog` per provider via a shared model-policy editor.
- **Auth**: OIDC credential type and extended OAuth2 fields (session mode, authorize/token/userinfo URLs, client id/secret, algorithms).
- **Gateway CRUD**: settings (slug/status/domain/session) and delete from the gateway switcher.
- **Cleanup**: consumer/registry payloads aligned to the new schema; dropped the phantom registry `weight`.
- **Branding**: NeuralTrust logo mark.
- **Local dev**: removed Kafka/Zookeeper from the compose stack (unused locally).

## Test plan
- [x] `tsc --noEmit` clean
- [ ] Manual QA against admin + proxy running via docker-compose

Made with [Cursor](https://cursor.com)