### PR TITLE
feat: add smart-routing load balancing strategy

### DIFF
--- a/frontend/src/components/entities/consumer-detail.tsx
+++ b/frontend/src/components/entities/consumer-detail.tsx
@@ -34,7 +34,8 @@ type Strategy =
   | "weighted"
   | "least-connections"
   | "random"
-  | "semantic";
+  | "semantic"
+  | "smart";
 
 const STRATEGY_META: Record<Strategy, { label: string; hint: string }> = {
   single: { label: "Single target", hint: "Route every request to the attached registry." },
@@ -53,6 +54,10 @@ const STRATEGY_META: Record<Strategy, { label: string; hint: string }> = {
   },
   random: { label: "Random", hint: "Pick an attached registry at random." },
   semantic: { label: "Semantic", hint: "Route by embedding similarity (requires an embedding model)." },
+  smart: {
+    label: "Smart routing",
+    hint: "Route by message complexity: each tier maps a minimum score to a registry.",
+  },
 };
 
 // A strategy that enables lb_config (anything other than single/fallback).
@@ -70,6 +75,8 @@ function algorithmFor(s: Strategy): Algorithm {
       return "random";
     case "semantic":
       return "semantic";
+    case "smart":
+      return "smart-routing";
     case "single":
     case "fallback":
     case "round-robin":
@@ -89,6 +96,8 @@ function strategyOf(c: Consumer): Strategy {
       return "random";
     case "semantic":
       return "semantic";
+    case "smart-routing":
+      return "smart";
     default:
       return "round-robin";
   }
@@ -328,6 +337,12 @@ function RoutingTab({ consumer, onClose }: { consumer: Consumer; onClose: () => 
   const [embProvider, setEmbProvider] = useState(emb?.provider ?? "");
   const [embModel, setEmbModel] = useState(emb?.model ?? "");
   const [embKey, setEmbKey] = useState("");
+  const [tiers, setTiers] = useState<{ min_score: string; registry_id: string }[]>(() =>
+    (consumer.lb_config?.smart_routing?.tiers ?? []).map((t) => ({
+      min_score: String(t.min_score),
+      registry_id: t.registry_id,
+    })),
+  );
   // Only user edits live in state; the displayed value falls back to the
   // consumer's configured weight, then a default of 1.
   const [weights, setWeights] = useState<Record<string, string>>(() => {
@@ -344,6 +359,17 @@ function RoutingTab({ consumer, onClose }: { consumer: Consumer; onClose: () => 
 
   const meta = STRATEGY_META[strategy];
   const showSemantic = consumer.lb_config?.algorithm === "semantic" || strategy === "semantic";
+  const showSmart = consumer.lb_config?.algorithm === "smart-routing" || strategy === "smart";
+
+  function addTier() {
+    setTiers((prev) => [...prev, { min_score: "", registry_id: "" }]);
+  }
+  function removeTier(index: number) {
+    setTiers((prev) => prev.filter((_, i) => i !== index));
+  }
+  function updateTier(index: number, patch: Partial<{ min_score: string; registry_id: string }>) {
+    setTiers((prev) => prev.map((tier, i) => (i === index ? { ...tier, ...patch } : tier)));
+  }
 
   function displayWeight(r: Registry): string {
     return weights[r.id] ?? String(weightFromConsumer(r.id) ?? 1);
@@ -434,6 +460,21 @@ function RoutingTab({ consumer, onClose }: { consumer: Consumer; onClose: () => 
         return;
       }
 
+      if (strategy === "smart") {
+        const parsed = tiers
+          .map((t) => ({ min_score: Number(t.min_score), registry_id: t.registry_id }))
+          .filter((t) => t.registry_id);
+        if (parsed.length === 0) {
+          toast({ variant: "error", title: "Add at least one smart-routing tier with a registry." });
+          return;
+        }
+        if (parsed.some((t) => Number.isNaN(t.min_score) || t.min_score < 0 || t.min_score > 1)) {
+          toast({ variant: "error", title: "Each tier min score must be between 0 and 1." });
+          return;
+        }
+        lb.smart_routing = { tiers: parsed };
+      }
+
       body.lb_config = lb;
       body.fallback = { enabled: false };
       body.model_policies = poolModelPolicies(consumer, attached);
@@ -508,6 +549,7 @@ function RoutingTab({ consumer, onClose }: { consumer: Consumer; onClose: () => 
             <option value="least-connections">{STRATEGY_META["least-connections"].label}</option>
             <option value="random">{STRATEGY_META.random.label}</option>
             {showSemantic && <option value="semantic">{STRATEGY_META.semantic.label}</option>}
+            {showSmart && <option value="smart">{STRATEGY_META.smart.label}</option>}
           </optgroup>
         </Select>
       </Field>
@@ -664,6 +706,67 @@ function RoutingTab({ consumer, onClose }: { consumer: Consumer; onClose: () => 
           <Field label="API key" hint="leave blank to keep the current key">
             <Input type="password" value={embKey} onChange={(e) => setEmbKey(e.target.value)} placeholder="sk-..." />
           </Field>
+        </div>
+      )}
+
+      {strategy === "smart" && (
+        <div className="rounded-(--radius) border border-border bg-surface-2/30 p-3.5 flex flex-col gap-3">
+          <p className="text-[13px] font-medium text-fg">Complexity tiers</p>
+          <p className="text-[12px] text-muted -mt-1">
+            The tier with the highest min score not above the message score wins. Requests fall back to
+            round robin when the Firewall Complexity API is unavailable.
+          </p>
+          {attached.length === 0 ? (
+            <p className="text-[12px] text-faint">Attach registries first (Bindings tab).</p>
+          ) : (
+            <div className="flex flex-col gap-2">
+              {tiers.map((tier, i) => (
+                <div key={i} className="flex items-end gap-2">
+                  <div className="w-28">
+                    <Field label="Min score">
+                      <Input
+                        type="number"
+                        min={0}
+                        max={1}
+                        step={0.05}
+                        value={tier.min_score}
+                        onChange={(e) => updateTier(i, { min_score: e.target.value })}
+                        placeholder="0.0"
+                      />
+                    </Field>
+                  </div>
+                  <div className="flex-1">
+                    <Field label="Registry">
+                      <Select
+                        value={tier.registry_id}
+                        onChange={(e) => updateTier(i, { registry_id: e.target.value })}
+                      >
+                        <option value="">Select registry…</option>
+                        {attached.map((r) => (
+                          <option key={r.id} value={r.id}>
+                            {r.name}
+                          </option>
+                        ))}
+                      </Select>
+                    </Field>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => removeTier(i)}
+                    aria-label="Remove tier"
+                    className="mb-1 grid size-9 place-items-center rounded-(--radius) border border-border text-muted hover:text-fg"
+                  >
+                    <X className="size-4" />
+                  </button>
+                </div>
+              ))}
+              <div>
+                <Button variant="secondary" onClick={addTier}>
+                  Add tier
+                </Button>
+              </div>
+            </div>
+          )}
         </div>
       )}
         </>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -149,7 +149,8 @@ export type Algorithm =
   | "random"
   | "weighted-round-robin"
   | "least-connections"
-  | "semantic";
+  | "semantic"
+  | "smart-routing";
 
 export interface EmbeddingAuth {
   api_key?: string;
@@ -171,12 +172,22 @@ export interface LBPoolMember {
   models?: string[];
 }
 
+export interface SmartRoutingTier {
+  min_score: number;
+  registry_id: string;
+}
+
+export interface SmartRoutingConfig {
+  tiers: SmartRoutingTier[];
+}
+
 export interface LBConfig {
   enabled: boolean;
   algorithm?: Algorithm;
   pool_alias?: string;
   members?: LBPoolMember[];
   embedding_config?: EmbeddingConfig | null;
+  smart_routing?: SmartRoutingConfig | null;
 }
 
 export interface RegistryWeight {

--- a/pkg/api/handler/http/consumer/request/create_consumer_request.go
+++ b/pkg/api/handler/http/consumer/request/create_consumer_request.go
@@ -100,11 +100,21 @@ type FallbackBudgetRequest struct {
 }
 
 type LBConfigRequest struct {
-	Enabled         bool                    `json:"enabled"`
-	Algorithm       string                  `json:"algorithm,omitempty"`
-	PoolAlias       string                  `json:"pool_alias,omitempty"`
-	Members         []LBPoolMemberRequest   `json:"members,omitempty"`
-	EmbeddingConfig *EmbeddingConfigRequest `json:"embedding_config,omitempty"`
+	Enabled         bool                       `json:"enabled"`
+	Algorithm       string                     `json:"algorithm,omitempty"`
+	PoolAlias       string                     `json:"pool_alias,omitempty"`
+	Members         []LBPoolMemberRequest      `json:"members,omitempty"`
+	EmbeddingConfig *EmbeddingConfigRequest    `json:"embedding_config,omitempty"`
+	SmartRouting    *SmartRoutingConfigRequest `json:"smart_routing,omitempty"`
+}
+
+type SmartRoutingConfigRequest struct {
+	Tiers []SmartRoutingTierRequest `json:"tiers"`
+}
+
+type SmartRoutingTierRequest struct {
+	MinScore   float64 `json:"min_score"`
+	RegistryID string  `json:"registry_id"`
 }
 
 type LBPoolMemberRequest struct {
@@ -150,6 +160,24 @@ type APIKeyAuthRequest struct {
 	ParamName     string `json:"param_name,omitempty"`
 	ParamValue    string `json:"param_value,omitempty"`
 	ParamLocation string `json:"param_location,omitempty"`
+}
+
+func (s *SmartRoutingConfigRequest) ToDomain() (*registrydomain.SmartRoutingConfig, error) {
+	if s == nil {
+		return nil, nil
+	}
+	tiers := make([]registrydomain.SmartRoutingTier, 0, len(s.Tiers))
+	for i, tier := range s.Tiers {
+		registryID, err := ids.Parse[ids.RegistryKind](tier.RegistryID)
+		if err != nil {
+			return nil, fmt.Errorf("lb_config.smart_routing.tiers[%d]: invalid registry_id %q: %w", i, tier.RegistryID, commonerrors.ErrValidation)
+		}
+		tiers = append(tiers, registrydomain.SmartRoutingTier{
+			MinScore:   tier.MinScore,
+			RegistryID: registryID,
+		})
+	}
+	return &registrydomain.SmartRoutingConfig{Tiers: tiers}, nil
 }
 
 func (e *EmbeddingConfigRequest) ToDomain() *registrydomain.EmbeddingConfig {
@@ -294,12 +322,17 @@ func (r *LBConfigRequest) ToDomain() (*domain.LBConfig, error) {
 			Models:     member.Models,
 		})
 	}
+	smartRouting, err := r.SmartRouting.ToDomain()
+	if err != nil {
+		return nil, err
+	}
 	return &domain.LBConfig{
 		Enabled:         r.Enabled,
 		Algorithm:       r.Algorithm,
 		PoolAlias:       r.PoolAlias,
 		Members:         members,
 		EmbeddingConfig: r.EmbeddingConfig.ToDomain(),
+		SmartRouting:    smartRouting,
 	}, nil
 }
 

--- a/pkg/api/handler/http/consumer/response/consumer_response.go
+++ b/pkg/api/handler/http/consumer/response/consumer_response.go
@@ -66,11 +66,21 @@ type ModelPolicyResponse struct {
 }
 
 type LBConfigResponse struct {
-	Enabled         bool                     `json:"enabled"`
-	Algorithm       string                   `json:"algorithm,omitempty"`
-	PoolAlias       string                   `json:"pool_alias,omitempty"`
-	Members         []LBPoolMemberResponse   `json:"members,omitempty"`
-	EmbeddingConfig *EmbeddingConfigResponse `json:"embedding_config,omitempty"`
+	Enabled         bool                        `json:"enabled"`
+	Algorithm       string                      `json:"algorithm,omitempty"`
+	PoolAlias       string                      `json:"pool_alias,omitempty"`
+	Members         []LBPoolMemberResponse      `json:"members,omitempty"`
+	EmbeddingConfig *EmbeddingConfigResponse    `json:"embedding_config,omitempty"`
+	SmartRouting    *SmartRoutingConfigResponse `json:"smart_routing,omitempty"`
+}
+
+type SmartRoutingConfigResponse struct {
+	Tiers []SmartRoutingTierResponse `json:"tiers"`
+}
+
+type SmartRoutingTierResponse struct {
+	MinScore   float64        `json:"min_score"`
+	RegistryID ids.RegistryID `json:"registry_id"`
 }
 
 type LBPoolMemberResponse struct {
@@ -183,7 +193,22 @@ func fromLBConfig(config *domain.LBConfig) *LBConfigResponse {
 		PoolAlias:       config.PoolAlias,
 		Members:         members,
 		EmbeddingConfig: embedding,
+		SmartRouting:    fromSmartRouting(config.SmartRouting),
 	}
+}
+
+func fromSmartRouting(config *registrydomain.SmartRoutingConfig) *SmartRoutingConfigResponse {
+	if config == nil {
+		return nil
+	}
+	tiers := make([]SmartRoutingTierResponse, 0, len(config.Tiers))
+	for _, tier := range config.Tiers {
+		tiers = append(tiers, SmartRoutingTierResponse{
+			MinScore:   tier.MinScore,
+			RegistryID: tier.RegistryID,
+		})
+	}
+	return &SmartRoutingConfigResponse{Tiers: tiers}
 }
 
 func fromToolkit(t domain.Toolkit) []ToolkitEntryResponse {

--- a/pkg/app/proxy/forwarder_test.go
+++ b/pkg/app/proxy/forwarder_test.go
@@ -91,7 +91,7 @@ func newTestForwarder(t *testing.T, invoker appproxy.ProviderInvoker) appproxy.F
 func newTestForwarderWithLimiter(t *testing.T, invoker appproxy.ProviderInvoker, limiter ratelimitapp.Checker) appproxy.Forwarder {
 	mgr := cache.NewTTLMapManager(time.Minute)
 	return appproxy.NewForwarder(
-		loadbalancer.NewBaseFactory(nil, nil),
+		loadbalancer.NewBaseFactory(nil, nil, nil, nil),
 		newPermissiveCache(t), mgr, invoker, nil, nil, approuting.NewResolver(), limiter, nil, newTestLogger(),
 	)
 }
@@ -112,7 +112,7 @@ func (f *fakeSessionStore) LastTurnID(_ context.Context, _, _ string) string {
 func newTestForwarderWithStore(t *testing.T, invoker appproxy.ProviderInvoker, store appsession.Store) appproxy.Forwarder {
 	mgr := cache.NewTTLMapManager(time.Minute)
 	return appproxy.NewForwarder(
-		loadbalancer.NewBaseFactory(nil, nil),
+		loadbalancer.NewBaseFactory(nil, nil, nil, nil),
 		newPermissiveCache(t), mgr, invoker, nil, store, approuting.NewResolver(), nil, nil, newTestLogger(),
 	)
 }

--- a/pkg/app/proxy/load_balancer_cache.go
+++ b/pkg/app/proxy/load_balancer_cache.go
@@ -57,13 +57,14 @@ func newLoadBalancerCache(
 func (c *loadBalancerCache) For(rc *appconsumer.RoutableConsumer) (*loadbalancer.LoadBalancer, error) {
 	key := loadBalancerCacheKey(rc.Consumer.GatewayID, rc.Consumer.ID)
 	return c.getOrBuild(key, func() loadbalancer.Pool {
-		lbAlgorithm, embeddingConfig := lbSettings(rc)
+		lbAlgorithm, embeddingConfig, smartRouting := lbSettings(rc)
 		return loadbalancer.Pool{
-			ID:              key,
-			Registries:      rc.Registries,
-			Weights:         rc.Consumer.RegistryWeights,
-			Algorithm:       lbAlgorithm,
-			EmbeddingConfig: embeddingConfig,
+			ID:                 key,
+			Registries:         rc.Registries,
+			Weights:            rc.Consumer.RegistryWeights,
+			Algorithm:          lbAlgorithm,
+			EmbeddingConfig:    embeddingConfig,
+			SmartRoutingConfig: smartRouting,
 		}
 	})
 }
@@ -75,13 +76,14 @@ func (c *loadBalancerCache) PoolFor(
 ) (*loadbalancer.LoadBalancer, error) {
 	key := poolLoadBalancerCacheKey(rc.Consumer.GatewayID, rc.Consumer.ID, alias)
 	return c.getOrBuild(key, func() loadbalancer.Pool {
-		lbAlgorithm, embeddingConfig := lbSettings(rc)
+		lbAlgorithm, embeddingConfig, smartRouting := lbSettings(rc)
 		return loadbalancer.Pool{
-			ID:              key,
-			Registries:      candidates.Registries(),
-			Weights:         rc.Consumer.RegistryWeights,
-			Algorithm:       lbAlgorithm,
-			EmbeddingConfig: embeddingConfig,
+			ID:                 key,
+			Registries:         candidates.Registries(),
+			Weights:            rc.Consumer.RegistryWeights,
+			Algorithm:          lbAlgorithm,
+			EmbeddingConfig:    embeddingConfig,
+			SmartRoutingConfig: smartRouting,
 		}
 	})
 }
@@ -129,16 +131,18 @@ func (c *loadBalancerCache) cached(key string) (*loadbalancer.LoadBalancer, bool
 	return lb, true
 }
 
-func lbSettings(rc *appconsumer.RoutableConsumer) (string, *domain.EmbeddingConfig) {
+func lbSettings(rc *appconsumer.RoutableConsumer) (string, *domain.EmbeddingConfig, *domain.SmartRoutingConfig) {
 	lbAlgorithm := algorithm.RoundRobin
 	var embeddingConfig *domain.EmbeddingConfig
+	var smartRouting *domain.SmartRoutingConfig
 	if lbCfg := rc.Consumer.LBConfig; lbCfg != nil && lbCfg.Enabled {
 		if lbCfg.Algorithm != "" {
 			lbAlgorithm = lbCfg.Algorithm
 		}
 		embeddingConfig = lbCfg.EmbeddingConfig
+		smartRouting = lbCfg.SmartRouting
 	}
-	return lbAlgorithm, embeddingConfig
+	return lbAlgorithm, embeddingConfig, smartRouting
 }
 
 func loadBalancerCacheKey(gatewayID ids.GatewayID, consumerID ids.ConsumerID) string {

--- a/pkg/app/proxy/plugin_runner_test.go
+++ b/pkg/app/proxy/plugin_runner_test.go
@@ -71,7 +71,7 @@ func forwarderWithPlugin(t *testing.T, invoker appproxy.ProviderInvoker, p apppl
 	exec := appplugins.NewExecutor(reg, newTestLogger())
 	mgr := cache.NewTTLMapManager(time.Minute)
 	return appproxy.NewForwarder(
-		loadbalancer.NewBaseFactory(nil, nil),
+		loadbalancer.NewBaseFactory(nil, nil, nil, nil),
 		newPermissiveCache(t), mgr, invoker, exec, nil, approuting.NewResolver(), nil, nil, newTestLogger(),
 	)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -106,6 +106,8 @@ const (
 
 	defaultTrustGuardTimeout = 15 * time.Second
 
+	defaultFirewallComplexityTimeout = 15 * time.Second
+
 	defaultOpenAIModerationTimeout = 15 * time.Second
 
 	defaultConfigSyncDataPlaneEnabled  = false
@@ -128,26 +130,27 @@ const (
 )
 
 type Config struct {
-	AppEnv           string
-	Server           ServerConfig
-	Database         DatabaseConfig
-	Redis            RedisConfig
-	Cache            CacheConfig
-	SemanticCache    SemanticCacheConfig
-	SessionStore     SessionStoreConfig
-	Kafka            KafkaConfig
-	Telemetry        TelemetryConfig
-	Metrics          MetricsConfig
-	Playground       PlaygroundConfig
-	Upstream         UpstreamConfig
-	Provider         ProviderConfig
-	Catalog          CatalogConfig
-	CORS             CORSConfig
-	Logger           LoggerConfig
-	TrustGuard       TrustGuardConfig
-	OpenAIModeration OpenAIModerationConfig
-	ConfigSync       ConfigSyncConfig
-	RateLimit        RateLimitConfig
+	AppEnv             string
+	Server             ServerConfig
+	Database           DatabaseConfig
+	Redis              RedisConfig
+	Cache              CacheConfig
+	SemanticCache      SemanticCacheConfig
+	SessionStore       SessionStoreConfig
+	Kafka              KafkaConfig
+	Telemetry          TelemetryConfig
+	Metrics            MetricsConfig
+	Playground         PlaygroundConfig
+	Upstream           UpstreamConfig
+	Provider           ProviderConfig
+	Catalog            CatalogConfig
+	CORS               CORSConfig
+	Logger             LoggerConfig
+	TrustGuard         TrustGuardConfig
+	FirewallComplexity FirewallComplexityConfig
+	OpenAIModeration   OpenAIModerationConfig
+	ConfigSync         ConfigSyncConfig
+	RateLimit          RateLimitConfig
 }
 
 const (
@@ -215,12 +218,12 @@ type ServerConfig struct {
 	// Empty disables admin auth token acceptance until resolved. In prod, when
 	// empty at boot, the DI layer auto-provisions a shared value in Redis
 	// (see crypto.ResolveSharedSecretKey) so replicas converge.
-	SecretKey            string
-	GatewayBaseDomain    string
-	MCPBaseDomain        string
-	STSIssuer            string
-	STSSigningKey        string
-	TrustXFCCFrom        []string
+	SecretKey         string
+	GatewayBaseDomain string
+	MCPBaseDomain     string
+	STSIssuer         string
+	STSSigningKey     string
+	TrustXFCCFrom     []string
 }
 
 type DatabaseConfig struct {
@@ -349,6 +352,15 @@ type TrustGuardConfig struct {
 	ClientSecret string
 }
 
+// FirewallComplexityConfig configures the Firewall Complexity API used by the
+// smart-routing load balancer. Token is a static bearer sent in the "token"
+// header; an empty BaseURL or Token disables smart routing at runtime.
+type FirewallComplexityConfig struct {
+	BaseURL string
+	Token   string // #nosec G117 -- config struct field, not a hardcoded credential
+	Timeout time.Duration
+}
+
 type OpenAIModerationConfig struct {
 	BaseURL string
 	Timeout time.Duration
@@ -361,26 +373,27 @@ type RateLimitConfig struct {
 
 func LoadConfig() (*Config, error) {
 	cfg := &Config{
-		AppEnv:           getEnv("APP_ENV", defaultAppEnv),
-		Server:           getServerConfig(),
-		Database:         getDatabaseConfig(),
-		Redis:            getRedisConfig(),
-		Cache:            getCacheConfig(),
-		SemanticCache:    getSemanticCacheConfig(),
-		SessionStore:     getSessionStoreConfig(),
-		Kafka:            getKafkaConfig(),
-		Telemetry:        getTelemetryConfig(),
-		Metrics:          getMetricsConfig(),
-		Playground:       getPlaygroundConfig(),
-		Upstream:         getUpstreamConfig(),
-		Provider:         getProviderConfig(),
-		Catalog:          getCatalogConfig(),
-		CORS:             getCORSConfig(),
-		Logger:           getLoggerConfig(),
-		TrustGuard:       getTrustGuardConfig(),
-		OpenAIModeration: getOpenAIModerationConfig(),
-		ConfigSync:       getConfigSyncConfig(),
-		RateLimit:        getRateLimitConfig(),
+		AppEnv:             getEnv("APP_ENV", defaultAppEnv),
+		Server:             getServerConfig(),
+		Database:           getDatabaseConfig(),
+		Redis:              getRedisConfig(),
+		Cache:              getCacheConfig(),
+		SemanticCache:      getSemanticCacheConfig(),
+		SessionStore:       getSessionStoreConfig(),
+		Kafka:              getKafkaConfig(),
+		Telemetry:          getTelemetryConfig(),
+		Metrics:            getMetricsConfig(),
+		Playground:         getPlaygroundConfig(),
+		Upstream:           getUpstreamConfig(),
+		Provider:           getProviderConfig(),
+		Catalog:            getCatalogConfig(),
+		CORS:               getCORSConfig(),
+		Logger:             getLoggerConfig(),
+		TrustGuard:         getTrustGuardConfig(),
+		FirewallComplexity: getFirewallComplexityConfig(),
+		OpenAIModeration:   getOpenAIModerationConfig(),
+		ConfigSync:         getConfigSyncConfig(),
+		RateLimit:          getRateLimitConfig(),
 	}
 	if err := cfg.Validate(); err != nil {
 		return nil, err
@@ -642,6 +655,14 @@ func getTrustGuardConfig() TrustGuardConfig {
 		Timeout:      getEnvDuration("TRUSTGUARD_TIMEOUT", defaultTrustGuardTimeout),
 		ClientID:     getEnv("TRUSTGUARD_CLIENT_ID", ""),
 		ClientSecret: getEnv("TRUSTGUARD_CLIENT_SECRET", ""),
+	}
+}
+
+func getFirewallComplexityConfig() FirewallComplexityConfig {
+	return FirewallComplexityConfig{
+		BaseURL: getEnv("FIREWALL_COMPLEXITY_BASE_URL", ""),
+		Token:   getEnv("FIREWALL_COMPLEXITY_TOKEN", ""),
+		Timeout: getEnvDuration("FIREWALL_COMPLEXITY_TIMEOUT", defaultFirewallComplexityTimeout),
 	}
 }
 

--- a/pkg/container/modules/loadbalancer.go
+++ b/pkg/container/modules/loadbalancer.go
@@ -15,11 +15,16 @@
 package modules
 
 import (
+	"log/slog"
+
+	"github.com/NeuralTrust/TrustGate/pkg/config"
 	"github.com/NeuralTrust/TrustGate/pkg/container"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/embedding"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/complexity"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/embedding/factory"
 	embeddingopenai "github.com/NeuralTrust/TrustGate/pkg/infra/embedding/openai"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/loadbalancer"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/loadbalancer/strategies"
 	"go.uber.org/dig"
 )
 
@@ -27,6 +32,8 @@ type loadBalancerParams struct {
 	dig.In
 	EmbeddingRepo  embedding.Repository            `optional:"true"`
 	ServiceLocator factory.EmbeddingServiceLocator `optional:"true"`
+	Complexity     strategies.ComplexityScorer
+	Logger         *slog.Logger
 }
 
 func LoadBalancer(c *container.Container) error {
@@ -37,7 +44,16 @@ func LoadBalancer(c *container.Container) error {
 	}); err != nil {
 		return err
 	}
+	if err := c.Provide(func(cfg *config.Config) strategies.ComplexityScorer {
+		return complexity.NewClient(
+			cfg.FirewallComplexity.BaseURL,
+			cfg.FirewallComplexity.Token,
+			cfg.FirewallComplexity.Timeout,
+		)
+	}); err != nil {
+		return err
+	}
 	return c.Provide(func(p loadBalancerParams) loadbalancer.Factory {
-		return loadbalancer.NewBaseFactory(p.EmbeddingRepo, p.ServiceLocator)
+		return loadbalancer.NewBaseFactory(p.EmbeddingRepo, p.ServiceLocator, p.Complexity, p.Logger)
 	})
 }

--- a/pkg/domain/consumer/lb_config.go
+++ b/pkg/domain/consumer/lb_config.go
@@ -30,11 +30,12 @@ type LBPoolMember struct {
 }
 
 type LBConfig struct {
-	Enabled         bool                      `json:"enabled"`
-	Algorithm       string                    `json:"algorithm,omitempty"`
-	PoolAlias       string                    `json:"pool_alias,omitempty"`
-	Members         []LBPoolMember            `json:"members,omitempty"`
-	EmbeddingConfig *registry.EmbeddingConfig `json:"embedding_config,omitempty"`
+	Enabled         bool                         `json:"enabled"`
+	Algorithm       string                       `json:"algorithm,omitempty"`
+	PoolAlias       string                       `json:"pool_alias,omitempty"`
+	Members         []LBPoolMember               `json:"members,omitempty"`
+	EmbeddingConfig *registry.EmbeddingConfig    `json:"embedding_config,omitempty"`
+	SmartRouting    *registry.SmartRoutingConfig `json:"smart_routing,omitempty"`
 }
 
 func (l LBConfig) Value() (driver.Value, error) {
@@ -70,7 +71,11 @@ func (l *LBConfig) Validate(inline ModelPolicies) error {
 			return err
 		}
 	}
-	if l.Algorithm == algorithm.Semantic {
+	switch l.Algorithm {
+	case algorithm.Semantic:
+		if l.SmartRouting != nil {
+			return fmt.Errorf("%w: smart_routing is only valid for the smart-routing algorithm", ErrInvalidLBConfig)
+		}
 		if l.EmbeddingConfig == nil {
 			return fmt.Errorf("%w: embedding_config required for semantic algorithm", ErrInvalidLBConfig)
 		}
@@ -78,9 +83,37 @@ func (l *LBConfig) Validate(inline ModelPolicies) error {
 			return fmt.Errorf("%w: %s", ErrInvalidLBConfig, err.Error())
 		}
 		return nil
+	case algorithm.SmartRouting:
+		if l.EmbeddingConfig != nil {
+			return fmt.Errorf("%w: embedding_config is only valid for the semantic algorithm", ErrInvalidLBConfig)
+		}
+		if l.SmartRouting == nil {
+			return fmt.Errorf("%w: smart_routing required for smart-routing algorithm", ErrInvalidLBConfig)
+		}
+		if err := l.SmartRouting.Validate(); err != nil {
+			return fmt.Errorf("%w: %s", ErrInvalidLBConfig, err.Error())
+		}
+		return l.validateSmartRoutingMembers()
+	default:
+		if l.EmbeddingConfig != nil {
+			return fmt.Errorf("%w: embedding_config is only valid for the semantic algorithm", ErrInvalidLBConfig)
+		}
+		if l.SmartRouting != nil {
+			return fmt.Errorf("%w: smart_routing is only valid for the smart-routing algorithm", ErrInvalidLBConfig)
+		}
+		return nil
 	}
-	if l.EmbeddingConfig != nil {
-		return fmt.Errorf("%w: embedding_config is only valid for the semantic algorithm", ErrInvalidLBConfig)
+}
+
+func (l *LBConfig) validateSmartRoutingMembers() error {
+	members := make(map[ids.RegistryID]struct{}, len(l.Members))
+	for _, member := range l.Members {
+		members[member.RegistryID] = struct{}{}
+	}
+	for i, tier := range l.SmartRouting.Tiers {
+		if _, ok := members[tier.RegistryID]; !ok {
+			return fmt.Errorf("%w: smart_routing.tiers[%d].registry_id %s is not a pool member", ErrInvalidLBConfig, i, tier.RegistryID)
+		}
 	}
 	return nil
 }

--- a/pkg/domain/registry/errors.go
+++ b/pkg/domain/registry/errors.go
@@ -27,6 +27,7 @@ var (
 	ErrInvalidGatewayID       = fmt.Errorf("registry: invalid gateway_id: %w", commonerrors.ErrValidation)
 	ErrInvalidRegistryID      = fmt.Errorf("registry: invalid registry_id: %w", commonerrors.ErrValidation)
 	ErrInvalidEmbeddingConfig = fmt.Errorf("registry: invalid embedding config: %w", commonerrors.ErrValidation)
+	ErrInvalidSmartRouting    = fmt.Errorf("registry: invalid smart routing config: %w", commonerrors.ErrValidation)
 	ErrInvalidRegistry        = fmt.Errorf("registry: invalid backend: %w", commonerrors.ErrValidation)
 	ErrInvalidHealthChecks    = fmt.Errorf("registry: invalid health checks: %w", commonerrors.ErrValidation)
 	ErrInvalidMCPTarget       = fmt.Errorf("registry: invalid mcp target: %w", commonerrors.ErrValidation)

--- a/pkg/domain/registry/smart_routing_config.go
+++ b/pkg/domain/registry/smart_routing_config.go
@@ -1,0 +1,76 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"fmt"
+
+	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
+)
+
+// SmartRoutingTier binds a complexity-score threshold to a target registry. A
+// tier is selected when the score is at least MinScore.
+type SmartRoutingTier struct {
+	MinScore   float64        `json:"min_score"`
+	RegistryID ids.RegistryID `json:"registry_id"`
+}
+
+// SmartRoutingConfig maps complexity scores in [0,1] to registries. The tier
+// with the greatest MinScore that does not exceed the score wins.
+type SmartRoutingConfig struct {
+	Tiers []SmartRoutingTier `json:"tiers"`
+}
+
+func (c *SmartRoutingConfig) Validate() error {
+	if c == nil || len(c.Tiers) == 0 {
+		return fmt.Errorf("%w: at least one tier is required", ErrInvalidSmartRouting)
+	}
+	seen := make(map[float64]struct{}, len(c.Tiers))
+	for i, tier := range c.Tiers {
+		if tier.MinScore < 0 || tier.MinScore > 1 {
+			return fmt.Errorf("%w: tiers[%d].min_score must be in [0,1]", ErrInvalidSmartRouting, i)
+		}
+		if _, dup := seen[tier.MinScore]; dup {
+			return fmt.Errorf("%w: tiers[%d].min_score %g is duplicated", ErrInvalidSmartRouting, i, tier.MinScore)
+		}
+		seen[tier.MinScore] = struct{}{}
+		if tier.RegistryID.IsNil() {
+			return fmt.Errorf("%w: tiers[%d].registry_id is required", ErrInvalidSmartRouting, i)
+		}
+	}
+	return nil
+}
+
+// RegistryForScore returns the registry mapped to the given complexity score:
+// the tier with the greatest MinScore that is not above the score. It reports
+// false when no tier applies (e.g. the score is below every threshold).
+func (c *SmartRoutingConfig) RegistryForScore(score float64) (ids.RegistryID, bool) {
+	var (
+		best     ids.RegistryID
+		bestMin  float64
+		selected bool
+	)
+	for _, tier := range c.Tiers {
+		if tier.MinScore > score {
+			continue
+		}
+		if !selected || tier.MinScore > bestMin {
+			best = tier.RegistryID
+			bestMin = tier.MinScore
+			selected = true
+		}
+	}
+	return best, selected
+}

--- a/pkg/domain/routing/algorithm/algorithm.go
+++ b/pkg/domain/routing/algorithm/algorithm.go
@@ -20,6 +20,7 @@ const (
 	WeightedRoundRobin = "weighted-round-robin"
 	LeastConnections   = "least-connections"
 	Semantic           = "semantic"
+	SmartRouting       = "smart-routing"
 )
 
 func Names() []string {
@@ -29,12 +30,13 @@ func Names() []string {
 		WeightedRoundRobin,
 		LeastConnections,
 		Semantic,
+		SmartRouting,
 	}
 }
 
 func IsValid(name string) bool {
 	switch name {
-	case RoundRobin, Random, WeightedRoundRobin, LeastConnections, Semantic:
+	case RoundRobin, Random, WeightedRoundRobin, LeastConnections, Semantic, SmartRouting:
 		return true
 	}
 	return false

--- a/pkg/domain/routing/algorithm/algorithm_test.go
+++ b/pkg/domain/routing/algorithm/algorithm_test.go
@@ -28,6 +28,7 @@ func TestIsValid(t *testing.T) {
 		{name: "weighted-round-robin", in: WeightedRoundRobin, want: true},
 		{name: "least-connections", in: LeastConnections, want: true},
 		{name: "semantic", in: Semantic, want: true},
+		{name: "smart-routing", in: SmartRouting, want: true},
 		{name: "empty", in: "", want: false},
 		{name: "unknown", in: "foo", want: false},
 		{name: "least-conn no s", in: "least-conn", want: false},
@@ -46,8 +47,8 @@ func TestIsValid(t *testing.T) {
 func TestNames(t *testing.T) {
 	t.Parallel()
 	names := Names()
-	if len(names) != 5 {
-		t.Fatalf("len(Names()) = %d, want 5", len(names))
+	if len(names) != 6 {
+		t.Fatalf("len(Names()) = %d, want 6", len(names))
 	}
 	for _, n := range names {
 		if !IsValid(n) {

--- a/pkg/infra/complexity/client.go
+++ b/pkg/infra/complexity/client.go
@@ -1,0 +1,116 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package complexity is a client for the Firewall Complexity API, which scores
+// the complexity of a user message in [0,1] so the load balancer can route by
+// difficulty.
+package complexity
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	complexityPath   = "/v1/complexity"
+	headerToken      = "token"
+	contentTypeJSON  = "application/json"
+	maxResponseBytes = 1 << 20
+	defaultTimeout   = 15 * time.Second
+)
+
+// ErrUnauthorized is returned when the Firewall Complexity API rejects the token.
+var ErrUnauthorized = errors.New("complexity: unauthorized")
+
+// ErrNotConfigured is returned when Score is called without a base URL and token.
+var ErrNotConfigured = errors.New("complexity: client not configured")
+
+// Client calls the Firewall Complexity API with a static bearer token.
+type Client struct {
+	http    *http.Client
+	baseURL string
+	token   string
+}
+
+// NewClient builds a Client. An empty baseURL or token leaves it unconfigured
+// (see Configured), so callers can fall back to another strategy.
+func NewClient(baseURL, token string, timeout time.Duration) *Client {
+	if timeout <= 0 {
+		timeout = defaultTimeout
+	}
+	return &Client{
+		http:    &http.Client{Timeout: timeout},
+		baseURL: strings.TrimRight(baseURL, "/"),
+		token:   token,
+	}
+}
+
+// Configured reports whether both a base URL and token are set.
+func (c *Client) Configured() bool {
+	return c.baseURL != "" && c.token != ""
+}
+
+// Score returns the session-smoothed complexity score in [0,1] for input.
+// conversationID and tenantID are optional and omitted from the request when empty.
+func (c *Client) Score(ctx context.Context, input, conversationID, tenantID string) (float64, error) {
+	if !c.Configured() {
+		return 0, ErrNotConfigured
+	}
+	payload, err := json.Marshal(scoreRequest{
+		Input:          input,
+		ConversationID: conversationID,
+		TenantID:       tenantID,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("complexity: marshal request: %w", err)
+	}
+	endpoint := c.baseURL + complexityPath
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return 0, fmt.Errorf("complexity: build request: %w", err)
+	}
+	req.Header.Set(headerToken, c.token)
+	req.Header.Set("Content-Type", contentTypeJSON)
+
+	res, err := c.http.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("complexity: score call: %w", err)
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, io.LimitReader(res.Body, maxResponseBytes))
+		_ = res.Body.Close()
+	}()
+	raw, err := io.ReadAll(io.LimitReader(res.Body, maxResponseBytes))
+	if err != nil {
+		return 0, fmt.Errorf("complexity: read response: %w", err)
+	}
+	if res.StatusCode == http.StatusUnauthorized {
+		return 0, ErrUnauthorized
+	}
+	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusMultipleChoices {
+		return 0, fmt.Errorf("complexity: unexpected status %d", res.StatusCode)
+	}
+	var out scoreResponse
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return 0, fmt.Errorf("complexity: decode response: %w", err)
+	}
+	return out.Score, nil
+}

--- a/pkg/infra/complexity/client_test.go
+++ b/pkg/infra/complexity/client_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package complexity
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_Configured(t *testing.T) {
+	t.Parallel()
+	assert.False(t, NewClient("", "", 0).Configured())
+	assert.False(t, NewClient("http://x", "", 0).Configured())
+	assert.False(t, NewClient("", "tok", 0).Configured())
+	assert.True(t, NewClient("http://x", "tok", 0).Configured())
+}
+
+func TestClient_Score_Success(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, complexityPath, r.URL.Path)
+		assert.Equal(t, "secret-token", r.Header.Get(headerToken))
+		body, _ := io.ReadAll(r.Body)
+		var got scoreRequest
+		require.NoError(t, json.Unmarshal(body, &got))
+		assert.Equal(t, "hello", got.Input)
+		assert.Equal(t, "chat_1", got.ConversationID)
+		assert.Equal(t, "tenant_1", got.TenantID)
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(scoreResponse{Score: 0.41, RawScore: 0.38})
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "secret-token", time.Second)
+	score, err := c.Score(context.Background(), "hello", "chat_1", "tenant_1")
+	require.NoError(t, err)
+	assert.InDelta(t, 0.41, score, 1e-9)
+}
+
+func TestClient_Score_NotConfigured(t *testing.T) {
+	t.Parallel()
+	c := NewClient("", "", time.Second)
+	_, err := c.Score(context.Background(), "hello", "", "")
+	assert.ErrorIs(t, err, ErrNotConfigured)
+}
+
+func TestClient_Score_Unauthorized(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "bad", time.Second)
+	_, err := c.Score(context.Background(), "hello", "", "")
+	assert.ErrorIs(t, err, ErrUnauthorized)
+}
+
+func TestClient_Score_ServerError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "tok", time.Second)
+	_, err := c.Score(context.Background(), "hello", "", "")
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, ErrUnauthorized))
+}

--- a/pkg/infra/complexity/types.go
+++ b/pkg/infra/complexity/types.go
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package loadbalancer
+package complexity
 
-import "github.com/NeuralTrust/TrustGate/pkg/infra/loadbalancer/strategies"
+type scoreRequest struct {
+	Input          string `json:"input"`
+	ConversationID string `json:"conversation_id,omitempty"`
+	TenantID       string `json:"tenant_id,omitempty"`
+}
 
-var (
-	_ Strategy = (*strategies.RoundRobin)(nil)
-	_ Strategy = (*strategies.Random)(nil)
-	_ Strategy = (*strategies.WeightedRoundRobin)(nil)
-	_ Strategy = (*strategies.LeastConnections)(nil)
-	_ Strategy = (*strategies.Semantic)(nil)
-	_ Strategy = (*strategies.SmartRouting)(nil)
-)
+type scoreResponse struct {
+	Score    float64 `json:"score"`
+	RawScore float64 `json:"raw_score"`
+}

--- a/pkg/infra/loadbalancer/base_factory.go
+++ b/pkg/infra/loadbalancer/base_factory.go
@@ -16,6 +16,7 @@ package loadbalancer
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/NeuralTrust/TrustGate/pkg/domain/embedding"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/routing/algorithm"
@@ -28,15 +29,21 @@ var _ Factory = (*BaseFactory)(nil)
 type BaseFactory struct {
 	embeddingRepo  embedding.Repository
 	serviceLocator factory.EmbeddingServiceLocator
+	complexity     strategies.ComplexityScorer
+	logger         *slog.Logger
 }
 
 func NewBaseFactory(
 	embeddingRepo embedding.Repository,
 	serviceLocator factory.EmbeddingServiceLocator,
+	complexity strategies.ComplexityScorer,
+	logger *slog.Logger,
 ) Factory {
 	return &BaseFactory{
 		embeddingRepo:  embeddingRepo,
 		serviceLocator: serviceLocator,
+		complexity:     complexity,
+		logger:         logger,
 	}
 }
 
@@ -52,6 +59,8 @@ func (f *BaseFactory) CreateStrategy(input StrategyInput) (Strategy, error) {
 		return strategies.NewLeastConnections(input.Registries), nil
 	case algorithm.Semantic:
 		return strategies.NewSemantic(input.EmbeddingConfig, input.Registries, f.embeddingRepo, f.serviceLocator), nil
+	case algorithm.SmartRouting:
+		return strategies.NewSmartRouting(input.Registries, input.SmartRoutingConfig, f.complexity, f.logger), nil
 	default:
 		return nil, fmt.Errorf("unsupported load balancing algorithm: %s", input.Algorithm)
 	}

--- a/pkg/infra/loadbalancer/base_factory_test.go
+++ b/pkg/infra/loadbalancer/base_factory_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestBaseFactory_CreateStrategy_KnownAlgorithms(t *testing.T) {
 	t.Parallel()
-	factory := loadbalancer.NewBaseFactory(nil, nil)
+	factory := loadbalancer.NewBaseFactory(nil, nil, nil, nil)
 	registries := []*registry.Registry{{ID: ids.New[ids.RegistryKind](), Name: "a", LLMTarget: &registry.LLMTarget{Provider: "openai"}}}
 
 	cases := []struct {
@@ -38,6 +38,7 @@ func TestBaseFactory_CreateStrategy_KnownAlgorithms(t *testing.T) {
 		{name: "weighted", alg: loadbalancer.AlgorithmWeightedRoundRobin, wantName: "weighted-round-robin"},
 		{name: "least-conn", alg: loadbalancer.AlgorithmLeastConnections, wantName: "least-connections"},
 		{name: "semantic", alg: loadbalancer.AlgorithmSemantic, wantName: "semantic"},
+		{name: "smart-routing", alg: loadbalancer.AlgorithmSmartRouting, wantName: "smart-routing"},
 	}
 	for _, tc := range cases {
 		tc := tc
@@ -59,7 +60,7 @@ func TestBaseFactory_CreateStrategy_KnownAlgorithms(t *testing.T) {
 
 func TestBaseFactory_CreateStrategy_UnknownAlgorithm(t *testing.T) {
 	t.Parallel()
-	factory := loadbalancer.NewBaseFactory(nil, nil)
+	factory := loadbalancer.NewBaseFactory(nil, nil, nil, nil)
 	_, err := factory.CreateStrategy(loadbalancer.StrategyInput{Algorithm: "bogus"})
 	if err == nil {
 		t.Fatal("expected error for unknown algorithm")
@@ -72,8 +73,8 @@ func TestBaseFactory_CreateStrategy_UnknownAlgorithm(t *testing.T) {
 func TestExportedConstantsMatchAlgorithmPackage(t *testing.T) {
 	t.Parallel()
 	algs := loadbalancer.Algorithms()
-	if len(algs) != 5 {
-		t.Fatalf("len(Algorithms) = %d, want 5", len(algs))
+	if len(algs) != 6 {
+		t.Fatalf("len(Algorithms) = %d, want 6", len(algs))
 	}
 	for _, a := range algs {
 		if !loadbalancer.IsValidAlgorithm(a) {

--- a/pkg/infra/loadbalancer/load_balancer.go
+++ b/pkg/infra/loadbalancer/load_balancer.go
@@ -38,11 +38,12 @@ type RedisProvider interface {
 }
 
 type Pool struct {
-	ID              string
-	Registries      []*registry.Registry
-	Weights         map[ids.RegistryID]int
-	Algorithm       string
-	EmbeddingConfig *registry.EmbeddingConfig
+	ID                 string
+	Registries         []*registry.Registry
+	Weights            map[ids.RegistryID]int
+	Algorithm          string
+	EmbeddingConfig    *registry.EmbeddingConfig
+	SmartRoutingConfig *registry.SmartRoutingConfig
 }
 
 type LoadBalancer struct {
@@ -74,10 +75,11 @@ func NewLoadBalancer(
 	}
 
 	strategy, err := factory.CreateStrategy(StrategyInput{
-		Algorithm:       pool.Algorithm,
-		Registries:      pool.Registries,
-		Weights:         pool.Weights,
-		EmbeddingConfig: embeddingCfg,
+		Algorithm:          pool.Algorithm,
+		Registries:         pool.Registries,
+		Weights:            pool.Weights,
+		EmbeddingConfig:    embeddingCfg,
+		SmartRoutingConfig: pool.SmartRoutingConfig,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create load balancing strategy: %w", err)

--- a/pkg/infra/loadbalancer/load_balancer_close_test.go
+++ b/pkg/infra/loadbalancer/load_balancer_close_test.go
@@ -53,7 +53,7 @@ func TestLoadBalancer_Close_IdempotentAndSafe(t *testing.T) {
 		t.Fatalf("NewLLMRegistry error: %v", err)
 	}
 
-	lb, err := loadbalancer.NewLoadBalancer(loadbalancer.NewBaseFactory(nil, nil), loadbalancer.Pool{
+	lb, err := loadbalancer.NewLoadBalancer(loadbalancer.NewBaseFactory(nil, nil, nil, nil), loadbalancer.Pool{
 		ID:         uuid.New().String(),
 		Registries: []*registry.Registry{bk},
 		Algorithm:  loadbalancer.AlgorithmRoundRobin,

--- a/pkg/infra/loadbalancer/load_balancer_health_test.go
+++ b/pkg/infra/loadbalancer/load_balancer_health_test.go
@@ -60,7 +60,7 @@ func TestLoadBalancer_NextBackend_SkipsUnhealthyViaMGet(t *testing.T) {
 		t.Fatalf("seed unhealthy status: %v", err)
 	}
 
-	lb, err := loadbalancer.NewLoadBalancer(loadbalancer.NewBaseFactory(nil, nil), loadbalancer.Pool{
+	lb, err := loadbalancer.NewLoadBalancer(loadbalancer.NewBaseFactory(nil, nil, nil, nil), loadbalancer.Pool{
 		ID:         uuid.New().String(),
 		Registries: []*registry.Registry{unhealthy, healthy},
 		Algorithm:  loadbalancer.AlgorithmRoundRobin,

--- a/pkg/infra/loadbalancer/strategies/smart_routing.go
+++ b/pkg/infra/loadbalancer/strategies/smart_routing.go
@@ -1,0 +1,125 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package strategies
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+
+	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
+	"github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	"github.com/NeuralTrust/TrustGate/pkg/domain/routing/algorithm"
+	infracontext "github.com/NeuralTrust/TrustGate/pkg/infra/context"
+)
+
+// ComplexityScorer scores the complexity of a user message in [0,1].
+type ComplexityScorer interface {
+	Score(ctx context.Context, input, conversationID, tenantID string) (float64, error)
+	Configured() bool
+}
+
+// SmartRouting routes by the complexity of the incoming message: it asks the
+// Firewall Complexity API for a score and maps that score to a target via the
+// configured tiers. It fails open to round-robin whenever the scorer is not
+// configured, the score is unavailable, or no candidate matches the score.
+type SmartRouting struct {
+	registries []*registry.Registry
+	config     *registry.SmartRoutingConfig
+	scorer     ComplexityScorer
+	fallback   *RoundRobin
+	logger     *slog.Logger
+	warnOnce   sync.Once
+}
+
+func NewSmartRouting(
+	registries []*registry.Registry,
+	config *registry.SmartRoutingConfig,
+	scorer ComplexityScorer,
+	logger *slog.Logger,
+) *SmartRouting {
+	return &SmartRouting{
+		registries: registries,
+		config:     config,
+		scorer:     scorer,
+		fallback:   NewRoundRobin(registries),
+		logger:     logger,
+	}
+}
+
+func (s *SmartRouting) Name() string { return algorithm.SmartRouting }
+
+func (s *SmartRouting) Next(
+	ctx context.Context,
+	req *infracontext.RequestContext,
+	exclude map[ids.RegistryID]struct{},
+) *registry.Registry {
+	candidates := filterExcluded(s.registries, exclude)
+	if len(candidates) == 0 {
+		return nil
+	}
+	if len(candidates) == 1 {
+		return candidates[0]
+	}
+	if s.config == nil || s.scorer == nil || !s.scorer.Configured() || req == nil {
+		return s.fallbackNext(ctx, req, exclude, "smart routing not configured")
+	}
+	input, err := extractPromptFromRequest(req.Body)
+	if err != nil {
+		return s.fallbackNext(ctx, req, exclude, "could not extract input from request")
+	}
+	score, err := s.scorer.Score(ctx, input, req.SessionID, req.GatewayID)
+	if err != nil {
+		return s.fallbackNext(ctx, req, exclude, "complexity score unavailable")
+	}
+	target := s.registryForScore(score, candidates)
+	if target == nil {
+		return s.fallbackNext(ctx, req, exclude, "no candidate matched complexity score")
+	}
+	if s.logger != nil {
+		s.logger.Debug("smart routing selected registry",
+			slog.String("registry_id", target.ID.String()),
+			slog.Float64("score", score),
+		)
+	}
+	return target
+}
+
+func (s *SmartRouting) registryForScore(score float64, candidates []*registry.Registry) *registry.Registry {
+	id, ok := s.config.RegistryForScore(score)
+	if !ok {
+		return nil
+	}
+	for _, b := range candidates {
+		if b.ID == id {
+			return b
+		}
+	}
+	return nil
+}
+
+func (s *SmartRouting) fallbackNext(
+	ctx context.Context,
+	req *infracontext.RequestContext,
+	exclude map[ids.RegistryID]struct{},
+	reason string,
+) *registry.Registry {
+	if s.logger != nil {
+		s.warnOnce.Do(func() {
+			s.logger.Warn("smart routing falling back to round-robin", slog.String("reason", reason))
+		})
+	}
+	return s.fallback.Next(ctx, req, exclude)
+}

--- a/pkg/infra/loadbalancer/strategies/smart_routing_test.go
+++ b/pkg/infra/loadbalancer/strategies/smart_routing_test.go
@@ -1,0 +1,167 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package strategies
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
+	"github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	infracontext "github.com/NeuralTrust/TrustGate/pkg/infra/context"
+)
+
+type fakeScorer struct {
+	score      float64
+	err        error
+	configured bool
+	calls      int
+}
+
+func (f *fakeScorer) Score(_ context.Context, _, _, _ string) (float64, error) {
+	f.calls++
+	return f.score, f.err
+}
+
+func (f *fakeScorer) Configured() bool { return f.configured }
+
+func tiersFor(backends []*registry.Registry, minScores ...float64) *registry.SmartRoutingConfig {
+	cfg := &registry.SmartRoutingConfig{}
+	for i, min := range minScores {
+		cfg.Tiers = append(cfg.Tiers, registry.SmartRoutingTier{MinScore: min, RegistryID: backends[i].ID})
+	}
+	return cfg
+}
+
+func promptReq() *infracontext.RequestContext {
+	return &infracontext.RequestContext{Body: []byte(`{"prompt":"hi"}`), SessionID: "chat_1", GatewayID: "gw_1"}
+}
+
+func TestSmartRouting_Name(t *testing.T) {
+	t.Parallel()
+	if name := (&SmartRouting{}).Name(); name != "smart-routing" {
+		t.Fatalf("Name() = %q", name)
+	}
+}
+
+func TestSmartRouting_MapsScoreToTier(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		score float64
+		want  string
+	}{
+		{"low", 0.1, "a"},
+		{"mid", 0.5, "b"},
+		{"high", 0.9, "c"},
+		{"boundary", 0.4, "b"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			backends := makeBackends("a", "b", "c")
+			cfg := tiersFor(backends, 0.0, 0.4, 0.8)
+			scorer := &fakeScorer{score: tc.score, configured: true}
+			s := NewSmartRouting(backends, cfg, scorer, nil)
+			got := s.Next(context.Background(), promptReq(), nil)
+			if got == nil || got.Name != tc.want {
+				t.Fatalf("score %g: got %+v, want %q", tc.score, got, tc.want)
+			}
+			if scorer.calls != 1 {
+				t.Fatalf("expected exactly one score call, got %d", scorer.calls)
+			}
+		})
+	}
+}
+
+func TestSmartRouting_NotConfiguredFallsBackToRoundRobin(t *testing.T) {
+	t.Parallel()
+	backends := makeBackends("a", "b", "c")
+	cfg := tiersFor(backends, 0.0, 0.4, 0.8)
+	scorer := &fakeScorer{score: 0.9, configured: false}
+	s := NewSmartRouting(backends, cfg, scorer, nil)
+	got := s.Next(context.Background(), promptReq(), nil)
+	if got == nil || got.Name != "a" {
+		t.Fatalf("unconfigured scorer should round-robin from first backend, got %+v", got)
+	}
+	if scorer.calls != 0 {
+		t.Fatalf("scorer must not be called when unconfigured, calls=%d", scorer.calls)
+	}
+}
+
+func TestSmartRouting_ScoreErrorFallsBackToRoundRobin(t *testing.T) {
+	t.Parallel()
+	backends := makeBackends("a", "b", "c")
+	cfg := tiersFor(backends, 0.0, 0.4, 0.8)
+	scorer := &fakeScorer{err: errors.New("boom"), configured: true}
+	s := NewSmartRouting(backends, cfg, scorer, nil)
+	got := s.Next(context.Background(), promptReq(), nil)
+	if got == nil || got.Name != "a" {
+		t.Fatalf("score error should round-robin from first backend, got %+v", got)
+	}
+}
+
+func TestSmartRouting_EmptyBodyFallsBackToRoundRobin(t *testing.T) {
+	t.Parallel()
+	backends := makeBackends("a", "b", "c")
+	cfg := tiersFor(backends, 0.0, 0.4, 0.8)
+	scorer := &fakeScorer{score: 0.9, configured: true}
+	s := NewSmartRouting(backends, cfg, scorer, nil)
+	got := s.Next(context.Background(), &infracontext.RequestContext{}, nil)
+	if got == nil || got.Name != "a" {
+		t.Fatalf("empty body should round-robin from first backend, got %+v", got)
+	}
+	if scorer.calls != 0 {
+		t.Fatalf("scorer must not be called when input cannot be extracted, calls=%d", scorer.calls)
+	}
+}
+
+func TestSmartRouting_MappedRegistryExcludedFallsBack(t *testing.T) {
+	t.Parallel()
+	backends := makeBackends("a", "b", "c")
+	cfg := tiersFor(backends, 0.0, 0.4, 0.8)
+	scorer := &fakeScorer{score: 0.9, configured: true}
+	s := NewSmartRouting(backends, cfg, scorer, nil)
+	exclude := map[ids.RegistryID]struct{}{backends[2].ID: {}}
+	got := s.Next(context.Background(), promptReq(), exclude)
+	if got == nil || got.Name == "c" {
+		t.Fatalf("excluded mapped registry must fall back to a candidate, got %+v", got)
+	}
+}
+
+func TestSmartRouting_SingleCandidateSkipsScorer(t *testing.T) {
+	t.Parallel()
+	backends := makeBackends("only")
+	cfg := tiersFor(backends, 0.0)
+	scorer := &fakeScorer{score: 0.9, configured: true}
+	s := NewSmartRouting(backends, cfg, scorer, nil)
+	got := s.Next(context.Background(), promptReq(), nil)
+	if got == nil || got.Name != "only" {
+		t.Fatalf("single candidate should be returned without scoring, got %+v", got)
+	}
+	if scorer.calls != 0 {
+		t.Fatalf("scorer must not be called with a single candidate, calls=%d", scorer.calls)
+	}
+}
+
+func TestSmartRouting_EmptyReturnsNil(t *testing.T) {
+	t.Parallel()
+	s := NewSmartRouting(nil, nil, nil, nil)
+	if s.Next(context.Background(), promptReq(), nil) != nil {
+		t.Fatal("empty SmartRouting.Next must return nil")
+	}
+}

--- a/pkg/infra/loadbalancer/strategy.go
+++ b/pkg/infra/loadbalancer/strategy.go
@@ -30,6 +30,7 @@ const (
 	AlgorithmWeightedRoundRobin = algorithm.WeightedRoundRobin
 	AlgorithmLeastConnections   = algorithm.LeastConnections
 	AlgorithmSemantic           = algorithm.Semantic
+	AlgorithmSmartRouting       = algorithm.SmartRouting
 )
 
 type Strategy interface {
@@ -38,10 +39,11 @@ type Strategy interface {
 }
 
 type StrategyInput struct {
-	Algorithm       string
-	Registries      []*registry.Registry
-	Weights         map[ids.RegistryID]int
-	EmbeddingConfig *embedding.Config
+	Algorithm          string
+	Registries         []*registry.Registry
+	Weights            map[ids.RegistryID]int
+	EmbeddingConfig    *embedding.Config
+	SmartRoutingConfig *registry.SmartRoutingConfig
 }
 
 type Factory interface {

--- a/tests/functional/firewall_complexity_stub_test.go
+++ b/tests/functional/firewall_complexity_stub_test.go
@@ -1,0 +1,98 @@
+//go:build functional
+
+package functional_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+)
+
+const (
+	firewallComplexityFunctionalToken = "functional-firewall-token"
+	firewallComplexityPath            = "/v1/complexity"
+
+	// Message-content markers the stub maps to deterministic complexity
+	// scores, so each test drives routing purely through the prompt it sends
+	// and never through shared mutable stub state.
+	smartRouteLowContent   = "route-low-complexity"
+	smartRouteHighContent  = "route-high-complexity"
+	smartRouteErrorContent = "route-score-error"
+
+	smartRouteLowScore  = 0.05
+	smartRouteHighScore = 0.95
+)
+
+// FirewallComplexityStub is the process-wide stub the gateway binary dials for
+// smart-routing complexity scores.
+var FirewallComplexityStub *firewallComplexityStub
+
+// StartFirewallComplexityStub boots the stub once and returns its base URL.
+func StartFirewallComplexityStub() string {
+	if FirewallComplexityStub != nil {
+		return FirewallComplexityStub.URL()
+	}
+	FirewallComplexityStub = newFirewallComplexityStubServer()
+	return FirewallComplexityStub.URL()
+}
+
+// StopFirewallComplexityStub tears the stub down at suite teardown.
+func StopFirewallComplexityStub() {
+	if FirewallComplexityStub == nil {
+		return
+	}
+	FirewallComplexityStub.server.Close()
+	FirewallComplexityStub = nil
+}
+
+// firewallComplexityStub is an in-process stand-in for the Firewall Complexity
+// API. It maps well-known input markers to fixed scores so functional tests can
+// assert smart-routing behaviour deterministically.
+type firewallComplexityStub struct {
+	server *httptest.Server
+}
+
+func (s *firewallComplexityStub) URL() string { return s.server.URL }
+
+type firewallScoreRequest struct {
+	Input          string `json:"input"`
+	ConversationID string `json:"conversation_id"`
+	TenantID       string `json:"tenant_id"`
+}
+
+type firewallScoreResponse struct {
+	Score    float64 `json:"score"`
+	RawScore float64 `json:"raw_score"`
+}
+
+func newFirewallComplexityStubServer() *firewallComplexityStub {
+	stub := &firewallComplexityStub{}
+	mux := http.NewServeMux()
+	mux.HandleFunc(firewallComplexityPath, func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("token") != firewallComplexityFunctionalToken {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		var req firewallScoreRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		switch {
+		case strings.Contains(req.Input, smartRouteErrorContent):
+			w.WriteHeader(http.StatusInternalServerError)
+		case strings.Contains(req.Input, smartRouteHighContent):
+			writeFirewallScore(w, smartRouteHighScore)
+		default:
+			writeFirewallScore(w, smartRouteLowScore)
+		}
+	})
+	stub.server = httptest.NewServer(mux)
+	return stub
+}
+
+func writeFirewallScore(w http.ResponseWriter, score float64) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(firewallScoreResponse{Score: score, RawScore: score})
+}

--- a/tests/functional/setup_test.go
+++ b/tests/functional/setup_test.go
@@ -87,7 +87,7 @@ func getEnv(key, fallback string) string {
 
 // buildCmdEnv returns the env the gateway binary will see, pinning
 // ENV_FILE so it loads the same .env.functional as TestMain.
-func buildCmdEnv(trustGuardBaseURL string) []string {
+func buildCmdEnv(trustGuardBaseURL, firewallComplexityBaseURL string) []string {
 	env := os.Environ()
 	env = append(env, "ENV_FILE=../../.env.functional")
 	env = append(env, "AWS_ENDPOINT_URL_BEDROCK_RUNTIME="+bedrockGuardrailEndpoint)
@@ -95,6 +95,10 @@ func buildCmdEnv(trustGuardBaseURL string) []string {
 	env = append(env, "TRUSTGUARD_CLIENT_SECRET="+trustGuardFunctionalClientSecret)
 	if trustGuardBaseURL != "" {
 		env = append(env, "TRUSTGUARD_BASE_URL="+trustGuardBaseURL)
+	}
+	if firewallComplexityBaseURL != "" {
+		env = append(env, "FIREWALL_COMPLEXITY_BASE_URL="+firewallComplexityBaseURL)
+		env = append(env, "FIREWALL_COMPLEXITY_TOKEN="+firewallComplexityFunctionalToken)
 	}
 	return env
 }
@@ -134,7 +138,8 @@ func setupTestEnvironment() {
 	_ = os.Setenv("CONFIG_SYNC_GRPC_LISTEN_ADDR", fmt.Sprintf(":%d", serverConfigSyncGRPCPort))
 
 	trustGuardStubURL := StartTrustGuardFunctionalStub()
-	cmdEnv := buildCmdEnv(trustGuardStubURL)
+	firewallComplexityStubURL := StartFirewallComplexityStub()
+	cmdEnv := buildCmdEnv(trustGuardStubURL, firewallComplexityStubURL)
 	gatewayBinaryPath = buildGatewayBinary(cmdEnv)
 
 	// The admin plane runs the migrations on boot; wait for it to be ready before
@@ -155,6 +160,7 @@ func setupTestEnvironment() {
 
 func teardownTestEnvironment() {
 	StopTrustGuardFunctionalStub()
+	StopFirewallComplexityStub()
 	if mcpCmd != nil && mcpCmd.Process != nil {
 		if err := syscall.Kill(-mcpCmd.Process.Pid, syscall.SIGKILL); err != nil {
 			log.Printf("error killing mcp server: %v", err)

--- a/tests/functional/smart_routing_e2e_test.go
+++ b/tests/functional/smart_routing_e2e_test.go
@@ -1,0 +1,114 @@
+//go:build functional
+
+package functional_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupSmartRoute wires a gateway with two OpenAI-compatible upstreams and a
+// consumer whose load balancer uses the smart-routing algorithm. The tiers map
+// score >= 0.0 to the low upstream and score >= 0.5 to the high upstream. Each
+// registry declares its own default model, so once smart routing picks a
+// registry by score the request is forwarded with that registry's default
+// model injected.
+func setupSmartRoute(t *testing.T, low, high *fakeUpstream, lowModel, highModel string) (string, string) {
+	t.Helper()
+	gatewayID := CreateGateway(t, map[string]any{"slug": uniqueName("smart-gw")})
+	lowID := CreateRegistry(t, gatewayID, openaiBackendPayload(uniqueName("be-low"), low.URL()))
+	highID := CreateRegistry(t, gatewayID, openaiBackendPayload(uniqueName("be-high"), high.URL()))
+
+	coID := CreateConsumer(t, gatewayID, map[string]any{
+		"name": uniqueName("smart-cons"),
+		"registries": []map[string]any{
+			{"id": lowID, "model_policies": map[string]any{"allowed": []string{lowModel}, "default": lowModel}},
+			{"id": highID, "model_policies": map[string]any{"allowed": []string{highModel}, "default": highModel}},
+		},
+		"lb_config": map[string]any{
+			"enabled":   true,
+			"algorithm": "smart-routing",
+			"members": []map[string]any{
+				{"registry_id": lowID},
+				{"registry_id": highID},
+			},
+			"smart_routing": map[string]any{
+				"tiers": []map[string]any{
+					{"min_score": 0.0, "registry_id": lowID},
+					{"min_score": 0.5, "registry_id": highID},
+				},
+			},
+		},
+	})
+	apiKey := createAndAttachAPIKey(t, gatewayID, coID)
+	return apiKey, chatCompletionsPath(t, coID)
+}
+
+// smartChatRequest builds an OpenAI chat body whose user message carries the
+// content marker the complexity stub keys its score off. It intentionally omits
+// the "model" field so the selected registry's default model is injected.
+func smartChatRequest(content string) map[string]any {
+	return map[string]any{
+		"messages": []map[string]string{{"role": "user", "content": content}},
+	}
+}
+
+func TestSmartRoutingE2E_RoutesByScoreAndInjectsRegistryDefaultModel(t *testing.T) {
+	defer Track(t, "SmartRoutingE2E")()
+
+	const (
+		lowModel  = "model-low-tier"
+		highModel = "model-high-tier"
+	)
+
+	t.Run("low score routes to the low tier and injects its default model", func(t *testing.T) {
+		low := newJSONUpstream(t, "served-by-low")
+		high := newJSONUpstream(t, "served-by-high")
+		apiKey, path := setupSmartRoute(t, low, high, lowModel, highModel)
+
+		status, _, body := proxyPost(t, apiKey, path, smartChatRequest(smartRouteLowContent))
+
+		require.Equal(t, http.StatusOK, status, "body: %s", body)
+		assert.Contains(t, string(body), "served-by-low", "a low score must route to the low-tier registry")
+		assert.Equal(t, 1, low.Hits())
+		assert.Equal(t, 0, high.Hits())
+		assert.Contains(t, string(low.LastBody()), lowModel,
+			"the low-tier registry's default model must be injected into the upstream request")
+	})
+
+	t.Run("high score routes to the high tier and injects its default model", func(t *testing.T) {
+		low := newJSONUpstream(t, "served-by-low")
+		high := newJSONUpstream(t, "served-by-high")
+		apiKey, path := setupSmartRoute(t, low, high, lowModel, highModel)
+
+		status, _, body := proxyPost(t, apiKey, path, smartChatRequest(smartRouteHighContent))
+
+		require.Equal(t, http.StatusOK, status, "body: %s", body)
+		assert.Contains(t, string(body), "served-by-high", "a high score must route to the high-tier registry")
+		assert.Equal(t, 1, high.Hits())
+		assert.Equal(t, 0, low.Hits())
+		assert.Contains(t, string(high.LastBody()), highModel,
+			"the high-tier registry's default model must be injected into the upstream request")
+	})
+}
+
+func TestSmartRoutingE2E_FallsBackToRoundRobinOnScoreError(t *testing.T) {
+	defer Track(t, "SmartRoutingE2E")()
+
+	low := newJSONUpstream(t, "served-by-low")
+	high := newJSONUpstream(t, "served-by-high")
+	apiKey, path := setupSmartRoute(t, low, high, "model-low-tier", "model-high-tier")
+
+	const total = 6
+	for i := 0; i < total; i++ {
+		status, _, body := proxyPost(t, apiKey, path, smartChatRequest(smartRouteErrorContent))
+		require.Equal(t, http.StatusOK, status, "request %d must still be served via fallback, body: %s", i, body)
+	}
+
+	assert.Greater(t, low.Hits(), 0, "fallback round-robin must reach the low upstream")
+	assert.Greater(t, high.Hits(), 0, "fallback round-robin must reach the high upstream")
+	assert.Equal(t, total, low.Hits()+high.Hits(), "every request must reach exactly one upstream")
+}


### PR DESCRIPTION
## Summary
Adds a new **`smart-routing`** load balancing strategy to TrustGate. For each incoming request it scores the user message with the **Firewall Complexity API** (`POST /v1/complexity`) and routes to a backend registry based on configurable score tiers.

- **Complexity client** (`pkg/infra/complexity`): calls the Firewall Complexity API with a static bearer token in the `token` header; `Configured()` gates activation.
- **`SmartRoutingConfig`**: ordered `min_score -> registry_id` tiers on the consumer `LBConfig`. The tier with the highest `min_score` not exceeding the score wins. Tier registry IDs are validated against pool members.
- **Strategy** (`strategies/smart_routing.go`): scores the prompt and picks the matching tier; **fail-open to round-robin** when the API is unconfigured, unreachable, errors, the body is empty, or no tier matches (warns once). Only score / registry / latency are logged — never message content.
- **Config**: `FIREWALL_COMPLEXITY_BASE_URL`, `FIREWALL_COMPLEXITY_TOKEN`, `FIREWALL_COMPLEXITY_TIMEOUT` (global env). Missing URL/token disables smart routing at runtime without blocking consumer config saves.
- **API + frontend**: request/response DTOs and a tier editor in the consumer detail UI.

## Notes
- `conversation_id` comes from `req.SessionID`, `tenant_id` from `req.GatewayID` (omitted when empty).
- This PR exceeds the 400-line soft cap; happy to split the frontend/API layer into a follow-up PR if preferred for review.

## Test plan
- [x] `go test -race ./...` (complexity client + smart-routing strategy unit tests)
- [x] `golangci-lint run` clean (pre-commit hook)
- [x] frontend `tsc --noEmit`
- [ ] Manual QA: configure a consumer with `smart-routing` tiers and verify routing by score, plus fallback when the API token is unset

Made with [Cursor](https://cursor.com)