### PR TITLE
fix(telemetry): playground must not write Activity traces

### DIFF
--- a/pkg/app/metrics/exporter_internal_test.go
+++ b/pkg/app/metrics/exporter_internal_test.go
@@ -346,3 +346,30 @@ func TestPipeline_PublishCallsPlaygroundStore(t *testing.T) {
 	saved := store.saved()
 	require.Len(t, saved, 1, "playground store must receive the event after the exporters run")
 }
+
+func TestPipeline_PlaygroundSkipsExportersKeepsStore(t *testing.T) {
+	builder := NewBuilder(adapter.NewRegistry(), stubPricing{})
+	factory := &fakeFactory{}
+	cache := NewExporterCache(factory, internalTestLogger())
+	store := &fakePlaygroundStore{}
+	p := NewPipeline(builder, cache, store, internalTestLogger(),
+		telemetrydomain.ExporterConfig{Name: "kafka"})
+
+	req := &infracontext.RequestContext{
+		GatewayID: "gw-1",
+		Method:    "POST",
+		Path:      "/v1/chat/completions",
+		Headers:   map[string][]string{"X-AG-Playground-Token": {"a.jwt.token"}},
+	}
+	resp := &infracontext.ResponseContext{StatusCode: 200}
+
+	targets := p.resolveTargets(nil)
+	require.Len(t, targets, 1)
+	exporter := targets[0].(*fakeExporter)
+
+	p.publish(nil, req, resp, time.Now(), time.Now(), nil)
+
+	assert.Equal(t, 0, exporter.publishedCount(), "playground must not publish to Activity exporters")
+	saved := store.saved()
+	require.Len(t, saved, 1, "playground store must still receive the event for the panel")
+}

--- a/pkg/app/metrics/pipeline.go
+++ b/pkg/app/metrics/pipeline.go
@@ -19,9 +19,10 @@ import (
 	"log/slog"
 	"time"
 
-	telemetrydomain "github.com/NeuralTrust/TrustGate/pkg/domain/telemetry"
+	telemetrydomain 	"github.com/NeuralTrust/TrustGate/pkg/domain/telemetry"
 	infracontext "github.com/NeuralTrust/TrustGate/pkg/infra/context"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics/events"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics/playground"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/trace"
 	metricsschema "github.com/NeuralTrust/TrustGate/pkg/metrics"
 )
@@ -80,12 +81,15 @@ func (p *Pipeline) publish(
 	}
 	ctx := context.Background()
 	evt := p.builder.Build(ctx, requestTrace, req, resp, startTime, endTime)
-	for _, exporter := range targets {
-		if err := exporter.Publish(ctx, viewForClass(evt, exporter.DataClass())); err != nil {
-			p.logger.Error("failed to publish metrics event",
-				slog.String("gateway_id", req.GatewayID),
-				slog.String("exporter", exporter.Name()),
-				slog.String("error", err.Error()))
+	// Playground traffic keeps Redis panel traces but must not write Activity (exporters/CH).
+	if !playground.IsPlaygroundRequest(req.Headers) {
+		for _, exporter := range targets {
+			if err := exporter.Publish(ctx, viewForClass(evt, exporter.DataClass())); err != nil {
+				p.logger.Error("failed to publish metrics event",
+					slog.String("gateway_id", req.GatewayID),
+					slog.String("exporter", exporter.Name()),
+					slog.String("error", err.Error()))
+			}
 		}
 	}
 	if p.playgroundStore != nil {

--- a/pkg/infra/metrics/playground/store.go
+++ b/pkg/infra/metrics/playground/store.go
@@ -119,3 +119,8 @@ func hasPlaygroundToken(headers map[string][]string) bool {
 	}
 	return false
 }
+
+// IsPlaygroundRequest reports whether the proxy request carries a playground token.
+func IsPlaygroundRequest(headers map[string][]string) bool {
+	return hasPlaygroundToken(headers)
+}

--- a/pkg/infra/plugins/trustguard/client.go
+++ b/pkg/infra/plugins/trustguard/client.go
@@ -27,9 +27,10 @@ import (
 )
 
 const (
-	evaluatePath     = "/v1/evaluate"
-	traceIDHeader    = "X-Trace-ID"
-	maxResponseBytes = 1 << 20
+	evaluatePath           = "/v1/evaluate"
+	traceIDHeader          = "X-Trace-ID"
+	playgroundOriginHeader = "X-AG-Playground"
+	maxResponseBytes       = 1 << 20
 )
 
 var errUnauthorized = errors.New("trustguard: unauthorized")
@@ -69,7 +70,7 @@ func newClient(timeout time.Duration) *client {
 	return &client{http: &http.Client{Timeout: timeout}}
 }
 
-func (c *client) Guard(ctx context.Context, baseURL, token, traceID string, body GuardRequest) (*GuardResponse, error) {
+func (c *client) Guard(ctx context.Context, baseURL, token, traceID string, body GuardRequest, playground bool) (*GuardResponse, error) {
 	payload, err := json.Marshal(body)
 	if err != nil {
 		return nil, fmt.Errorf("trustguard: marshal request: %w", err)
@@ -83,6 +84,9 @@ func (c *client) Guard(ctx context.Context, baseURL, token, traceID string, body
 	req.Header.Set("Content-Type", contentTypeJSON)
 	if traceID != "" {
 		req.Header.Set(traceIDHeader, traceID)
+	}
+	if playground {
+		req.Header.Set(playgroundOriginHeader, "1")
 	}
 	res, err := c.http.Do(req)
 	if err != nil {

--- a/pkg/infra/plugins/trustguard/client_test.go
+++ b/pkg/infra/plugins/trustguard/client_test.go
@@ -115,7 +115,7 @@ func TestGuardDecodesResponses(t *testing.T) {
 			defer srv.Close()
 
 			c := newClient(2 * time.Second)
-			resp, err := c.Guard(context.Background(), srv.URL, "secret-key", "", sampleRequest())
+			resp, err := c.Guard(context.Background(), srv.URL, "secret-key", "", sampleRequest(), false)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf("expected error, got nil")
@@ -164,7 +164,7 @@ func TestGuardTrimsTrailingSlash(t *testing.T) {
 	defer srv.Close()
 
 	c := newClient(time.Second)
-	if _, err := c.Guard(context.Background(), srv.URL+"/", "k", "", sampleRequest()); err != nil {
+	if _, err := c.Guard(context.Background(), srv.URL+"/", "k", "", sampleRequest(), false); err != nil {
 		t.Fatalf("Guard returned error: %v", err)
 	}
 }
@@ -175,7 +175,7 @@ func TestGuardTransportError(t *testing.T) {
 	srv.Close()
 
 	c := newClient(time.Second)
-	if _, err := c.Guard(context.Background(), srv.URL, "k", "", sampleRequest()); err == nil {
+	if _, err := c.Guard(context.Background(), srv.URL, "k", "", sampleRequest(), false); err == nil {
 		t.Fatal("expected transport error, got nil")
 	}
 }
@@ -188,7 +188,7 @@ func TestGuardUnauthorizedReturnsSentinel(t *testing.T) {
 	defer srv.Close()
 
 	c := newClient(time.Second)
-	_, err := c.Guard(context.Background(), srv.URL, "stale-token", "", sampleRequest())
+	_, err := c.Guard(context.Background(), srv.URL, "stale-token", "", sampleRequest(), false)
 	if !errors.Is(err, errUnauthorized) {
 		t.Fatalf("err = %v, want errUnauthorized", err)
 	}
@@ -203,7 +203,7 @@ func TestGuardUnavailableReturnsTypedError(t *testing.T) {
 	defer srv.Close()
 
 	c := newClient(time.Second)
-	_, err := c.Guard(context.Background(), srv.URL, "k", "", sampleRequest())
+	_, err := c.Guard(context.Background(), srv.URL, "k", "", sampleRequest(), false)
 	var unavailable *entitlementsUnavailableError
 	if !errors.As(err, &unavailable) {
 		t.Fatalf("err = %v, want *entitlementsUnavailableError", err)
@@ -226,7 +226,7 @@ func TestGuardRateLimitedReturnsTypedError(t *testing.T) {
 	defer srv.Close()
 
 	c := newClient(time.Second)
-	_, err := c.Guard(context.Background(), srv.URL, "k", "", sampleRequest())
+	_, err := c.Guard(context.Background(), srv.URL, "k", "", sampleRequest(), false)
 	var limited *rateLimitedError
 	if !errors.As(err, &limited) {
 		t.Fatalf("err = %v, want *rateLimitedError", err)
@@ -251,7 +251,7 @@ func TestGuardRateLimitedWithoutHeaders(t *testing.T) {
 	defer srv.Close()
 
 	c := newClient(time.Second)
-	_, err := c.Guard(context.Background(), srv.URL, "k", "", sampleRequest())
+	_, err := c.Guard(context.Background(), srv.URL, "k", "", sampleRequest(), false)
 	var limited *rateLimitedError
 	if !errors.As(err, &limited) {
 		t.Fatalf("err = %v, want *rateLimitedError", err)
@@ -276,7 +276,7 @@ func TestGuardRateLimitedIgnoresUnrelatedHeaders(t *testing.T) {
 	defer srv.Close()
 
 	c := newClient(time.Second)
-	_, err := c.Guard(context.Background(), srv.URL, "k", "", sampleRequest())
+	_, err := c.Guard(context.Background(), srv.URL, "k", "", sampleRequest(), false)
 	var limited *rateLimitedError
 	if !errors.As(err, &limited) {
 		t.Fatalf("err = %v, want *rateLimitedError", err)
@@ -303,7 +303,7 @@ func TestGuardContextCanceled(t *testing.T) {
 	cancel()
 
 	c := newClient(time.Second)
-	if _, err := c.Guard(ctx, srv.URL, "k", "", sampleRequest()); err == nil {
+	if _, err := c.Guard(ctx, srv.URL, "k", "", sampleRequest(), false); err == nil {
 		t.Fatal("expected context error, got nil")
 	}
 }
@@ -320,7 +320,7 @@ func TestGuardSetsTraceIDHeader(t *testing.T) {
 	defer srv.Close()
 
 	c := newClient(time.Second)
-	if _, err := c.Guard(context.Background(), srv.URL, "k", wantTraceID, sampleRequest()); err != nil {
+	if _, err := c.Guard(context.Background(), srv.URL, "k", wantTraceID, sampleRequest(), false); err != nil {
 		t.Fatalf("Guard returned error: %v", err)
 	}
 }
@@ -336,7 +336,7 @@ func TestGuardOmitsTraceIDHeaderWhenEmpty(t *testing.T) {
 	defer srv.Close()
 
 	c := newClient(time.Second)
-	if _, err := c.Guard(context.Background(), srv.URL, "k", "", sampleRequest()); err != nil {
+	if _, err := c.Guard(context.Background(), srv.URL, "k", "", sampleRequest(), false); err != nil {
 		t.Fatalf("Guard returned error: %v", err)
 	}
 }

--- a/pkg/infra/plugins/trustguard/plugin.go
+++ b/pkg/infra/plugins/trustguard/plugin.go
@@ -26,6 +26,7 @@ import (
 
 	appplugins "github.com/NeuralTrust/TrustGate/pkg/app/plugins"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/policy"
+	infracontext "github.com/NeuralTrust/TrustGate/pkg/infra/context"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/adapter"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/trace"
 )
@@ -221,7 +222,8 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 	}
 
 	traceID := gatewayTraceID(ctx)
-	resp, err := p.guard(ctx, baseURL, cfg.CollectorID, traceID, body)
+	playground := requestHasPlaygroundToken(in.Request)
+	resp, err := p.guard(ctx, baseURL, cfg.CollectorID, traceID, body, playground)
 	if err != nil {
 		var limited *rateLimitedError
 		if errors.As(err, &limited) {
@@ -300,7 +302,24 @@ func gatewayTraceID(ctx context.Context) string {
 	return rt.TraceID()
 }
 
-func (p *Plugin) guard(ctx context.Context, baseURL, collectorID, traceID string, body GuardRequest) (*GuardResponse, error) {
+func requestHasPlaygroundToken(req *infracontext.RequestContext) bool {
+	if req == nil {
+		return false
+	}
+	for key, values := range req.Headers {
+		if !strings.EqualFold(key, "x-ag-playground-token") {
+			continue
+		}
+		for _, v := range values {
+			if v != "" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (p *Plugin) guard(ctx context.Context, baseURL, collectorID, traceID string, body GuardRequest, playground bool) (*GuardResponse, error) {
 	params := tokenParams{
 		baseURL:     baseURL,
 		collectorID: collectorID,
@@ -310,7 +329,7 @@ func (p *Plugin) guard(ctx context.Context, baseURL, collectorID, traceID string
 	if err != nil {
 		return nil, err
 	}
-	resp, err := p.client.Guard(ctx, baseURL, token, traceID, body)
+	resp, err := p.client.Guard(ctx, baseURL, token, traceID, body, playground)
 	if err == nil {
 		return resp, nil
 	}
@@ -322,7 +341,7 @@ func (p *Plugin) guard(ctx context.Context, baseURL, collectorID, traceID string
 	if err != nil {
 		return nil, err
 	}
-	return p.client.Guard(ctx, baseURL, token, traceID, body)
+	return p.client.Guard(ctx, baseURL, token, traceID, body, playground)
 }
 
 func (p *Plugin) warn(ctx context.Context, msg string, attrs ...any) {


### PR DESCRIPTION
## Summary
- Playground proxy traffic no longer publishes to metrics exporters (ClickHouse Activity).
- Redis playground panel store is unchanged.
- TrustGuard plugin sets `X-AG-Playground: 1` on evaluate so Guard skips CH export.

## Linear
RUN-1008 — https://linear.app/neuraltrust/issue/RUN-1008/fixtelemetry-playground-must-not-write-activity-traces

## Test plan
- [x] `go test` metrics + playground store + trustguard plugin
- [ ] Playground chat: panel has trace; Gate Activity has no new row
- [ ] Real consumer traffic still appears in Activity