### PR TITLE
feat(bundle): default SaaS control-plane endpoint and enable telemetry in dataplane compose

### DIFF
--- a/downloads/docker-compose.yml
+++ b/downloads/docker-compose.yml
@@ -32,8 +32,9 @@ services:
       # TrustGate proxy — config sync (DB-less: dial the control plane)
       # ----------------------------------------------------------------------
       CONFIG_SYNC_DATA_PLANE_ENABLED: "true"
-      # Control-plane gRPC endpoint (host:port) this data plane dials.
-      CONFIG_SYNC_GRPC_ENDPOINT: ${CONFIG_SYNC_GRPC_ENDPOINT:?set CONFIG_SYNC_GRPC_ENDPOINT (host:port)}
+      # Control-plane gRPC endpoint (host:port) this data plane dials. Defaults to
+      # the NeuralTrust SaaS control plane; override only for self-hosted setups.
+      CONFIG_SYNC_GRPC_ENDPOINT: ${CONFIG_SYNC_GRPC_ENDPOINT:-agentgateway-configsync.neuraltrust.ai:443}
       # Bearer token that authenticates this data plane to the control plane.
       CONFIG_SYNC_TOKEN: ${CONFIG_SYNC_TOKEN:?set CONFIG_SYNC_TOKEN}
       # Instance id bound to the registered gateway instance. If omitted it is
@@ -58,14 +59,15 @@ services:
       REDIS_DB: "3"
 
       # ----------------------------------------------------------------------
-      # TrustGate proxy — telemetry / OTel collector (optional)
-      # Point ENDPOINT at your collector; the collector auth token travels in
-      # OTEL_EXPORTER_OTLP_HEADERS as a comma-separated key=value list, e.g.
-      # "authorization=Bearer <token>". Leave ENDPOINT empty to disable OTLP.
-      # Telemetry is opt-in: set TELEMETRY_EXPORTERS_FILE to the baked path
-      # (/etc/trustgate/telemetry.yaml, exporters metadata→otlp + raw→postgres)
-      # AND an OTLP endpoint. Empty TELEMETRY_EXPORTERS_FILE = no exporters.
-      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
+      # TrustGate proxy — telemetry / OTel collector
+      # ENDPOINT defaults to the NeuralTrust SaaS collector; override only to
+      # point at a different collector. The collector auth token, if any, travels
+      # in OTEL_EXPORTER_OTLP_HEADERS as a comma-separated key=value list, e.g.
+      # "authorization=Bearer <token>".
+      # Telemetry still requires TELEMETRY_EXPORTERS_FILE set to the baked path
+      # (/etc/trustgate/telemetry.yaml, exporters metadata→otlp + raw→postgres);
+      # empty TELEMETRY_EXPORTERS_FILE = no exporters.
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-https://telemetry.neuraltrust.ai}
       OTEL_EXPORTER_OTLP_HEADERS: ${OTEL_EXPORTER_OTLP_HEADERS:-}
       OTEL_EXPORTER_OTLP_PROTOCOL: ${OTEL_EXPORTER_OTLP_PROTOCOL:-http/protobuf}
       OTEL_EXPORTER_OTLP_TIMEOUT: ${OTEL_EXPORTER_OTLP_TIMEOUT:-10000}

--- a/downloads/docker-compose.yml
+++ b/downloads/docker-compose.yml
@@ -27,6 +27,11 @@ services:
       LOG_FORMAT: json
       # REQUIRED to boot: >=32 bytes. openssl rand -base64 32
       SERVER_SECRET_KEY: ${SERVER_SECRET_KEY:?set SERVER_SECRET_KEY (openssl rand -base64 32)}
+      # RSA private key (base64-encoded PEM) used by the MCP server to sign STS
+      # session tokens. REQUIRED because APP_ENV=prod (ephemeral keys are not
+      # shared across replicas). Must be stable across restarts/replicas.
+      # openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 | base64
+      STS_SIGNING_KEY: ${STS_SIGNING_KEY:?set STS_SIGNING_KEY (base64 of an RSA private key PEM)}
 
       # ----------------------------------------------------------------------
       # TrustGate proxy — config sync (DB-less: dial the control plane)


### PR DESCRIPTION
## Summary

Reduce the variables a user must set to run the dataplane bundle by baking SaaS-fixed defaults into `downloads/docker-compose.yml`:

- **Control plane:** `CONFIG_SYNC_GRPC_ENDPOINT` defaults to `agentgateway-configsync.neuraltrust.ai:443`.
- **Telemetry (enabled by default):** `TELEMETRY_EXPORTERS_FILE` defaults to the baked `/etc/trustgate/telemetry.yaml`, and TrustGate exports over plain OTLP to the **loopback egress collector** at `http://127.0.0.1:4318` (`OTEL_EXPORTER_OTLP_INSECURE=true`).

All defaults use `${VAR:-default}`, so they stay overridable for self-hosted deployments.

## Telemetry architecture (why loopback, not the SaaS URL)

TrustGate does **not** talk to `https://telemetry.neuraltrust.ai` directly. It sends to the in-image egress collector, which authenticates to the SaaS ingest via the DataAgent enrolment exchange and forwards upstream:

```
TrustGate ──plain OTLP──▶ 127.0.0.1:4318 (egress collector, in the bundle image)
                              │ oauth2client → DataAgent OAuth broker (127.0.0.1:9465)
                              │ ExchangeTelemetryToken over DataBridge (uses ENROLMENT_TOKEN)
                              ▼
                    https://telemetry.neuraltrust.ai  (OIDC JWT, aud=otlp-ingest)
```

- No `OTEL_EXPORTER_OTLP_HEADERS` is set — SaaS auth is the enrolment exchange, not a static bearer. `ENROLMENT_TOKEN` on DataAgent is sufficient.
- The SaaS endpoint lives in the egress collector config (`CLICKSTACK_OTLP_ENDPOINT`, defaulted in `dataplane-bundle`), not in this compose.
- Requires a DataAgent build with the loopback OAuth broker (`OAUTH_BROKER_ADDR`, default `127.0.0.1:9465`).

## Resulting startup command

Only per-tenant tokens remain user-supplied (two keys auto-generate):

```bash
curl -fsSL https://raw.githubusercontent.com/NeuralTrust/TrustGate/main/downloads/docker-compose.yml | \
  SERVER_SECRET_KEY="$(openssl rand -base64 32)" \
  CONFIG_SYNC_LKG_KEY="$(openssl rand -base64 32)" \
  CONFIG_SYNC_TOKEN="<config-sync token>" \
  ENROLMENT_TOKEN="<enrolment token>" \
  DATABRIDGE_ADDR=databridge.neuraltrust.ai:443 \
  docker compose -f - up -d
```

## Test plan

- [x] `docker compose -f downloads/docker-compose.yml config` resolves all defaults with no env vars set (control-plane endpoint, loopback OTLP endpoint, insecure=true, exporters file)
- [x] pre-commit hook (golangci-lint + gosec + suite) green