### PR TITLE
feat(telemetry): playground publishes Activity exporters again

### DIFF
--- a/pkg/api/middleware/plan_ratelimit.go
+++ b/pkg/api/middleware/plan_ratelimit.go
@@ -1,0 +1,118 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"errors"
+	"log/slog"
+
+	appgateway "github.com/NeuralTrust/TrustGate/pkg/app/gateway"
+	ratelimitapp "github.com/NeuralTrust/TrustGate/pkg/app/ratelimit"
+	domain "github.com/NeuralTrust/TrustGate/pkg/domain/gateway"
+	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
+	infracontext "github.com/NeuralTrust/TrustGate/pkg/infra/context"
+	"github.com/gofiber/fiber/v2"
+)
+
+// PlanRateLimitMiddleware enforces plan burst/quota on authenticated admin API routes.
+type PlanRateLimitMiddleware struct {
+	limiter  ratelimitapp.Checker
+	gateways appgateway.Finder
+	logger   *slog.Logger
+}
+
+func NewPlanRateLimitMiddleware(limiter ratelimitapp.Checker, gateways appgateway.Finder, logger *slog.Logger) *PlanRateLimitMiddleware {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &PlanRateLimitMiddleware{limiter: limiter, gateways: gateways, logger: logger}
+}
+
+// ForGateway charges the gateway from path params gateway_id (nested) or id (CRUD).
+func (m *PlanRateLimitMiddleware) ForGateway() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		if m == nil || m.limiter == nil {
+			return c.Next()
+		}
+		gatewayID, ok := pathGatewayID(c)
+		if !ok {
+			return c.Next()
+		}
+		return m.enforce(c, gatewayID)
+	}
+}
+
+// ForTenant charges against one of the tenant's gateway instances (list/create / catalogs).
+func (m *PlanRateLimitMiddleware) ForTenant() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		if m == nil || m.limiter == nil || m.gateways == nil {
+			return c.Next()
+		}
+		tenantID, _ := c.Locals(string(infracontext.TenantIDContextKey)).(string)
+		if tenantID == "" {
+			return c.Next()
+		}
+		items, _, err := m.gateways.List(c.Context(), domain.ListFilter{TenantID: tenantID, Page: 1, Size: 1})
+		if err != nil || len(items) == 0 || items[0] == nil || items[0].ID.IsNil() {
+			return c.Next()
+		}
+		return m.enforce(c, items[0].ID)
+	}
+}
+
+func (m *PlanRateLimitMiddleware) enforce(c *fiber.Ctx, gatewayID ids.GatewayID) error {
+	if err := m.limiter.Check(c.Context(), gatewayID); err != nil {
+		var limited *ratelimitapp.Exceeded
+		if errors.As(err, &limited) {
+			for k, vals := range limited.Headers() {
+				if len(vals) > 0 {
+					c.Set(k, vals[0])
+				}
+			}
+			return c.Status(fiber.StatusTooManyRequests).JSON(fiber.Map{
+				"error":  "rate limit exceeded",
+				"reason": limited.Reason,
+			})
+		}
+		if errors.Is(err, ratelimitapp.ErrUnavailable) {
+			return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+				"error": "rate limit entitlements unavailable",
+			})
+		}
+		m.logger.Error("plan rate limit check failed", slog.Any("error", err))
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "failed to enforce rate limit",
+		})
+	}
+	return c.Next()
+}
+
+func pathGatewayID(c *fiber.Ctx) (ids.GatewayID, bool) {
+	if raw := c.Params("gateway_id"); raw != "" {
+		id, err := ids.Parse[ids.GatewayKind](raw)
+		if err != nil || id.IsNil() {
+			return ids.GatewayID{}, false
+		}
+		return id, true
+	}
+	if raw := c.Params("id"); raw != "" {
+		id, err := ids.Parse[ids.GatewayKind](raw)
+		if err != nil || id.IsNil() {
+			return ids.GatewayID{}, false
+		}
+		return id, true
+	}
+	return ids.GatewayID{}, false
+}

--- a/pkg/api/middleware/plan_ratelimit_test.go
+++ b/pkg/api/middleware/plan_ratelimit_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	gatewaymocks "github.com/NeuralTrust/TrustGate/pkg/app/gateway/mocks"
+	ratelimitapp "github.com/NeuralTrust/TrustGate/pkg/app/ratelimit"
+	domain "github.com/NeuralTrust/TrustGate/pkg/domain/gateway"
+	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
+	infracontext "github.com/NeuralTrust/TrustGate/pkg/infra/context"
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type stubGateChecker struct {
+	last ids.GatewayID
+	err  error
+}
+
+func (s *stubGateChecker) Check(_ context.Context, id ids.GatewayID) error {
+	s.last = id
+	return s.err
+}
+
+func TestPlanRateLimitForGatewayPrefersGatewayIDParam(t *testing.T) {
+	gatewayID := ids.New[ids.GatewayKind]()
+	policyID := ids.New[ids.PolicyKind]()
+	limiter := &stubGateChecker{err: &ratelimitapp.Exceeded{
+		Reason:     ratelimitapp.ReasonBurst,
+		Limit:      60,
+		Remaining:  0,
+		RetryAfter: 5 * time.Second,
+	}}
+	m := NewPlanRateLimitMiddleware(limiter, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	app := fiber.New()
+	app.Get("/v1/gateways/:gateway_id/policies/:id", m.ForGateway(), func(c *fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	path := "/v1/gateways/" + gatewayID.String() + "/policies/" + policyID.String()
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, path, nil))
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusTooManyRequests, resp.StatusCode)
+	require.Equal(t, gatewayID, limiter.last)
+	require.Equal(t, "burst", resp.Header.Get("X-RateLimit-Reason"))
+}
+
+func TestPlanRateLimitForTenantUsesFinder(t *testing.T) {
+	gatewayID := ids.New[ids.GatewayKind]()
+	finder := gatewaymocks.NewFinder(t)
+	finder.EXPECT().List(mock.Anything, domain.ListFilter{TenantID: "tenant-1", Page: 1, Size: 1}).
+		Return([]*domain.Gateway{{ID: gatewayID}}, 1, nil).Once()
+
+	limiter := &stubGateChecker{}
+	m := NewPlanRateLimitMiddleware(limiter, finder, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	app := fiber.New()
+	app.Get("/v1/providers-catalog", func(c *fiber.Ctx) error {
+		c.Locals(string(infracontext.TenantIDContextKey), "tenant-1")
+		return m.ForTenant()(c)
+	}, func(c *fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/v1/providers-catalog", nil))
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+	require.Equal(t, gatewayID, limiter.last)
+}

--- a/pkg/app/metrics/exporter_internal_test.go
+++ b/pkg/app/metrics/exporter_internal_test.go
@@ -347,7 +347,7 @@ func TestPipeline_PublishCallsPlaygroundStore(t *testing.T) {
 	require.Len(t, saved, 1, "playground store must receive the event after the exporters run")
 }
 
-func TestPipeline_PlaygroundSkipsExportersKeepsStore(t *testing.T) {
+func TestPipeline_PlaygroundPublishesExportersAndStore(t *testing.T) {
 	builder := NewBuilder(adapter.NewRegistry(), stubPricing{})
 	factory := &fakeFactory{}
 	cache := NewExporterCache(factory, internalTestLogger())
@@ -369,7 +369,7 @@ func TestPipeline_PlaygroundSkipsExportersKeepsStore(t *testing.T) {
 
 	p.publish(nil, req, resp, time.Now(), time.Now(), nil)
 
-	assert.Equal(t, 0, exporter.publishedCount(), "playground must not publish to Activity exporters")
+	assert.Equal(t, 1, exporter.publishedCount(), "playground must publish to Activity exporters")
 	saved := store.saved()
 	require.Len(t, saved, 1, "playground store must still receive the event for the panel")
 }

--- a/pkg/app/metrics/pipeline.go
+++ b/pkg/app/metrics/pipeline.go
@@ -22,7 +22,6 @@ import (
 	telemetrydomain 	"github.com/NeuralTrust/TrustGate/pkg/domain/telemetry"
 	infracontext "github.com/NeuralTrust/TrustGate/pkg/infra/context"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics/events"
-	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics/playground"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/trace"
 	metricsschema "github.com/NeuralTrust/TrustGate/pkg/metrics"
 )
@@ -81,15 +80,12 @@ func (p *Pipeline) publish(
 	}
 	ctx := context.Background()
 	evt := p.builder.Build(ctx, requestTrace, req, resp, startTime, endTime)
-	// Playground traffic keeps Redis panel traces but must not write Activity (exporters/CH).
-	if !playground.IsPlaygroundRequest(req.Headers) {
-		for _, exporter := range targets {
-			if err := exporter.Publish(ctx, viewForClass(evt, exporter.DataClass())); err != nil {
-				p.logger.Error("failed to publish metrics event",
-					slog.String("gateway_id", req.GatewayID),
-					slog.String("exporter", exporter.Name()),
-					slog.String("error", err.Error()))
-			}
+	for _, exporter := range targets {
+		if err := exporter.Publish(ctx, viewForClass(evt, exporter.DataClass())); err != nil {
+			p.logger.Error("failed to publish metrics event",
+				slog.String("gateway_id", req.GatewayID),
+				slog.String("exporter", exporter.Name()),
+				slog.String("error", err.Error()))
 		}
 	}
 	if p.playgroundStore != nil {

--- a/pkg/container/modules/server_admin.go
+++ b/pkg/container/modules/server_admin.go
@@ -60,6 +60,7 @@ type adminRouterParams struct {
 	dig.In
 	Transport      *middleware.Transport `name:"admin"`
 	AdminAuth      *middleware.AdminAuthMiddleware
+	PlanRateLimit  *middleware.PlanRateLimitMiddleware
 	HealthHandler  *apihandler.HealthHandler
 	VersionHandler *apihandler.VersionHandler
 
@@ -126,6 +127,9 @@ func ServerAdmin(c *container.Container) error {
 	if err := c.Provide(adminTransport, dig.Name("admin")); err != nil {
 		return err
 	}
+	if err := c.Provide(middleware.NewPlanRateLimitMiddleware); err != nil {
+		return err
+	}
 	if err := c.Provide(func(repo *configsyncconnrepo.Repository) *configsynchttp.ListConnectionsHandler {
 		return configsynchttp.NewListConnectionsHandler(repo)
 	}); err != nil {
@@ -136,6 +140,7 @@ func ServerAdmin(c *container.Container) error {
 			return router.NewAdminRouter(router.AdminRouterDeps{
 				MiddlewareTransport:    p.Transport,
 				AdminAuth:              p.AdminAuth,
+				PlanRateLimit:          p.PlanRateLimit,
 				HealthHandler:          p.HealthHandler,
 				VersionHandler:         p.VersionHandler,
 				CreateGateway:          p.CreateGateway,

--- a/pkg/server/router/admin_router.go
+++ b/pkg/server/router/admin_router.go
@@ -50,6 +50,7 @@ const (
 type AdminRouterDeps struct {
 	MiddlewareTransport *middleware.Transport
 	AdminAuth           *middleware.AdminAuthMiddleware
+	PlanRateLimit       *middleware.PlanRateLimitMiddleware
 	HealthHandler       *apihandler.HealthHandler
 	VersionHandler      *apihandler.VersionHandler
 
@@ -126,13 +127,13 @@ func (r *adminRouter) BuildRoutes(app *fiber.App) error {
 	app.Get(DocsPath, fiberSwagger.HandlerDefault)
 
 	gw := app.Group(GatewaysPath, r.deps.AdminAuth.Middleware())
-	gw.Post("", r.deps.CreateGateway.Handle)
-	gw.Get("", r.deps.ListGateway.Handle)
-	gw.Get("/:id", r.deps.GetGateway.Handle)
-	gw.Put("/:id", r.deps.UpdateGateway.Handle)
-	gw.Delete("/:id", r.deps.DeleteGateway.Handle)
+	gw.Post("", r.tenantRL(), r.deps.CreateGateway.Handle)
+	gw.Get("", r.tenantRL(), r.deps.ListGateway.Handle)
+	gw.Get("/:id", r.gatewayRL(), r.deps.GetGateway.Handle)
+	gw.Put("/:id", r.gatewayRL(), r.deps.UpdateGateway.Handle)
+	gw.Delete("/:id", r.gatewayRL(), r.deps.DeleteGateway.Handle)
 
-	registries := gw.Group("/:gateway_id/registries")
+	registries := gw.Group("/:gateway_id/registries", r.gatewayRL())
 	registries.Post("", r.deps.CreateRegistry.Handle)
 	registries.Post("/test-connection", r.deps.TestRegistryConnection.Handle)
 	registries.Get("", r.deps.ListRegistry.Handle)
@@ -141,7 +142,7 @@ func (r *adminRouter) BuildRoutes(app *fiber.App) error {
 	registries.Put("/:id", r.deps.UpdateRegistry.Handle)
 	registries.Delete("/:id", r.deps.DeleteRegistry.Handle)
 
-	policies := gw.Group("/:gateway_id/policies")
+	policies := gw.Group("/:gateway_id/policies", r.gatewayRL())
 	policies.Post("", r.deps.CreatePolicy.Handle)
 	policies.Get("", r.deps.ListPolicy.Handle)
 	policies.Get("/:id", r.deps.GetPolicy.Handle)
@@ -151,7 +152,7 @@ func (r *adminRouter) BuildRoutes(app *fiber.App) error {
 	policies.Delete("/:id/global", r.deps.GlobalPolicy.UnsetGlobal)
 	policies.Post("/:id/duplicate", r.deps.DuplicatePolicy.Handle)
 
-	consumers := gw.Group("/:gateway_id/consumers")
+	consumers := gw.Group("/:gateway_id/consumers", r.gatewayRL())
 	consumers.Post("", r.deps.CreateConsumer.Handle)
 	consumers.Get("", r.deps.ListConsumer.Handle)
 	consumers.Get("/:id", r.deps.GetConsumer.Handle)
@@ -166,7 +167,7 @@ func (r *adminRouter) BuildRoutes(app *fiber.App) error {
 	consumers.Post("/:id/policies/:policy_id", r.deps.ConsumerAssociation.AttachPolicy)
 	consumers.Delete("/:id/policies/:policy_id", r.deps.ConsumerAssociation.DetachPolicy)
 
-	roles := gw.Group("/:gateway_id/roles")
+	roles := gw.Group("/:gateway_id/roles", r.gatewayRL())
 	roles.Post("", r.deps.CreateRole.Handle)
 	roles.Get("", r.deps.ListRole.Handle)
 	roles.Get("/:id", r.deps.GetRole.Handle)
@@ -175,24 +176,40 @@ func (r *adminRouter) BuildRoutes(app *fiber.App) error {
 	roles.Post("/:role_id/registries/:registry_id", r.deps.RoleAssociation.AttachRegistry)
 	roles.Delete("/:role_id/registries/:registry_id", r.deps.RoleAssociation.DetachRegistry)
 
-	auths := gw.Group("/:gateway_id/auths")
+	auths := gw.Group("/:gateway_id/auths", r.gatewayRL())
 	auths.Post("", r.deps.CreateAuth.Handle)
 	auths.Get("", r.deps.ListAuth.Handle)
 	auths.Get("/:id", r.deps.GetAuth.Handle)
 	auths.Put("/:id", r.deps.UpdateAuth.Handle)
 	auths.Delete("/:id", r.deps.DeleteAuth.Handle)
 
-	app.Get(ProvidersCatalog, r.deps.AdminAuth.Middleware(), r.deps.ListProvidersCatalog.Handle)
-	app.Get(ModelsCatalogPath, r.deps.AdminAuth.Middleware(), r.deps.ListModelsCatalog.Handle)
-	app.Get(PoliciesCatalogPath, r.deps.AdminAuth.Middleware(), r.deps.ListPoliciesCatalog.Handle)
-	app.Get(MCPServersCatalogPath, r.deps.AdminAuth.Middleware(), r.deps.ListMCPServersCatalog.Handle)
+	app.Get(ProvidersCatalog, r.deps.AdminAuth.Middleware(), r.tenantRL(), r.deps.ListProvidersCatalog.Handle)
+	app.Get(ModelsCatalogPath, r.deps.AdminAuth.Middleware(), r.tenantRL(), r.deps.ListModelsCatalog.Handle)
+	app.Get(PoliciesCatalogPath, r.deps.AdminAuth.Middleware(), r.tenantRL(), r.deps.ListPoliciesCatalog.Handle)
+	app.Get(MCPServersCatalogPath, r.deps.AdminAuth.Middleware(), r.tenantRL(), r.deps.ListMCPServersCatalog.Handle)
 
-	app.Get(PlaygroundTracePath, r.deps.AdminAuth.Middleware(), r.deps.GetTrace.Handle)
+	app.Get(PlaygroundTracePath, r.deps.AdminAuth.Middleware(), r.tenantRL(), r.deps.GetTrace.Handle)
 
-	app.Get(ConfigSyncConnPath, r.deps.AdminAuth.Middleware(), r.deps.ListConfigSyncConnections.Handle)
+	app.Get(ConfigSyncConnPath, r.deps.AdminAuth.Middleware(), r.tenantRL(), r.deps.ListConfigSyncConnections.Handle)
 
 	return nil
 }
+
+func (r *adminRouter) tenantRL() fiber.Handler {
+	if r.deps.PlanRateLimit == nil {
+		return passthrough
+	}
+	return r.deps.PlanRateLimit.ForTenant()
+}
+
+func (r *adminRouter) gatewayRL() fiber.Handler {
+	if r.deps.PlanRateLimit == nil {
+		return passthrough
+	}
+	return r.deps.PlanRateLimit.ForGateway()
+}
+
+func passthrough(c *fiber.Ctx) error { return c.Next() }
 
 func installMiddlewares(app *fiber.App, transport *middleware.Transport) {
 	for _, h := range transport.GetMiddlewares() {


### PR DESCRIPTION
## Summary
- Playground Activity exporters publish again (reverse skip from RUN-1008).
- Plan rate limiting middleware covers **all authenticated admin API** routes (gateway CRUD + nested, catalogs, playground traces, config-sync). Subject = path `gateway_id`/`id`, or a tenant gateway when listing/creating.
- `RATE_LIMIT_ENABLED` remains **false** (default / `.env.example`). Do not enable in this PR.

## Linear
RUN-1010 — https://linear.app/neuraltrust/issue/RUN-1010

## Test plan
- [x] Unit tests for plan rate-limit middleware
- [ ] CI green
- [ ] Manual smoke with flag still off (no 429 from plan limiter)