### PR TITLE
fix(trustguard): send LLM evaluate as chat messages for IPI

### DIFF
--- a/pkg/infra/plugins/trustguard/data.go
+++ b/pkg/infra/plugins/trustguard/data.go
@@ -31,7 +31,8 @@ type GuardRequest struct {
 	Attributes GuardAttributes `json:"attributes"`
 }
 
-// GuardPayload is the LLM evaluate body: flattened text plus optional attachments.
+// GuardPayload is the minimal LLM evaluate body used for response-direction
+// inspect (assistant text). Request-direction LLM evaluates use messages[].
 type GuardPayload struct {
 	Input       string            `json:"input"`
 	Attachments []GuardAttachment `json:"attachments,omitempty"`

--- a/pkg/infra/plugins/trustguard/llm.go
+++ b/pkg/infra/plugins/trustguard/llm.go
@@ -1,0 +1,109 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trustguard
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/adapter"
+)
+
+// llmRequestPayload builds a protocol=llm evaluate payload that preserves chat
+// roles (including role=tool responses and assistant tool_calls). Flattening to
+// {input} loses roles, so detectors that only inspect tool content cannot run.
+func llmRequestPayload(creq *adapter.CanonicalRequest) (json.RawMessage, error) {
+	return json.Marshal(map[string]any{
+		"messages": guardChatMessages(creq),
+	})
+}
+
+func guardChatMessages(creq *adapter.CanonicalRequest) []map[string]any {
+	if creq == nil {
+		return nil
+	}
+	out := make([]map[string]any, 0, len(creq.Messages)+1)
+	if s := strings.TrimSpace(creq.System); s != "" {
+		out = append(out, map[string]any{
+			"role":    "system",
+			"content": s,
+		})
+	}
+	for _, msg := range creq.Messages {
+		out = append(out, guardChatMessage(msg))
+	}
+	return out
+}
+
+func guardChatMessage(msg adapter.CanonicalMessage) map[string]any {
+	m := map[string]any{
+		"role": msg.Role,
+	}
+	if len(msg.ToolCalls) > 0 {
+		calls := make([]map[string]any, 0, len(msg.ToolCalls))
+		for _, tc := range msg.ToolCalls {
+			calls = append(calls, map[string]any{
+				"id":   tc.ID,
+				"type": "function",
+				"function": map[string]any{
+					"name":      tc.Name,
+					"arguments": tc.Arguments,
+				},
+			})
+		}
+		m["tool_calls"] = calls
+		if strings.TrimSpace(msg.Content) == "" {
+			m["content"] = nil
+		} else {
+			m["content"] = msg.Content
+		}
+	} else {
+		m["content"] = msg.Content
+	}
+	if msg.ToolCallID != "" {
+		m["tool_call_id"] = msg.ToolCallID
+	}
+	return m
+}
+
+// joinedTransformedMessages rebuilds the newline-joined text TrustGate uses for
+// request rewrite from a Guard transformed_payload that carries messages[].
+// Order matches requestParts: system (as role=system) then each non-empty content.
+func joinedTransformedMessages(payload map[string]any) (string, bool) {
+	raw, ok := payload["messages"]
+	if !ok || raw == nil {
+		return "", false
+	}
+	arr, ok := raw.([]any)
+	if !ok || len(arr) == 0 {
+		return "", false
+	}
+	parts := make([]string, 0, len(arr))
+	for _, item := range arr {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		content, ok := m["content"].(string)
+		if !ok || strings.TrimSpace(content) == "" {
+			continue
+		}
+		parts = append(parts, content)
+	}
+	if len(parts) == 0 {
+		return "", false
+	}
+	return strings.Join(parts, "\n"), true
+}

--- a/pkg/infra/plugins/trustguard/llm_test.go
+++ b/pkg/infra/plugins/trustguard/llm_test.go
@@ -1,0 +1,122 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trustguard
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/adapter"
+)
+
+func TestLLMRequestPayloadPreservesToolRoles(t *testing.T) {
+	t.Parallel()
+
+	creq := &adapter.CanonicalRequest{
+		System: "be safe",
+		Messages: []adapter.CanonicalMessage{
+			{Role: "user", Content: "get weather"},
+			{
+				Role:    "assistant",
+				Content: "",
+				ToolCalls: []adapter.CanonicalToolCall{{
+					ID:        "call_1",
+					Name:      "get_weather",
+					Arguments: `{"city":"Paris"}`,
+				}},
+			},
+			{Role: "tool", Content: `{"temp":18}`, ToolCallID: "call_1"},
+		},
+	}
+
+	raw, err := llmRequestPayload(creq)
+	if err != nil {
+		t.Fatalf("llmRequestPayload: %v", err)
+	}
+	var payload struct {
+		Messages []map[string]any `json:"messages"`
+		Input    string           `json:"input"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if payload.Input != "" {
+		t.Fatalf("input = %q, want empty (roles must not be flattened)", payload.Input)
+	}
+	if len(payload.Messages) != 4 {
+		t.Fatalf("messages len = %d, want 4", len(payload.Messages))
+	}
+	if payload.Messages[0]["role"] != "system" || payload.Messages[0]["content"] != "be safe" {
+		t.Fatalf("system message = %#v", payload.Messages[0])
+	}
+	if payload.Messages[1]["role"] != "user" {
+		t.Fatalf("user role = %#v", payload.Messages[1]["role"])
+	}
+	if payload.Messages[2]["role"] != "assistant" {
+		t.Fatalf("assistant role = %#v", payload.Messages[2]["role"])
+	}
+	if payload.Messages[2]["content"] != nil {
+		t.Fatalf("assistant content = %#v, want null", payload.Messages[2]["content"])
+	}
+	calls, ok := payload.Messages[2]["tool_calls"].([]any)
+	if !ok || len(calls) != 1 {
+		t.Fatalf("tool_calls = %#v", payload.Messages[2]["tool_calls"])
+	}
+	if payload.Messages[3]["role"] != "tool" {
+		t.Fatalf("tool role = %#v", payload.Messages[3]["role"])
+	}
+	if payload.Messages[3]["content"] != `{"temp":18}` {
+		t.Fatalf("tool content = %#v", payload.Messages[3]["content"])
+	}
+	if payload.Messages[3]["tool_call_id"] != "call_1" {
+		t.Fatalf("tool_call_id = %#v", payload.Messages[3]["tool_call_id"])
+	}
+}
+
+func TestJoinedTransformedMessages(t *testing.T) {
+	t.Parallel()
+
+	got, ok := joinedTransformedMessages(map[string]any{
+		"messages": []any{
+			map[string]any{"role": "system", "content": "be safe"},
+			map[string]any{"role": "user", "content": "hello"},
+			map[string]any{"role": "assistant", "content": nil, "tool_calls": []any{}},
+			map[string]any{"role": "tool", "content": "weather ok"},
+		},
+	})
+	if !ok {
+		t.Fatal("expected joined text")
+	}
+	if got != "be safe\nhello\nweather ok" {
+		t.Fatalf("joined = %q, want system/user/tool contents", got)
+	}
+}
+
+func TestTransformedInputPrefersInputThenMessages(t *testing.T) {
+	t.Parallel()
+
+	if got, ok := transformedInput(map[string]any{"input": "flat"}); !ok || got != "flat" {
+		t.Fatalf("input key: got %q ok=%v", got, ok)
+	}
+	got, ok := transformedInput(map[string]any{
+		"messages": []any{
+			map[string]any{"role": "user", "content": "a"},
+			map[string]any{"role": "tool", "content": "b"},
+		},
+	})
+	if !ok || got != "a\nb" {
+		t.Fatalf("messages fallback: got %q ok=%v", got, ok)
+	}
+}

--- a/pkg/infra/plugins/trustguard/plugin.go
+++ b/pkg/infra/plugins/trustguard/plugin.go
@@ -231,11 +231,23 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 			if decErr != nil || creq == nil {
 				return passThrough(), nil
 			}
-			text = joinRequestText(creq)
+			if strings.TrimSpace(joinRequestText(creq)) == "" {
+				return passThrough(), nil
+			}
 			reg := p.registry
 			tgt.apply = func(masked string) ([]byte, bool) {
 				return rewriteRequest(reg, format, creq, masked)
 			}
+			raw, err := llmRequestPayload(creq)
+			if err != nil {
+				p.warn(ctx, "trustguard llm payload build failed, failing open",
+					slog.String("plugin", PluginName),
+					slog.Any("error", err),
+				)
+				setExtras(in.Event, guardData{Direction: direction, Decision: decisionFailedOpen, FailedOpen: true})
+				return passThrough(), nil
+			}
+			payload = raw
 		} else {
 			if in.Response == nil || in.Response.Streaming || len(in.Response.Body) == 0 {
 				return passThrough(), nil
@@ -245,24 +257,24 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 				return passThrough(), nil
 			}
 			text = cresp.Content
+			if strings.TrimSpace(text) == "" {
+				return passThrough(), nil
+			}
 			reg := p.registry
 			tgt.apply = func(masked string) ([]byte, bool) {
 				return rewriteResponse(reg, format, cresp, masked)
 			}
+			raw, err := llmPayload(text)
+			if err != nil {
+				p.warn(ctx, "trustguard llm payload build failed, failing open",
+					slog.String("plugin", PluginName),
+					slog.Any("error", err),
+				)
+				setExtras(in.Event, guardData{Direction: direction, Decision: decisionFailedOpen, FailedOpen: true})
+				return passThrough(), nil
+			}
+			payload = raw
 		}
-		if strings.TrimSpace(text) == "" {
-			return passThrough(), nil
-		}
-		raw, err := llmPayload(text)
-		if err != nil {
-			p.warn(ctx, "trustguard llm payload build failed, failing open",
-				slog.String("plugin", PluginName),
-				slog.Any("error", err),
-			)
-			setExtras(in.Event, guardData{Direction: direction, Decision: decisionFailedOpen, FailedOpen: true})
-			return passThrough(), nil
-		}
-		payload = raw
 	}
 
 	protocol := protocolFor(in.Request.ConsumerType)

--- a/pkg/infra/plugins/trustguard/plugin_test.go
+++ b/pkg/infra/plugins/trustguard/plugin_test.go
@@ -42,6 +42,35 @@ func llmPayloadInput(t *testing.T, raw json.RawMessage) string {
 	return p.Input
 }
 
+func llmPayloadMessages(t *testing.T, raw json.RawMessage) []map[string]any {
+	t.Helper()
+	var p struct {
+		Messages []map[string]any `json:"messages"`
+	}
+	if err := json.Unmarshal(raw, &p); err != nil {
+		t.Fatalf("unmarshal llm messages payload: %v", err)
+	}
+	return p.Messages
+}
+
+func assertLLMRequestMessages(t *testing.T, raw json.RawMessage, wantRoles []string, wantContents []string) {
+	t.Helper()
+	msgs := llmPayloadMessages(t, raw)
+	if len(msgs) != len(wantRoles) {
+		t.Fatalf("messages len = %d, want %d (%#v)", len(msgs), len(wantRoles), msgs)
+	}
+	for i := range wantRoles {
+		if got, _ := msgs[i]["role"].(string); got != wantRoles[i] {
+			t.Fatalf("messages[%d].role = %q, want %q", i, got, wantRoles[i])
+		}
+		if i < len(wantContents) && wantContents[i] != "" {
+			if got, _ := msgs[i]["content"].(string); got != wantContents[i] {
+				t.Fatalf("messages[%d].content = %q, want %q", i, got, wantContents[i])
+			}
+		}
+	}
+}
+
 func mcpPayloadMap(t *testing.T, raw json.RawMessage) map[string]any {
 	t.Helper()
 	var m map[string]any
@@ -248,9 +277,7 @@ func TestExecutePreRequestBlockReturns403(t *testing.T) {
 	if got.Attributes.Model.Name != "gpt-4o-mini" || got.Attributes.Model.Provider != "openai" {
 		t.Fatalf("model = %+v, want gpt-4o-mini/openai", got.Attributes.Model)
 	}
-	if llmPayloadInput(t, got.Payload) != "be safe\nhello world" {
-		t.Fatalf("input = %q, want %q", llmPayloadInput(t, got.Payload), "be safe\nhello world")
-	}
+	assertLLMRequestMessages(t, got.Payload, []string{"system", "user"}, []string{"be safe", "hello world"})
 }
 
 func TestExecutePreRequestRateLimitReturns429(t *testing.T) {
@@ -760,9 +787,7 @@ func TestExecuteForwardsFullGuardRequest(t *testing.T) {
 	if got.ConsumerID != "consumer-real-42" {
 		t.Fatalf("consumer_id = %q, want consumer-real-42", got.ConsumerID)
 	}
-	if llmPayloadInput(t, got.Payload) != "be safe\nhello world" {
-		t.Fatalf("input = %q, want %q", llmPayloadInput(t, got.Payload), "be safe\nhello world")
-	}
+	assertLLMRequestMessages(t, got.Payload, []string{"system", "user"}, []string{"be safe", "hello world"})
 	if got.Attributes.ContentType != contentTypeJSON {
 		t.Fatalf("attributes.content_type = %q, want %q", got.Attributes.ContentType, contentTypeJSON)
 	}
@@ -1067,6 +1092,49 @@ func TestExecuteMCPTransformObservePassesThrough(t *testing.T) {
 	}
 	if res == nil || res.StatusCode != http.StatusOK || res.StopUpstream {
 		t.Fatalf("expected pass-through in observe mode, got %+v", res)
+	}
+}
+
+func TestExecutePreRequestSendsOpenAIToolMessages(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: GuardResponse{Status: "allowed"}}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	req := requestContext()
+	req.Body = []byte(`{
+		"model":"gpt-4o",
+		"messages":[
+			{"role":"system","content":"be safe"},
+			{"role":"user","content":"get weather"},
+			{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{\"city\":\"Paris\"}"}}]},
+			{"role":"tool","tool_call_id":"call_1","content":"{\"temp\":18}"}
+		],
+		"tools":[{"type":"function","function":{"name":"get_weather","parameters":{"type":"object"}}}]
+	}`)
+	in := execInput(policy.StagePreRequest, policy.ModeEnforce, settings(""), req, nil)
+	if _, err := p.Execute(context.Background(), in); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := f.captured()
+	if got.Protocol != protocolLLM {
+		t.Fatalf("protocol = %q, want %q", got.Protocol, protocolLLM)
+	}
+	msgs := llmPayloadMessages(t, got.Payload)
+	if len(msgs) != 4 {
+		t.Fatalf("messages = %#v, want 4 turns", msgs)
+	}
+	if msgs[3]["role"] != "tool" {
+		t.Fatalf("last role = %#v, want tool", msgs[3]["role"])
+	}
+	if msgs[3]["content"] != `{"temp":18}` {
+		t.Fatalf("tool content = %#v", msgs[3]["content"])
+	}
+	calls, _ := msgs[2]["tool_calls"].([]any)
+	if len(calls) != 1 {
+		t.Fatalf("assistant tool_calls = %#v", msgs[2]["tool_calls"])
 	}
 }
 

--- a/pkg/infra/plugins/trustguard/rewrite.go
+++ b/pkg/infra/plugins/trustguard/rewrite.go
@@ -28,19 +28,19 @@ type transformTarget struct {
 	apply      func(masked string) ([]byte, bool)
 }
 
-// transformedInput extracts the masked string TrustGuard returns under the
-// payload's "input" key. TrustGate always sends a minimal {input: text} payload,
-// so the transform mirrors that shape.
+// transformedInput extracts the masked string TrustGuard returns for rewrite.
+// Prefer the legacy "input" key (response path and older clients). For LLM
+// request evaluates that send messages[], fall back to joining non-empty
+// message contents in the same order as requestParts.
 func transformedInput(payload map[string]any) (string, bool) {
 	if payload == nil {
 		return "", false
 	}
-	value, ok := payload[transformedInputKey]
-	if !ok {
-		return "", false
+	if value, ok := payload[transformedInputKey]; ok {
+		masked, ok := value.(string)
+		return masked, ok
 	}
-	masked, ok := value.(string)
-	return masked, ok
+	return joinedTransformedMessages(payload)
 }
 
 // requestParts returns the ordered text segments TrustGate sends to TrustGuard:


### PR DESCRIPTION
## Summary
- LLM **request** TrustGuard evaluates now send `payload.messages` with OpenAI roles (`system` / `user` / `assistant`+`tool_calls` / `tool`) instead of flattened `{input}`.
- Lets Guard IPI score **tool responses** (`role=tool`) on protocol LLM (OpenAI agent tool loop), matching the MCP path behavior.
- Response-direction evaluates stay on `{input}`; transform rewrite prefers `transformed_payload.input`, with a `messages[]` join fallback.

## Test plan
- [x] `go test ./pkg/infra/plugins/trustguard/...`
- [ ] Deploy hotfix to prod / smoke OpenAI chat with tool_calls + `role=tool` and confirm Guard evaluate payload includes tool messages
- [ ] Confirm IPI fires on poisoned tool response content (not on user/system alone)