### PR TITLE
feat(oauth): let an MCP consumer use the built-in default IdP on a mu…

### DIFF
--- a/pkg/app/oauth/default_idp_selection_test.go
+++ b/pkg/app/oauth/default_idp_selection_test.go
@@ -77,6 +77,47 @@ func TestGatewayScopedAuth_NoDefaultKeepsError(t *testing.T) {
 	require.Equal(t, "invalid_request", oauthError.Code)
 }
 
+// A gateway that hosts several operator-configured IdPs is normally ambiguous,
+// but when the built-in default is configured a consumer that pinned none of
+// them resolves to the default instead of failing with invalid_target — this is
+// how a consumer opts into the default while other IdPs coexist on the gateway.
+func TestGatewayScopedAuth_AmbiguousFallsBackToDefault(t *testing.T) {
+	def := appauth.BuildDefaultIdP(appauth.DefaultIdPConfig{
+		Issuer: "https://app.neuraltrust.ai/api/mcp/oauth", ClientID: "tg",
+	})
+	gw := ids.New[ids.GatewayKind]()
+	authA := realOAuth2(t, "https://idp-a.example.com")
+	authA.GatewayID = gw
+	authB := realOAuth2(t, "https://idp-b.example.com")
+	authB.GatewayID = gw
+	p := &authProxy{credentials: &fakeCredentialFinder{
+		oauth2:     []*authdomain.Auth{authA, authB},
+		defaultIdP: def,
+	}}
+
+	auth, err := p.gatewayScopedAuth(t.Context(), gw)
+	require.NoError(t, err)
+	require.True(t, appauth.IsDefaultIdP(auth))
+	require.Equal(t, gw, auth.GatewayID)
+}
+
+// Without a default configured, the same multi-IdP gateway stays a hard
+// invalid_target error: the gateway never silently picks one of several
+// operator-configured IdPs.
+func TestGatewayScopedAuth_AmbiguousNoDefaultStaysError(t *testing.T) {
+	gw := ids.New[ids.GatewayKind]()
+	authA := realOAuth2(t, "https://idp-a.example.com")
+	authA.GatewayID = gw
+	authB := realOAuth2(t, "https://idp-b.example.com")
+	authB.GatewayID = gw
+	p := &authProxy{credentials: &fakeCredentialFinder{oauth2: []*authdomain.Auth{authA, authB}}}
+
+	_, err := p.gatewayScopedAuth(t.Context(), gw)
+	var oauthError *OAuthError
+	require.True(t, errors.As(err, &oauthError))
+	require.Equal(t, "invalid_target", oauthError.Code)
+}
+
 // The consent detour must target the gateway captured at authorize time, not
 // the default IdP's (nil) gateway — otherwise the upstream-connect screen never
 // opens for MCP consumers that rely on the built-in default.

--- a/pkg/app/oauth/proxy_auth_selection.go
+++ b/pkg/app/oauth/proxy_auth_selection.go
@@ -64,6 +64,16 @@ func (p *authProxy) gatewayScopedAuth(ctx context.Context, gatewayID ids.Gateway
 	a, err := p.singleOAuth2AuthForGateway(ctx, gatewayID)
 	switch {
 	case errors.Is(err, ErrAmbiguousAuthorizationServer):
+		// The gateway hosts several operator-configured IdPs and this MCP consumer
+		// pinned none of them. When the built-in NeuralTrust default IdP is
+		// configured, fall back to it: this lets a consumer opt into the default
+		// simply by not attaching an oauth2 auth of its own, even on a gateway that
+		// also serves other identity providers (a consumer that needs a specific
+		// one still pins it by attaching that oauth2 auth). Without a default there
+		// is no safe way to pick one, so the ambiguity stays a hard error.
+		if def := p.credentials.DefaultOAuth2ForGateway(gatewayID); def != nil {
+			return def, nil
+		}
 		return nil, oauthErr("invalid_target",
 			"multiple identity providers configured for this gateway; attach a single oauth2 identity provider to the MCP consumer")
 	case errors.Is(err, ErrNoAuthorizationServer):


### PR DESCRIPTION
…lti-IdP gateway

Previously a consumer that pinned no oauth2 auth on a gateway hosting several identity providers failed with `invalid_target` ("multiple identity providers configured for this gateway"), even when the built-in NeuralTrust default IdP was configured. The default only kicked in when the gateway had zero real IdPs.

Extend gatewayScopedAuth so that, on an ambiguous gateway, it falls back to the built-in default IdP when one is configured. This lets a consumer opt into the default simply by not attaching an oauth2 auth of its own, while consumers that need a specific provider still pin it by attaching that oauth2 auth — so multiple IdPs and default-backed consumers coexist on the same gateway. With no default configured the ambiguity remains a hard error (the gateway never silently picks one of several operator-configured IdPs).


Claude-Session: https://claude.ai/code/session_01Ud4DKqxYxsgMEo5J6iE9L5