### PR TITLE
feat(catalog): hide broken MCP servers and add catalog probe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: help build run run-admin run-proxy run-mcp run-all run-proxy-sandbox run-servers up down logs local-dns test test-race test-cover test-functional test-repositories lint fmt tidy generate proto gen-mocks tools swagger openapi docs license license-check \
-        install-pre-commit \
+        install-pre-commit mcp-catalog-probe \
         docker-build docker-push compose-up compose-down compose-logs
 
 # --- Build metadata injected into the binary via -ldflags ------------------
@@ -41,6 +41,10 @@ run-proxy: build ## Build and run the proxy server
 run-mcp: build ## Build and run the MCP server
 	@$(info $(M) Running $(APP_NAME) mcp ...)
 	./bin/$(APP_NAME) mcp
+
+mcp-catalog-probe: ## Probe curated MCP catalog URLs (see docs/mcp/testing-guide.md); add -apply to hide broken_*
+	@$(info $(M) Probing MCP catalog ...)
+	go run ./cmd/mcp-catalog-probe -catalog seed/mcp-catalog/enterprise-servers.json $(ARGS)
 
 run-all: build ## Build and run admin + proxy together in one process (single-node)
 	@$(info $(M) Running $(APP_NAME) admin + proxy ...)

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ curl localhost:8082/healthz       # mcp
 curl localhost:8080/__/version    # build info (version, commit, build date)
 ```
 
+To configure MCP registries/consumers and smoke-test JSON-RPC (`tools/list`,
+`tools/call`) or point Cursor at the MCP plane, follow
+[`docs/mcp/testing-guide.md`](docs/mcp/testing-guide.md).
+
 > The image is pinned to `linux/amd64` because `confluent-kafka-go` only bundles
 > an amd64 `librdkafka`; on Apple Silicon the build runs under emulation out of the box.
 
@@ -285,7 +289,7 @@ flowchart LR
 |-------|------|------------------|
 | **Admin** | `8080` | Gateway, registry, consumer, auth, policy and catalog management. Applies DB migrations. |
 | **Proxy** | `8081` | Request routing, load balancing, policy & plugin execution, provider forwarding, telemetry. |
-| **MCP** | `8082` | Model Context Protocol server: exposes registered MCP targets and tools to agents. |
+| **MCP** | `8082` | Model Context Protocol server: exposes registered MCP targets and tools to agents. See the [MCP testing guide](docs/mcp/testing-guide.md). |
 
 ## 🔌 Plugins
 

--- a/cmd/mcp-catalog-probe/main.go
+++ b/cmd/mcp-catalog-probe/main.go
@@ -133,7 +133,9 @@ func main() {
 	for _, r := range results {
 		counts[r.Status]++
 		line, _ := json.Marshal(r)
-		fmt.Fprintln(out, string(line))
+		if _, err := fmt.Fprintln(out, string(line)); err != nil {
+			fatalf("write report: %v", err)
+		}
 	}
 	fmt.Fprintf(os.Stderr, "probed %d servers:", len(results))
 	for _, k := range []string{
@@ -209,10 +211,6 @@ func probeOne(client *http.Client, timeout time.Duration, s map[string]any) prob
 		HiddenReason: reason,
 	}
 	defer func() { res.DurationMS = time.Since(start).Milliseconds() }()
-
-	if hidden {
-		// Still classify so --apply / reports stay useful when -include-hidden.
-	}
 
 	if transport == "sse" {
 		res.Status = statusBrokenUnsupp

--- a/cmd/mcp-catalog-probe/main.go
+++ b/cmd/mcp-catalog-probe/main.go
@@ -1,0 +1,370 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command mcp-catalog-probe probes curated MCP server URLs and optionally marks
+// broken entries as hidden in seed/mcp-catalog/enterprise-servers.json.
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	statusOK              = "ok"
+	statusAuthRequired    = "auth_required"
+	statusBrokenForbidden = "broken_forbidden"
+	statusBrokenUnreach   = "broken_unreachable"
+	statusBrokenProtocol  = "broken_protocol"
+	statusBrokenUnsupp    = "broken_unsupported"
+	statusSkippedConfig   = "skipped_needs_config"
+	statusSkippedHidden   = "skipped_hidden"
+)
+
+type catalogFile struct {
+	Servers []map[string]any `json:"servers"`
+}
+
+type probeResult struct {
+	Name         string `json:"name"`
+	Vendor       string `json:"vendor,omitempty"`
+	URL          string `json:"url"`
+	Transport    string `json:"transport"`
+	Status       string `json:"status"`
+	HTTPStatus   int    `json:"http_status,omitempty"`
+	Detail       string `json:"detail,omitempty"`
+	WasHidden    bool   `json:"was_hidden,omitempty"`
+	HiddenReason string `json:"hidden_reason,omitempty"`
+	DurationMS   int64  `json:"duration_ms"`
+}
+
+func main() {
+	catalogPath := flag.String("catalog", "seed/mcp-catalog/enterprise-servers.json", "path to enterprise-servers.json")
+	outPath := flag.String("out", "", "write JSONL report to this path (default stdout)")
+	concurrency := flag.Int("concurrency", 8, "max parallel probes")
+	timeout := flag.Duration("timeout", 15*time.Second, "per-server probe timeout")
+	apply := flag.Bool("apply", false, "write hidden/hidden_reason back into the catalog for broken_* results")
+	includeHidden := flag.Bool("include-hidden", false, "also probe entries that are already hidden")
+	only := flag.String("only", "", "comma-separated server names to probe")
+	flag.Parse()
+
+	raw, err := os.ReadFile(*catalogPath)
+	if err != nil {
+		fatalf("read catalog: %v", err)
+	}
+	var cat catalogFile
+	if err := json.Unmarshal(raw, &cat); err != nil {
+		fatalf("parse catalog: %v", err)
+	}
+
+	onlySet := map[string]struct{}{}
+	for _, n := range strings.Split(*only, ",") {
+		n = strings.TrimSpace(n)
+		if n != "" {
+			onlySet[n] = struct{}{}
+		}
+	}
+
+	jobs := make([]int, 0, len(cat.Servers))
+	for i, s := range cat.Servers {
+		name, _ := s["name"].(string)
+		if len(onlySet) > 0 {
+			if _, ok := onlySet[name]; !ok {
+				continue
+			}
+		}
+		hidden, _ := s["hidden"].(bool)
+		if hidden && !*includeHidden && len(onlySet) == 0 {
+			continue
+		}
+		jobs = append(jobs, i)
+	}
+
+	results := make([]probeResult, len(jobs))
+	sem := make(chan struct{}, max(1, *concurrency))
+	var wg sync.WaitGroup
+	client := &http.Client{Timeout: *timeout}
+
+	for ji, idx := range jobs {
+		wg.Add(1)
+		go func(ji, idx int) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			results[ji] = probeOne(client, *timeout, cat.Servers[idx])
+		}(ji, idx)
+	}
+	wg.Wait()
+
+	out := io.Writer(os.Stdout)
+	var outFile *os.File
+	if *outPath != "" {
+		outFile, err = os.Create(*outPath)
+		if err != nil {
+			fatalf("create out: %v", err)
+		}
+		defer func() { _ = outFile.Close() }()
+		out = outFile
+	}
+
+	counts := map[string]int{}
+	for _, r := range results {
+		counts[r.Status]++
+		line, _ := json.Marshal(r)
+		fmt.Fprintln(out, string(line))
+	}
+	fmt.Fprintf(os.Stderr, "probed %d servers:", len(results))
+	for _, k := range []string{
+		statusOK, statusAuthRequired, statusBrokenForbidden, statusBrokenUnreach,
+		statusBrokenProtocol, statusBrokenUnsupp, statusSkippedConfig, statusSkippedHidden,
+	} {
+		if n := counts[k]; n > 0 {
+			fmt.Fprintf(os.Stderr, " %s=%d", k, n)
+		}
+	}
+	fmt.Fprintln(os.Stderr)
+
+	if !*apply {
+		return
+	}
+	byName := map[string]probeResult{}
+	for _, r := range results {
+		byName[r.Name] = r
+	}
+	changed := 0
+	for _, s := range cat.Servers {
+		name, _ := s["name"].(string)
+		r, ok := byName[name]
+		if !ok {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(r.Status, "broken_"):
+			s["hidden"] = true
+			s["hidden_reason"] = hideReason(r)
+			changed++
+		case r.Status == statusOK:
+			if hidden, _ := s["hidden"].(bool); hidden {
+				delete(s, "hidden")
+				delete(s, "hidden_reason")
+				changed++
+			}
+		}
+	}
+	encoded, err := json.MarshalIndent(cat, "", "  ")
+	if err != nil {
+		fatalf("encode catalog: %v", err)
+	}
+	encoded = append(encoded, '\n')
+	if err := os.WriteFile(*catalogPath, encoded, 0o644); err != nil {
+		fatalf("write catalog: %v", err)
+	}
+	fmt.Fprintf(os.Stderr, "applied hidden updates to %d entries in %s\n", changed, *catalogPath)
+}
+
+func hideReason(r probeResult) string {
+	if r.Detail != "" {
+		return truncate(fmt.Sprintf("%s: %s", r.Status, r.Detail), 200)
+	}
+	return r.Status
+}
+
+func probeOne(client *http.Client, timeout time.Duration, s map[string]any) probeResult {
+	start := time.Now()
+	name, _ := s["name"].(string)
+	vendor, _ := s["vendor"].(string)
+	url, _ := s["server_url"].(string)
+	transport, _ := s["transport"].(string)
+	hidden, _ := s["hidden"].(bool)
+	reason, _ := s["hidden_reason"].(string)
+
+	res := probeResult{
+		Name:         name,
+		Vendor:       vendor,
+		URL:          url,
+		Transport:    transport,
+		WasHidden:    hidden,
+		HiddenReason: reason,
+	}
+	defer func() { res.DurationMS = time.Since(start).Milliseconds() }()
+
+	if hidden {
+		// Still classify so --apply / reports stay useful when -include-hidden.
+	}
+
+	if transport == "sse" {
+		res.Status = statusBrokenUnsupp
+		res.Detail = "TrustGate MCP plane only supports streamable-http"
+		return res
+	}
+
+	if needsURLConfig(s, url) {
+		res.Status = statusSkippedConfig
+		res.Detail = "server_url has unresolved required variables"
+		return res
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	status, body, err := postInitialize(ctx, client, url)
+	res.HTTPStatus = status
+	if err != nil {
+		res.Status, res.Detail = classifyDialError(err)
+		return res
+	}
+
+	switch {
+	case status == http.StatusUnauthorized:
+		res.Status = statusAuthRequired
+		res.Detail = "HTTP 401"
+	case status == http.StatusForbidden:
+		res.Status = statusBrokenForbidden
+		res.Detail = "HTTP 403"
+	case status >= 500:
+		res.Status = statusBrokenUnreach
+		res.Detail = fmt.Sprintf("HTTP %d", status)
+	case status >= 400:
+		// Other 4xx without a clear auth challenge — treat as forbidden/broken for catalog.
+		if status == http.StatusNotFound {
+			res.Status = statusBrokenUnreach
+			res.Detail = "HTTP 404"
+		} else {
+			res.Status = statusBrokenForbidden
+			res.Detail = fmt.Sprintf("HTTP %d", status)
+		}
+	case status >= 200 && status < 300:
+		if looksLikeMCPInitialize(body) {
+			res.Status = statusOK
+			res.Detail = "initialize ok"
+		} else {
+			res.Status = statusBrokenProtocol
+			res.Detail = truncate(string(body), 120)
+		}
+	default:
+		res.Status = statusBrokenProtocol
+		res.Detail = fmt.Sprintf("unexpected HTTP %d", status)
+	}
+	return res
+}
+
+func needsURLConfig(s map[string]any, url string) bool {
+	if strings.Contains(url, "{") {
+		return true
+	}
+	vars, _ := s["url_variables"].([]any)
+	for _, raw := range vars {
+		m, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		required, _ := m["required"].(bool)
+		if required {
+			return true
+		}
+	}
+	return false
+}
+
+func postInitialize(ctx context.Context, client *http.Client, endpoint string) (int, []byte, error) {
+	payload := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2025-03-26",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "trustgate-catalog-probe", "version": "1.0"},
+		},
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return 0, nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(raw))
+	if err != nil {
+		return 0, nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
+	return resp.StatusCode, body, nil
+}
+
+func looksLikeMCPInitialize(body []byte) bool {
+	var envelope map[string]any
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		// Some streamable servers return SSE framing; accept "event:" / "data:" with protocolVersion.
+		text := string(body)
+		return strings.Contains(text, "protocolVersion") || strings.Contains(text, "serverInfo")
+	}
+	if errObj, ok := envelope["error"].(map[string]any); ok {
+		// Initialize reached an MCP server that rejected the call — still "reachable protocol".
+		_ = errObj
+		return true
+	}
+	result, _ := envelope["result"].(map[string]any)
+	if result == nil {
+		return false
+	}
+	_, hasPV := result["protocolVersion"]
+	_, hasInfo := result["serverInfo"]
+	return hasPV || hasInfo
+}
+
+func classifyDialError(err error) (string, string) {
+	msg := err.Error()
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return statusBrokenUnreach, "timeout"
+	}
+	if errors.Is(err, context.DeadlineExceeded) || strings.Contains(msg, "context deadline exceeded") {
+		return statusBrokenUnreach, "timeout"
+	}
+	if strings.Contains(msg, "no such host") || strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "network is unreachable") || strings.Contains(msg, "TLS") ||
+		strings.Contains(msg, "certificate") {
+		return statusBrokenUnreach, truncate(msg, 160)
+	}
+	return statusBrokenUnreach, truncate(msg, 160)
+}
+
+func truncate(s string, n int) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/cmd/mcp-catalog-probe/main_test.go
+++ b/cmd/mcp-catalog-probe/main_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestNeedsURLConfig(t *testing.T) {
+	t.Parallel()
+	if !needsURLConfig(map[string]any{}, "https://x.example/{tenant}/mcp") {
+		t.Fatal("expected template URL to need config")
+	}
+	if needsURLConfig(map[string]any{}, "https://x.example/mcp") {
+		t.Fatal("plain URL should not need config")
+	}
+	s := map[string]any{
+		"url_variables": []any{map[string]any{"name": "tenant", "required": true}},
+	}
+	if !needsURLConfig(s, "https://x.example/mcp") {
+		t.Fatal("required url_variables should need config")
+	}
+}
+
+func TestLooksLikeMCPInitialize(t *testing.T) {
+	t.Parallel()
+	ok := []byte(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-26","serverInfo":{"name":"x"}}}`)
+	if !looksLikeMCPInitialize(ok) {
+		t.Fatal("expected valid initialize result")
+	}
+	rpcErr := []byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"auth"}}`)
+	if !looksLikeMCPInitialize(rpcErr) {
+		t.Fatal("MCP-level error still means protocol reached")
+	}
+	if looksLikeMCPInitialize([]byte(`{"ok":true}`)) {
+		t.Fatal("non-MCP JSON should fail")
+	}
+}
+
+func TestClassifyDialError(t *testing.T) {
+	t.Parallel()
+	status, _ := classifyDialError(context.DeadlineExceeded)
+	if status != statusBrokenUnreach {
+		t.Fatalf("deadline => %s", status)
+	}
+	status, _ = classifyDialError(&net.DNSError{Err: "no such host", Name: "x", IsNotFound: true})
+	if status != statusBrokenUnreach {
+		t.Fatalf("dns => %s", status)
+	}
+	status, _ = classifyDialError(timeoutError{})
+	if status != statusBrokenUnreach {
+		t.Fatalf("timeout => %s", status)
+	}
+}
+
+type timeoutError struct{}
+
+func (timeoutError) Error() string   { return "i/o timeout" }
+func (timeoutError) Timeout() bool   { return true }
+func (timeoutError) Temporary() bool { return true }
+
+func TestProbeOne_SSE(t *testing.T) {
+	t.Parallel()
+	r := probeOne(nil, time.Second, map[string]any{
+		"name":       "io.invideo/mcp",
+		"vendor":     "InVideo",
+		"transport":  "sse",
+		"server_url": "https://mcp.invideo.io/sse",
+	})
+	if r.Status != statusBrokenUnsupp {
+		t.Fatalf("status = %s, want %s", r.Status, statusBrokenUnsupp)
+	}
+}

--- a/docs/mcp/testing-guide.md
+++ b/docs/mcp/testing-guide.md
@@ -1,0 +1,354 @@
+# MCP testing guide
+
+How to exercise TrustGate’s **MCP plane** locally: configure registries and
+consumers on Admin, call JSON-RPC on `:8082`, point an agent client at the
+gateway, and map manual checks to the functional suite.
+
+This is **not** the Proxy LLM plane’s OpenAI-style tool calling. Agents talk
+MCP **to** TrustGate; TrustGate dials upstream MCP servers **as a client**
+(`streamable-http` via the official Go SDK).
+
+## 1. Mental model
+
+```mermaid
+flowchart LR
+  Agent["Agent_Cursor_Claude"] -->|"JSON-RPC MCP"| MCPPlane["TrustGate_MCP_:8082"]
+  Admin["Admin_:8080"] -.->|config| MCPPlane
+  MCPPlane -->|"composer + go-sdk"| Upstream["Upstream_MCP_servers"]
+  MCPPlane -->|"optional plugin"| Guard["TrustGuard_tool_guard"]
+```
+
+| Role | Who | Notes |
+|------|-----|--------|
+| MCP **client** | Cursor, Claude, `curl`, SDKs | Calls TrustGate |
+| MCP **server** (gateway) | TrustGate MCP plane | Aggregates tools/prompts/resources |
+| MCP **client** (upstream) | TrustGate composer | Dials registered MCP targets |
+| MCP **server** (upstream) | Vendor or local MCP | Registered as registry `type: mcp` |
+
+### Admin objects
+
+1. **Gateway** — owns registries, consumers, auth, roles, policies.
+2. **Registry** (`type: mcp`) — `mcp_target.url` (+ optional auth:
+   `none` / `static` / `passthrough` / `exchange` / `forwarded`).
+3. **Consumer** (`type: mcp`) — binds registries; optional `toolkit`,
+   `fail_mode` (`open` \| `closed`), or `routing_mode: role_based` with
+   `mcp_policies` on roles.
+
+### Auth (consumer → TrustGate)
+
+Preference for interactive agents is **OAuth2** (gateway brokers login;
+plain OIDC attach is rejected for MCP consumers). For smoke tests, an
+**API key** attached to the MCP consumer is enough — send it as
+`X-AG-API-Key` (same header as the Proxy plane). Bearer tokens are also
+accepted when OAuth/JWT auth is configured.
+
+### Endpoint shape
+
+Shared-host / path-scoped (what functional tests use):
+
+```text
+POST {MCP_URL}/{consumer_slug}/mcp
+```
+
+Pin the **Host** header to the gateway MCP host
+(`{gateway_slug}.{MCP_BASE_DOMAIN}` from the gateway create/get response
+`hosts.mcp`). Path-first auth resolves the consumer from
+`/{consumer_slug}/mcp`; the Host must still match a known gateway host
+so scoping works.
+
+Do **not** send the Admin JWT to the MCP plane — only the consumer
+credential.
+
+## 2. Prerequisites / process smoke
+
+```bash
+# Full stack (admin + proxy + mcp + infra)
+make up
+curl -sf localhost:8080/healthz   # admin
+curl -sf localhost:8082/healthz   # mcp
+
+# Or infra in Docker + planes on the host
+make compose-up
+make run-admin   # :8080
+make run-mcp     # :8082
+```
+
+Relevant env (see `.env.example`):
+
+| Variable | Default / role |
+|----------|----------------|
+| `SERVER_MCP_PORT` | `8082` |
+| `MCP_BASE_DOMAIN` | MCP host suffix (`{slug}.<domain>`) |
+| `GATEWAY_BASE_DOMAIN` | Proxy host suffix (separate from MCP) |
+| `STS_SIGNING_KEY` | RSA PEM for MCP session / JWKS (required in prod; ephemeral OK in local non-prod) |
+
+Mint an Admin token the same way as the README “Admin token” section
+(`SERVER_SECRET_KEY` → HS256 JWT).
+
+## 3. Happy path (Admin API + curl)
+
+Replace `$TOKEN`, URLs, and IDs as needed. Type fields are case-insensitive
+in the Admin API (`mcp` → `MCP`).
+
+### 3.1 Gateway
+
+```bash
+ADMIN="http://localhost:8080"
+MCP="http://localhost:8082"
+TOKEN="$ADMIN_TOKEN"
+
+GW=$(curl -s -X POST "$ADMIN/v1/gateways" \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"name":"MCP Demo","slug":"mcp-demo"}')
+GW_ID=$(echo "$GW" | jq -r .id)
+GW_SLUG=$(echo "$GW" | jq -r .slug)
+MCP_HOST=$(echo "$GW" | jq -r .hosts.mcp)   # e.g. mcp-demo.mcp.neuraltrust.sandbox
+```
+
+### 3.2 MCP registry (upstream)
+
+**Option A — catalog prefill**
+
+```bash
+curl -s "$ADMIN/v1/mcp-servers-catalog" \
+  -H "Authorization: Bearer $TOKEN" | jq '.mcp_servers[0:3]'
+```
+
+Use a catalog entry’s URL (and auth hints) when creating the registry, or
+add it from the Admin UI (“Add MCP server”).
+
+**Option B — local upstream**
+
+Functional tests spin a real streamable-HTTP MCP with
+`startMCPUpstream` in
+[`tests/functional/mcp_e2e_test.go`](../../tests/functional/mcp_e2e_test.go).
+Point `mcp_target.url` at any reachable streamable-HTTP MCP (your process,
+or a public catalog server in read-only mode).
+
+```bash
+# Example: registry pointing at an upstream you already run
+REG=$(curl -s -X POST "$ADMIN/v1/gateways/$GW_ID/registries" \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{
+    "name": "local-mcp",
+    "type": "mcp",
+    "weight": 1,
+    "mcp_target": { "url": "http://127.0.0.1:9100/mcp" }
+  }')
+REG_ID=$(echo "$REG" | jq -r .id)
+```
+
+Transport defaults to `streamable-http`. Omit `mcp_target.auth` (or set
+`"mode":"none"`) for an open local upstream.
+
+### 3.3 MCP consumer + API key
+
+An empty / omitted `toolkit` on an **inline** MCP consumer grants **full
+access** to tools exposed by bound registries (see
+`TestMCPServer_ToolsListAndCallWithFullAccess`).
+
+```bash
+CON=$(curl -s -X POST "$ADMIN/v1/gateways/$GW_ID/consumers" \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{
+    "name": "agent-client",
+    "type": "mcp",
+    "registries": [{"id": "'"$REG_ID"'"}]
+  }')
+CON_ID=$(echo "$CON" | jq -r .id)
+CON_SLUG=$(echo "$CON" | jq -r .slug)
+
+AUTH=$(curl -s -X POST "$ADMIN/v1/gateways/$GW_ID/auths" \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"name":"agent-key","type":"api_key"}')
+AUTH_ID=$(echo "$AUTH" | jq -r .id)
+API_KEY=$(echo "$AUTH" | jq -r .api_key)
+
+curl -s -X POST "$ADMIN/v1/gateways/$GW_ID/consumers/$CON_ID/auths/$AUTH_ID" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Optional toolkit (filter + alias), matching E2E:
+
+```json
+"toolkit": [
+  { "registry_id": "<REG_ID>", "tool": "echo", "expose_as": "alias-echo" }
+]
+```
+
+Optional `fail_mode`: `"closed"` fails the whole list/call when any bound
+upstream is down; `"open"` skips dead upstreams.
+
+### 3.4 JSON-RPC smoke
+
+Helpers in the suite (`mcpPost` / `mcpRPC`) POST to
+`MCPURL + "/" + consumerSlug + "/mcp"`, set `Content-Type: application/json`,
+send `X-AG-API-Key`, and pin `Host` to the gateway host.
+
+```bash
+mcp_rpc() {
+  local method="$1"
+  local params="${2:-null}"
+  curl -s -X POST "$MCP/$CON_SLUG/mcp" \
+    -H "Host: $MCP_HOST" \
+    -H "Content-Type: application/json" \
+    -H "X-AG-API-Key: $API_KEY" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"$method\",\"params\":$params}"
+}
+
+mcp_rpc initialize '{"protocolVersion":"2025-03-26"}'
+mcp_rpc ping null
+mcp_rpc tools/list null
+mcp_rpc tools/call '{"name":"echo","arguments":{"message":"hola"}}'
+
+# Optional
+mcp_rpc prompts/list null
+mcp_rpc resources/list null
+```
+
+Notifications (no `id`) return **202 Accepted**:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" -X POST "$MCP/$CON_SLUG/mcp" \
+  -H "Host: $MCP_HOST" \
+  -H "Content-Type: application/json" \
+  -H "X-AG-API-Key: $API_KEY" \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+```
+
+GET on the MCP path returns **405** (POST only for JSON-RPC).
+
+### Admin UI path
+
+Same objects via the frontend: gateway → **MCP** registries (“Add MCP
+server” from catalog or custom URL) → consumer type MCP → attach auth →
+call the MCP URL above.
+
+## 4. Real agent client (Cursor / Claude)
+
+Point the client at the TrustGate MCP URL with the consumer API key.
+Exact config keys vary by client version; the contract is:
+
+- **URL**: `http://localhost:8082/{consumer_slug}/mcp` (or the public MCP
+  host / path your ingress exposes).
+- **Headers**: `X-AG-API-Key: <key>`. If the client cannot set `Host`, use
+  a DNS/ingress name that already resolves to `{gateway_slug}.{MCP_BASE_DOMAIN}`.
+
+Example shape for Cursor `mcp.json` (adjust to your client’s schema):
+
+```json
+{
+  "mcpServers": {
+    "trustgate": {
+      "url": "http://localhost:8082/agent-client/mcp",
+      "headers": {
+        "X-AG-API-Key": "<consumer api key>"
+      }
+    }
+  }
+}
+```
+
+Checklist:
+
+1. Client completes `initialize` against TrustGate (not the upstream).
+2. `tools/list` shows only toolkit-/role-allowed tools (and aliases).
+3. `tools/call` returns upstream content; blocked tools get an RPC error
+   (e.g. `-32602` for toolkit miss).
+
+For OAuth-backed consumers, use the MCP plane’s well-known /
+`/oauth/*` flow (see §5 OAuth shared host) instead of a static API key.
+
+## 5. Scenario checklist ↔ functional tests
+
+Run the automated suite (boots a real binary including the MCP plane):
+
+```bash
+cp .env.functional.example .env.functional   # once
+make test-functional
+```
+
+| Scenario | What to try manually | Test reference |
+|----------|----------------------|----------------|
+| Reject unauthenticated | Omit `X-AG-API-Key` → HTTP 401 | `TestMCPServer_RejectsUnauthenticatedRequests` |
+| initialize / ping / notification | §3.4 | `TestMCPServer_InitializePingAndNotification` |
+| tools list/call (full access) | Empty toolkit, call a tool | `TestMCPServer_ToolsListAndCallWithFullAccess` |
+| Toolkit filter + aliases | Toolkit entry with `expose_as`; call alias; raw name fails | `TestMCPServer_ToolkitFiltersAndAliasesTools` |
+| Prompts / resources | `prompts/*`, `resources/*` with toolkit globs | `TestMCPServer_PromptsAndResources` |
+| Fail closed / open | Bind a dead upstream URL | `TestMCPServer_FailModeClosedRejectsWhenUpstreamIsDown`, `TestMCPServer_FailModeOpenSkipsDeadUpstream` |
+| Cross-consumer credential | Key of consumer B on path of consumer A | `TestMCPServer_CredentialOfAnotherConsumerIsRejected` |
+| Unknown / malformed RPC | Bad method / `jsonrpc: "1.0"` | `TestMCPServer_UnknownMethodAndMalformedBody` |
+| Role `mcp_policies` | `routing_mode: role_based` + role toolkit | `TestMCPServer_RoleBasedConsumer*` |
+| OAuth shared host | `/{slug}/mcp` + well-known resource metadata | `tests/functional/mcp_oauth_shared_host_test.go` |
+| Plugin enforce / observe | TrustGuard (or stub) on tool call chain | `tests/functional/mcp_plugin_chain_test.go` |
+| Per-tool rate limit | Rate limiter deny on `tools/call` | `TestPluginE2E_PerToolRateLimiter_MCPToolCallDeny` |
+| DB-less OAuth vault | Redis-backed vault without Postgres session store | `tests/functional/dbless_mcp_vault_test.go` |
+
+Living documentation: [`tests/functional/mcp_e2e_test.go`](../../tests/functional/mcp_e2e_test.go).
+
+## 6. Catalog health / hide broken vendors
+
+The curated list lives in
+[`seed/mcp-catalog/enterprise-servers.json`](../../seed/mcp-catalog/enterprise-servers.json)
+and is embedded at build time. Entries with `"hidden": true` are **omitted**
+from `GET /v1/mcp-servers-catalog` (so the Admin UI and the product Registry
+“Add MCP server” flow never show them). Keep the row in git with
+`hidden_reason` for audit / re-probe.
+
+Probe every concrete `server_url` (unauthenticated reachability):
+
+```bash
+make mcp-catalog-probe ARGS='-out /tmp/mcp-catalog-probe.jsonl'
+# After reviewing broken_* lines:
+make mcp-catalog-probe ARGS='-out /tmp/mcp-catalog-probe.jsonl -apply'
+```
+
+| Probe status | Meaning | `-apply` |
+|--------------|---------|----------|
+| `ok` | `initialize` reached an MCP server | clears `hidden` if set |
+| `auth_required` | HTTP 401 (expected for many OAuth/static servers) | no change |
+| `broken_forbidden` | HTTP 403 / other hard client deny (e.g. vendor allowlist) | sets `hidden` |
+| `broken_unreachable` | DNS / TLS / timeout / 5xx / 404 | sets `hidden` |
+| `broken_protocol` | HTTP 2xx but not MCP | sets `hidden` |
+| `broken_unsupported` | `transport: sse` (TrustGate only speaks `streamable-http`) | sets `hidden` |
+| `skipped_needs_config` | URL templates / required `url_variables` | no change |
+
+Known seed hides (not shown in catalog API):
+
+- SSE unsupported: Replicate (`com.replicate/mcp`), InVideo (`io.invideo/mcp`)
+- Probe `broken_*`: DocuSign, SonarCloud, Zapier, Rube, Datadog, PayPal
+
+Figma (`com.figma/mcp`) may return **401** (keep; OAuth) or **403** (vendor
+allowlist) depending on network — only hide when the probe reports
+`broken_forbidden`.
+
+## 7. Appendix: TrustGuard on the MCP chain
+
+When a gateway policy runs the TrustGuard plugin on MCP `tools/call`
+(pre-request / pre-response), poisoned tool descriptions and argument
+inspection are product concerns of **TrustGuard**, not this happy path.
+
+Use:
+
+- TrustGuard QA: **RT-UC-07** (poisoned MCP tool description) in that
+  repo’s `docs/qa/runtime-usecases.md`
+- Postman folder **07 — Agent & MCP Security (`tool_guard`)**
+- Payload shapes: TrustGuard `docs/api/provider-signatures.md` (MCP
+  JSON-RPC / tool_guard)
+
+TrustGate’s own plugin-chain behaviour is covered by
+`mcp_plugin_chain_test.go` (enforce block, observe-only, fail-open on
+guard errors).
+
+## 8. Troubleshooting
+
+| Symptom | Likely cause |
+|---------|----------------|
+| HTTP 401 | Missing/wrong `X-AG-API-Key`; auth not attached to this consumer; wrong Host / path so path-first auth cannot scope |
+| HTTP 403 / 401 with another key | Credential of a different consumer (`TestMCPServer_CredentialOfAnotherConsumerIsRejected`) |
+| Empty `tools` | No registry bound; toolkit/role policy denies all; upstream down with `fail_mode=closed` (RPC `-32603`) |
+| Toolkit call error `-32602` | Tool name not in toolkit (use `expose_as` alias if configured) |
+| Resource read error `-32002` | URI outside toolkit resource glob |
+| OAuth / session issues | Set a stable `STS_SIGNING_KEY` (required in prod); DB-less deployments need Redis vault (`dbless_mcp_vault_test.go`) |
+| GET → 405 | Expected — MCP JSON-RPC is POST-only on `/{slug}/mcp` |
+| Confusing LLM tool_calls | That traffic hits the **Proxy** plane (`:8081`), not MCP (`:8082`) |

--- a/pkg/app/catalog/mcp_servers.go
+++ b/pkg/app/catalog/mcp_servers.go
@@ -82,6 +82,10 @@ type rawServer struct {
 	OAuth        *domain.MCPOAuth        `json:"oauth"`
 	Tools        []domain.MCPTool        `json:"tools"`
 	Relevance    int                     `json:"relevance"`
+	// Hidden keeps the entry in the seed for audit/re-probe but omits it from
+	// ListMCPServers (Admin UI / product catalog).
+	Hidden       bool   `json:"hidden,omitempty"`
+	HiddenReason string `json:"hidden_reason,omitempty"`
 }
 
 func loadCuratedMCPServers() ([]domain.MCPServer, error) {
@@ -106,6 +110,9 @@ func parseCuratedMCPServers(data []byte) ([]domain.MCPServer, error) {
 			return nil, fmt.Errorf("mcp catalog: duplicate server code %q", s.Name)
 		}
 		seen[s.Name] = struct{}{}
+		if s.Hidden {
+			continue
+		}
 		servers = append(servers, domain.MCPServer{
 			Code:           s.Name,
 			DisplayName:    s.Vendor,

--- a/pkg/app/catalog/mcp_servers_test.go
+++ b/pkg/app/catalog/mcp_servers_test.go
@@ -43,6 +43,12 @@ func TestNewMCPServerCatalog_LoadsCuratedList(t *testing.T) {
 		require.Falsef(t, dup, "duplicate code %q", s.Code)
 		codes[s.Code] = struct{}{}
 	}
+
+	// Seed-hidden vendors must not appear in the served catalog.
+	require.NotContains(t, codes, "com.replicate/mcp")
+	require.NotContains(t, codes, "io.invideo/mcp")
+	require.NotContains(t, codes, "com.zapier/mcp")
+	require.NotContains(t, codes, "com.docusign/mcp")
 }
 
 func TestListMCPServers_SortedByRelevanceDesc(t *testing.T) {
@@ -99,6 +105,24 @@ func TestParseCuratedMCPServers_AcceptsUniqueCodes(t *testing.T) {
 	servers, err := parseCuratedMCPServers(data)
 	require.NoError(t, err)
 	require.Len(t, servers, 2)
+}
+
+func TestParseCuratedMCPServers_OmitsHidden(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`{"servers":[
+		{"name":"com.acme/mcp","transport":"streamable-http","server_url":"https://a.example.com/mcp"},
+		{"name":"com.hidden/mcp","transport":"streamable-http","server_url":"https://h.example.com/mcp","hidden":true,"hidden_reason":"broken"},
+		{"name":"com.beta/mcp","transport":"streamable-http","server_url":"https://b.example.com/mcp","hidden":false}
+	]}`)
+
+	servers, err := parseCuratedMCPServers(data)
+	require.NoError(t, err)
+	require.Len(t, servers, 2)
+	codes := []string{servers[0].Code, servers[1].Code}
+	require.Contains(t, codes, "com.acme/mcp")
+	require.Contains(t, codes, "com.beta/mcp")
+	require.NotContains(t, codes, "com.hidden/mcp")
 }
 
 func TestRequiresConfig_Classification(t *testing.T) {

--- a/seed/mcp-catalog/enterprise-servers.json
+++ b/seed/mcp-catalog/enterprise-servers.json
@@ -3466,7 +3466,9 @@
           "name": "RUBE_REMOTE_WORKBENCH",
           "description": "Cloud Python sandbox for processing between tool calls"
         }
-      ]
+      ],
+      "hidden": true,
+      "hidden_reason": "probe: broken_unreachable DNS failure"
     },
     {
       "name": "com.contentful/mcp",
@@ -4077,7 +4079,9 @@
           "name": "get_datadog_database_recommendations",
           "description": "Get DB recommendations"
         }
-      ]
+      ],
+      "hidden": true,
+      "hidden_reason": "probe: broken_unreachable HTTP 404"
     },
     {
       "name": "com.getdbt/mcp",
@@ -4797,7 +4801,9 @@
         ],
         "resource": "https://mcp-d.docusign.com/mcp"
       },
-      "relevance": 75
+      "relevance": 75,
+      "hidden": true,
+      "hidden_reason": "probe: broken_forbidden HTTP 403"
     },
     {
       "name": "com.dropbox/mcp",
@@ -7408,7 +7414,9 @@
       "description": "AI video generation and editing via InVideo.",
       "transport": "sse",
       "server_url": "https://mcp.invideo.io/sse",
-      "requires_auth": false
+      "requires_auth": false,
+      "hidden": true,
+      "hidden_reason": "connect fails: TrustGate MCP plane does not support SSE transport"
     },
     {
       "name": "dev.jam/mcp",
@@ -10761,7 +10769,9 @@
           "name": "list_transactions",
           "description": "List transactions"
         }
-      ]
+      ],
+      "hidden": true,
+      "hidden_reason": "probe: broken_unreachable HTTP 404"
     },
     {
       "name": "io.pendo/mcp",
@@ -11836,6 +11846,8 @@
       "transport": "sse",
       "server_url": "https://mcp.replicate.com/sse",
       "requires_auth": true,
+      "hidden": true,
+      "hidden_reason": "connect fails: TrustGate MCP plane does not support SSE transport",
       "oauth": {
         "required": true,
         "resource_metadata": true,
@@ -13053,7 +13065,9 @@
           "name": "change_security_hotspot_status",
           "description": "Review/change a hotspot status"
         }
-      ]
+      ],
+      "hidden": true,
+      "hidden_reason": "probe: broken_forbidden HTTP 400"
     },
     {
       "name": "com.sonatype/mcp",
@@ -15293,7 +15307,9 @@
           "name": "send_feedback",
           "description": "Send feedback to Zapier"
         }
-      ]
+      ],
+      "hidden": true,
+      "hidden_reason": "probe: broken_forbidden HTTP 403"
     },
     {
       "name": "us.zoom/docs",


### PR DESCRIPTION
## Summary
- Add `hidden` / `hidden_reason` on curated MCP catalog seed entries; loader omits them from `GET /v1/mcp-servers-catalog` (Admin UI + app Registry Connect).
- Hide vendors that fail to connect: Replicate & InVideo (SSE unsupported), plus probe-broken DocuSign, SonarCloud, Zapier, Rube, Datadog, PayPal.
- Add `cmd/mcp-catalog-probe` (`make mcp-catalog-probe`) and document MCP testing + catalog health in `docs/mcp/testing-guide.md`.

App needs no changes — it already proxies the TrustGate catalog API.

## Test plan
- [x] `go test ./pkg/app/catalog/... ./cmd/mcp-catalog-probe/...`
- [x] Full catalog probe run (`ok` / `auth_required` / `broken_*` classification)
- [ ] Confirm Replicate / InVideo / Zapier no longer appear in Admin or app “Add MCP server”
- [ ] Optional: `make mcp-catalog-probe ARGS='-out /tmp/report.jsonl'`