### PR TITLE
feat(routing): support auto and pinned model selection

### DIFF
--- a/pkg/api/handler/http/proxy/proxy_handler.go
+++ b/pkg/api/handler/http/proxy/proxy_handler.go
@@ -376,8 +376,7 @@ func mapProxyError(err error) (int, httpio.ErrorBody) {
 	case errors.Is(err, appproxy.ErrInvalidRequestPayload):
 		return fiber.StatusBadRequest, httpio.ErrorBody{Error: errCodeInvalidRequest, Message: err.Error()}
 	case errors.Is(err, routingdomain.ErrInvalidModelRef),
-		errors.Is(err, routingdomain.ErrUnknownPoolAlias),
-		errors.Is(err, routingdomain.ErrAmbiguousModel):
+		errors.Is(err, routingdomain.ErrUnknownPoolAlias):
 		return fiber.StatusBadRequest, httpio.ErrorBody{Error: errCodeInvalidModel, Message: err.Error()}
 	case errors.Is(err, routingdomain.ErrModelDenied),
 		errors.Is(err, appproxy.ErrModelNotAllowed):

--- a/pkg/app/proxy/provider_invoker_test.go
+++ b/pkg/app/proxy/provider_invoker_test.go
@@ -224,3 +224,35 @@ func TestProviderInvoke_SourceFormatFromPath(t *testing.T) {
 		assert.Equal(t, "message", anthropicResp.Type, "response adapted back to anthropic")
 	})
 }
+
+func TestProviderInvoke_GeminiUsesDefaultModelAfterAutoRouting(t *testing.T) {
+	const defaultModel = "gemini-2.5-flash"
+	client := providermocks.NewClient(t)
+	client.EXPECT().
+		Completions(mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, config *providers.Config, body []byte) ([]byte, error) {
+			model, err := adapter.ExtractModel(body)
+			require.NoError(t, err)
+			assert.Equal(t, defaultModel, model)
+			assert.Equal(t, defaultModel, config.Model)
+			assert.NotContains(t, string(body), `"auto"`)
+			return []byte(`{"candidates":[]}`), nil
+		}).
+		Once()
+
+	locator := factorymocks.NewProviderLocator(t)
+	locator.EXPECT().Get("google").Return(client, nil).Once()
+
+	inv := appproxy.NewProviderInvoker(locator, adapter.NewRegistry(), newTestLogger())
+	req := &infracontext.RequestContext{
+		Body:          []byte(`{"contents":[]}`),
+		SourceFormat:  string(adapter.FormatGemini),
+		AllowedModels: []string{defaultModel},
+		DefaultModel:  defaultModel,
+	}
+	resp, err := inv.Invoke(context.Background(), apiKeyTarget("google"), req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}

--- a/pkg/app/proxy/routing.go
+++ b/pkg/app/proxy/routing.go
@@ -117,7 +117,14 @@ func modelRefFromRequest(req *infracontext.RequestContext) (string, error) {
 }
 
 func applyIntentToBody(req *infracontext.RequestContext, intent routingdomain.Intent) {
-	if req == nil || intent.IsZero() {
+	if req == nil {
+		return
+	}
+	if intent.IsAuto() {
+		req.Body = adapter.StripModel(req.Body)
+		return
+	}
+	if intent.IsZero() {
 		return
 	}
 	if intent.IsPool() {
@@ -175,7 +182,7 @@ func (f *forwarder) routeBackend(
 			excluded: make(map[ids.RegistryID]struct{}),
 		}, nil
 	}
-	if intent.IsQualified() {
+	if intent.IsQualified() || intent.IsShortModel() {
 		return routedBackend{
 			backend:  candidates.Candidates()[0].Registry,
 			excluded: make(map[ids.RegistryID]struct{}),

--- a/pkg/app/proxy/routing_forwarder_test.go
+++ b/pkg/app/proxy/routing_forwarder_test.go
@@ -17,6 +17,7 @@ package proxy_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	appconsumer "github.com/NeuralTrust/TrustGate/pkg/app/consumer"
@@ -28,6 +29,7 @@ import (
 	roledomain "github.com/NeuralTrust/TrustGate/pkg/domain/role"
 	routingdomain "github.com/NeuralTrust/TrustGate/pkg/domain/routing"
 	infracontext "github.com/NeuralTrust/TrustGate/pkg/infra/context"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/adapter"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/trace"
 	"github.com/stretchr/testify/mock"
 )
@@ -259,7 +261,7 @@ func TestForward_RoleBasedWithoutRolesIs503(t *testing.T) {
 	}
 }
 
-func TestForward_ShortModelAmbiguousAcrossProviders(t *testing.T) {
+func TestForward_ShortModelPinsFirstMatchingProvider(t *testing.T) {
 	gatewayID := ids.New[ids.GatewayKind]()
 	openai := backendFor(gatewayID, "openai")
 	azure := backendFor(gatewayID, "azure")
@@ -269,20 +271,31 @@ func TestForward_ShortModelAmbiguousAcrossProviders(t *testing.T) {
 		azure.ID:  {Allowed: []string{"gpt-5"}},
 	}
 
-	fwd := newTestForwarder(t, proxymocks.NewProviderInvoker(t))
-	_, err := fwd.Forward(context.Background(), appproxy.ForwardInput{
+	invoker := proxymocks.NewProviderInvoker(t)
+	invoker.EXPECT().
+		Invoke(mock.Anything, mock.MatchedBy(func(bk *registrydomain.Registry) bool {
+			return bk.ID == openai.ID
+		}), mock.Anything).
+		Return(&appproxy.ProviderResponse{StatusCode: 200, Body: []byte("ok")}, nil).
+		Once()
+
+	fwd := newTestForwarder(t, invoker)
+	res, err := fwd.Forward(context.Background(), appproxy.ForwardInput{
 		GatewayID: gatewayID,
 		Consumer:  rc,
 		Request: &infracontext.RequestContext{
 			Body: []byte(`{"model":"gpt-5"}`),
 		},
 	})
-	if !errors.Is(err, routingdomain.ErrAmbiguousModel) {
-		t.Fatalf("expected ErrAmbiguousModel, got %v", err)
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+	if res.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", res.StatusCode)
 	}
 }
 
-func TestForward_ShortModelSingleProviderKeepsBalancing(t *testing.T) {
+func TestForward_ShortModelPinsFirstMatchingRegistry(t *testing.T) {
 	gatewayID := ids.New[ids.GatewayKind]()
 	a := backendFor(gatewayID, "openai")
 	b := backendFor(gatewayID, "openai")
@@ -294,7 +307,9 @@ func TestForward_ShortModelSingleProviderKeepsBalancing(t *testing.T) {
 
 	invoker := proxymocks.NewProviderInvoker(t)
 	invoker.EXPECT().
-		Invoke(mock.Anything, mock.Anything, mock.Anything).
+		Invoke(mock.Anything, mock.MatchedBy(func(bk *registrydomain.Registry) bool {
+			return bk.ID == a.ID
+		}), mock.Anything).
 		Return(&appproxy.ProviderResponse{StatusCode: 200, Body: []byte("ok")}, nil).
 		Once()
 
@@ -304,6 +319,106 @@ func TestForward_ShortModelSingleProviderKeepsBalancing(t *testing.T) {
 		Consumer:  rc,
 		Request: &infracontext.RequestContext{
 			Body: []byte(`{"model":"gpt-5"}`),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+	if res.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", res.StatusCode)
+	}
+}
+
+func TestForward_AutoUsesLoadBalancerAndStripsSentinel(t *testing.T) {
+	gatewayID := ids.New[ids.GatewayKind]()
+	a := backendFor(gatewayID, "openai")
+	b := backendFor(gatewayID, "anthropic")
+	withoutDefault := backendFor(gatewayID, "mistral")
+	rc := routableConsumerWith(gatewayID, a, b, withoutDefault)
+	rc.Consumer.ModelPolicies = domainconsumer.ModelPolicies{
+		a.ID:              {Allowed: []string{"gpt-5"}, Default: "gpt-5"},
+		b.ID:              {Allowed: []string{"claude-4"}, Default: "claude-4"},
+		withoutDefault.ID: {Allowed: []string{"mistral-large"}},
+	}
+
+	wantDefaults := map[ids.RegistryID]string{
+		a.ID: "gpt-5",
+		b.ID: "claude-4",
+	}
+	invocations := make(map[ids.RegistryID]int)
+	invoker := proxymocks.NewProviderInvoker(t)
+	invoker.EXPECT().
+		Invoke(mock.Anything, mock.Anything, mock.Anything).
+		Run(func(_ context.Context, bk *registrydomain.Registry, req *infracontext.RequestContext) {
+			if strings.Contains(string(req.Body), `"auto"`) {
+				t.Fatalf("auto sentinel reached provider body: %s", req.Body)
+			}
+			wantDefault, ok := wantDefaults[bk.ID]
+			if !ok {
+				t.Fatalf("auto selected registry without a default model: %s", bk.ID)
+			}
+			if req.DefaultModel != wantDefault {
+				t.Fatalf("backend %s default = %q, want %q", bk.ID, req.DefaultModel, wantDefault)
+			}
+			invocations[bk.ID]++
+		}).
+		Return(&appproxy.ProviderResponse{StatusCode: 200, Body: []byte("ok")}, nil).
+		Times(6)
+
+	fwd := newTestForwarder(t, invoker)
+	for range 6 {
+		res, err := fwd.Forward(context.Background(), appproxy.ForwardInput{
+			GatewayID: gatewayID,
+			Consumer:  rc,
+			Request: &infracontext.RequestContext{
+				Body: []byte(`{"model":"auto","messages":[]}`),
+			},
+		})
+		if err != nil {
+			t.Fatalf("Forward: %v", err)
+		}
+		if res.StatusCode != 200 {
+			t.Fatalf("expected 200, got %d", res.StatusCode)
+		}
+	}
+	if len(invocations) != 2 {
+		t.Fatalf("auto must balance across both registries, got invocations %v", invocations)
+	}
+	if invocations[withoutDefault.ID] != 0 {
+		t.Fatalf("registry without default received %d invocations", invocations[withoutDefault.ID])
+	}
+}
+
+func TestForward_GeminiAutoFromPathUsesBackendDefault(t *testing.T) {
+	gatewayID := ids.New[ids.GatewayKind]()
+	google := backendFor(gatewayID, "google")
+	rc := routableConsumerWith(gatewayID, google)
+	rc.Consumer.ModelPolicies = domainconsumer.ModelPolicies{
+		google.ID: {Allowed: []string{"gemini-2.5-flash"}, Default: "gemini-2.5-flash"},
+	}
+
+	invoker := proxymocks.NewProviderInvoker(t)
+	invoker.EXPECT().
+		Invoke(mock.Anything, mock.Anything, mock.Anything).
+		Run(func(_ context.Context, _ *registrydomain.Registry, req *infracontext.RequestContext) {
+			if strings.Contains(string(req.Body), `"auto"`) {
+				t.Fatalf("auto sentinel reached Gemini provider body: %s", req.Body)
+			}
+			if req.DefaultModel != "gemini-2.5-flash" {
+				t.Fatalf("Gemini default = %q, want gemini-2.5-flash", req.DefaultModel)
+			}
+		}).
+		Return(&appproxy.ProviderResponse{StatusCode: 200, Body: []byte("ok")}, nil).
+		Once()
+
+	fwd := newTestForwarder(t, invoker)
+	res, err := fwd.Forward(context.Background(), appproxy.ForwardInput{
+		GatewayID: gatewayID,
+		Consumer:  rc,
+		Request: &infracontext.RequestContext{
+			Path:         "/v1beta/models/auto:generateContent",
+			Body:         []byte(`{"contents":[]}`),
+			SourceFormat: string(adapter.FormatGemini),
 		},
 	})
 	if err != nil {

--- a/pkg/domain/routing/candidate.go
+++ b/pkg/domain/routing/candidate.go
@@ -16,7 +16,6 @@ package routing
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
@@ -139,6 +138,9 @@ func (s *CandidateSet) ResolveIntent(intent Intent) (*CandidateSet, error) {
 	if s == nil || intent.IsZero() {
 		return s, nil
 	}
+	if intent.IsAuto() {
+		return s.resolveAuto()
+	}
 	if intent.IsQualified() {
 		return s.resolveQualified(intent.Provider, intent.Model)
 	}
@@ -146,6 +148,20 @@ func (s *CandidateSet) ResolveIntent(intent Intent) (*CandidateSet, error) {
 		return s.resolveShortModel(intent.Model)
 	}
 	return s, nil
+}
+
+func (s *CandidateSet) resolveAuto() (*CandidateSet, error) {
+	out := NewCandidateSet()
+	for _, c := range s.candidates {
+		if c.Default == "" {
+			continue
+		}
+		out.Add(c)
+	}
+	if out.Len() == 0 {
+		return nil, fmt.Errorf("%w: auto routing requires at least one registry with a default model", ErrModelDenied)
+	}
+	return out, nil
 }
 
 func (s *CandidateSet) resolveQualified(provider, model string) (*CandidateSet, error) {
@@ -172,38 +188,16 @@ func (s *CandidateSet) resolveQualified(provider, model string) (*CandidateSet, 
 }
 
 func (s *CandidateSet) resolveShortModel(model string) (*CandidateSet, error) {
-	providers := make(map[string]struct{})
-	matches := make([]Candidate, 0, len(s.candidates))
+	out := NewCandidateSet()
 	for _, c := range s.candidates {
 		if !c.AllowsModel(model) {
 			continue
 		}
-		providers[strings.ToLower(c.Registry.Provider())] = struct{}{}
-		matches = append(matches, c)
+		c.Model = model
+		out.Add(c)
 	}
-	switch len(providers) {
-	case 0:
+	if out.Len() == 0 {
 		return nil, fmt.Errorf("%w: model %q is not allowed for this consumer", ErrModelDenied, model)
-	case 1:
-		out := NewCandidateSet()
-		for _, c := range matches {
-			c.Model = model
-			out.Add(c)
-		}
-		return out, nil
-	default:
-		return nil, fmt.Errorf(
-			"%w: model %q is available from multiple providers, use one of: %s",
-			ErrAmbiguousModel, model, strings.Join(qualifiedAlternatives(providers, model), ", "),
-		)
 	}
-}
-
-func qualifiedAlternatives(providers map[string]struct{}, model string) []string {
-	out := make([]string, 0, len(providers))
-	for provider := range providers {
-		out = append(out, qualifiedPrefix+provider+"/"+model)
-	}
-	sort.Strings(out)
-	return out
+	return out, nil
 }

--- a/pkg/domain/routing/candidate_test.go
+++ b/pkg/domain/routing/candidate_test.go
@@ -16,7 +16,6 @@ package routing_test
 
 import (
 	"errors"
-	"strings"
 	"testing"
 
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
@@ -149,22 +148,27 @@ func TestCandidateSet_ResolveShortModelSingleProvider(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if out.Len() != 2 {
-		t.Fatalf("same-provider registries must stay balanceable, got %d", out.Len())
+		t.Fatalf("expected both matching registries, got %d", out.Len())
 	}
 }
 
-func TestCandidateSet_ResolveShortModelAmbiguous(t *testing.T) {
+func TestCandidateSet_ResolveShortModelPreservesRegistryOrder(t *testing.T) {
 	t.Parallel()
+	openai := newTestRegistry(t, "openai")
+	azure := newTestRegistry(t, "azure")
 	s := routing.NewCandidateSet()
-	s.Add(routing.Candidate{Registry: newTestRegistry(t, "openai"), Allowed: []string{"gpt-5"}})
-	s.Add(routing.Candidate{Registry: newTestRegistry(t, "azure"), Allowed: []string{"gpt-5"}})
+	s.Add(routing.Candidate{Registry: openai, Allowed: []string{"gpt-5"}})
+	s.Add(routing.Candidate{Registry: azure, Allowed: []string{"gpt-5"}})
 
-	_, err := s.ResolveIntent(routing.Intent{Model: "gpt-5"})
-	if !errors.Is(err, routing.ErrAmbiguousModel) {
-		t.Fatalf("expected ErrAmbiguousModel, got %v", err)
+	out, err := s.ResolveIntent(routing.Intent{Model: "gpt-5"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "azure/gpt-5") || !strings.Contains(err.Error(), "openai/gpt-5") {
-		t.Fatalf("error must list qualified alternatives, got %q", err.Error())
+	if out.Len() != 2 {
+		t.Fatalf("expected both matching registries, got %d", out.Len())
+	}
+	if out.Candidates()[0].Registry.ID != openai.ID {
+		t.Fatalf("expected first registry to stay first, got %s", out.Candidates()[0].Registry.ID)
 	}
 }
 
@@ -174,6 +178,37 @@ func TestCandidateSet_ResolveShortModelDenied(t *testing.T) {
 	s.Add(routing.Candidate{Registry: newTestRegistry(t, "openai"), Allowed: []string{"gpt-5"}})
 
 	_, err := s.ResolveIntent(routing.Intent{Model: "claude-4"})
+	if !errors.Is(err, routing.ErrModelDenied) {
+		t.Fatalf("expected ErrModelDenied, got %v", err)
+	}
+}
+
+func TestCandidateSet_ResolveAutoFiltersRegistriesWithoutDefaults(t *testing.T) {
+	t.Parallel()
+	withDefault := newTestRegistry(t, "openai")
+	withoutDefault := newTestRegistry(t, "anthropic")
+	s := routing.NewCandidateSet()
+	s.Add(routing.Candidate{Registry: withoutDefault, Allowed: []string{"claude-4"}})
+	s.Add(routing.Candidate{Registry: withDefault, Allowed: []string{"gpt-5"}, Default: "gpt-5"})
+
+	out, err := s.ResolveIntent(routing.Intent{Auto: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Len() != 1 || !out.HasRegistry(withDefault.ID) {
+		t.Fatalf("auto candidates = %v, want only %s", out.Registries(), withDefault.ID)
+	}
+}
+
+func TestCandidateSet_ResolveAutoDeniedWithoutDefaults(t *testing.T) {
+	t.Parallel()
+	s := routing.NewCandidateSet()
+	s.Add(routing.Candidate{
+		Registry: newTestRegistry(t, "openai"),
+		Allowed:  []string{"gpt-5"},
+	})
+
+	_, err := s.ResolveIntent(routing.Intent{Auto: true})
 	if !errors.Is(err, routing.ErrModelDenied) {
 		t.Fatalf("expected ErrModelDenied, got %v", err)
 	}

--- a/pkg/domain/routing/errors.go
+++ b/pkg/domain/routing/errors.go
@@ -24,5 +24,8 @@ import (
 var (
 	ErrInvalidModelRef  = fmt.Errorf("routing: invalid model reference: %w", commonerrors.ErrValidation)
 	ErrUnknownPoolAlias = fmt.Errorf("routing: unknown pool alias: %w", commonerrors.ErrValidation)
+	// ErrAmbiguousModel is retained for source compatibility.
+	// Deprecated: short model references now pin the first eligible registry.
+	ErrAmbiguousModel = fmt.Errorf("routing: ambiguous model: %w", commonerrors.ErrValidation)
 	ErrModelDenied      = errors.New("routing: model denied")
 )

--- a/pkg/domain/routing/errors.go
+++ b/pkg/domain/routing/errors.go
@@ -24,6 +24,5 @@ import (
 var (
 	ErrInvalidModelRef  = fmt.Errorf("routing: invalid model reference: %w", commonerrors.ErrValidation)
 	ErrUnknownPoolAlias = fmt.Errorf("routing: unknown pool alias: %w", commonerrors.ErrValidation)
-	ErrAmbiguousModel   = fmt.Errorf("routing: ambiguous model: %w", commonerrors.ErrValidation)
 	ErrModelDenied      = errors.New("routing: model denied")
 )

--- a/pkg/domain/routing/intent.go
+++ b/pkg/domain/routing/intent.go
@@ -22,12 +22,14 @@ import (
 const (
 	poolPrefix      = "pool:"
 	qualifiedPrefix = "@"
+	autoKeyword     = "auto"
 )
 
 type Intent struct {
 	Provider  string
 	Model     string
 	PoolAlias string
+	Auto      bool
 }
 
 func (i Intent) IsZero() bool {
@@ -43,13 +45,20 @@ func (i Intent) IsQualified() bool {
 }
 
 func (i Intent) IsShortModel() bool {
-	return i.Provider == "" && i.Model != "" && i.PoolAlias == ""
+	return i.Provider == "" && i.Model != "" && i.PoolAlias == "" && !i.Auto
+}
+
+func (i Intent) IsAuto() bool {
+	return i.Auto
 }
 
 func ParseModelRef(ref string) (Intent, error) {
 	ref = strings.TrimSpace(ref)
 	if ref == "" {
 		return Intent{}, nil
+	}
+	if strings.EqualFold(ref, autoKeyword) {
+		return Intent{Auto: true}, nil
 	}
 	if strings.HasPrefix(strings.ToLower(ref), poolPrefix) {
 		alias := strings.TrimSpace(ref[len(poolPrefix):])

--- a/pkg/domain/routing/intent_test.go
+++ b/pkg/domain/routing/intent_test.go
@@ -31,6 +31,8 @@ func TestParseModelRef(t *testing.T) {
 	}{
 		{"empty is zero intent", "", routing.Intent{}, nil},
 		{"whitespace is zero intent", "   ", routing.Intent{}, nil},
+		{"auto", "auto", routing.Intent{Auto: true}, nil},
+		{"auto is case insensitive", "AUTO", routing.Intent{Auto: true}, nil},
 		{"qualified provider model", "@openai/gpt-5", routing.Intent{Provider: "openai", Model: "gpt-5"}, nil},
 		{"provider is lowercased", "@OpenAI/gpt-5", routing.Intent{Provider: "openai", Model: "gpt-5"}, nil},
 		{"model keeps nested slashes", "@openrouter/meta-llama/llama-3-70b", routing.Intent{Provider: "openrouter", Model: "meta-llama/llama-3-70b"}, nil},
@@ -83,5 +85,9 @@ func TestRoutingIntentPredicates(t *testing.T) {
 	pool := routing.Intent{PoolAlias: "fast"}
 	if !pool.IsPool() || pool.IsZero() {
 		t.Fatal("pool intent predicates mismatch")
+	}
+	auto := routing.Intent{Auto: true}
+	if !auto.IsAuto() || auto.IsZero() || auto.IsShortModel() || auto.IsQualified() || auto.IsPool() {
+		t.Fatal("auto intent predicates mismatch")
 	}
 }

--- a/pkg/infra/database/migrations/20260723110000_add_consumer_registry_position.go
+++ b/pkg/infra/database/migrations/20260723110000_add_consumer_registry_position.go
@@ -1,0 +1,52 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrations
+
+import (
+	"context"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/database"
+	"github.com/jackc/pgx/v5"
+)
+
+func init() {
+	database.RegisterMigration(database.Migration{
+		ID:   "20260723110000_add_consumer_registry_position",
+		Name: "preserve consumer registry insertion order",
+		Up:   upConsumerRegistryPosition,
+		Down: downConsumerRegistryPosition,
+	})
+}
+
+func upConsumerRegistryPosition(ctx context.Context, tx pgx.Tx) error {
+	const ddl = `
+		CREATE SEQUENCE IF NOT EXISTS consumer_registry_position_seq;
+
+		ALTER TABLE consumer_registry ADD COLUMN IF NOT EXISTS position BIGINT;
+
+		ALTER SEQUENCE consumer_registry_position_seq OWNED BY consumer_registry.position;
+		ALTER TABLE consumer_registry
+			ALTER COLUMN position SET DEFAULT nextval('consumer_registry_position_seq');`
+	_, err := tx.Exec(ctx, ddl)
+	return err
+}
+
+func downConsumerRegistryPosition(ctx context.Context, tx pgx.Tx) error {
+	const ddl = `
+		ALTER TABLE consumer_registry DROP COLUMN IF EXISTS position;
+		DROP SEQUENCE IF EXISTS consumer_registry_position_seq;`
+	_, err := tx.Exec(ctx, ddl)
+	return err
+}

--- a/pkg/infra/database/migrations/20260723110000_add_consumer_registry_position_test.go
+++ b/pkg/infra/database/migrations/20260723110000_add_consumer_registry_position_test.go
@@ -1,0 +1,181 @@
+//go:build functional
+
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrations
+
+import (
+	"context"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+func TestConsumerRegistryPositionMigration(t *testing.T) {
+	dsn := os.Getenv("PG_TEST_URL")
+	if dsn == "" {
+		t.Skip("PG_TEST_URL not set")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	conn, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer func() { _ = conn.Close(context.Background()) }()
+
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer func() { _ = tx.Rollback(context.Background()) }()
+
+	const consumerID = "00000000-0000-0000-0000-000000000100"
+	const registryOne = "00000000-0000-0000-0000-000000000001"
+	const registryTwo = "00000000-0000-0000-0000-000000000002"
+	const registryThree = "00000000-0000-0000-0000-000000000003"
+	const registryFour = "00000000-0000-0000-0000-000000000004"
+
+	const setup = `
+		CREATE TEMP TABLE consumer_registry (
+			consumer_id UUID NOT NULL,
+			registry_id UUID NOT NULL,
+			weight INT NOT NULL DEFAULT 1,
+			PRIMARY KEY (consumer_id, registry_id)
+		) ON COMMIT DROP;
+		SET LOCAL search_path TO pg_temp;
+		INSERT INTO consumer_registry (consumer_id, registry_id) VALUES
+			($1, $2),
+			($1, $3),
+			($1, $4);`
+	if _, err := tx.Exec(ctx, setup, consumerID, registryThree, registryOne, registryTwo); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	if err := upConsumerRegistryPosition(ctx, tx); err != nil {
+		t.Fatalf("up: %v", err)
+	}
+	assertConsumerRegistryPositionObjects(t, ctx, tx, true)
+	assertRegistryOrder(t, ctx, tx, []string{registryOne, registryTwo, registryThree})
+	assertNullPositionCount(t, ctx, tx, 3)
+
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO consumer_registry (consumer_id, registry_id) VALUES ($1, $2)`,
+		consumerID,
+		registryFour,
+	); err != nil {
+		t.Fatalf("legacy insert: %v", err)
+	}
+	assertRegistryOrder(t, ctx, tx, []string{registryOne, registryTwo, registryThree, registryFour})
+	var appendedPosition int64
+	if err := tx.QueryRow(ctx,
+		`SELECT position FROM consumer_registry WHERE registry_id = $1`,
+		registryFour,
+	).Scan(&appendedPosition); err != nil {
+		t.Fatalf("read appended position: %v", err)
+	}
+	if appendedPosition != 1 {
+		t.Fatalf("appended position = %d, want 1", appendedPosition)
+	}
+
+	if err := downConsumerRegistryPosition(ctx, tx); err != nil {
+		t.Fatalf("down: %v", err)
+	}
+	assertConsumerRegistryPositionObjects(t, ctx, tx, false)
+
+	if err := upConsumerRegistryPosition(ctx, tx); err != nil {
+		t.Fatalf("reapply: %v", err)
+	}
+	assertConsumerRegistryPositionObjects(t, ctx, tx, true)
+	assertRegistryOrder(t, ctx, tx, []string{registryOne, registryTwo, registryThree, registryFour})
+	assertNullPositionCount(t, ctx, tx, 4)
+}
+
+func assertRegistryOrder(
+	t *testing.T,
+	ctx context.Context,
+	tx pgx.Tx,
+	wantRegistries []string,
+) {
+	t.Helper()
+	var registries []string
+	if err := tx.QueryRow(ctx, `
+		SELECT array_agg(registry_id::text ORDER BY position NULLS FIRST, registry_id)
+		  FROM consumer_registry`,
+	).Scan(&registries); err != nil {
+		t.Fatalf("read registry order: %v", err)
+	}
+	if !reflect.DeepEqual(registries, wantRegistries) {
+		t.Fatalf("registries = %v, want %v", registries, wantRegistries)
+	}
+}
+
+func assertNullPositionCount(t *testing.T, ctx context.Context, tx pgx.Tx, want int) {
+	t.Helper()
+	var count int
+	if err := tx.QueryRow(ctx,
+		`SELECT COUNT(*) FROM consumer_registry WHERE position IS NULL`,
+	).Scan(&count); err != nil {
+		t.Fatalf("count null positions: %v", err)
+	}
+	if count != want {
+		t.Fatalf("null positions = %d, want %d", count, want)
+	}
+}
+
+func assertConsumerRegistryPositionObjects(t *testing.T, ctx context.Context, tx pgx.Tx, want bool) {
+	t.Helper()
+	var hasColumn bool
+	var hasSequence bool
+	var ownsSequence bool
+	if err := tx.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			  FROM pg_attribute
+			 WHERE attrelid = 'consumer_registry'::regclass
+			   AND attname = 'position'
+			   AND NOT attisdropped
+		),
+		to_regclass('consumer_registry_position_seq') IS NOT NULL,
+		EXISTS (
+			SELECT 1
+			  FROM pg_depend d
+			  JOIN pg_class seq ON seq.oid = d.objid
+			  JOIN pg_attribute a
+			    ON a.attrelid = d.refobjid
+			   AND a.attnum = d.refobjsubid
+			 WHERE seq.relname = 'consumer_registry_position_seq'
+			   AND d.refobjid = 'consumer_registry'::regclass
+			   AND a.attname = 'position'
+			   AND d.deptype = 'a'
+		)`,
+	).Scan(&hasColumn, &hasSequence, &ownsSequence); err != nil {
+		t.Fatalf("read migration objects: %v", err)
+	}
+	if hasColumn != want || hasSequence != want || ownsSequence != want {
+		t.Fatalf(
+			"position objects = column:%t sequence:%t ownership:%t, want %t",
+			hasColumn,
+			hasSequence,
+			ownsSequence,
+			want,
+		)
+	}
+}

--- a/pkg/infra/repository/consumer/repository.go
+++ b/pkg/infra/repository/consumer/repository.go
@@ -53,7 +53,7 @@ const (
 const consumerSelectColumns = `
 		SELECT c.id, c.gateway_id, c.name, c.type, c.slug, c.routing_mode, c.lb_config, c.fallback, c.model_policies, c.toolkit, c.fail_mode, c.headers, c.active,
 		       c.created_at, c.updated_at,
-		       COALESCE((SELECT array_agg(cb.registry_id ORDER BY cb.registry_id)
+		       COALESCE((SELECT array_agg(cb.registry_id ORDER BY cb.position NULLS FIRST, cb.registry_id)
 		                   FROM consumer_registry cb WHERE cb.consumer_id = c.id), '{}')::uuid[] AS registry_ids,
 		       COALESCE((SELECT json_object_agg(cw.registry_id, cw.weight)
 		                   FROM consumer_registry cw WHERE cw.consumer_id = c.id), '{}')::jsonb AS registry_weights,

--- a/tests/functional/repositories/consumer/repository_test.go
+++ b/tests/functional/repositories/consumer/repository_test.go
@@ -195,6 +195,34 @@ func TestRepository_SaveAndFindByID(t *testing.T) {
 	}
 }
 
+func TestRepository_SavePreservesRegistryOrder(t *testing.T) {
+	f := setupRepo(t)
+	ctx := context.Background()
+	gwID := seedGateway(t, f.gw, "ordered-registries")
+	first := seedRegistry(t, f.be, gwID, "be-first")
+	second := seedRegistry(t, f.be, gwID, "be-second")
+	third := seedRegistry(t, f.be, gwID, "be-third")
+
+	want := []ids.RegistryID{third, first, second}
+	c := validConsumer(t, gwID, "ordered-consumer", want...)
+	if err := f.repo.Save(ctx, c); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := f.repo.FindByID(ctx, c.ID)
+	if err != nil {
+		t.Fatalf("FindByID: %v", err)
+	}
+	if len(got.RegistryIDs) != len(want) {
+		t.Fatalf("RegistryIDs = %v, want %v", got.RegistryIDs, want)
+	}
+	for i := range want {
+		if got.RegistryIDs[i] != want[i] {
+			t.Fatalf("RegistryIDs = %v, want %v", got.RegistryIDs, want)
+		}
+	}
+}
+
 func TestRepository_SaveAndFindByID_RoundTripsFallback(t *testing.T) {
 	f := setupRepo(t)
 	ctx := context.Background()

--- a/tests/functional/routing_intent_test.go
+++ b/tests/functional/routing_intent_test.go
@@ -240,6 +240,45 @@ func TestRoutingIntent_PinVersusLB(t *testing.T) {
 		assert.Equal(t, 0, other.Hits(), "the load balancer must never route a pinned request")
 	})
 
+	t.Run("auto uses the load balancer and each backend default model", func(t *testing.T) {
+		openai := newJSONUpstream(t, "openai-served")
+		compat := newJSONUpstream(t, "compat-served")
+		gatewayID := CreateGateway(t, map[string]any{"slug": uniqueName("autolb-gw")})
+		openaiID := CreateRegistry(t, gatewayID, openaiBackendPayload(uniqueName("be-oai"), openai.URL()))
+		compatID := CreateRegistry(t, gatewayID, openaiCompatibleBackendPayload(uniqueName("be-compat"), compat.URL()))
+		coID := CreateConsumer(t, gatewayID, map[string]any{
+			"name": uniqueName("cons"),
+			"registries": []map[string]any{
+				{"id": openaiID, "model_policies": map[string]any{"allowed": []string{"gpt-4o-mini"}, "default": "gpt-4o-mini"}},
+				{"id": compatID, "model_policies": map[string]any{"allowed": []string{"compat-model"}, "default": "compat-model"}},
+			},
+			"lb_config": map[string]any{
+				"enabled":   true,
+				"algorithm": "round-robin",
+				"members": []map[string]any{
+					{"registry_id": openaiID},
+					{"registry_id": compatID},
+				},
+			},
+		})
+		apiKey := createAndAttachAPIKey(t, gatewayID, coID)
+		path := chatCompletionsPath(t, coID)
+
+		const total = 4
+		for i := 0; i < total; i++ {
+			status, _, body := proxyPost(t, apiKey, path, chatRequestModel("auto"))
+			assert.Equal(t, http.StatusOK, status, "request %d body: %s", i, body)
+		}
+
+		assert.Greater(t, openai.Hits(), 0, "the OpenAI backend must receive traffic")
+		assert.Greater(t, compat.Hits(), 0, "the compatible backend must receive traffic")
+		assert.Equal(t, total, openai.Hits()+compat.Hits())
+		assert.Contains(t, string(openai.LastBody()), `"model":"gpt-4o-mini"`)
+		assert.Contains(t, string(compat.LastBody()), `"model":"compat-model"`)
+		assert.NotContains(t, string(openai.LastBody()), `"model":"auto"`)
+		assert.NotContains(t, string(compat.LastBody()), `"model":"auto"`)
+	})
+
 	t.Run("qualified pin never fails over, even to a same-provider chain", func(t *testing.T) {
 		primary := newFailingUpstream(t, http.StatusInternalServerError)
 		chain := newFailingUpstream(t, http.StatusServiceUnavailable)
@@ -305,7 +344,7 @@ func TestRoutingIntent_ShortModel(t *testing.T) {
 		assert.Equal(t, 0, compatUp.Hits())
 	})
 
-	t.Run("ambiguous short model returns 400 with qualified alternatives", func(t *testing.T) {
+	t.Run("short model shared by providers pins the first registry", func(t *testing.T) {
 		openaiUp := newJSONUpstream(t, "openai-served")
 		compatUp := newJSONUpstream(t, "compat-served")
 		apiKey, path := setupTwoProviderRoute(t, openaiUp, compatUp,
@@ -313,11 +352,10 @@ func TestRoutingIntent_ShortModel(t *testing.T) {
 
 		status, _, body := proxyPost(t, apiKey, path, chatRequestModel("shared-model"))
 
-		assert.Equal(t, http.StatusBadRequest, status, "body: %s", body)
-		assert.Contains(t, string(body), "invalid_model")
-		assert.Contains(t, string(body), "@openai/shared-model")
-		assert.Contains(t, string(body), "@openai_compatible/shared-model")
-		assert.Equal(t, 0, openaiUp.Hits()+compatUp.Hits())
+		assert.Equal(t, http.StatusOK, status, "body: %s", body)
+		assert.Contains(t, string(body), "openai-served")
+		assert.Equal(t, 1, openaiUp.Hits())
+		assert.Equal(t, 0, compatUp.Hits())
 	})
 
 	t.Run("short model outside every allow-list returns 403", func(t *testing.T) {


### PR DESCRIPTION
## What
Adds explicit `auto` model routing, deterministic short-model pinning, and persistent consumer registry order so provider selection remains stable.

## How
- Adds a rolling-compatible, sequence-backed `consumer_registry.position` column and ordered repository reads.
- Parses `auto` case-insensitively and limits load balancing to registries with default models.
- Strips the `auto` sentinel before provider invocation so each backend applies its configured default.
- Pins qualified and short-model intents while leaving pool aliases load-balanced.
- Retains the deprecated exported ambiguity error for source compatibility.
- Covers migration lifecycle, repository ordering, shared models, Gemini routing, and HTTP behavior.

## Testing
- `GOFLAGS=-mod=mod make test`
- `GOFLAGS=-mod=mod go vet ./...`
- `GOFLAGS=-mod=mod make lint`
- Focused routing tests and all pre-commit hooks pass.
- The PostgreSQL functional migration test requires `PG_TEST_URL` in CI/local infrastructure.
- Standard vendor-mode commands are currently blocked by pre-existing grpc drift on `develop` (`go.mod` 1.82.1 vs vendor 1.81.1).

## Risk
Medium — this includes reversible PostgreSQL DDL and intentionally changes bare-model ambiguity from HTTP 400 to deterministic pinning. Rollback is to revert the routing commits and run the migration Down path.

@ops

## Size exception

This PR contains 556 additions and 58 deletions. The scope is intentionally kept together because deterministic short-model pinning depends on persisted registry order, and 181 added lines are isolated migration lifecycle coverage.

## Pre-flight checks

| Check | Result |
|---|---|
| Review (reviewer) | ✅ clean after compatibility fix |
| Security (security-scanner) | ✅ no blockers |
| Performance (perf-analyzer) | ✅ no blockers |

<details>
<summary>Non-blocking review notes</summary>

- Legacy NULL positions retain deterministic UUID order; a future batched backfill can be considered separately.
- `auto` is reserved routing syntax; a provider model named `auto` remains addressable as `@provider/auto`.
- Auto currently reuses the full consumer balancer with exclusions; narrowing the cached pool is a future optimization if registry counts grow.
- Auto body rewriting should be profiled if large auto traffic becomes common.

</details>