### PR TITLE
fix(trustguard): send MCP JSON-RPC payload to TrustGuard

### DIFF
--- a/pkg/infra/plugins/trustguard/client_test.go
+++ b/pkg/infra/plugins/trustguard/client_test.go
@@ -27,8 +27,12 @@ import (
 )
 
 func sampleRequest() GuardRequest {
+	payload, err := llmPayload("hello world")
+	if err != nil {
+		panic(err)
+	}
 	return GuardRequest{
-		Payload:    GuardPayload{Input: "hello world"},
+		Payload:    payload,
 		Direction:  "input",
 		Protocol:   "llm",
 		SessionID:  "session-1",
@@ -106,8 +110,8 @@ func TestGuardDecodesResponses(t *testing.T) {
 				if got.ConsumerID != "consumer-1" {
 					t.Errorf("consumer_id = %q, want %q", got.ConsumerID, "consumer-1")
 				}
-				if got.Payload.Input != "hello world" {
-					t.Errorf("payload.input = %q, want %q", got.Payload.Input, "hello world")
+				if llmPayloadInput(t, got.Payload) != "hello world" {
+					t.Errorf("payload.input = %q, want %q", llmPayloadInput(t, got.Payload), "hello world")
 				}
 				w.WriteHeader(tt.statusCode)
 				_, _ = io.WriteString(w, tt.respBody)

--- a/pkg/infra/plugins/trustguard/data.go
+++ b/pkg/infra/plugins/trustguard/data.go
@@ -15,12 +15,14 @@
 package trustguard
 
 import (
+	"encoding/json"
+
 	appplugins "github.com/NeuralTrust/TrustGate/pkg/app/plugins"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics"
 )
 
 type GuardRequest struct {
-	Payload    GuardPayload    `json:"payload"`
+	Payload    json.RawMessage `json:"payload"`
 	Direction  string          `json:"direction"`
 	Protocol   string          `json:"protocol"`
 	GatewayID  string          `json:"gateway_id"`
@@ -29,6 +31,7 @@ type GuardRequest struct {
 	Attributes GuardAttributes `json:"attributes"`
 }
 
+// GuardPayload is the LLM evaluate body: flattened text plus optional attachments.
 type GuardPayload struct {
 	Input       string            `json:"input"`
 	Attachments []GuardAttachment `json:"attachments,omitempty"`

--- a/pkg/infra/plugins/trustguard/mcp.go
+++ b/pkg/infra/plugins/trustguard/mcp.go
@@ -117,3 +117,45 @@ func blockIsText(block mcpContentBlock) bool {
 	}
 	return block.Type == "text"
 }
+
+// mcpToolsCallPayload wraps Gate's {name,arguments} tools/call params in the
+// JSON-RPC envelope TrustGuard expects for protocol=mcp.
+func mcpToolsCallPayload(body []byte) (json.RawMessage, error) {
+	var call mcpToolCall
+	if err := json.Unmarshal(body, &call); err != nil {
+		return nil, err
+	}
+	params := map[string]any{"name": call.Name}
+	if len(call.Arguments) > 0 {
+		var args any
+		if err := json.Unmarshal(call.Arguments, &args); err != nil {
+			params["arguments"] = string(call.Arguments)
+		} else {
+			params["arguments"] = args
+		}
+	}
+	return json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params":  params,
+	})
+}
+
+// mcpToolsResultPayload wraps a CallToolResult body as a JSON-RPC result
+// envelope for protocol=mcp output evaluation.
+func mcpToolsResultPayload(body []byte) (json.RawMessage, error) {
+	var result any
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, err
+	}
+	return json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"result":  result,
+	})
+}
+
+func llmPayload(input string) (json.RawMessage, error) {
+	return json.Marshal(GuardPayload{Input: input})
+}

--- a/pkg/infra/plugins/trustguard/mcp_test.go
+++ b/pkg/infra/plugins/trustguard/mcp_test.go
@@ -167,3 +167,40 @@ func TestFlattenArgumentStrings(t *testing.T) {
 		})
 	}
 }
+
+func TestMCPToolsCallPayload(t *testing.T) {
+	t.Parallel()
+	raw, err := mcpToolsCallPayload([]byte(`{"name":"search","arguments":{"query":"find me"}}`))
+	if err != nil {
+		t.Fatalf("mcpToolsCallPayload: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m["jsonrpc"] != "2.0" || m["method"] != "tools/call" {
+		t.Fatalf("envelope = %#v", m)
+	}
+	params, _ := m["params"].(map[string]any)
+	if params["name"] != "search" {
+		t.Fatalf("name = %#v", params["name"])
+	}
+}
+
+func TestMCPToolsResultPayload(t *testing.T) {
+	t.Parallel()
+	raw, err := mcpToolsResultPayload([]byte(`{"content":[{"type":"text","text":"ok"}],"isError":false}`))
+	if err != nil {
+		t.Fatalf("mcpToolsResultPayload: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m["jsonrpc"] != "2.0" {
+		t.Fatalf("jsonrpc = %#v", m["jsonrpc"])
+	}
+	if _, ok := m["result"]; !ok {
+		t.Fatalf("missing result: %#v", m)
+	}
+}

--- a/pkg/infra/plugins/trustguard/plugin.go
+++ b/pkg/infra/plugins/trustguard/plugin.go
@@ -16,6 +16,7 @@ package trustguard
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -177,6 +178,7 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 	}
 
 	var text string
+	var payload json.RawMessage
 	tgt := transformTarget{isResponse: direction == directionOutput}
 	if mcpMode {
 		if direction == directionInput {
@@ -184,11 +186,37 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 				return passThrough(), nil
 			}
 			text = mcpInputText(in.Request.Body)
+			if strings.TrimSpace(text) == "" {
+				return passThrough(), nil
+			}
+			raw, err := mcpToolsCallPayload(in.Request.Body)
+			if err != nil {
+				p.warn(ctx, "trustguard mcp tools/call payload build failed, failing open",
+					slog.String("plugin", PluginName),
+					slog.Any("error", err),
+				)
+				setExtras(in.Event, guardData{Direction: direction, Decision: decisionFailedOpen, FailedOpen: true})
+				return passThrough(), nil
+			}
+			payload = raw
 		} else {
 			if in.Response == nil || in.Response.Streaming || len(in.Response.Body) == 0 {
 				return passThrough(), nil
 			}
 			text = mcpOutputText(in.Response.Body)
+			if strings.TrimSpace(text) == "" {
+				return passThrough(), nil
+			}
+			raw, err := mcpToolsResultPayload(in.Response.Body)
+			if err != nil {
+				p.warn(ctx, "trustguard mcp tools/result payload build failed, failing open",
+					slog.String("plugin", PluginName),
+					slog.Any("error", err),
+				)
+				setExtras(in.Event, guardData{Direction: direction, Decision: decisionFailedOpen, FailedOpen: true})
+				return passThrough(), nil
+			}
+			payload = raw
 		}
 	} else {
 		format, err := adapter.ResolveAgentFormat(in.Request.Provider, in.Request.SourceFormat, nil)
@@ -222,9 +250,19 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 				return rewriteResponse(reg, format, cresp, masked)
 			}
 		}
-	}
-	if strings.TrimSpace(text) == "" {
-		return passThrough(), nil
+		if strings.TrimSpace(text) == "" {
+			return passThrough(), nil
+		}
+		raw, err := llmPayload(text)
+		if err != nil {
+			p.warn(ctx, "trustguard llm payload build failed, failing open",
+				slog.String("plugin", PluginName),
+				slog.Any("error", err),
+			)
+			setExtras(in.Event, guardData{Direction: direction, Decision: decisionFailedOpen, FailedOpen: true})
+			return passThrough(), nil
+		}
+		payload = raw
 	}
 
 	protocol := protocolFor(in.Request.ConsumerType)
@@ -232,7 +270,7 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 		protocol = protocolMCP
 	}
 	body := GuardRequest{
-		Payload:    GuardPayload{Input: text},
+		Payload:    payload,
 		Direction:  direction,
 		Protocol:   protocol,
 		GatewayID:  in.Request.GatewayID,

--- a/pkg/infra/plugins/trustguard/plugin_test.go
+++ b/pkg/infra/plugins/trustguard/plugin_test.go
@@ -33,6 +33,24 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/infra/trace"
 )
 
+func llmPayloadInput(t *testing.T, raw json.RawMessage) string {
+	t.Helper()
+	var p GuardPayload
+	if err := json.Unmarshal(raw, &p); err != nil {
+		t.Fatalf("unmarshal llm payload: %v", err)
+	}
+	return p.Input
+}
+
+func mcpPayloadMap(t *testing.T, raw json.RawMessage) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal mcp payload: %v", err)
+	}
+	return m
+}
+
 const testTimeout = 2 * time.Second
 
 func openAIRequestBody() []byte {
@@ -230,8 +248,8 @@ func TestExecutePreRequestBlockReturns403(t *testing.T) {
 	if got.Attributes.Model.Name != "gpt-4o-mini" || got.Attributes.Model.Provider != "openai" {
 		t.Fatalf("model = %+v, want gpt-4o-mini/openai", got.Attributes.Model)
 	}
-	if got.Payload.Input != "be safe\nhello world" {
-		t.Fatalf("input = %q, want %q", got.Payload.Input, "be safe\nhello world")
+	if llmPayloadInput(t, got.Payload) != "be safe\nhello world" {
+		t.Fatalf("input = %q, want %q", llmPayloadInput(t, got.Payload), "be safe\nhello world")
 	}
 }
 
@@ -395,8 +413,8 @@ func TestExecutePreResponseBlockReturns403(t *testing.T) {
 	if got.Direction != directionOutput {
 		t.Fatalf("direction = %q, want %q", got.Direction, directionOutput)
 	}
-	if got.Payload.Input != "the answer" {
-		t.Fatalf("input = %q, want %q", got.Payload.Input, "the answer")
+	if llmPayloadInput(t, got.Payload) != "the answer" {
+		t.Fatalf("input = %q, want %q", llmPayloadInput(t, got.Payload), "the answer")
 	}
 }
 
@@ -742,8 +760,8 @@ func TestExecuteForwardsFullGuardRequest(t *testing.T) {
 	if got.ConsumerID != "consumer-real-42" {
 		t.Fatalf("consumer_id = %q, want consumer-real-42", got.ConsumerID)
 	}
-	if got.Payload.Input != "be safe\nhello world" {
-		t.Fatalf("input = %q, want %q", got.Payload.Input, "be safe\nhello world")
+	if llmPayloadInput(t, got.Payload) != "be safe\nhello world" {
+		t.Fatalf("input = %q, want %q", llmPayloadInput(t, got.Payload), "be safe\nhello world")
 	}
 	if got.Attributes.ContentType != contentTypeJSON {
 		t.Fatalf("attributes.content_type = %q, want %q", got.Attributes.ContentType, contentTypeJSON)
@@ -1096,8 +1114,17 @@ func TestExecuteMCPInputBlock(t *testing.T) {
 	if got.Attributes.Model.Provider != "" {
 		t.Fatalf("provider = %q, want empty", got.Attributes.Model.Provider)
 	}
-	if got.Payload.Input != "search\nfind me" {
-		t.Fatalf("input = %q, want %q", got.Payload.Input, "search\nfind me")
+	payload := mcpPayloadMap(t, got.Payload)
+	if payload["jsonrpc"] != "2.0" || payload["method"] != "tools/call" {
+		t.Fatalf("mcp payload = %#v, want jsonrpc tools/call", payload)
+	}
+	params, _ := payload["params"].(map[string]any)
+	if params["name"] != "search" {
+		t.Fatalf("params.name = %#v, want search", params["name"])
+	}
+	args, _ := params["arguments"].(map[string]any)
+	if args["query"] != "find me" {
+		t.Fatalf("params.arguments = %#v, want query=find me", args)
 	}
 }
 
@@ -1145,8 +1172,18 @@ func TestExecuteMCPOutputBlock(t *testing.T) {
 	if got.Protocol != protocolMCP {
 		t.Fatalf("protocol = %q, want %q", got.Protocol, protocolMCP)
 	}
-	if got.Payload.Input != "the answer" {
-		t.Fatalf("input = %q, want %q", got.Payload.Input, "the answer")
+	payload := mcpPayloadMap(t, got.Payload)
+	if payload["jsonrpc"] != "2.0" {
+		t.Fatalf("mcp payload jsonrpc = %#v, want 2.0", payload["jsonrpc"])
+	}
+	result, _ := payload["result"].(map[string]any)
+	content, _ := result["content"].([]any)
+	if len(content) == 0 {
+		t.Fatalf("mcp result missing content: %#v", payload)
+	}
+	block, _ := content[0].(map[string]any)
+	if block["text"] != "the answer" {
+		t.Fatalf("result content text = %#v, want the answer", block["text"])
 	}
 }
 
@@ -1205,8 +1242,8 @@ func TestExecuteMCPInputBlockWithNilRegistry(t *testing.T) {
 	if _, ok := appplugins.AsPluginError(err); !ok {
 		t.Fatalf("expected *PluginError, got %v", err)
 	}
-	if got := f.captured(); got.Payload.Input != "search\nfind me" {
-		t.Fatalf("input = %q, want %q", got.Payload.Input, "search\nfind me")
+	if got := f.captured(); mcpPayloadMap(t, got.Payload)["method"] != "tools/call" {
+		t.Fatalf("mcp payload = %#v, want tools/call", mcpPayloadMap(t, got.Payload))
 	}
 }
 

--- a/tests/functional/plugin_trustguard_test.go
+++ b/tests/functional/plugin_trustguard_test.go
@@ -52,7 +52,7 @@ func TestPluginE2E_TrustGuard_Enforce(t *testing.T) {
 		assert.Equal(t, "llm", guard.Protocol)
 		assert.NotEmpty(t, guard.GatewayID)
 		assert.NotEmpty(t, guard.ConsumerID)
-		assert.Contains(t, guard.Payload.Input, "hello, how are you?")
+		assert.Contains(t, trustGuardInspectText(guard.Payload), "hello, how are you?")
 
 		tokensAfterFirst := tg.TokenHits()
 		status, _, raw = proxyRequest(t, http.MethodPost, apiKey, path, nil,

--- a/tests/functional/trustguard_stub_test.go
+++ b/tests/functional/trustguard_stub_test.go
@@ -63,13 +63,62 @@ type trustGuardTokenCapture struct {
 }
 
 type trustGuardGuardCapture struct {
-	Payload struct {
+	Payload    json.RawMessage `json:"payload"`
+	Direction  string          `json:"direction"`
+	Protocol   string          `json:"protocol"`
+	GatewayID  string          `json:"gateway_id"`
+	ConsumerID string          `json:"consumer_id"`
+}
+
+func trustGuardInspectText(payload json.RawMessage) string {
+	if len(payload) == 0 {
+		return ""
+	}
+	var llm struct {
 		Input string `json:"input"`
-	} `json:"payload"`
-	Direction  string `json:"direction"`
-	Protocol   string `json:"protocol"`
-	GatewayID  string `json:"gateway_id"`
-	ConsumerID string `json:"consumer_id"`
+	}
+	if err := json.Unmarshal(payload, &llm); err == nil && strings.TrimSpace(llm.Input) != "" {
+		return llm.Input
+	}
+	var mcp map[string]any
+	if err := json.Unmarshal(payload, &mcp); err != nil {
+		return string(payload)
+	}
+	var parts []string
+	if params, ok := mcp["params"].(map[string]any); ok {
+		parts = append(parts, flattenJSONStrings(params)...)
+	}
+	if result, ok := mcp["result"].(map[string]any); ok {
+		parts = append(parts, flattenJSONStrings(result)...)
+	}
+	if len(parts) == 0 {
+		return string(payload)
+	}
+	return strings.Join(parts, "\n")
+}
+
+func flattenJSONStrings(v any) []string {
+	switch x := v.(type) {
+	case string:
+		if strings.TrimSpace(x) == "" {
+			return nil
+		}
+		return []string{x}
+	case map[string]any:
+		out := make([]string, 0, len(x))
+		for _, child := range x {
+			out = append(out, flattenJSONStrings(child)...)
+		}
+		return out
+	case []any:
+		out := make([]string, 0, len(x))
+		for _, child := range x {
+			out = append(out, flattenJSONStrings(child)...)
+		}
+		return out
+	default:
+		return nil
+	}
 }
 
 func (s *trustGuardStub) URL() string { return s.server.URL }
@@ -148,17 +197,18 @@ func (s *trustGuardStub) handleGuard(w http.ResponseWriter, r *http.Request) {
 	s.lastGuardAuth = r.Header.Get("Authorization")
 	s.mu.Unlock()
 
-	if strings.Contains(strings.ToLower(req.Payload.Input), trustGuardErrorWord) {
+	text := trustGuardInspectText(req.Payload)
+	if strings.Contains(strings.ToLower(text), trustGuardErrorWord) {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	if strings.Contains(strings.ToLower(req.Payload.Input), trustGuardBlockWord) {
+	if strings.Contains(strings.ToLower(text), trustGuardBlockWord) {
 		_, _ = io.WriteString(w, `{"status":"block","findings":[{"source":{"kind":"detector","plugin":"prompt_guard"},"signal":{"type":"prompt_injection"},"outcome":{"action":"block"}}],"trace_id":"tg-trace-1","request_id":"tg-req-1"}`)
 		return
 	}
-	if strings.Contains(req.Payload.Input, trustGuardMaskWord) {
-		masked := strings.ReplaceAll(req.Payload.Input, trustGuardMaskWord, trustGuardMaskToken)
+	if strings.Contains(text, trustGuardMaskWord) {
+		masked := strings.ReplaceAll(text, trustGuardMaskWord, trustGuardMaskToken)
 		payload, _ := json.Marshal(map[string]string{"input": masked})
 		_, _ = io.WriteString(w, `{"status":"transform","transformed_payload":`+string(payload)+`,"findings":[{"source":{"kind":"detector","plugin":"data_loss_prevention"},"signal":{"type":"pii"},"outcome":{"action":"transform"}}],"trace_id":"tg-trace-3","request_id":"tg-req-3"}`)
 		return


### PR DESCRIPTION
## Summary
- Native MCP evaluate calls now send a **JSON-RPC** `payload` (`tools/call` / `result`) instead of `{ "input": "flattened text" }`.
- Matches TrustGuard `validateMCP` contract (JSON-RPC or `messages`+`tools`).
- LLM path unchanged (`payload.input` flattened transcript).

## Why
Gate was failing open on MCP: Guard returns 400 for bare `input` when `protocol=mcp`.

## Test plan
- [x] `go test ./pkg/infra/plugins/trustguard/`
- [ ] Review live Gate→Guard `/v1/evaluate` body for an MCP `tools/call`
- [ ] Confirm MCP policy/detectors no longer fail-open on shape

**Do not merge until reviewed.**