### PR TITLE
Shrink recompile debounce to 250ms and log snapshot publish latency

### DIFF
--- a/k8s/overlays/dev/config.env
+++ b/k8s/overlays/dev/config.env
@@ -32,7 +32,7 @@ TRUSTGUARD_CLIENT_ID=tgc_platform_dev
 # CONFIG_SYNC_DATA_PLANE_ENABLED is set per-deployment (true on proxy/mcp only).
 CONFIG_SYNC_GRPC_ENDPOINT=agentgateway-admin.agentgateway.svc.cluster.local:8083
 CONFIG_SYNC_LKG_PATH=/var/lib/trustgate/snapshot.lkg
-CONFIG_SYNC_RECOMPILE_DEBOUNCE=2s
+CONFIG_SYNC_RECOMPILE_DEBOUNCE=250ms
 CONFIG_SYNC_RECOMPILE_BACKSTOP=5m
 CONFIG_SYNC_POLL_INTERVAL=5m
 # Config-sync data-plane authentication (admin control plane verifies incoming data planes).

--- a/k8s/overlays/prod-us/config.env
+++ b/k8s/overlays/prod-us/config.env
@@ -30,7 +30,7 @@ TRUSTGUARD_CLIENT_ID=tgc_platform_prod_us
 # CONFIG_SYNC_DATA_PLANE_ENABLED is set per-deployment (true on proxy/mcp only).
 CONFIG_SYNC_GRPC_ENDPOINT=agentgateway-admin.agentgateway.svc.cluster.local:8083
 CONFIG_SYNC_LKG_PATH=/var/lib/trustgate/snapshot.lkg
-CONFIG_SYNC_RECOMPILE_DEBOUNCE=2s
+CONFIG_SYNC_RECOMPILE_DEBOUNCE=250ms
 CONFIG_SYNC_RECOMPILE_BACKSTOP=5m
 CONFIG_SYNC_POLL_INTERVAL=5m
 # Config-sync data-plane authentication (admin control plane verifies incoming data planes).

--- a/k8s/overlays/prod/config.env
+++ b/k8s/overlays/prod/config.env
@@ -30,7 +30,7 @@ TRUSTGUARD_CLIENT_ID=tgc_platform_prod
 # CONFIG_SYNC_DATA_PLANE_ENABLED is set per-deployment (true on proxy/mcp only).
 CONFIG_SYNC_GRPC_ENDPOINT=agentgateway-admin.agentgateway.svc.cluster.local:8083
 CONFIG_SYNC_LKG_PATH=/var/lib/trustgate/snapshot.lkg
-CONFIG_SYNC_RECOMPILE_DEBOUNCE=2s
+CONFIG_SYNC_RECOMPILE_DEBOUNCE=250ms
 CONFIG_SYNC_RECOMPILE_BACKSTOP=5m
 CONFIG_SYNC_POLL_INTERVAL=5m
 # Config-sync data-plane authentication (admin control plane verifies incoming data planes).

--- a/pkg/app/configsnapshot/dispatcher.go
+++ b/pkg/app/configsnapshot/dispatcher.go
@@ -29,7 +29,7 @@ import (
 const component = "configsnapshot"
 
 const (
-	defaultDebounce  = 2 * time.Second
+	defaultDebounce  = 250 * time.Millisecond
 	defaultBackstop  = 5 * time.Minute
 	defaultRetention = 24 * time.Hour
 	defaultMaxRows   = 10000
@@ -220,10 +220,12 @@ func (d *Dispatcher) dispatch(ctx context.Context) error {
 		pending = nil
 	}
 
+	compileStart := time.Now()
 	raw, version, scoped, err := d.compile(ctx)
 	if err != nil {
 		return err
 	}
+	compileDuration := time.Since(compileStart)
 
 	// The global snapshot is derived from every gateway plus the shared catalog, so
 	// any change bumps the global version; that makes it a safe outer gate for the
@@ -249,6 +251,11 @@ func (d *Dispatcher) dispatch(ctx context.Context) error {
 				delete(d.publishedScoped, scope)
 			}
 		}
+		d.logger.Info("published config snapshot",
+			slog.String("component", component),
+			slog.String("version", version),
+			slog.Duration("compile", compileDuration),
+			slog.Int("bytes", len(raw)))
 	}
 	d.mu.Unlock()
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -115,7 +115,11 @@ const (
 	defaultConfigSyncDataPlaneEnabled  = false
 	defaultConfigSyncLKGPath           = "/var/lib/trustgate/snapshot.lkg"
 	defaultConfigSyncPollInterval      = 5 * time.Minute
-	defaultConfigSyncRecompileDebounce = 2 * time.Second
+	// The dispatcher fires immediately on the first write signal (leading edge);
+	// the debounce is only the horizon for folding a burst of follow-up writes
+	// into one trailing recompile, so it stays short to keep propagation of
+	// multi-call admin flows (create consumer + key + policies) near-immediate.
+	defaultConfigSyncRecompileDebounce = 250 * time.Millisecond
 	defaultConfigSyncRecompileBackstop = 5 * time.Minute
 
 	defaultRateLimitEnabled = true


### PR DESCRIPTION
With leading-edge dispatch the debounce no longer delays the first write; it is only the horizon for folding a burst of follow-up admin calls into one trailing recompile. A 2s window still made multi-call flows (create consumer, attach key, set policies) wait up to 2s for the trailing edge before the data plane saw the full config. 250ms keeps burst folding while making end-to-end propagation feel immediate.

Also log "published config snapshot" with the compile duration and body size on every version change, so propagation latency can be measured in production by correlating it with the data plane's "applied config snapshot" log line.


Claude-Session: https://claude.ai/code/session_01Mn1tatcBxdsrBZmKAcvyct