### PR TITLE
feat: per-plugin policy settings form

### DIFF
--- a/frontend/src/app/api/playground/[...path]/route.ts
+++ b/frontend/src/app/api/playground/[...path]/route.ts
@@ -8,6 +8,11 @@ export const dynamic = "force-dynamic";
 // pkg/api/resolver/playground_resolver.go HeaderPlaygroundToken).
 const PLAYGROUND_TOKEN_HEADER = "X-AG-Playground-Token";
 
+// Header carrying the gateway slug for header-based discovery (see backend
+// pkg/api/resolver/gateway_resolver.go HeaderGatewaySlug). Locally the proxy
+// runs in header mode, so this replaces subdomain host resolution.
+const GATEWAY_SLUG_HEADER = "X-AG-Gateway-Slug";
+
 interface RouteContext {
   params: Promise<{ path: string[] }>;
 }
@@ -26,6 +31,14 @@ async function handler(req: NextRequest, ctx: RouteContext): Promise<NextRespons
   }
   const target = `${proxyBaseUrl()}/${path.join("/")}${req.nextUrl.search}`;
 
+  const gatewaySlug = req.headers.get(GATEWAY_SLUG_HEADER)?.trim();
+  if (!gatewaySlug) {
+    return NextResponse.json(
+      { error: "bff_error", message: `missing ${GATEWAY_SLUG_HEADER} header` },
+      { status: 400 },
+    );
+  }
+
   const body = await req.text();
 
   try {
@@ -35,6 +48,7 @@ async function handler(req: NextRequest, ctx: RouteContext): Promise<NextRespons
       headers: {
         "Content-Type": "application/json",
         [PLAYGROUND_TOKEN_HEADER]: token,
+        [GATEWAY_SLUG_HEADER]: gatewaySlug,
       },
       body: body.length > 0 ? body : undefined,
       cache: "no-store",

--- a/frontend/src/components/entities/playground-view.tsx
+++ b/frontend/src/components/entities/playground-view.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { Send, FlaskConical } from "lucide-react";
 import { useList, errorMessage } from "@/lib/hooks";
+import { useGateway } from "@/components/layout/gateway-context";
 import { useToast } from "@/components/ui/toast";
 import { PageHeader } from "@/components/ui/page";
 import { Button } from "@/components/ui/button";
@@ -36,6 +37,7 @@ export function PlaygroundView() {
   const { data: consumers, isLoading } = useList<Consumer>("consumers");
   const llmConsumers = (consumers ?? []).filter((c) => c.type === "LLM" && c.active);
 
+  const { active: activeGateway } = useGateway();
   const { toast } = useToast();
   const [consumerId, setConsumerId] = useState("");
   const [model, setModel] = useState("");
@@ -69,7 +71,10 @@ export function PlaygroundView() {
     try {
       const res = await fetch(`/api/playground/${selected.slug}/v1/chat/completions`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          "X-AG-Gateway-Slug": activeGateway.slug,
+        },
         body: JSON.stringify(body),
       });
 

--- a/frontend/src/components/entities/policies-view.tsx
+++ b/frontend/src/components/entities/policies-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Plus, Pencil, Trash2, ShieldCheck, Globe } from "lucide-react";
 import { api, gatewayScope } from "@/lib/admin-client";
 import { useActiveGatewayId } from "@/components/layout/gateway-context";
@@ -18,9 +18,13 @@ import {
   DialogFooter,
   DialogClose,
 } from "@/components/ui/dialog";
-import { Field, Input, Select, Label } from "@/components/ui/field";
+import { Field, Input, Select } from "@/components/ui/field";
 import { Section, SwitchRow, Grid2, Divider } from "@/components/ui/form-bits";
-import { JsonEditor } from "@/components/ui/json-editor";
+import {
+  PolicySettingsForm,
+  buildSettingsDefaults,
+  coerceSettings,
+} from "@/components/entities/policy-settings-form";
 import { cn } from "@/lib/cn";
 import type { Policy, PolicyStage, PolicyCatalogEntry } from "@/lib/types";
 
@@ -30,8 +34,6 @@ const FALLBACK_SLUGS = [
   "request_size_limiter",
   "semantic_cache",
 ];
-
-const STAGES: PolicyStage[] = ["pre_request", "post_request", "pre_response", "post_response"];
 
 export function PoliciesView() {
   const { data: policies, isLoading } = useList<Policy>("policies");
@@ -230,56 +232,53 @@ function PolicyFormDialog({
   const [slug, setSlug] = useState(policy?.slug ?? slugOptions[0]!);
   const [mode, setMode] = useState(policy?.mode ?? "");
   const [enabled, setEnabled] = useState(policy?.enabled ?? true);
-  const [parallel, setParallel] = useState(policy?.parallel ?? false);
-  const [priority, setPriority] = useState(String(policy?.priority ?? 0));
   const [stages, setStages] = useState<PolicyStage[]>(policy?.stages ?? ["pre_request"]);
-  const [settings, setSettings] = useState(
-    policy?.settings ? JSON.stringify(policy.settings, null, 2) : "{\n  \n}",
-  );
-  const [settingsValid, setSettingsValid] = useState(true);
+  const [settings, setSettings] = useState<Record<string, unknown>>(policy?.settings ?? {});
   const [submitting, setSubmitting] = useState(false);
 
   const entry = entries.find((e) => e.slug === slug);
   const supportedModes = entry?.supported_modes ?? [];
   const settingsFields = entry?.settings_schema?.fields ?? [];
 
-  function selectSlug(next: string) {
-    setSlug(next);
-    const catalogEntry = entries.find((e) => e.slug === next);
+  // When creating, derive stages, mode and default settings from the selected
+  // plugin's catalog schema. Editing keeps the persisted policy values.
+  useEffect(() => {
+    if (isEdit) return;
+    const catalogEntry = entries.find((e) => e.slug === slug);
     if (!catalogEntry) return;
-    if (catalogEntry.mandatory_stages.length > 0) {
-      setStages(catalogEntry.mandatory_stages);
-    } else if (catalogEntry.supported_stages.length > 0) {
-      setStages([catalogEntry.supported_stages[0]!]);
-    }
-    setMode(catalogEntry.default_mode || "");
-  }
-
-  function toggleStage(stage: PolicyStage) {
-    setStages((prev) =>
-      prev.includes(stage) ? prev.filter((s) => s !== stage) : [...prev, stage],
+    setStages(
+      catalogEntry.mandatory_stages.length > 0
+        ? catalogEntry.mandatory_stages
+        : catalogEntry.supported_stages.slice(0, 1),
     );
-  }
+    setMode(catalogEntry.default_mode || "");
+    setSettings(buildSettingsDefaults(catalogEntry.settings_schema?.fields ?? []));
+    // entries is derived from catalogGroups; depend on the stable query data.
+  }, [slug, isEdit, catalogGroups]);
 
   async function submit() {
     if (!name.trim() || !slug.trim()) {
       toast({ variant: "error", title: "Name and plugin are required" });
       return;
     }
-    if (!settingsValid) {
-      toast({ variant: "error", title: "Settings JSON is invalid" });
-      return;
+
+    let parsedSettings: Record<string, unknown>;
+    if (settingsFields.length > 0) {
+      try {
+        parsedSettings = coerceSettings(settingsFields, settings);
+      } catch {
+        toast({
+          variant: "error",
+          title: "Invalid settings",
+          description: "Check the free-form JSON fields.",
+        });
+        return;
+      }
+    } else {
+      // Schema not loaded (or plugin has none): preserve settings as-is.
+      parsedSettings = settings;
     }
 
-    let parsedSettings: Record<string, unknown> | undefined;
-    try {
-      parsedSettings = settings.trim() ? JSON.parse(settings) : undefined;
-    } catch {
-      toast({ variant: "error", title: "Settings JSON is invalid" });
-      return;
-    }
-
-    // Mandatory stages must always be present regardless of the toggles.
     const finalStages = entry
       ? Array.from(new Set([...entry.mandatory_stages, ...stages]))
       : stages;
@@ -288,12 +287,12 @@ function PolicyFormDialog({
       name: name.trim(),
       slug: slug.trim(),
       enabled,
-      parallel,
-      priority: Number(priority) || 0,
+      parallel: policy?.parallel ?? false,
+      priority: policy?.priority ?? 0,
       stages: finalStages,
     };
     if (mode.trim()) body.mode = mode.trim();
-    if (parsedSettings) body.settings = parsedSettings;
+    if (Object.keys(parsedSettings).length > 0) body.settings = parsedSettings;
 
     setSubmitting(true);
     try {
@@ -328,7 +327,7 @@ function PolicyFormDialog({
             </Field>
             <Field label="Plugin">
               {catalogGroups && catalogGroups.length > 0 ? (
-                <Select value={slug} onChange={(e) => selectSlug(e.target.value)} disabled={isEdit}>
+                <Select value={slug} onChange={(e) => setSlug(e.target.value)} disabled={isEdit}>
                   {catalogGroups.map((group) => (
                     <optgroup key={group.type} label={group.type}>
                       {group.items.map((it) => (
@@ -340,7 +339,7 @@ function PolicyFormDialog({
                   ))}
                 </Select>
               ) : (
-                <Select value={slug} onChange={(e) => selectSlug(e.target.value)} disabled={isEdit}>
+                <Select value={slug} onChange={(e) => setSlug(e.target.value)} disabled={isEdit}>
                   {slugOptions.map((s) => (
                     <option key={s} value={s}>
                       {s}
@@ -354,10 +353,7 @@ function PolicyFormDialog({
           {entry?.description && <p className="text-[12px] text-muted -mt-2">{entry.description}</p>}
 
           <Grid2>
-            <Field label="Priority" hint="lower runs first">
-              <Input type="number" value={priority} onChange={(e) => setPriority(e.target.value)} />
-            </Field>
-            {supportedModes.length > 0 ? (
+            {supportedModes.length > 0 && (
               <Field label="Mode">
                 <Select value={mode} onChange={(e) => setMode(e.target.value)}>
                   {supportedModes.map((m) => (
@@ -367,66 +363,16 @@ function PolicyFormDialog({
                   ))}
                 </Select>
               </Field>
-            ) : (
-              <div className="flex flex-col gap-2 justify-end">
-                <SwitchRow label="Enabled" checked={enabled} onCheckedChange={setEnabled} />
-              </div>
             )}
-          </Grid2>
-
-          {supportedModes.length > 0 && (
-            <SwitchRow label="Enabled" checked={enabled} onCheckedChange={setEnabled} />
-          )}
-
-          <SwitchRow
-            label="Parallel"
-            description="Run this policy concurrently with others in the same stage."
-            checked={parallel}
-            onCheckedChange={setParallel}
-          />
-
-          <div className="flex flex-col gap-2">
-            <Label>Stages</Label>
-            <div className="grid grid-cols-2 gap-2">
-              {STAGES.map((stage) => {
-                const active = stages.includes(stage);
-                return (
-                  <button
-                    key={stage}
-                    type="button"
-                    onClick={() => toggleStage(stage)}
-                    className={cn(
-                      "rounded-(--radius) border px-3 h-9 text-[13px] text-left transition-colors",
-                      active
-                        ? "border-accent/50 bg-accent/10 text-fg"
-                        : "border-border bg-surface-2/40 text-muted hover:text-fg",
-                    )}
-                  >
-                    {stage}
-                  </button>
-                );
-              })}
+            <div className="flex flex-col gap-2 justify-end">
+              <SwitchRow label="Enabled" checked={enabled} onCheckedChange={setEnabled} />
             </div>
-          </div>
+          </Grid2>
 
           <Divider />
 
-          <Section title="Settings" description="Plugin-specific configuration as JSON.">
-            {settingsFields.length > 0 && (
-              <div className="rounded-(--radius) border border-border bg-surface-2/30 px-3 py-2.5 flex flex-col gap-1">
-                <p className="text-[11px] font-medium uppercase tracking-wider text-faint">Available fields</p>
-                <ul className="flex flex-col gap-0.5">
-                  {settingsFields.map((f) => (
-                    <li key={f.key} className="text-[12px] text-muted">
-                      <code className="text-accent">{f.key}</code>
-                      <span className="text-faint"> · {f.type}{f.required ? " · required" : ""}</span>
-                      {f.description ? <span className="text-faint"> — {f.description}</span> : null}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
-            <JsonEditor value={settings} onChange={setSettings} onValidityChange={setSettingsValid} rows={9} />
+          <Section title="Settings" description="Plugin-specific configuration.">
+            <PolicySettingsForm fields={settingsFields} value={settings} onChange={setSettings} />
           </Section>
         </DialogBody>
         <DialogFooter>

--- a/frontend/src/components/entities/policy-settings-form.tsx
+++ b/frontend/src/components/entities/policy-settings-form.tsx
@@ -1,0 +1,493 @@
+"use client";
+
+import { useState } from "react";
+import { Plus, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Field, Input, Select, Label } from "@/components/ui/field";
+import { SwitchRow } from "@/components/ui/form-bits";
+import { JsonEditor } from "@/components/ui/json-editor";
+import type { PolicyCatalogField } from "@/lib/types";
+
+type Obj = Record<string, unknown>;
+
+function isObj(v: unknown): v is Obj {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function strv(v: unknown): string {
+  return v === undefined || v === null ? "" : String(v);
+}
+
+function setKey(obj: Obj, key: string, value: unknown): Obj {
+  const next = { ...obj };
+  if (value === undefined) delete next[key];
+  else next[key] = value;
+  return next;
+}
+
+function defaultValue(field: PolicyCatalogField): unknown {
+  switch (field.type) {
+    case "boolean":
+      return field.default ?? false;
+    case "integer":
+    case "number":
+    case "string":
+    case "duration":
+    case "enum":
+      return field.default;
+    case "object": {
+      if (field.fields && field.fields.length > 0) {
+        const o = buildFields(field.fields);
+        return Object.keys(o).length > 0 ? o : undefined;
+      }
+      return undefined;
+    }
+    case "array":
+      return Array.isArray(field.default) ? field.default : undefined;
+    case "map":
+      return undefined;
+    default: {
+      const _exhaustive: never = field.type;
+      return _exhaustive;
+    }
+  }
+}
+
+function buildFields(fields: PolicyCatalogField[]): Obj {
+  const out: Obj = {};
+  for (const f of fields) {
+    const v = defaultValue(f);
+    if (v !== undefined) out[f.key] = v;
+  }
+  return out;
+}
+
+function blankValue(field: PolicyCatalogField): unknown {
+  const d = defaultValue(field);
+  if (d !== undefined) return d;
+  switch (field.type) {
+    case "boolean":
+      return false;
+    case "object":
+      return field.fields && field.fields.length > 0 ? buildFields(field.fields) : {};
+    case "array":
+      return [];
+    case "map":
+      return {};
+    default:
+      return "";
+  }
+}
+
+/** buildSettingsDefaults produces the initial settings object for a plugin schema. */
+export function buildSettingsDefaults(fields: PolicyCatalogField[]): Obj {
+  return buildFields(fields);
+}
+
+function coerceScalar(field: PolicyCatalogField, v: unknown): unknown {
+  switch (field.type) {
+    case "boolean":
+      return typeof v === "boolean" ? v : v === "true";
+    case "integer": {
+      const n = typeof v === "number" ? v : parseInt(String(v), 10);
+      return Number.isFinite(n) ? Math.trunc(n) : undefined;
+    }
+    case "number": {
+      const n = typeof v === "number" ? v : parseFloat(String(v));
+      return Number.isFinite(n) ? n : undefined;
+    }
+    default: {
+      const s = strv(v).trim();
+      return s === "" ? undefined : s;
+    }
+  }
+}
+
+function coerceValue(field: PolicyCatalogField, v: unknown): unknown {
+  switch (field.type) {
+    case "string":
+    case "duration":
+    case "enum":
+    case "integer":
+    case "number":
+    case "boolean":
+      return coerceScalar(field, v);
+    case "object": {
+      if (field.fields && field.fields.length > 0) {
+        const o = coerceFields(field.fields, isObj(v) ? v : {});
+        return Object.keys(o).length > 0 ? o : undefined;
+      }
+      if (typeof v === "string") {
+        const t = v.trim();
+        return t === "" ? undefined : JSON.parse(t);
+      }
+      return isObj(v) ? v : undefined;
+    }
+    case "array": {
+      if (!Array.isArray(v)) return undefined;
+      const item = field.item as PolicyCatalogField | undefined;
+      const arr = item ? v.map((x) => coerceValue(item, x)).filter((x) => x !== undefined) : v;
+      return arr.length > 0 ? arr : undefined;
+    }
+    case "map": {
+      if (!isObj(v)) return undefined;
+      const valField = field.value as PolicyCatalogField | undefined;
+      const out: Obj = {};
+      for (const [k, val] of Object.entries(v)) {
+        if (k.trim() === "") continue;
+        const cv = valField ? coerceValue(valField, val) : val;
+        if (cv !== undefined) out[k] = cv;
+      }
+      return Object.keys(out).length > 0 ? out : undefined;
+    }
+    default: {
+      const _exhaustive: never = field.type;
+      return _exhaustive;
+    }
+  }
+}
+
+function coerceFields(fields: PolicyCatalogField[], value: Obj): Obj {
+  const out: Obj = {};
+  for (const f of fields) {
+    const cv = coerceValue(f, value[f.key]);
+    if (cv !== undefined) out[f.key] = cv;
+  }
+  return out;
+}
+
+/**
+ * coerceSettings walks the plugin schema and turns raw form state into the typed
+ * settings payload the API expects, dropping empty values. It may throw if a
+ * free-form JSON object field contains invalid JSON.
+ */
+export function coerceSettings(fields: PolicyCatalogField[], value: Obj): Obj {
+  return coerceFields(fields, value);
+}
+
+function Described({ field, children }: { field: PolicyCatalogField; children: React.ReactNode }) {
+  return (
+    <Field label={field.label} hint={field.required ? "required" : undefined}>
+      {children}
+      {field.description && <p className="text-[11px] text-faint leading-snug">{field.description}</p>}
+    </Field>
+  );
+}
+
+function FieldControl({
+  field,
+  value,
+  onChange,
+}: {
+  field: PolicyCatalogField;
+  value: unknown;
+  onChange: (v: unknown) => void;
+}) {
+  switch (field.type) {
+    case "boolean":
+      return (
+        <SwitchRow
+          label={field.label}
+          description={field.description}
+          checked={value === true}
+          onCheckedChange={onChange}
+        />
+      );
+    case "enum":
+      return (
+        <Described field={field}>
+          <Select value={strv(value)} onChange={(e) => onChange(e.target.value || undefined)}>
+            {!field.required && <option value="">—</option>}
+            {(field.enum ?? []).map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label || o.value}
+              </option>
+            ))}
+          </Select>
+        </Described>
+      );
+    case "integer":
+    case "number":
+      return (
+        <Described field={field}>
+          <Input
+            type="number"
+            step={field.type === "integer" ? "1" : "any"}
+            value={strv(value)}
+            placeholder={field.default != null ? String(field.default) : undefined}
+            onChange={(e) => onChange(e.target.value === "" ? undefined : e.target.value)}
+          />
+        </Described>
+      );
+    case "string":
+    case "duration":
+      return (
+        <Described field={field}>
+          <Input
+            value={strv(value)}
+            placeholder={field.default != null ? String(field.default) : undefined}
+            onChange={(e) => onChange(e.target.value === "" ? undefined : e.target.value)}
+          />
+        </Described>
+      );
+    case "object":
+      return <ObjectControl field={field} value={value} onChange={onChange} />;
+    case "array":
+      return (
+        <ArrayControl field={field} value={Array.isArray(value) ? value : []} onChange={onChange} />
+      );
+    case "map":
+      return <MapControl field={field} value={isObj(value) ? value : {}} onChange={onChange} />;
+    default: {
+      const _exhaustive: never = field.type;
+      return _exhaustive;
+    }
+  }
+}
+
+function ObjectControl({
+  field,
+  value,
+  onChange,
+}: {
+  field: PolicyCatalogField;
+  value: unknown;
+  onChange: (v: unknown) => void;
+}) {
+  if (field.fields && field.fields.length > 0) {
+    const obj = isObj(value) ? value : {};
+    return (
+      <div className="flex flex-col gap-1.5">
+        <Label hint={field.required ? "required" : undefined}>{field.label}</Label>
+        {field.description && <p className="text-[11px] text-faint leading-snug">{field.description}</p>}
+        <div className="rounded-(--radius) border border-border bg-surface-2/30 p-3 flex flex-col gap-4">
+          {field.fields.map((f) => (
+            <FieldControl
+              key={f.key}
+              field={f}
+              value={obj[f.key]}
+              onChange={(v) => onChange(setKey(obj, f.key, v))}
+            />
+          ))}
+        </div>
+      </div>
+    );
+  }
+  const text = typeof value === "string" ? value : value ? JSON.stringify(value, null, 2) : "";
+  return (
+    <Described field={field}>
+      <JsonEditor value={text} onChange={(v) => onChange(v === "" ? undefined : v)} rows={5} />
+    </Described>
+  );
+}
+
+function ItemBody({
+  field,
+  value,
+  onChange,
+  title,
+}: {
+  field: PolicyCatalogField;
+  value: unknown;
+  onChange: (v: unknown) => void;
+  title?: string;
+}) {
+  if (field.type === "object" && field.fields && field.fields.length > 0) {
+    const obj = isObj(value) ? value : {};
+    return (
+      <div className="flex flex-col gap-3">
+        {title && (
+          <p className="text-[11px] font-medium uppercase tracking-wider text-faint">{title}</p>
+        )}
+        {field.fields.map((f) => (
+          <FieldControl
+            key={f.key}
+            field={f}
+            value={obj[f.key]}
+            onChange={(v) => onChange(setKey(obj, f.key, v))}
+          />
+        ))}
+      </div>
+    );
+  }
+  return <FieldControl field={field} value={value} onChange={onChange} />;
+}
+
+function ArrayControl({
+  field,
+  value,
+  onChange,
+}: {
+  field: PolicyCatalogField;
+  value: unknown[];
+  onChange: (v: unknown) => void;
+}) {
+  const item = field.item as PolicyCatalogField | undefined;
+
+  function update(i: number, v: unknown) {
+    const next = [...value];
+    next[i] = v;
+    onChange(next);
+  }
+  function remove(i: number) {
+    const next = value.filter((_, idx) => idx !== i);
+    onChange(next.length > 0 ? next : undefined);
+  }
+  function add() {
+    onChange([...value, item ? blankValue(item) : ""]);
+  }
+
+  const itemLabel = item?.label ?? "Item";
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Label hint={field.required ? "required" : undefined}>{field.label}</Label>
+      {field.description && <p className="text-[11px] text-faint leading-snug -mt-1">{field.description}</p>}
+      <div className="flex flex-col gap-2">
+        {value.length === 0 && <p className="text-[12px] text-faint">No entries.</p>}
+        {value.map((it, i) => (
+          <div
+            key={i}
+            className="rounded-(--radius) border border-border bg-surface-2/30 p-2.5 flex gap-2 items-start"
+          >
+            <div className="flex-1 min-w-0">
+              {item ? (
+                <ItemBody
+                  field={item}
+                  value={it}
+                  onChange={(v) => update(i, v)}
+                  title={`${itemLabel} ${i + 1}`}
+                />
+              ) : (
+                <Input value={strv(it)} onChange={(e) => update(i, e.target.value)} />
+              )}
+            </div>
+            <Button variant="ghost" size="icon" onClick={() => remove(i)} aria-label="Remove entry">
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </div>
+        ))}
+      </div>
+      <div>
+        <Button variant="secondary" size="sm" onClick={add}>
+          <Plus className="h-4 w-4" />
+          Add {itemLabel.toLowerCase()}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function MapControl({
+  field,
+  value,
+  onChange,
+}: {
+  field: PolicyCatalogField;
+  value: Obj;
+  onChange: (v: unknown) => void;
+}) {
+  const valField = field.value as PolicyCatalogField | undefined;
+  const keyOptions = field.key_options ?? [];
+  const [newKey, setNewKey] = useState("");
+
+  const usedKeys = new Set(Object.keys(value));
+  const availableKeys = keyOptions.filter((k) => !usedKeys.has(k));
+
+  function setEntry(k: string, v: unknown) {
+    onChange(setKey(value, k, v));
+  }
+  function removeKey(k: string) {
+    const next = { ...value };
+    delete next[k];
+    onChange(Object.keys(next).length > 0 ? next : undefined);
+  }
+  function addKey(k: string) {
+    const key = k.trim();
+    if (key === "" || usedKeys.has(key)) return;
+    onChange({ ...value, [key]: valField ? blankValue(valField) : "" });
+    setNewKey("");
+  }
+
+  const entries = Object.entries(value);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Label hint={field.required ? "required" : undefined}>{field.label}</Label>
+      {field.description && <p className="text-[11px] text-faint leading-snug -mt-1">{field.description}</p>}
+      <div className="flex flex-col gap-2">
+        {entries.length === 0 && <p className="text-[12px] text-faint">No entries.</p>}
+        {entries.map(([k, v]) => (
+          <div
+            key={k}
+            className="rounded-(--radius) border border-border bg-surface-2/30 p-2.5 flex flex-col gap-2"
+          >
+            <div className="flex items-center justify-between gap-2">
+              <code className="text-[12px] text-accent">{k}</code>
+              <Button variant="ghost" size="icon" onClick={() => removeKey(k)} aria-label="Remove entry">
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </div>
+            {valField ? (
+              <ItemBody field={valField} value={v} onChange={(nv) => setEntry(k, nv)} />
+            ) : (
+              <Input value={strv(v)} onChange={(e) => setEntry(k, e.target.value)} />
+            )}
+          </div>
+        ))}
+      </div>
+      <div className="flex gap-2">
+        {availableKeys.length > 0 ? (
+          <Select value={newKey} onChange={(e) => setNewKey(e.target.value)} className="flex-1">
+            <option value="">Select key…</option>
+            {availableKeys.map((k) => (
+              <option key={k} value={k}>
+                {k}
+              </option>
+            ))}
+          </Select>
+        ) : keyOptions.length === 0 ? (
+          <Input
+            value={newKey}
+            onChange={(e) => setNewKey(e.target.value)}
+            placeholder="New key"
+            className="flex-1"
+          />
+        ) : (
+          <p className="text-[12px] text-faint flex-1 self-center">All keys added.</p>
+        )}
+        <Button variant="secondary" size="sm" onClick={() => addKey(newKey)} disabled={newKey.trim() === ""}>
+          <Plus className="h-4 w-4" />
+          Add
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/** PolicySettingsForm renders a plugin's settings schema as a typed form. */
+export function PolicySettingsForm({
+  fields,
+  value,
+  onChange,
+}: {
+  fields: PolicyCatalogField[];
+  value: Obj;
+  onChange: (v: Obj) => void;
+}) {
+  if (!fields || fields.length === 0) {
+    return <p className="text-[12px] text-muted">This plugin has no configurable settings.</p>;
+  }
+  return (
+    <div className="flex flex-col gap-4">
+      {fields.map((f) => (
+        <FieldControl
+          key={f.key}
+          field={f}
+          value={value[f.key]}
+          onChange={(v) => onChange(setKey(value, f.key, v))}
+        />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Follow-up to #245. Improves the embedded admin dashboard policy editor and fixes local playground routing.

- **Policy settings as a per-plugin form**: replace the free-form JSON editor with a typed form generated from `/v1/policies-catalog` `settings_schema`. A new recursive `PolicySettingsForm` renders string/duration/number/boolean/enum/object/array/map fields, with add/remove for arrays and map keys (honoring `key_options`), and a JSON editor only for genuinely free-form object fields (e.g. `tool_injection.parameters`).
- **Hide Priority, Parallel and Stage** from the form. Stages are derived from the plugin's mandatory (or first supported) stage; priority/parallel keep their persisted values.
- `coerceSettings` types and prunes values on submit; existing settings are preserved as-is when the catalog schema has not loaded yet.
- **Playground fix**: forward `X-AG-Gateway-Slug` from the playground BFF and client so the local proxy resolves the gateway by header instead of subdomain host.

## Test plan
- [x] `tsc --noEmit` clean
- [ ] Manual QA: create/edit policies for each plugin group; run a playground request

Made with [Cursor](https://cursor.com)