### PR TITLE
feat: apply TrustGuard masked transform to request/response body

### DIFF
--- a/pkg/app/plugins/catalog_metadata.go
+++ b/pkg/app/plugins/catalog_metadata.go
@@ -836,7 +836,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 	"trustguard": {
 		name:        "TrustGuard",
 		group:       groupGuardrails,
-		description: "Inspect request and/or response content with the external TrustGuard service and block flagged content. Fails open on any error; streaming responses cannot be blocked in realtime.",
+		description: "Inspect request and/or response content with the external TrustGuard service, block flagged content, and apply TrustGuard data-masking transforms to the body. Fails open on guard errors; a masking transform that cannot be applied fails closed. Streaming responses cannot be inspected in realtime.",
 		schema: SettingsSchema{
 			Fields: []Field{
 				{

--- a/pkg/infra/plugins/trustguard/data.go
+++ b/pkg/infra/plugins/trustguard/data.go
@@ -89,14 +89,16 @@ type GuardFinding struct {
 }
 
 type guardData struct {
-	Direction     string         `json:"direction,omitempty"`
-	Status        string         `json:"status,omitempty"`
-	Decision      string         `json:"decision,omitempty"`
-	TraceID       string         `json:"trace_id,omitempty"`
-	RequestID     string         `json:"request_id,omitempty"`
-	FindingsCount int            `json:"findings_count,omitempty"`
-	Findings      []GuardFinding `json:"findings,omitempty"`
-	FailedOpen    bool           `json:"failed_open,omitempty"`
+	Direction      string         `json:"direction,omitempty"`
+	Status         string         `json:"status,omitempty"`
+	Decision       string         `json:"decision,omitempty"`
+	TraceID        string         `json:"trace_id,omitempty"`
+	RequestID      string         `json:"request_id,omitempty"`
+	FindingsCount  int            `json:"findings_count,omitempty"`
+	Findings       []GuardFinding `json:"findings,omitempty"`
+	FailedOpen     bool           `json:"failed_open,omitempty"`
+	Degraded       bool           `json:"degraded,omitempty"`
+	DegradedReason string         `json:"degraded_reason,omitempty"`
 }
 
 func setExtras(event *metrics.EventContext, data guardData) {

--- a/pkg/infra/plugins/trustguard/plugin.go
+++ b/pkg/infra/plugins/trustguard/plugin.go
@@ -46,13 +46,23 @@ const (
 )
 
 const (
-	decisionBlocked    = "blocked"
-	decisionReported   = "reported"
-	decisionAllowed    = "allowed"
-	decisionFailedOpen = "failed_open"
-	statusBlock        = "block"
-	statusReport       = "report"
+	decisionBlocked     = "blocked"
+	decisionReported    = "reported"
+	decisionAllowed     = "allowed"
+	decisionFailedOpen  = "failed_open"
+	decisionTransformed = "transformed"
+	statusBlock         = "block"
+	statusReport        = "report"
+	statusTransform     = "transform"
 )
+
+const (
+	reasonTransformNoPayload    = "transform_no_payload"
+	reasonTransformUnsupported  = "transform_unsupported_path"
+	reasonTransformEncodeFailed = "transform_encode_failed"
+)
+
+const transformedInputKey = "input"
 
 var _ appplugins.Plugin = (*Plugin)(nil)
 
@@ -95,9 +105,16 @@ func (p *Plugin) SupportedModes() []policy.Mode {
 	return []policy.Mode{policy.ModeEnforce, policy.ModeObserve}
 }
 
-func (p *Plugin) MutatesRequestBody() bool { return false }
+// MutatesRequestBody reports that TrustGuard may rewrite the request body when
+// TrustGuard returns a transform (data-masking) outcome. Declaring this keeps
+// the plugin out of parallel batches with other body writers so the masked body
+// is applied deterministically and downstream plugins observe it.
+func (p *Plugin) MutatesRequestBody() bool { return true }
 
-func (p *Plugin) MutatesResponseBody() bool { return false }
+// MutatesResponseBody reports that TrustGuard may rewrite the response body when
+// TrustGuard returns a transform (data-masking) outcome. See MutatesRequestBody
+// for why this forces sequential execution.
+func (p *Plugin) MutatesResponseBody() bool { return true }
 
 func (p *Plugin) MutatesMetadata() bool { return false }
 
@@ -160,6 +177,7 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 	}
 
 	var text string
+	tgt := transformTarget{isResponse: direction == directionOutput}
 	if mcpMode {
 		if direction == directionInput {
 			if len(in.Request.Body) == 0 {
@@ -186,6 +204,10 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 				return passThrough(), nil
 			}
 			text = joinRequestText(creq)
+			reg := p.registry
+			tgt.apply = func(masked string) ([]byte, bool) {
+				return rewriteRequest(reg, format, creq, masked)
+			}
 		} else {
 			if in.Response == nil || in.Response.Streaming || len(in.Response.Body) == 0 {
 				return passThrough(), nil
@@ -195,6 +217,10 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 				return passThrough(), nil
 			}
 			text = cresp.Content
+			reg := p.registry
+			tgt.apply = func(masked string) ([]byte, bool) {
+				return rewriteResponse(reg, format, cresp, masked)
+			}
 		}
 	}
 	if strings.TrimSpace(text) == "" {
@@ -254,6 +280,10 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 		Findings:      resp.Findings,
 	}
 
+	if resp.Status == statusTransform {
+		return p.applyTransform(in, data, resp, tgt)
+	}
+
 	data.Decision = guardOutcomeDecision(resp.Status, in.Mode)
 	if data.Decision == decisionBlocked {
 		recordGuardOutcome(in.Event, data)
@@ -261,6 +291,47 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 	}
 	recordGuardOutcome(in.Event, data)
 	return passThrough(), nil
+}
+
+// applyTransform enforces a TrustGuard transform (data-masking) outcome. In
+// observe mode the masked body is not applied and the outcome is reported. In
+// enforce mode the masked payload is written back into the provider body; when
+// it cannot be applied safely (missing payload, path without body propagation,
+// or re-encode failure) the request is blocked rather than forwarding the
+// unmasked data upstream.
+func (p *Plugin) applyTransform(in appplugins.ExecInput, data guardData, resp *GuardResponse, tgt transformTarget) (*appplugins.Result, error) {
+	if !appplugins.Blocks(in.Mode) {
+		data.Decision = decisionReported
+		recordGuardOutcome(in.Event, data)
+		return passThrough(), nil
+	}
+
+	masked, ok := transformedInput(resp.TransformedPayload)
+	if !ok {
+		return p.transformDegraded(in, data, resp, reasonTransformNoPayload)
+	}
+	if tgt.apply == nil {
+		return p.transformDegraded(in, data, resp, reasonTransformUnsupported)
+	}
+	body, ok := tgt.apply(masked)
+	if !ok {
+		return p.transformDegraded(in, data, resp, reasonTransformEncodeFailed)
+	}
+
+	data.Decision = decisionTransformed
+	recordGuardOutcome(in.Event, data)
+	if tgt.isResponse {
+		return &appplugins.Result{StatusCode: http.StatusOK, Body: body, StopUpstream: true}, nil
+	}
+	return &appplugins.Result{StatusCode: http.StatusOK, RequestBody: body}, nil
+}
+
+func (p *Plugin) transformDegraded(in appplugins.ExecInput, data guardData, resp *GuardResponse, reason string) (*appplugins.Result, error) {
+	data.Decision = decisionBlocked
+	data.Degraded = true
+	data.DegradedReason = reason
+	recordGuardOutcome(in.Event, data)
+	return nil, blockError(resp)
 }
 
 func guardOutcomeDecision(status string, mode policy.Mode) string {
@@ -360,19 +431,6 @@ func protocolFor(consumerType string) string {
 	default:
 		return protocolLLM
 	}
-}
-
-func joinRequestText(creq *adapter.CanonicalRequest) string {
-	parts := make([]string, 0, len(creq.Messages)+1)
-	if strings.TrimSpace(creq.System) != "" {
-		parts = append(parts, creq.System)
-	}
-	for _, msg := range creq.Messages {
-		if strings.TrimSpace(msg.Content) != "" {
-			parts = append(parts, msg.Content)
-		}
-	}
-	return strings.Join(parts, "\n")
 }
 
 func passThrough() *appplugins.Result {

--- a/pkg/infra/plugins/trustguard/plugin_test.go
+++ b/pkg/infra/plugins/trustguard/plugin_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -422,7 +423,7 @@ func TestExecuteObserveModeOnBlockPassesThrough(t *testing.T) {
 func TestExecuteAllowStatusesPassThrough(t *testing.T) {
 	t.Parallel()
 
-	for _, status := range []string{"report", "transform", ""} {
+	for _, status := range []string{"report", ""} {
 		status := status
 		t.Run("status_"+status, func(t *testing.T) {
 			t.Parallel()
@@ -851,6 +852,203 @@ func TestExecuteRetriesOnceOn401(t *testing.T) {
 	}
 	if got := atomic.LoadInt32(&tokenHits); got != 2 {
 		t.Fatalf("token hits = %d, want 2 (initial + refresh after 401)", got)
+	}
+}
+
+func TestMutatesBodyReportsTrue(t *testing.T) {
+	t.Parallel()
+
+	p := New(adapter.NewRegistry(), "", testTimeout, "id", "secret", nil)
+	if !p.MutatesRequestBody() {
+		t.Fatal("MutatesRequestBody must be true so the planner runs TrustGuard sequentially")
+	}
+	if !p.MutatesResponseBody() {
+		t.Fatal("MutatesResponseBody must be true so the planner runs TrustGuard sequentially")
+	}
+}
+
+func transformResponse(masked string) GuardResponse {
+	return GuardResponse{
+		Status:             statusTransform,
+		TransformedPayload: map[string]any{"input": masked},
+		Findings: []GuardFinding{{
+			Source:  &GuardFindingSource{Kind: "detector", Plugin: "data_loss_prevention"},
+			Signal:  &GuardFindingSignal{Type: "pii"},
+			Outcome: &GuardFindingOutcome{Action: "transform"},
+		}},
+		TraceID: "trace-transform",
+	}
+}
+
+func TestExecutePreRequestTransformRewritesBody(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: transformResponse("be safe\nhello [MASKED_PII]")}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	event, span := newEvent()
+	in := execInputWithEvent(policy.StagePreRequest, policy.ModeEnforce, settings(""), requestContext(), nil, event)
+	res, err := p.Execute(context.Background(), in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res == nil || res.StatusCode != http.StatusOK || res.StopUpstream {
+		t.Fatalf("expected pass-through result carrying request body, got %+v", res)
+	}
+	if len(res.RequestBody) == 0 {
+		t.Fatal("expected rewritten RequestBody, got none")
+	}
+	if res.Body != nil {
+		t.Fatalf("pre_request must not set response Body, got %q", res.Body)
+	}
+	got := string(res.RequestBody)
+	if !strings.Contains(got, "hello [MASKED_PII]") {
+		t.Fatalf("rewritten body missing masked text: %s", got)
+	}
+	if strings.Contains(got, "hello world") {
+		t.Fatalf("rewritten body still contains unmasked text: %s", got)
+	}
+	if attrs := span.PluginAttrsCopy(); attrs.Decision != decisionTransformed {
+		t.Fatalf("span decision = %q, want %q", attrs.Decision, decisionTransformed)
+	}
+}
+
+func TestExecutePreResponseTransformRewritesBody(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: transformResponse("the [MASKED_PII]")}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	resp := &infracontext.ResponseContext{StatusCode: 200, Body: openAIResponseBody()}
+	in := execInput(policy.StagePreResponse, policy.ModeEnforce, settings(""), requestContext(), resp)
+	res, err := p.Execute(context.Background(), in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res == nil || res.StatusCode != http.StatusOK || !res.StopUpstream {
+		t.Fatalf("expected response rewrite with StopUpstream, got %+v", res)
+	}
+	if len(res.Body) == 0 {
+		t.Fatal("expected rewritten response Body, got none")
+	}
+	got := string(res.Body)
+	if !strings.Contains(got, "the [MASKED_PII]") {
+		t.Fatalf("rewritten response missing masked text: %s", got)
+	}
+	if strings.Contains(got, "the answer") {
+		t.Fatalf("rewritten response still contains unmasked text: %s", got)
+	}
+}
+
+func TestExecuteTransformObserveDoesNotRewrite(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: transformResponse("be safe\nhello [MASKED_PII]")}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	event, span := newEvent()
+	in := execInputWithEvent(policy.StagePreRequest, policy.ModeObserve, settings(""), requestContext(), nil, event)
+	res, err := p.Execute(context.Background(), in)
+	if err != nil {
+		t.Fatalf("observe mode must not error, got %v", err)
+	}
+	if res == nil || res.StatusCode != http.StatusOK || res.StopUpstream {
+		t.Fatalf("expected pass-through in observe mode, got %+v", res)
+	}
+	if res.RequestBody != nil {
+		t.Fatalf("observe mode must not rewrite the body, got %q", res.RequestBody)
+	}
+	if attrs := span.PluginAttrsCopy(); attrs.Decision != decisionReported {
+		t.Fatalf("span decision = %q, want %q", attrs.Decision, decisionReported)
+	}
+}
+
+func TestExecuteTransformMissingPayloadBlocks(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: GuardResponse{Status: statusTransform, TraceID: "trace-empty"}}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	event, span := newEvent()
+	in := execInputWithEvent(policy.StagePreRequest, policy.ModeEnforce, settings(""), requestContext(), nil, event)
+	res, err := p.Execute(context.Background(), in)
+	if res != nil {
+		t.Fatalf("expected block on unapplicable transform, got %+v", res)
+	}
+	if _, ok := appplugins.AsPluginError(err); !ok {
+		t.Fatalf("expected *PluginError, got %v", err)
+	}
+	attrs := span.PluginAttrsCopy()
+	extras, ok := attrs.Extras.(guardData)
+	if !ok {
+		t.Fatalf("extras type = %T, want guardData", attrs.Extras)
+	}
+	if !extras.Degraded || extras.DegradedReason != reasonTransformNoPayload {
+		t.Fatalf("extras = %+v, want degraded no-payload", extras)
+	}
+}
+
+func TestExecuteTransformLineCountMismatchBlocks(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: transformResponse("be safe\nhello\n[MASKED_PII]")}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	in := execInput(policy.StagePreRequest, policy.ModeEnforce, settings(""), requestContext(), nil)
+	res, err := p.Execute(context.Background(), in)
+	if res != nil {
+		t.Fatalf("expected block on ambiguous transform, got %+v", res)
+	}
+	if _, ok := appplugins.AsPluginError(err); !ok {
+		t.Fatalf("expected *PluginError, got %v", err)
+	}
+}
+
+func TestExecuteMCPTransformEnforceBlocks(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: transformResponse("search\nfind [MASKED_PII]")}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	event, span := newEvent()
+	in := execInputWithEvent(policy.StagePreRequest, policy.ModeEnforce, settings(""), mcpRequestContext(), nil, event)
+	res, err := p.Execute(context.Background(), in)
+	if res != nil {
+		t.Fatalf("expected block on MCP transform (no body propagation), got %+v", res)
+	}
+	if _, ok := appplugins.AsPluginError(err); !ok {
+		t.Fatalf("expected *PluginError, got %v", err)
+	}
+	attrs := span.PluginAttrsCopy()
+	extras, ok := attrs.Extras.(guardData)
+	if !ok {
+		t.Fatalf("extras type = %T, want guardData", attrs.Extras)
+	}
+	if !extras.Degraded || extras.DegradedReason != reasonTransformUnsupported {
+		t.Fatalf("extras = %+v, want degraded unsupported-path", extras)
+	}
+}
+
+func TestExecuteMCPTransformObservePassesThrough(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: transformResponse("search\nfind [MASKED_PII]")}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	in := execInput(policy.StagePreRequest, policy.ModeObserve, settings(""), mcpRequestContext(), nil)
+	res, err := p.Execute(context.Background(), in)
+	if err != nil {
+		t.Fatalf("observe mode must not error, got %v", err)
+	}
+	if res == nil || res.StatusCode != http.StatusOK || res.StopUpstream {
+		t.Fatalf("expected pass-through in observe mode, got %+v", res)
 	}
 }
 

--- a/pkg/infra/plugins/trustguard/rewrite.go
+++ b/pkg/infra/plugins/trustguard/rewrite.go
@@ -1,0 +1,172 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trustguard
+
+import (
+	"strings"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/adapter"
+)
+
+// transformTarget carries the closure that applies TrustGuard's masked text back
+// into the provider body for the current direction. apply is nil when the path
+// (e.g. native MCP) cannot propagate a rewritten body.
+type transformTarget struct {
+	isResponse bool
+	apply      func(masked string) ([]byte, bool)
+}
+
+// transformedInput extracts the masked string TrustGuard returns under the
+// payload's "input" key. TrustGate always sends a minimal {input: text} payload,
+// so the transform mirrors that shape.
+func transformedInput(payload map[string]any) (string, bool) {
+	if payload == nil {
+		return "", false
+	}
+	value, ok := payload[transformedInputKey]
+	if !ok {
+		return "", false
+	}
+	masked, ok := value.(string)
+	return masked, ok
+}
+
+// requestParts returns the ordered text segments TrustGate sends to TrustGuard:
+// the system prompt (when non-empty) followed by each non-empty message content.
+// joinRequestText and applyMaskedRequest must build this list identically so the
+// masked result maps back to the exact segments that were inspected.
+func requestParts(creq *adapter.CanonicalRequest) []string {
+	parts := make([]string, 0, len(creq.Messages)+1)
+	if strings.TrimSpace(creq.System) != "" {
+		parts = append(parts, creq.System)
+	}
+	for _, msg := range creq.Messages {
+		if strings.TrimSpace(msg.Content) != "" {
+			parts = append(parts, msg.Content)
+		}
+	}
+	return parts
+}
+
+func joinRequestText(creq *adapter.CanonicalRequest) string {
+	return strings.Join(requestParts(creq), "\n")
+}
+
+func rewriteRequest(reg *adapter.Registry, format adapter.Format, creq *adapter.CanonicalRequest, masked string) ([]byte, bool) {
+	if reg == nil || creq == nil {
+		return nil, false
+	}
+	if !applyMaskedRequest(creq, masked) {
+		return nil, false
+	}
+	adp, err := reg.GetAdapter(format)
+	if err != nil {
+		return nil, false
+	}
+	body, err := adp.EncodeRequest(creq)
+	if err != nil {
+		return nil, false
+	}
+	return body, true
+}
+
+func rewriteResponse(reg *adapter.Registry, format adapter.Format, cresp *adapter.CanonicalResponse, masked string) ([]byte, bool) {
+	if reg == nil || cresp == nil {
+		return nil, false
+	}
+	cresp.Content = masked
+	adp, err := reg.GetAdapter(format)
+	if err != nil {
+		return nil, false
+	}
+	body, err := adp.EncodeResponse(cresp)
+	if err != nil {
+		return nil, false
+	}
+	return body, true
+}
+
+// applyMaskedRequest writes the masked text back into the same segments that
+// joinRequestText concatenated. TrustGuard masks only detected spans and never
+// adds or removes newlines, so the masked text keeps the original line count and
+// can be split back into the per-segment values. A line-count mismatch means the
+// mapping is ambiguous, so it fails rather than corrupting the body.
+func applyMaskedRequest(creq *adapter.CanonicalRequest, masked string) bool {
+	setters := requestSegmentSetters(creq)
+	if len(setters) == 0 {
+		return false
+	}
+	parts := make([]string, len(setters))
+	for i, s := range setters {
+		parts[i] = s.value
+	}
+	maskedParts, ok := redistribute(masked, parts)
+	if !ok {
+		return false
+	}
+	for i, s := range setters {
+		s.set(maskedParts[i])
+	}
+	return true
+}
+
+type segmentSetter struct {
+	value string
+	set   func(string)
+}
+
+func requestSegmentSetters(creq *adapter.CanonicalRequest) []segmentSetter {
+	setters := make([]segmentSetter, 0, len(creq.Messages)+1)
+	if strings.TrimSpace(creq.System) != "" {
+		setters = append(setters, segmentSetter{
+			value: creq.System,
+			set:   func(s string) { creq.System = s },
+		})
+	}
+	for i := range creq.Messages {
+		i := i
+		if strings.TrimSpace(creq.Messages[i].Content) != "" {
+			setters = append(setters, segmentSetter{
+				value: creq.Messages[i].Content,
+				set:   func(s string) { creq.Messages[i].Content = s },
+			})
+		}
+	}
+	return setters
+}
+
+// redistribute splits the newline-joined masked text back into one entry per
+// original part, preserving each part's original line count. It returns false
+// when the total line count differs, which signals that the masking altered the
+// newline structure and the mapping can no longer be trusted.
+func redistribute(masked string, parts []string) ([]string, bool) {
+	maskedLines := strings.Split(masked, "\n")
+	counts := make([]int, len(parts))
+	total := 0
+	for i, part := range parts {
+		counts[i] = strings.Count(part, "\n") + 1
+		total += counts[i]
+	}
+	if total != len(maskedLines) {
+		return nil, false
+	}
+	out := make([]string, len(parts))
+	idx := 0
+	for i, count := range counts {
+		out[i] = strings.Join(maskedLines[idx:idx+count], "\n")
+		idx += count
+	}
+	return out, true
+}

--- a/pkg/infra/plugins/trustguard/rewrite_test.go
+++ b/pkg/infra/plugins/trustguard/rewrite_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trustguard
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/adapter"
+)
+
+func TestRedistributePreservesMultilineSegments(t *testing.T) {
+	t.Parallel()
+
+	parts := []string{"be safe", "line one\nline two", "final"}
+	masked := strings.Join(parts, "\n")
+	masked = strings.Replace(masked, "line two", "[MASKED] two", 1)
+
+	out, ok := redistribute(masked, parts)
+	if !ok {
+		t.Fatal("redistribute must succeed when newline count is preserved")
+	}
+	if len(out) != len(parts) {
+		t.Fatalf("got %d parts, want %d", len(out), len(parts))
+	}
+	if out[0] != "be safe" || out[2] != "final" {
+		t.Fatalf("unmatched segments altered: %#v", out)
+	}
+	if out[1] != "line one\n[MASKED] two" {
+		t.Fatalf("multiline segment = %q, want %q", out[1], "line one\n[MASKED] two")
+	}
+}
+
+func TestRedistributeRejectsLineCountChange(t *testing.T) {
+	t.Parallel()
+
+	parts := []string{"one", "two"}
+	if _, ok := redistribute("one\ntwo\nextra", parts); ok {
+		t.Fatal("redistribute must reject a changed newline count")
+	}
+}
+
+func TestApplyMaskedRequestMapsSystemAndMessages(t *testing.T) {
+	t.Parallel()
+
+	creq := &adapter.CanonicalRequest{
+		System: "be safe",
+		Messages: []adapter.CanonicalMessage{
+			{Role: "user", Content: "email me at a@b.com"},
+			{Role: "assistant", Content: ""},
+			{Role: "user", Content: "thanks"},
+		},
+	}
+	masked := "be safe\nemail me at [MASKED_EMAIL]\nthanks"
+
+	if !applyMaskedRequest(creq, masked) {
+		t.Fatal("applyMaskedRequest must succeed")
+	}
+	if creq.System != "be safe" {
+		t.Fatalf("system = %q, want unchanged", creq.System)
+	}
+	if creq.Messages[0].Content != "email me at [MASKED_EMAIL]" {
+		t.Fatalf("message[0] = %q, want masked", creq.Messages[0].Content)
+	}
+	if creq.Messages[1].Content != "" {
+		t.Fatalf("empty message must stay empty, got %q", creq.Messages[1].Content)
+	}
+	if creq.Messages[2].Content != "thanks" {
+		t.Fatalf("message[2] = %q, want unchanged", creq.Messages[2].Content)
+	}
+}

--- a/tests/functional/plugin_trustguard_test.go
+++ b/tests/functional/plugin_trustguard_test.go
@@ -76,6 +76,31 @@ func TestPluginE2E_TrustGuard_Enforce(t *testing.T) {
 	})
 }
 
+func TestPluginE2E_TrustGuard_TransformMasksRequestBody(t *testing.T) {
+	defer Track(t, "PluginTrustGuard")()
+
+	require.NotNil(t, TrustGuardFunctionalStub, "TrustGuard stub must be started in TestMain")
+	tg := TrustGuardFunctionalStub
+	tg.Reset()
+
+	up := newJSONUpstream(t, "tg-mask")
+	apiKey, path := setupPolicyRoute(t, up, policyPlugin("trustguard", trustGuardPolicySettings()))
+
+	hitsBefore := up.Hits()
+	status, _, raw := proxyRequest(t, http.MethodPost, apiKey, path, nil,
+		mustJSON(t, trustGuardChatRequest("please contact "+trustGuardMaskWord+" now")),
+	)
+	require.Equal(t, http.StatusOK, status, "body: %s", raw)
+	require.Equal(t, hitsBefore+1, up.Hits())
+	assert.GreaterOrEqual(t, tg.GuardHits(), 1)
+
+	forwarded := string(up.LastBody())
+	assert.Contains(t, forwarded, trustGuardMaskToken,
+		"the masked body from TrustGuard must reach the upstream")
+	assert.NotContains(t, forwarded, trustGuardMaskWord,
+		"the unmasked sensitive token must not reach the upstream")
+}
+
 func TestPluginE2E_TrustGuard_ObserveNeverBlocks(t *testing.T) {
 	defer Track(t, "PluginTrustGuard")()
 

--- a/tests/functional/trustguard_stub_test.go
+++ b/tests/functional/trustguard_stub_test.go
@@ -19,6 +19,8 @@ const (
 	trustGuardFunctionalAccessToken  = "functional-trustguard-access-token"
 	trustGuardBlockWord              = "sql-injection-flag"
 	trustGuardErrorWord              = "guard-boom-flag"
+	trustGuardMaskWord               = "mask-me-flag"
+	trustGuardMaskToken              = "[MASKED_PII]"
 )
 
 var TrustGuardFunctionalStub *trustGuardStub
@@ -153,6 +155,12 @@ func (s *trustGuardStub) handleGuard(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	if strings.Contains(strings.ToLower(req.Payload.Input), trustGuardBlockWord) {
 		_, _ = io.WriteString(w, `{"status":"block","findings":[{"source":{"kind":"detector","plugin":"prompt_guard"},"signal":{"type":"prompt_injection"},"outcome":{"action":"block"}}],"trace_id":"tg-trace-1","request_id":"tg-req-1"}`)
+		return
+	}
+	if strings.Contains(req.Payload.Input, trustGuardMaskWord) {
+		masked := strings.ReplaceAll(req.Payload.Input, trustGuardMaskWord, trustGuardMaskToken)
+		payload, _ := json.Marshal(map[string]string{"input": masked})
+		_, _ = io.WriteString(w, `{"status":"transform","transformed_payload":`+string(payload)+`,"findings":[{"source":{"kind":"detector","plugin":"data_loss_prevention"},"signal":{"type":"pii"},"outcome":{"action":"transform"}}],"trace_id":"tg-trace-3","request_id":"tg-req-3"}`)
 		return
 	}
 	_, _ = io.WriteString(w, `{"status":"allowed","findings":[],"trace_id":"tg-trace-2","request_id":"tg-req-2"}`)


### PR DESCRIPTION
## Summary

When the TrustGuard plugin was enabled and TrustGuard's data-masking (DLP) plugin produced a masked payload (`status: "transform"`), TrustGate parsed `transformed_payload` but **never applied it**: the plugin declared itself non-mutating (`MutatesRequestBody/ResponseBody = false`) and always returned pass-through, so the **original, unmasked** body was still sent to the model.

This PR makes TrustGate apply TrustGuard's masked transform to the body, and treats the plugin as a body mutator so it runs **sequentially** (never in a parallel batch with other body writers).

## Changes

- **Apply `transform`**: on `status: "transform"`, rewrite the provider body with the masked text from `transformed_payload.input`, re-encoding via the provider adapter (same pattern as `bedrock_guardrail`).
  - pre_request → `Result.RequestBody` (masked body forwarded upstream)
  - pre_response → `Result.Body` + `StopUpstream`
- **Sequential execution**: `MutatesRequestBody()`/`MutatesResponseBody()` now return `true`, so the executor's capability-aware planner keeps TrustGuard out of parallel batches with other body writers, applying the mutation deterministically.
- **Observe mode**: reports the transform without mutating the body.
- **Fail-closed**: a transform that cannot be applied safely (missing payload, ambiguous newline mapping, re-encode failure) blocks instead of forwarding unmasked data.
- **MCP**: the native MCP path does not propagate body mutations yet, so an MCP transform blocks in enforce mode (report in observe). Native MCP masking propagation is a follow-up.
- Robust reconstruction: masked concatenated text is redistributed back into `system` / `messages[].content` by preserving each segment's line count (TrustGuard never adds/removes newlines).
- Updated the plugin catalog description.

## Test plan

- [x] Unit tests: request/response rewrite, observe (no mutation), fail-closed (no payload / line-count mismatch), MCP block, `redistribute`/`applyMaskedRequest`.
- [x] Functional test mocking the TrustGuard API (`/v1/token` + `/v1/evaluate` with a `transform` response) asserting the masked body reaches the upstream and the sensitive token does not. Requires local Postgres+Redis to run.
- [x] `go build ./...`, `go vet`, `golangci-lint`, `go test -race` (package) and full unit suite green; pre-commit hook (lint + gosec + tests) passed.

Made with [Cursor](https://cursor.com)