### PR TITLE
feat(downloads): expose TrustGate MCP port in dataplane compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ scripts/secret/
 .DS_Store
 .cursor/sdd
 docs/internal/*
+downloads/start.sh

--- a/downloads/docker-compose.yml
+++ b/downloads/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     restart: unless-stopped
     ports:
       - "8081:8081"   # TrustGate proxy (DataPlane traffic)
+      - "8082:8082"   # TrustGate MCP server
       - "8090:8090"   # DataAgent local health probe
     depends_on:
       redis:
@@ -21,6 +22,7 @@ services:
       # ----------------------------------------------------------------------
       APP_ENV: prod
       SERVER_PROXY_PORT: "8081"
+      SERVER_MCP_PORT: "8082"
       LOG_LEVEL: INFO
       LOG_FORMAT: json
       GATEWAY_DISCOVERY_MODE: header


### PR DESCRIPTION
## Summary
- Maps host **8082** → container MCP port in `downloads/docker-compose.yml`.
- Sets `SERVER_MCP_PORT=8082` for the dataplane service.
- Ignores `downloads/start.sh` (local helper that may hold secrets).

Pairs with the dataplane-bundle change that starts `trustgate mcp` in the image.

## Test plan
- [ ] `docker compose -f downloads/docker-compose.yml config` shows 8082 published
- [ ] With a built bundle that runs MCP, traffic on 8082 reaches the MCP plane


Made with [Cursor](https://cursor.com)