### PR TITLE
fix(bundle): append /v1/logs to loopback OTLP endpoint default

### DIFF
--- a/downloads/docker-compose.yml
+++ b/downloads/docker-compose.yml
@@ -69,14 +69,15 @@ services:
 
       # ----------------------------------------------------------------------
       # TrustGate proxy — telemetry / OTel egress
-      # TrustGate exports over plain OTLP to the loopback egress collector baked
-      # into the image (127.0.0.1:4318). That collector authenticates to the SaaS
-      # ingest via the DataAgent enrolment exchange (OAuth broker on 127.0.0.1:9465)
-      # and forwards to the SaaS endpoint, so no OTLP auth header is set here.
+      # TrustGate exports OTLP/HTTP logs to the loopback egress collector baked
+      # into the image. The path /v1/logs is required: with an http:// URL the
+      # OTel SDK uses WithEndpointURL and does not append the signal path.
+      # That collector authenticates to SaaS ingest via the DataAgent enrolment
+      # exchange (OAuth broker on 127.0.0.1:9465), so no OTLP auth header here.
       # Telemetry is enabled by default via the baked exporters file
       # (/etc/trustgate/telemetry.yaml, exporters metadata→otlp + raw→postgres).
       # Set TELEMETRY_EXPORTERS_FILE empty to disable all exporters.
-      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://127.0.0.1:4318}
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://127.0.0.1:4318/v1/logs}
       OTEL_EXPORTER_OTLP_HEADERS: ${OTEL_EXPORTER_OTLP_HEADERS:-}
       OTEL_EXPORTER_OTLP_PROTOCOL: ${OTEL_EXPORTER_OTLP_PROTOCOL:-http/protobuf}
       OTEL_EXPORTER_OTLP_TIMEOUT: ${OTEL_EXPORTER_OTLP_TIMEOUT:-10000}


### PR DESCRIPTION
## Summary

After pulling the rebuilt `neuraltrust/dataplane:stable` (with `otelcol-egress`), TrustGate still logged:

```
failed to send logs to http://127.0.0.1:4318: 404 Not Found
```

Cause: with an `http://` endpoint the OTel SDK uses `WithEndpointURL` and does **not** append `/v1/logs`, so the export hit the collector root.

## Fix

Default `OTEL_EXPORTER_OTLP_ENDPOINT` in `downloads/docker-compose.yml` to:

```
http://127.0.0.1:4318/v1/logs
```

Verified locally: chat still `200`, and the 404 / `failed to send` disappears with this path.

## Test plan

- [x] Recreate dataplane with new stable image + `/v1/logs` endpoint
- [x] `POST /v1/chat/completions` → 200
- [x] No `404` / `connection refused` on OTLP export after the request

Made with [Cursor](https://cursor.com)