### PR TITLE
fix(consumer): preserve registry binding order

### DIFF
--- a/pkg/infra/database/migrations/20260723110000_add_consumer_registry_position.go
+++ b/pkg/infra/database/migrations/20260723110000_add_consumer_registry_position.go
@@ -1,0 +1,52 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrations
+
+import (
+	"context"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/database"
+	"github.com/jackc/pgx/v5"
+)
+
+func init() {
+	database.RegisterMigration(database.Migration{
+		ID:   "20260723110000_add_consumer_registry_position",
+		Name: "preserve consumer registry insertion order",
+		Up:   upConsumerRegistryPosition,
+		Down: downConsumerRegistryPosition,
+	})
+}
+
+func upConsumerRegistryPosition(ctx context.Context, tx pgx.Tx) error {
+	const ddl = `
+		CREATE SEQUENCE IF NOT EXISTS consumer_registry_position_seq;
+
+		ALTER TABLE consumer_registry ADD COLUMN IF NOT EXISTS position BIGINT;
+
+		ALTER SEQUENCE consumer_registry_position_seq OWNED BY consumer_registry.position;
+		ALTER TABLE consumer_registry
+			ALTER COLUMN position SET DEFAULT nextval('consumer_registry_position_seq');`
+	_, err := tx.Exec(ctx, ddl)
+	return err
+}
+
+func downConsumerRegistryPosition(ctx context.Context, tx pgx.Tx) error {
+	const ddl = `
+		ALTER TABLE consumer_registry DROP COLUMN IF EXISTS position;
+		DROP SEQUENCE IF EXISTS consumer_registry_position_seq;`
+	_, err := tx.Exec(ctx, ddl)
+	return err
+}

--- a/pkg/infra/database/migrations/20260723110000_add_consumer_registry_position_test.go
+++ b/pkg/infra/database/migrations/20260723110000_add_consumer_registry_position_test.go
@@ -1,0 +1,181 @@
+//go:build functional
+
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrations
+
+import (
+	"context"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+func TestConsumerRegistryPositionMigration(t *testing.T) {
+	dsn := os.Getenv("PG_TEST_URL")
+	if dsn == "" {
+		t.Skip("PG_TEST_URL not set")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	conn, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer func() { _ = conn.Close(context.Background()) }()
+
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer func() { _ = tx.Rollback(context.Background()) }()
+
+	const consumerID = "00000000-0000-0000-0000-000000000100"
+	const registryOne = "00000000-0000-0000-0000-000000000001"
+	const registryTwo = "00000000-0000-0000-0000-000000000002"
+	const registryThree = "00000000-0000-0000-0000-000000000003"
+	const registryFour = "00000000-0000-0000-0000-000000000004"
+
+	const setup = `
+		CREATE TEMP TABLE consumer_registry (
+			consumer_id UUID NOT NULL,
+			registry_id UUID NOT NULL,
+			weight INT NOT NULL DEFAULT 1,
+			PRIMARY KEY (consumer_id, registry_id)
+		) ON COMMIT DROP;
+		SET LOCAL search_path TO pg_temp;
+		INSERT INTO consumer_registry (consumer_id, registry_id) VALUES
+			($1, $2),
+			($1, $3),
+			($1, $4);`
+	if _, err := tx.Exec(ctx, setup, consumerID, registryThree, registryOne, registryTwo); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	if err := upConsumerRegistryPosition(ctx, tx); err != nil {
+		t.Fatalf("up: %v", err)
+	}
+	assertConsumerRegistryPositionObjects(t, ctx, tx, true)
+	assertRegistryOrder(t, ctx, tx, []string{registryOne, registryTwo, registryThree})
+	assertNullPositionCount(t, ctx, tx, 3)
+
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO consumer_registry (consumer_id, registry_id) VALUES ($1, $2)`,
+		consumerID,
+		registryFour,
+	); err != nil {
+		t.Fatalf("legacy insert: %v", err)
+	}
+	assertRegistryOrder(t, ctx, tx, []string{registryOne, registryTwo, registryThree, registryFour})
+	var appendedPosition int64
+	if err := tx.QueryRow(ctx,
+		`SELECT position FROM consumer_registry WHERE registry_id = $1`,
+		registryFour,
+	).Scan(&appendedPosition); err != nil {
+		t.Fatalf("read appended position: %v", err)
+	}
+	if appendedPosition != 1 {
+		t.Fatalf("appended position = %d, want 1", appendedPosition)
+	}
+
+	if err := downConsumerRegistryPosition(ctx, tx); err != nil {
+		t.Fatalf("down: %v", err)
+	}
+	assertConsumerRegistryPositionObjects(t, ctx, tx, false)
+
+	if err := upConsumerRegistryPosition(ctx, tx); err != nil {
+		t.Fatalf("reapply: %v", err)
+	}
+	assertConsumerRegistryPositionObjects(t, ctx, tx, true)
+	assertRegistryOrder(t, ctx, tx, []string{registryOne, registryTwo, registryThree, registryFour})
+	assertNullPositionCount(t, ctx, tx, 4)
+}
+
+func assertRegistryOrder(
+	t *testing.T,
+	ctx context.Context,
+	tx pgx.Tx,
+	wantRegistries []string,
+) {
+	t.Helper()
+	var registries []string
+	if err := tx.QueryRow(ctx, `
+		SELECT array_agg(registry_id::text ORDER BY position NULLS FIRST, registry_id)
+		  FROM consumer_registry`,
+	).Scan(&registries); err != nil {
+		t.Fatalf("read registry order: %v", err)
+	}
+	if !reflect.DeepEqual(registries, wantRegistries) {
+		t.Fatalf("registries = %v, want %v", registries, wantRegistries)
+	}
+}
+
+func assertNullPositionCount(t *testing.T, ctx context.Context, tx pgx.Tx, want int) {
+	t.Helper()
+	var count int
+	if err := tx.QueryRow(ctx,
+		`SELECT COUNT(*) FROM consumer_registry WHERE position IS NULL`,
+	).Scan(&count); err != nil {
+		t.Fatalf("count null positions: %v", err)
+	}
+	if count != want {
+		t.Fatalf("null positions = %d, want %d", count, want)
+	}
+}
+
+func assertConsumerRegistryPositionObjects(t *testing.T, ctx context.Context, tx pgx.Tx, want bool) {
+	t.Helper()
+	var hasColumn bool
+	var hasSequence bool
+	var ownsSequence bool
+	if err := tx.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			  FROM pg_attribute
+			 WHERE attrelid = 'consumer_registry'::regclass
+			   AND attname = 'position'
+			   AND NOT attisdropped
+		),
+		to_regclass('consumer_registry_position_seq') IS NOT NULL,
+		EXISTS (
+			SELECT 1
+			  FROM pg_depend d
+			  JOIN pg_class seq ON seq.oid = d.objid
+			  JOIN pg_attribute a
+			    ON a.attrelid = d.refobjid
+			   AND a.attnum = d.refobjsubid
+			 WHERE seq.relname = 'consumer_registry_position_seq'
+			   AND d.refobjid = 'consumer_registry'::regclass
+			   AND a.attname = 'position'
+			   AND d.deptype = 'a'
+		)`,
+	).Scan(&hasColumn, &hasSequence, &ownsSequence); err != nil {
+		t.Fatalf("read migration objects: %v", err)
+	}
+	if hasColumn != want || hasSequence != want || ownsSequence != want {
+		t.Fatalf(
+			"position objects = column:%t sequence:%t ownership:%t, want %t",
+			hasColumn,
+			hasSequence,
+			ownsSequence,
+			want,
+		)
+	}
+}

--- a/pkg/infra/repository/consumer/repository.go
+++ b/pkg/infra/repository/consumer/repository.go
@@ -53,7 +53,7 @@ const (
 const consumerSelectColumns = `
 		SELECT c.id, c.gateway_id, c.name, c.type, c.slug, c.routing_mode, c.lb_config, c.fallback, c.model_policies, c.toolkit, c.fail_mode, c.headers, c.active,
 		       c.created_at, c.updated_at,
-		       COALESCE((SELECT array_agg(cb.registry_id ORDER BY cb.registry_id)
+		       COALESCE((SELECT array_agg(cb.registry_id ORDER BY cb.position NULLS FIRST, cb.registry_id)
 		                   FROM consumer_registry cb WHERE cb.consumer_id = c.id), '{}')::uuid[] AS registry_ids,
 		       COALESCE((SELECT json_object_agg(cw.registry_id, cw.weight)
 		                   FROM consumer_registry cw WHERE cw.consumer_id = c.id), '{}')::jsonb AS registry_weights,

--- a/tests/functional/repositories/consumer/repository_test.go
+++ b/tests/functional/repositories/consumer/repository_test.go
@@ -195,6 +195,34 @@ func TestRepository_SaveAndFindByID(t *testing.T) {
 	}
 }
 
+func TestRepository_SavePreservesRegistryOrder(t *testing.T) {
+	f := setupRepo(t)
+	ctx := context.Background()
+	gwID := seedGateway(t, f.gw, "ordered-registries")
+	first := seedRegistry(t, f.be, gwID, "be-first")
+	second := seedRegistry(t, f.be, gwID, "be-second")
+	third := seedRegistry(t, f.be, gwID, "be-third")
+
+	want := []ids.RegistryID{third, first, second}
+	c := validConsumer(t, gwID, "ordered-consumer", want...)
+	if err := f.repo.Save(ctx, c); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := f.repo.FindByID(ctx, c.ID)
+	if err != nil {
+		t.Fatalf("FindByID: %v", err)
+	}
+	if len(got.RegistryIDs) != len(want) {
+		t.Fatalf("RegistryIDs = %v, want %v", got.RegistryIDs, want)
+	}
+	for i := range want {
+		if got.RegistryIDs[i] != want[i] {
+			t.Fatalf("RegistryIDs = %v, want %v", got.RegistryIDs, want)
+		}
+	}
+}
+
 func TestRepository_SaveAndFindByID_RoundTripsFallback(t *testing.T) {
 	f := setupRepo(t)
 	ctx := context.Background()


### PR DESCRIPTION
## What
Preserves the declaration order of a consumer's registry bindings so later routing can deterministically select the first eligible registry.

## How
- Adds a nullable, sequence-backed `consumer_registry.position` column for rolling compatibility.
- Orders loaded registry IDs by position while retaining deterministic ordering for legacy NULL rows.
- Covers repository ordering and migration up/down/reapply behavior.

## Testing
- `GOFLAGS=-mod=mod make test`
- `GOFLAGS=-mod=mod go vet ./...`
- `GOFLAGS=-mod=mod make lint`
- Pre-commit hook passed.
- PostgreSQL functional migration test is included but requires `PG_TEST_URL` in CI/local infrastructure.

## Risk
Medium — this adds reversible PostgreSQL DDL; rollback uses the migration Down path to remove the column and owned sequence.

@ops

## Chain Context

| Field | Value |
|---|---|
| Chain | Model routing auto and pinning |
| Tracker PR | #280 |
| Position | 1 of 2 |
| Base | `feat/model-routing-auto-pin-tracker` |
| Depends on | #280 |
| Follow-up | #282 |
| Review budget | 263 / 400 |
| Starts at | Draft tracker branch |
| Ends with | Registry bindings load in stable declaration order |

### Chain overview

```text
develop
 └── #280 Tracker
      └── 📍 #281 Registry order (this PR)
           └── #282 Routing contract
```

### Scope
- Includes: schema migration, repository ordering, and focused tests.
- Excludes: routing-intent behavior, delivered by #282.

### Autonomy checklist
- [x] Pre-commit hook passes
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests cover repository and migration behavior

## Pre-flight checks

| Check | Result |
|---|---|
| Review (reviewer) | ✅ 1 non-blocking suggestion |
| Security (security-scanner) | ✅ no blockers |
| Performance (perf-analyzer) | ✅ no blockers |

<details>
<summary>Non-blocking review notes</summary>

- Legacy NULL positions retain deterministic UUID order; a future batched backfill can be considered separately.
- Re-attaching an existing registry retains its original position; exact re-attach ordering could receive additional regression coverage.
- An index is unnecessary at current junction cardinality but should be reconsidered if consumers bind many registries.

</details>