### PR TITLE
feat(crypto): auto-provision SERVER_SECRET_KEY in Redis for prod dataplane

### DIFF
--- a/downloads/docker-compose.yml
+++ b/downloads/docker-compose.yml
@@ -25,8 +25,11 @@ services:
       SERVER_MCP_PORT: "8082"
       LOG_LEVEL: INFO
       LOG_FORMAT: json
-      # REQUIRED to boot: >=32 bytes. openssl rand -base64 32
-      SERVER_SECRET_KEY: ${SERVER_SECRET_KEY:?set SERVER_SECRET_KEY (openssl rand -base64 32)}
+      # Optional: when empty, TrustGate auto-provisions a shared SERVER_SECRET_KEY
+      # in Redis (vault encryption + admin JWTs, stable across restarts). Set it
+      # only to pin a specific key from your secret manager.
+      # openssl rand -base64 32
+      SERVER_SECRET_KEY: ${SERVER_SECRET_KEY:-}
       # RSA private key (PEM, optionally base64-encoded) used by the MCP server
       # to sign STS session tokens. Optional: when empty, TrustGate auto-provisions
       # a key in Redis (shared across replicas, stable across restarts). Set it

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -211,8 +211,10 @@ type ServerConfig struct {
 	ReadTimeout  time.Duration
 	WriteTimeout time.Duration
 	IdleTimeout  time.Duration
-	// SecretKey signs and verifies admin-plane JWTs. Empty disables admin auth
-	// token acceptance (every token is rejected).
+	// SecretKey signs and verifies admin-plane JWTs and encrypts vault material.
+	// Empty disables admin auth token acceptance until resolved. In prod, when
+	// empty at boot, the DI layer auto-provisions a shared value in Redis
+	// (see crypto.ResolveSharedSecretKey) so replicas converge.
 	SecretKey            string
 	GatewayBaseDomain    string
 	MCPBaseDomain        string

--- a/pkg/container/modules/core.go
+++ b/pkg/container/modules/core.go
@@ -17,10 +17,12 @@ package modules
 import (
 	"context"
 	"log/slog"
+	"strings"
 
 	"github.com/NeuralTrust/TrustGate/pkg/config"
 	"github.com/NeuralTrust/TrustGate/pkg/container"
 	vaultdomain "github.com/NeuralTrust/TrustGate/pkg/domain/vault"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/cache"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/crypto"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/database"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/logger"
@@ -74,7 +76,21 @@ func provideRuntimeBase(c *container.Container) error {
 	}); err != nil {
 		return err
 	}
-	return c.Provide(func(cfg *config.Config) (vaultdomain.Encrypter, error) {
-		return crypto.NewCipher(cfg.Server.SecretKey)
+	return c.Provide(func(cfg *config.Config, cc cache.Client, logger *slog.Logger) (vaultdomain.Encrypter, error) {
+		secret := cfg.Server.SecretKey
+		if secret == "" {
+			env := strings.ToLower(strings.TrimSpace(cfg.AppEnv))
+			if env == "prod" || env == "production" {
+				resolved, err := crypto.ResolveSharedSecretKey(context.Background(), cc.RedisClient(), logger)
+				if err != nil {
+					return nil, err
+				}
+				secret = resolved
+				// Mutate the shared ServerConfig so JWT managers (which hold a
+				// pointer to it) verify with the same secret as the vault cipher.
+				cfg.Server.SecretKey = resolved
+			}
+		}
+		return crypto.NewCipher(secret)
 	})
 }

--- a/pkg/infra/crypto/secret.go
+++ b/pkg/infra/crypto/secret.go
@@ -1,0 +1,75 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crypto
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// SharedSecretKeyRedisKey is the Redis key under which the auto-provisioned
+// SERVER_SECRET_KEY is stored so every replica encrypts vault material and
+// verifies admin-plane JWTs with the same secret.
+const SharedSecretKeyRedisKey = "trustgate:server:secret-key"
+
+const sharedSecretBytes = 32
+
+// ResolveSharedSecretKey returns a base64-encoded secret shared across replicas
+// via Redis. It returns the stored secret when present; otherwise it generates
+// one and stores it with SETNX so concurrent replicas converge on a single
+// value instead of each minting with its own ephemeral secret.
+func ResolveSharedSecretKey(ctx context.Context, rdb *redis.Client, logger *slog.Logger) (string, error) {
+	if rdb == nil {
+		return "", errors.New("crypto: redis client is required to auto-provision SERVER_SECRET_KEY")
+	}
+	if existing, err := rdb.Get(ctx, SharedSecretKeyRedisKey).Result(); err == nil && existing != "" {
+		return existing, nil
+	} else if err != nil && !errors.Is(err, redis.Nil) {
+		return "", fmt.Errorf("crypto: read shared secret key: %w", err)
+	}
+	generated, err := generateSecretKey()
+	if err != nil {
+		return "", err
+	}
+	won, err := rdb.SetNX(ctx, SharedSecretKeyRedisKey, generated, 0).Result()
+	if err != nil {
+		return "", fmt.Errorf("crypto: persist shared secret key: %w", err)
+	}
+	if won {
+		if logger != nil {
+			logger.Info("crypto: auto-provisioned shared SERVER_SECRET_KEY in redis")
+		}
+		return generated, nil
+	}
+	stored, err := rdb.Get(ctx, SharedSecretKeyRedisKey).Result()
+	if err != nil {
+		return "", fmt.Errorf("crypto: read shared secret key after race: %w", err)
+	}
+	return stored, nil
+}
+
+func generateSecretKey() (string, error) {
+	buf := make([]byte, sharedSecretBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("crypto: generate secret key: %w", err)
+	}
+	return base64.StdEncoding.EncodeToString(buf), nil
+}

--- a/pkg/infra/crypto/secret_test.go
+++ b/pkg/infra/crypto/secret_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crypto
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveSharedSecretKey_GeneratesAndPersists(t *testing.T) {
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	ctx := context.Background()
+
+	first, err := ResolveSharedSecretKey(ctx, rdb, nil)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(first), minSecretLen)
+
+	stored, err := mr.Get(SharedSecretKeyRedisKey)
+	require.NoError(t, err)
+	require.Equal(t, first, stored)
+
+	second, err := ResolveSharedSecretKey(ctx, rdb, nil)
+	require.NoError(t, err)
+	require.Equal(t, first, second, "existing secret must be reused, not regenerated")
+}
+
+func TestResolveSharedSecretKey_ConcurrentReplicasConverge(t *testing.T) {
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	ctx := context.Background()
+
+	const replicas = 8
+	results := make([]string, replicas)
+	var wg sync.WaitGroup
+	wg.Add(replicas)
+	for i := 0; i < replicas; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			key, err := ResolveSharedSecretKey(ctx, rdb, nil)
+			require.NoError(t, err)
+			results[idx] = key
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 1; i < replicas; i++ {
+		require.Equal(t, results[0], results[i], "all replicas must converge on one secret")
+	}
+}
+
+func TestResolveSharedSecretKey_NilClient(t *testing.T) {
+	_, err := ResolveSharedSecretKey(context.Background(), nil, nil)
+	require.Error(t, err)
+}
+
+func TestResolveSharedSecretKey_UsableByCipher(t *testing.T) {
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+	secret, err := ResolveSharedSecretKey(context.Background(), rdb, nil)
+	require.NoError(t, err)
+
+	cipher, err := NewCipher(secret)
+	require.NoError(t, err)
+
+	enc, err := cipher.Encrypt("vault-material")
+	require.NoError(t, err)
+	plain, err := cipher.Decrypt(enc)
+	require.NoError(t, err)
+	require.Equal(t, "vault-material", plain)
+}


### PR DESCRIPTION
## Summary

Auto-provision `SERVER_SECRET_KEY` in prod when unset (same Redis SETNX pattern as `STS_SIGNING_KEY`), so the dataplane bundle no longer requires users to generate or pass it.

- New `crypto.ResolveSharedSecretKey`: generate 32 random bytes (base64), store under `trustgate:server:secret-key`, converge concurrent replicas with SETNX.
- DI (`provideRuntimeBase`): if secret empty and `APP_ENV` is `prod`/`production`, resolve from Redis and mutate `cfg.Server.SecretKey` so JWT managers sharing that pointer verify with the same secret as the vault cipher.
- `downloads/docker-compose.yml`: `SERVER_SECRET_KEY` is optional (`${SERVER_SECRET_KEY:-}`); pin only when you want a fixed key from a secret manager.

## Startup curl (after this)

Only per-tenant tokens + the LKG key remain:

```bash
curl -fsSL https://raw.githubusercontent.com/NeuralTrust/TrustGate/main/downloads/docker-compose.yml | \
  CONFIG_SYNC_LKG_KEY="$(openssl rand -base64 32)" \
  CONFIG_SYNC_TOKEN="<config-sync token>" \
  ENROLMENT_TOKEN="<enrolment token>" \
  docker compose -f - up -d
```

## Test plan

- [x] `go test ./pkg/infra/crypto/... ./pkg/container/modules/...`
- [x] `docker compose config` boots without `SERVER_SECRET_KEY`
- [x] pre-commit hook green

Made with [Cursor](https://cursor.com)