### PR TITLE
fix(metrics): populate security engine score labels in gateway events

### DIFF
--- a/pkg/infra/metrics/event_context.go
+++ b/pkg/infra/metrics/event_context.go
@@ -70,6 +70,17 @@ func (e *EventContext) SetDecision(decision string) {
 	e.span.SetDecision(decision)
 }
 
+// SetScore records the detection score and its label on the metrics span. The
+// label is what the analytics Security Engine breakdown groups by, so security
+// plugins should pass the detected category (e.g. the moderation category or the
+// guard signal type) rather than a plugin-internal identifier.
+func (e *EventContext) SetScore(score float64, label string) {
+	if e == nil || e.span == nil {
+		return
+	}
+	e.span.SetScore(score, label)
+}
+
 func (e *EventContext) HasDecision() bool {
 	if e == nil || e.span == nil {
 		return false

--- a/pkg/infra/plugins/azurecontentsafety/data.go
+++ b/pkg/infra/plugins/azurecontentsafety/data.go
@@ -33,3 +33,26 @@ func setExtras(event *metrics.EventContext, data *Data) {
 	}
 	event.SetExtras(data)
 }
+
+// azureSeverityScale is Azure Content Safety's maximum severity level. Scores
+// are normalized to 0..1 so they are comparable with the confidence-style scores
+// other security engines report.
+const azureSeverityScale = 7
+
+// recordScore surfaces the most severe breached category on the metrics span so
+// it feeds the analytics Security Engine breakdown.
+func recordScore(event *metrics.EventContext, breaches []breachedCategory) {
+	if event == nil || len(breaches) == 0 {
+		return
+	}
+	top := breaches[0]
+	for _, b := range breaches[1:] {
+		if b.Severity > top.Severity {
+			top = b
+		}
+	}
+	if top.Category == "" {
+		return
+	}
+	event.SetScore(float64(top.Severity)/azureSeverityScale, top.Category)
+}

--- a/pkg/infra/plugins/azurecontentsafety/data_test.go
+++ b/pkg/infra/plugins/azurecontentsafety/data_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azurecontentsafety
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/trace"
+)
+
+func TestRecordScoreTopBreach(t *testing.T) {
+	t.Parallel()
+	rt := trace.New("t", trace.Metadata{})
+	span := rt.StartSpan(trace.SpanPlugin, PluginName)
+
+	recordScore(metrics.NewEventContext(span), []breachedCategory{
+		{Category: "Hate", Severity: 4, Threshold: 2},
+		{Category: "Violence", Severity: 6, Threshold: 2},
+	})
+
+	attrs := span.PluginAttrsCopy()
+	require.Equal(t, "Violence", attrs.ScoreLabel)
+	require.NotNil(t, attrs.Score)
+	assert.InDelta(t, 6.0/azureSeverityScale, *attrs.Score, 1e-9)
+}
+
+func TestRecordScoreEmptyIsNoOp(t *testing.T) {
+	t.Parallel()
+	rt := trace.New("t", trace.Metadata{})
+	span := rt.StartSpan(trace.SpanPlugin, PluginName)
+
+	recordScore(metrics.NewEventContext(span), nil)
+
+	attrs := span.PluginAttrsCopy()
+	assert.Empty(t, attrs.ScoreLabel)
+	assert.Nil(t, attrs.Score)
+}
+
+func TestRecordScoreNilEventSafe(t *testing.T) {
+	t.Parallel()
+	assert.NotPanics(t, func() {
+		recordScore(nil, []breachedCategory{{Category: "Hate", Severity: 4}})
+	})
+}

--- a/pkg/infra/plugins/azurecontentsafety/plugin.go
+++ b/pkg/infra/plugins/azurecontentsafety/plugin.go
@@ -155,6 +155,7 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 		data.Decision = decisionBlocked
 		data.Breached = breachedNames(breaches)
 		setExtras(in.Event, data)
+		recordScore(in.Event, breaches)
 		appplugins.SetDecisionFromOutcome(in.Event, decisionBlocked)
 		return nil, blockError(cfg.Message, breaches)
 	}
@@ -166,6 +167,9 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 		data.Decision = decisionAllowed
 	}
 	setExtras(in.Event, data)
+	if len(breaches) > 0 {
+		recordScore(in.Event, breaches)
+	}
 	appplugins.SetDecisionFromOutcome(in.Event, data.Decision)
 	return passThrough(), nil
 }

--- a/pkg/infra/plugins/bedrockguardrail/data.go
+++ b/pkg/infra/plugins/bedrockguardrail/data.go
@@ -38,3 +38,21 @@ func setExtras(event *metrics.EventContext, data *Data) {
 	}
 	event.SetExtras(data)
 }
+
+// recordScore surfaces the matched guardrail detection on the metrics span so it
+// feeds the analytics Security Engine breakdown. Bedrock guardrails return no
+// confidence score, so only the label (the matched entity, falling back to the
+// policy) is meaningful and the numeric score stays 0.
+func recordScore(event *metrics.EventContext, data *Data) {
+	if event == nil || data == nil {
+		return
+	}
+	label := data.Name
+	if label == "" {
+		label = data.Policy
+	}
+	if label == "" {
+		return
+	}
+	event.SetScore(0, label)
+}

--- a/pkg/infra/plugins/bedrockguardrail/data_test.go
+++ b/pkg/infra/plugins/bedrockguardrail/data_test.go
@@ -14,10 +14,59 @@
 
 package bedrockguardrail
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/trace"
+)
 
 func TestSetExtrasNilSafe(t *testing.T) {
 	t.Parallel()
 	setExtras(nil, &Data{Decision: "allowed"})
 	setExtras(nil, nil)
+}
+
+func TestRecordScore(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		data      *Data
+		wantSet   bool
+		wantLabel string
+	}{
+		{name: "prefers name", data: &Data{Name: "HATE", Policy: "content"}, wantSet: true, wantLabel: "HATE"},
+		{name: "falls back to policy", data: &Data{Policy: "sensitive_information"}, wantSet: true, wantLabel: "sensitive_information"},
+		{name: "no label", data: &Data{}, wantSet: false},
+		{name: "nil data", data: nil, wantSet: false},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rt := trace.New("t", trace.Metadata{})
+			span := rt.StartSpan(trace.SpanPlugin, PluginName)
+			recordScore(metrics.NewEventContext(span), tc.data)
+
+			attrs := span.PluginAttrsCopy()
+			if !tc.wantSet {
+				if attrs.ScoreLabel != "" || attrs.Score != nil {
+					t.Fatalf("expected no score, got label=%q score=%v", attrs.ScoreLabel, attrs.Score)
+				}
+				return
+			}
+			if attrs.ScoreLabel != tc.wantLabel {
+				t.Fatalf("ScoreLabel = %q, want %q", attrs.ScoreLabel, tc.wantLabel)
+			}
+			if attrs.Score == nil || *attrs.Score != 0 {
+				t.Fatalf("Score = %v, want 0", attrs.Score)
+			}
+		})
+	}
+}
+
+func TestRecordScoreNilEventSafe(t *testing.T) {
+	t.Parallel()
+	recordScore(nil, &Data{Name: "HATE"})
 }

--- a/pkg/infra/plugins/bedrockguardrail/plugin.go
+++ b/pkg/infra/plugins/bedrockguardrail/plugin.go
@@ -190,6 +190,7 @@ func (p *Plugin) runGuardrail(ctx context.Context, in appplugins.ExecInput, cfg 
 
 	if res.block != nil {
 		applyFinding(data, res.block)
+		recordScore(in.Event, data)
 		if appplugins.Blocks(in.Mode) {
 			data.Decision = decisionBlocked
 			setExtras(in.Event, data)
@@ -204,6 +205,7 @@ func (p *Plugin) runGuardrail(ctx context.Context, in appplugins.ExecInput, cfg 
 
 	if res.anonymize != nil {
 		applyFinding(data, res.anonymize)
+		recordScore(in.Event, data)
 		if appplugins.Blocks(in.Mode) {
 			return p.anonymizeEnforce(in, data, out, span, res.anonymize)
 		}

--- a/pkg/infra/plugins/openaimoderation/data.go
+++ b/pkg/infra/plugins/openaimoderation/data.go
@@ -60,3 +60,13 @@ func setExtras(event *metrics.EventContext, data ModerationData) {
 	}
 	event.SetExtras(data)
 }
+
+// recordScore surfaces the dominant moderation category on the metrics span so
+// it feeds the analytics Security Engine breakdown. It no-ops when no category
+// score was produced (e.g. fail-open or empty input).
+func recordScore(event *metrics.EventContext, data ModerationData) {
+	if event == nil || data.MaxScoreCategory == "" {
+		return
+	}
+	event.SetScore(data.MaxScore, data.MaxScoreCategory)
+}

--- a/pkg/infra/plugins/openaimoderation/data_test.go
+++ b/pkg/infra/plugins/openaimoderation/data_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/trace"
 )
 
 func TestSetExtrasNilSafe(t *testing.T) {
@@ -32,6 +33,33 @@ func TestSetExtrasNilSafe(t *testing.T) {
 	assert.NotPanics(t, func() {
 		setExtras(metrics.NewEventContext(nil), ModerationData{Decision: "allowed"})
 	})
+}
+
+func TestRecordScoreSetsMaxCategory(t *testing.T) {
+	t.Parallel()
+	assert.NotPanics(t, func() {
+		recordScore(nil, ModerationData{MaxScoreCategory: "hate", MaxScore: 0.9})
+	})
+
+	rt := trace.New("t", trace.Metadata{})
+	span := rt.StartSpan(trace.SpanPlugin, PluginName)
+	recordScore(metrics.NewEventContext(span), ModerationData{MaxScoreCategory: "hate", MaxScore: 0.87})
+
+	attrs := span.PluginAttrsCopy()
+	require.Equal(t, "hate", attrs.ScoreLabel)
+	require.NotNil(t, attrs.Score)
+	assert.InDelta(t, 0.87, *attrs.Score, 1e-9)
+}
+
+func TestRecordScoreNoCategoryIsNoOp(t *testing.T) {
+	t.Parallel()
+	rt := trace.New("t", trace.Metadata{})
+	span := rt.StartSpan(trace.SpanPlugin, PluginName)
+	recordScore(metrics.NewEventContext(span), ModerationData{MaxScore: 0.5})
+
+	attrs := span.PluginAttrsCopy()
+	assert.Empty(t, attrs.ScoreLabel)
+	assert.Nil(t, attrs.Score)
 }
 
 func TestModerationDataOmitempty(t *testing.T) {

--- a/pkg/infra/plugins/openaimoderation/plugin.go
+++ b/pkg/infra/plugins/openaimoderation/plugin.go
@@ -153,6 +153,7 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 	if len(violations) > 0 && appplugins.Blocks(in.Mode) {
 		data.Decision = decisionBlock
 		setExtras(in.Event, data)
+		recordScore(in.Event, data)
 		appplugins.SetDecisionFromOutcome(in.Event, decisionBlock)
 		return nil, blockError(cfg.Action.Message, violations)
 	}
@@ -163,6 +164,9 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 		data.Decision = decisionAllowed
 	}
 	setExtras(in.Event, data)
+	if len(violations) > 0 {
+		recordScore(in.Event, data)
+	}
 	appplugins.SetDecisionFromOutcome(in.Event, data.Decision)
 	return passThrough(), nil
 }

--- a/pkg/infra/plugins/trustguard/data.go
+++ b/pkg/infra/plugins/trustguard/data.go
@@ -110,5 +110,52 @@ func setExtras(event *metrics.EventContext, data guardData) {
 
 func recordGuardOutcome(event *metrics.EventContext, data guardData) {
 	setExtras(event, data)
+	if scoreLabelWorthy(data.Decision) {
+		if label, score, ok := primaryFinding(data.Findings); ok {
+			event.SetScore(score, label)
+		}
+	}
 	appplugins.SetDecisionFromOutcome(event, data.Decision)
+}
+
+// scoreLabelWorthy reports whether a guard decision represents an actual
+// detection worth surfacing in the Security Engine breakdown. Pass-through
+// outcomes (allowed, failed_open) must not emit a score label.
+func scoreLabelWorthy(decision string) bool {
+	switch decision {
+	case decisionBlocked, decisionReported, decisionTransformed:
+		return true
+	default:
+		return false
+	}
+}
+
+// primaryFinding selects the finding that best represents the guard decision for
+// the Security Engine metric: the enforced detection with the highest
+// confidence, falling back to the highest-confidence signal when nothing was
+// enforced. It returns ok=false when no finding carries a usable signal type.
+func primaryFinding(findings []GuardFinding) (label string, score float64, ok bool) {
+	var enforced, any *GuardFinding
+	for i := range findings {
+		f := &findings[i]
+		if f.Signal == nil || f.Signal.Type == "" {
+			continue
+		}
+		if any == nil || f.Signal.Confidence > any.Signal.Confidence {
+			any = f
+		}
+		if f.Outcome != nil && f.Outcome.Action != "" {
+			if enforced == nil || f.Signal.Confidence > enforced.Signal.Confidence {
+				enforced = f
+			}
+		}
+	}
+	chosen := enforced
+	if chosen == nil {
+		chosen = any
+	}
+	if chosen == nil {
+		return "", 0, false
+	}
+	return chosen.Signal.Type, chosen.Signal.Confidence, true
 }

--- a/pkg/infra/plugins/trustguard/data_test.go
+++ b/pkg/infra/plugins/trustguard/data_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 
 	"github.com/NeuralTrust/TrustGate/pkg/domain/policy"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/trace"
 )
 
 func TestGuardFindingJSONRoundTrip(t *testing.T) {
@@ -77,5 +79,128 @@ func TestGuardOutcomeDecision(t *testing.T) {
 				t.Fatalf("guardOutcomeDecision(%q, %q) = %q, want %q", tc.status, tc.mode, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestScoreLabelWorthy(t *testing.T) {
+	t.Parallel()
+	for _, d := range []string{decisionBlocked, decisionReported, decisionTransformed} {
+		if !scoreLabelWorthy(d) {
+			t.Fatalf("scoreLabelWorthy(%q) = false, want true", d)
+		}
+	}
+	for _, d := range []string{decisionAllowed, decisionFailedOpen, ""} {
+		if scoreLabelWorthy(d) {
+			t.Fatalf("scoreLabelWorthy(%q) = true, want false", d)
+		}
+	}
+}
+
+func TestPrimaryFinding(t *testing.T) {
+	t.Parallel()
+	block := &GuardFindingOutcome{Action: "block"}
+
+	tests := []struct {
+		name      string
+		findings  []GuardFinding
+		wantLabel string
+		wantScore float64
+		wantOK    bool
+	}{
+		{name: "no findings", findings: nil, wantOK: false},
+		{
+			name:     "signal without type is ignored",
+			findings: []GuardFinding{{Signal: &GuardFindingSignal{Confidence: 0.9}}},
+			wantOK:   false,
+		},
+		{
+			name: "prefers enforced over higher-confidence unenforced",
+			findings: []GuardFinding{
+				{Signal: &GuardFindingSignal{Type: "toxicity", Confidence: 0.95}},
+				{Signal: &GuardFindingSignal{Type: "prompt_injection", Confidence: 0.6}, Outcome: block},
+			},
+			wantLabel: "prompt_injection",
+			wantScore: 0.6,
+			wantOK:    true,
+		},
+		{
+			name: "highest confidence among enforced",
+			findings: []GuardFinding{
+				{Signal: &GuardFindingSignal{Type: "toxicity", Confidence: 0.7}, Outcome: block},
+				{Signal: &GuardFindingSignal{Type: "prompt_injection", Confidence: 0.9}, Outcome: block},
+			},
+			wantLabel: "prompt_injection",
+			wantScore: 0.9,
+			wantOK:    true,
+		},
+		{
+			name: "falls back to highest confidence signal",
+			findings: []GuardFinding{
+				{Signal: &GuardFindingSignal{Type: "toxicity", Confidence: 0.4}},
+				{Signal: &GuardFindingSignal{Type: "pii", Confidence: 0.8}},
+			},
+			wantLabel: "pii",
+			wantScore: 0.8,
+			wantOK:    true,
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			label, score, ok := primaryFinding(tc.findings)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !tc.wantOK {
+				return
+			}
+			if label != tc.wantLabel {
+				t.Fatalf("label = %q, want %q", label, tc.wantLabel)
+			}
+			if score != tc.wantScore {
+				t.Fatalf("score = %v, want %v", score, tc.wantScore)
+			}
+		})
+	}
+}
+
+func TestRecordGuardOutcomeSetsScoreLabel(t *testing.T) {
+	t.Parallel()
+	rt := trace.New("t", trace.Metadata{})
+	span := rt.StartSpan(trace.SpanPlugin, PluginName)
+
+	recordGuardOutcome(metrics.NewEventContext(span), guardData{
+		Decision: decisionBlocked,
+		Findings: []GuardFinding{
+			{Signal: &GuardFindingSignal{Type: "prompt_injection", Confidence: 0.93}, Outcome: &GuardFindingOutcome{Action: "block"}},
+		},
+	})
+
+	attrs := span.PluginAttrsCopy()
+	if attrs.ScoreLabel != "prompt_injection" {
+		t.Fatalf("ScoreLabel = %q, want prompt_injection", attrs.ScoreLabel)
+	}
+	if attrs.Score == nil || *attrs.Score != 0.93 {
+		t.Fatalf("Score = %v, want 0.93", attrs.Score)
+	}
+}
+
+func TestRecordGuardOutcomeAllowedHasNoScoreLabel(t *testing.T) {
+	t.Parallel()
+	rt := trace.New("t", trace.Metadata{})
+	span := rt.StartSpan(trace.SpanPlugin, PluginName)
+
+	recordGuardOutcome(metrics.NewEventContext(span), guardData{
+		Decision: decisionAllowed,
+		Findings: []GuardFinding{{Signal: &GuardFindingSignal{Type: "toxicity", Confidence: 0.9}}},
+	})
+
+	attrs := span.PluginAttrsCopy()
+	if attrs.ScoreLabel != "" {
+		t.Fatalf("ScoreLabel = %q, want empty", attrs.ScoreLabel)
+	}
+	if attrs.Score != nil {
+		t.Fatalf("Score = %v, want nil", attrs.Score)
 	}
 }


### PR DESCRIPTION
## Summary

The Analytics **Security Engine** panel was empty for all traffic. Gateway events never carried `score_label`, so DataCore's `trustGateSecurityEngine` query (which filters `policy_chain[].score_label != ''`) always returned zero rows.

Root cause: detection plugins recorded their `decision` and `extras` on the metrics span but **never called a score setter** — in fact `EventContext` did not even expose one. `Span.SetScore` was only ever invoked from a unit test, so `PluginAttrs.ScoreLabel` was always empty in real traffic.

## Fix

- Expose `EventContext.SetScore(score, label)` (delegates to the span).
- Each security engine now emits its detection category + score on **real detections only** (block / report / transform / anonymize), never on pass-through outcomes (allowed / failed_open / failed_closed):

| Plugin | `score_label` | `score` |
|---|---|---|
| `trustguard` | primary finding `Signal.Type` (enforced, highest confidence) | `Signal.Confidence` |
| `openai_moderation` | `MaxScoreCategory` | `MaxScore` |
| `azure_content_safety` | most severe breached category | severity normalized 0..1 (`/7`) |
| `bedrock_guardrail` | matched entity `Name` (fallback `Policy`) | `0` (no confidence from Bedrock) |

No changes needed in DataCore or the frontend — the field was already read and persisted; it was simply never populated.

## Notes / decisions

- The Security Engine breakdown groups by `score_label` + decision only; the numeric `score` is not aggregated there (used for per-event detail), so scale normalization choices don't affect the panel counts.
- Bedrock has no confidence signal, so `score` is `0` and only the label is meaningful.

## Test plan

- [x] `go build ./...`, `go vet`, `golangci-lint run` (0 issues) on touched packages
- [x] Unit tests: `EventContext.SetScore`, `primaryFinding`/`scoreLabelWorthy` (trustguard), `recordScore` (openai/azure/bedrock) — including pass-through outcomes emit no label
- [x] Full pre-commit suite (lint + gosec + tests) green
- [ ] Manual QA: trigger a TrustGuard/moderation detection and confirm the Security Engine panel populates

Made with [Cursor](https://cursor.com)