### PR TITLE
fix(ci): restore develop promotion pipeline

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,7 +20,7 @@
         "clsx": "^2.1.1",
         "jose": "^6.2.3",
         "lucide-react": "^1.17.0",
-        "next": "^16.2.7",
+        "next": "16.2.11",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-hook-form": "^7.77.0",
@@ -698,15 +698,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.7.tgz",
-      "integrity": "sha512-tMJizPlj6ZYpBMMdK8S0LJufrP4QTdR6pcv9KQ/bVETPAmg0j1mlHE9G2c38UyGHxoBapgwuj7XjbGJ2RcDFOg==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.11.tgz",
+      "integrity": "sha512-0do5A3BJ2gxWr0ZCMcD6BhW+e595jyxdTl3rXTS6lOtD8ektMiW6CO+EPwt1Eca1DBnm90r/7GdiKWBKxH++DA==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.7.tgz",
-      "integrity": "sha512-vm1EDI/pVaBNNiychmxk3fft+OhQPVD9cIM/tReLZIQ3TfQ4kqI9DwKk00dzuS1ulC7icbrzCFrmRRlk9PfNdw==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.11.tgz",
+      "integrity": "sha512-wryL4pjKmDwGv2ox6+GZDFxvmtSRLqApBR8kL1j4+vhB7Z5vJC/zAnXpiR9Xkfzl0AS8WLMnsuGV/UKI67/rrw==",
       "cpu": [
         "arm64"
       ],
@@ -720,9 +720,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.7.tgz",
-      "integrity": "sha512-O3IRSv1ZBL1zs0WrIgefTEcTKFVn+ryxBNe54erJ6KsD+2f/Mmt7g2jOYh8PSBdUwPtKQJuCsTMlZ7tIu2AcsQ==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.11.tgz",
+      "integrity": "sha512-aZl2j4f/fLyjQvOhv0Oe9UaMAQHolYpKhctsoYzplSumKJKPUmgjcf6545aBtysLTcu994TREd0+pSgNE4ohmg==",
       "cpu": [
         "x64"
       ],
@@ -736,11 +736,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.7.tgz",
-      "integrity": "sha512-Re6PZtjBDd0aMU+VcZcC/PrIvj4WhrjDYtMhhCVQamWN4L90EVP0pcEOBQD25prSlw7OzNw5QpHLWMilRLsRNw==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.11.tgz",
+      "integrity": "sha512-5jEriyEnH/LWFy27L2ZG0XaLlyEJIjhsImEsiS9P563PKEVp2BVups/xfOucIrsvVntp11oNcZwjHvaDPYVB5g==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -752,11 +755,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.7.tgz",
-      "integrity": "sha512-qyogG9QtBzWxgJfeGBvOEHI3851gTfCF3wLZ5RDLTBJGAmE9p1qDwKCOdrBrvBzRvYDT+gUDp72pzlSEfAXgNA==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.11.tgz",
+      "integrity": "sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -768,11 +774,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.7.tgz",
-      "integrity": "sha512-Vhe4ZDuBpmMogrGi5D4R2Kq4JAQlj6+wvgaFYy31zfES0zPmt6TLA+cuYpM/OLrPZjo2MYQTHVqNUSCR6+fDZQ==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.11.tgz",
+      "integrity": "sha512-8WgzpaWMs46qJT9kiV47cje86L0x/Mu9t8/Gwj+pnbgW3rETVfCnaScPjlYUwNScpOozdcIMHWmAvuZJUonR2w==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -784,11 +793,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.7.tgz",
-      "integrity": "sha512-srvian89JahFLw1YLBEuhvPJ0DO5lpUeJQMXy4xYo7g628ZlNgXdNkqoxSAv9OYrBfByh6vxISMwW/mRbzCY+g==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.11.tgz",
+      "integrity": "sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -800,9 +812,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.7.tgz",
-      "integrity": "sha512-GX3wvLpULFuRFJzwHaKfm7QZJ18F4ZSuxlPJ96BoBglCzBmdSjyeBKF+ZhWhvL/ckxNfLnNa7bsObO2ipYpszw==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.11.tgz",
+      "integrity": "sha512-n89CjtcThnjrwgJMAiI5xbqwLY51zvwC9tSlArmVndAJLYVl9T9UAdlkXTmZvE++idoXe8KdglQlhNRdUp1c6g==",
       "cpu": [
         "arm64"
       ],
@@ -816,9 +828,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.7.tgz",
-      "integrity": "sha512-J4WlM72NMk076Qsg0jTdK3SNXatlSdnjW7L7oNGLst1tAGjHrJh/FYi+pw9wyIjEtGRKDNzD0zuiY16oWYWVaw==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.11.tgz",
+      "integrity": "sha512-md8CLNggS1Dx9pUgApzps5uAf+N8GN9xywzmNx9vHAWo94HtBwCCqkSnhIrdfQe83Dhz8Lfo/20Nb1Zxal092w==",
       "cpu": [
         "x64"
       ],
@@ -2447,12 +2459,12 @@
       }
     },
     "node_modules/next": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.7.tgz",
-      "integrity": "sha512-eMJxgjRzBaj3olkP4cBamHDXL79A8FC6u1GcsO1D1Tsx8bw/LLXUJCaoajVxtnhD3A1IJqIT8IcRJjgBIPJq4w==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.11.tgz",
+      "integrity": "sha512-B339zaqbyK8cmxhoAvLrcwoabwCP1wz21zSzfqxqXAemTu2BXnH7tQnfcglKv1vnMUIDBc+Hth7XODQriTZiRQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.7",
+        "@next/env": "16.2.11",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -2466,14 +2478,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.7",
-        "@next/swc-darwin-x64": "16.2.7",
-        "@next/swc-linux-arm64-gnu": "16.2.7",
-        "@next/swc-linux-arm64-musl": "16.2.7",
-        "@next/swc-linux-x64-gnu": "16.2.7",
-        "@next/swc-linux-x64-musl": "16.2.7",
-        "@next/swc-win32-arm64-msvc": "16.2.7",
-        "@next/swc-win32-x64-msvc": "16.2.7",
+        "@next/swc-darwin-arm64": "16.2.11",
+        "@next/swc-darwin-x64": "16.2.11",
+        "@next/swc-linux-arm64-gnu": "16.2.11",
+        "@next/swc-linux-arm64-musl": "16.2.11",
+        "@next/swc-linux-x64-gnu": "16.2.11",
+        "@next/swc-linux-x64-musl": "16.2.11",
+        "@next/swc-win32-arm64-msvc": "16.2.11",
+        "@next/swc-win32-x64-msvc": "16.2.11",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
     "clsx": "^2.1.1",
     "jose": "^6.2.3",
     "lucide-react": "^1.17.0",
-    "next": "^16.2.7",
+    "next": "16.2.11",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-hook-form": "^7.77.0",

--- a/tests/functional/proxy_e2e_test.go
+++ b/tests/functional/proxy_e2e_test.go
@@ -318,7 +318,7 @@ func TestProxyE2E_NonStreaming_LB(t *testing.T) {
 
 	const total = 6
 	for i := 0; i < total; i++ {
-		status, headers, body := proxyPost(t, apiKey, path, chatRequest(false))
+		status, headers, body := proxyPost(t, apiKey, path, chatRequestNoModel())
 		assert.Equal(t, http.StatusOK, status, "request %d body: %s", i, body)
 		assert.Equal(t, "openai", headers.Get("X-Selected-Provider"))
 	}
@@ -338,7 +338,9 @@ func TestProxyE2E_Streaming_LB(t *testing.T) {
 	const total = 6
 	servedByA, servedByB := 0, 0
 	for i := 0; i < total; i++ {
-		status, headers, body := proxyPost(t, apiKey, path, chatRequest(true))
+		request := chatRequestNoModel()
+		request["stream"] = true
+		status, headers, body := proxyPost(t, apiKey, path, request)
 		assert.Equal(t, http.StatusOK, status, "request %d body: %s", i, body)
 		assert.Equal(t, "openai", headers.Get("X-Selected-Provider"))
 		assert.Contains(t, string(body), "[DONE]", "request %d must yield a terminated stream", i)
@@ -506,7 +508,7 @@ func TestProxyE2E_Fallback(t *testing.T) {
 		fallback := newJSONUpstream(t, "fallback-served")
 		apiKey, path := setupFallbackRoute(t, primary, fallback, true)
 
-		status, headers, body := proxyPost(t, apiKey, path, chatRequest(false))
+		status, headers, body := proxyPost(t, apiKey, path, chatRequestNoModel())
 
 		assert.Equal(t, http.StatusOK, status, "the fallback must rescue the request, body: %s", body)
 		assert.Contains(t, string(body), "fallback-served")
@@ -520,7 +522,7 @@ func TestProxyE2E_Fallback(t *testing.T) {
 		fallback := newFailingUpstream(t, http.StatusBadGateway)
 		apiKey, path := setupFallbackRoute(t, primary, fallback, true)
 
-		status, _, body := proxyPost(t, apiKey, path, chatRequest(false))
+		status, _, body := proxyPost(t, apiKey, path, chatRequestNoModel())
 
 		assert.Equal(t, http.StatusBadGateway, status, "the final fallback error is relayed, body: %s", body)
 		assert.Equal(t, expectedAttempts(), primary.Hits(), "primary must be fully retried")
@@ -532,7 +534,7 @@ func TestProxyE2E_Fallback(t *testing.T) {
 		fallback := newJSONUpstream(t, "must-not-serve")
 		apiKey, path := setupFallbackRoute(t, primary, fallback, true, "http_5xx")
 
-		status, _, body := proxyPost(t, apiKey, path, chatRequest(false))
+		status, _, body := proxyPost(t, apiKey, path, chatRequestNoModel())
 
 		assert.Equal(t, http.StatusTooManyRequests, status, "the 429 must be relayed verbatim, body: %s", body)
 		assert.Equal(t, expectedAttempts(), primary.Hits(), "primary retries are not gated by triggers")
@@ -544,7 +546,7 @@ func TestProxyE2E_Fallback(t *testing.T) {
 		fallback := newJSONUpstream(t, "rescued-from-429")
 		apiKey, path := setupFallbackRoute(t, primary, fallback, true, "http_429")
 
-		status, _, body := proxyPost(t, apiKey, path, chatRequest(false))
+		status, _, body := proxyPost(t, apiKey, path, chatRequestNoModel())
 
 		assert.Equal(t, http.StatusOK, status, "body: %s", body)
 		assert.Contains(t, string(body), "rescued-from-429")
@@ -556,7 +558,7 @@ func TestProxyE2E_Fallback(t *testing.T) {
 		fallback := newJSONUpstream(t, "rescued-from-timeout")
 		apiKey, path := setupFallbackRoute(t, primary, fallback, true, "timeout")
 
-		status, _, body := proxyPost(t, apiKey, path, chatRequest(false))
+		status, _, body := proxyPost(t, apiKey, path, chatRequestNoModel())
 
 		assert.Equal(t, http.StatusOK, status, "body: %s", body)
 		assert.Contains(t, string(body), "rescued-from-timeout")
@@ -569,7 +571,7 @@ func TestProxyE2E_Fallback(t *testing.T) {
 		fallback := newJSONUpstream(t, "must-not-serve")
 		apiKey, path := setupFallbackRoute(t, primary, fallback, true, "http_5xx")
 
-		status, _, body := proxyPost(t, apiKey, path, chatRequest(false))
+		status, _, body := proxyPost(t, apiKey, path, chatRequestNoModel())
 
 		assert.Equal(t, http.StatusRequestTimeout, status, "the 408 must be relayed verbatim, body: %s", body)
 		assert.Equal(t, expectedAttempts(), primary.Hits(), "primary retries are not gated by triggers")
@@ -581,7 +583,7 @@ func TestProxyE2E_Fallback(t *testing.T) {
 		fallback := newJSONUpstream(t, "must-not-serve")
 		apiKey, path := setupFallbackRoute(t, primary, fallback, false)
 
-		status, _, body := proxyPost(t, apiKey, path, chatRequest(false))
+		status, _, body := proxyPost(t, apiKey, path, chatRequestNoModel())
 
 		assert.Equal(t, http.StatusInternalServerError, status, "body: %s", body)
 		assert.Equal(t, expectedAttempts(), primary.Hits())


### PR DESCRIPTION
## What
Fixes the Functional Tests and Trivy failures blocking the `develop` to `main` promotion in #283.

## How
- Sends model-less payloads in legacy LB and fallback functional tests so short-model pinning does not disable the behavior under test.
- Pins Next.js 16.2.11 and refreshes the lockfile, resolving CVE-2026-64641, CVE-2026-64642, CVE-2026-64645, and CVE-2026-64649.

## Testing
- `GOFLAGS=-mod=mod make test`
- `GOFLAGS=-mod=mod go vet ./...`
- `GOFLAGS=-mod=mod make lint`
- `npm run typecheck`
- `npm run build`
- `npm audit --omit=dev` reports only two moderate PostCSS findings; no HIGH/CRITICAL findings remain.
- Focused functional execution requires PostgreSQL on `localhost:5432`, which is unavailable locally; CI validates these cases.

## Risk
Low — production changes are limited to a patched Next.js release; Go changes only correct test request intent.

Related: #283

Made with [Cursor](https://cursor.com)