### PR TITLE
Compile the snapshot from bulk table scans instead of per-gateway que…

### DIFF
--- a/pkg/app/configsnapshot/compiler.go
+++ b/pkg/app/configsnapshot/compiler.go
@@ -24,19 +24,27 @@ import (
 	commonerrors "github.com/NeuralTrust/TrustGate/pkg/common/errors"
 	authdomain "github.com/NeuralTrust/TrustGate/pkg/domain/auth"
 	catalogdomain "github.com/NeuralTrust/TrustGate/pkg/domain/catalog"
+	consumerdomain "github.com/NeuralTrust/TrustGate/pkg/domain/consumer"
 	gatewaydomain "github.com/NeuralTrust/TrustGate/pkg/domain/gateway"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
+	policydomain "github.com/NeuralTrust/TrustGate/pkg/domain/policy"
 	registrydomain "github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	roledomain "github.com/NeuralTrust/TrustGate/pkg/domain/role"
 	"github.com/NeuralTrust/TrustGate/pkg/runtimeconfig/snapshot/readmodel"
 	"golang.org/x/sync/errgroup"
 )
 
 const compilerPageSize = 100
 
+// compilerBulkPageSize is the page size for the bulk collect path's
+// whole-table scans, where fewer round-trips matter more than page weight.
+const compilerBulkPageSize = 500
+
 // compilerConcurrency bounds how many gateways are collected from the database
-// at once. Each gateway costs several sequential queries; collecting gateways
-// serially makes compile time grow linearly with the tenant count, which
-// directly delays config propagation to the data planes.
+// at once on the per-gateway fallback path. Each gateway costs several
+// sequential queries; collecting gateways serially makes compile time grow
+// linearly with the tenant count, which directly delays config propagation to
+// the data planes.
 const compilerConcurrency = 8
 
 type Compiler struct {
@@ -218,13 +226,146 @@ func (c *Compiler) listGateways(ctx context.Context) ([]gatewaydomain.Gateway, e
 	}
 }
 
-// collectGateways loads each gateway's config concurrently, bounded by
-// compilerConcurrency, and returns per-gateway data aligned by index with
-// gateways. A nil entry marks a gateway skipped for corrupt persisted config;
-// any other collect error fails the whole compile. Callers append the results
-// in slice order, so the compiled snapshot stays byte-identical to a serial
-// collect and version hashes remain stable.
+// collectGateways loads every gateway's config and returns per-gateway data
+// aligned by index with gateways. It prefers the bulk path -- one paged scan
+// per entity table, so compile latency stays flat as the tenant count grows --
+// and falls back to per-gateway collection when a bulk scan hits corrupt
+// persisted config, so a corrupt tenant still only knocks out its own gateway.
+// A nil entry marks a gateway skipped for corrupt persisted config.
 func (c *Compiler) collectGateways(ctx context.Context, gateways []gatewaydomain.Gateway) ([]*readmodel.Data, error) {
+	byGateway, err := c.collectAllBulk(ctx)
+	if err == nil {
+		out := make([]*readmodel.Data, len(gateways))
+		for i := range gateways {
+			if d, ok := byGateway[gateways[i].ID]; ok {
+				out[i] = d
+			} else {
+				out[i] = &readmodel.Data{}
+			}
+		}
+		return out, nil
+	}
+	if !errors.Is(err, commonerrors.ErrCorruptData) {
+		return nil, err
+	}
+	c.logger.Warn("bulk snapshot collect hit corrupt persisted config; falling back to per-gateway collect",
+		slog.String("component", component),
+		slog.String("error", err.Error()))
+	return c.collectGatewaysEach(ctx, gateways)
+}
+
+// collectAllBulk loads the five gateway-scoped entity tables with one paged
+// scan each and groups the rows by gateway in memory. All snapshot data is
+// sorted before encoding, so grouping order never affects version hashes.
+func (c *Compiler) collectAllBulk(ctx context.Context) (map[ids.GatewayID]*readmodel.Data, error) {
+	var (
+		consumers  []*consumerdomain.Consumer
+		registries []*registrydomain.Registry
+		policies   []*policydomain.Policy
+		auths      []*authdomain.Auth
+		roles      []*roledomain.Role
+	)
+	g, gctx := errgroup.WithContext(ctx)
+	g.Go(func() (err error) {
+		consumers, err = listAll(gctx, "consumers", func(ctx context.Context, page int) ([]*consumerdomain.Consumer, int, error) {
+			return c.consumers.List(ctx, consumerdomain.ListFilter{Page: page, Size: compilerBulkPageSize})
+		})
+		return err
+	})
+	g.Go(func() (err error) {
+		registries, err = listAll(gctx, "registries", func(ctx context.Context, page int) ([]*registrydomain.Registry, int, error) {
+			return c.registries.List(ctx, registrydomain.ListFilter{Page: page, Size: compilerBulkPageSize})
+		})
+		return err
+	})
+	g.Go(func() (err error) {
+		policies, err = listAll(gctx, "policies", func(ctx context.Context, page int) ([]*policydomain.Policy, int, error) {
+			return c.policies.List(ctx, policydomain.ListFilter{Page: page, Size: compilerBulkPageSize})
+		})
+		return err
+	})
+	g.Go(func() (err error) {
+		auths, err = listAll(gctx, "auths", func(ctx context.Context, page int) ([]*authdomain.Auth, int, error) {
+			return c.auths.List(ctx, authdomain.ListFilter{Page: page, Size: compilerBulkPageSize})
+		})
+		return err
+	})
+	g.Go(func() (err error) {
+		roles, err = listAll(gctx, "roles", func(ctx context.Context, page int) ([]*roledomain.Role, int, error) {
+			return c.roles.List(ctx, roledomain.ListFilter{Page: page, Size: compilerBulkPageSize})
+		})
+		return err
+	})
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	byGateway := make(map[ids.GatewayID]*readmodel.Data)
+	bucket := func(id ids.GatewayID) *readmodel.Data {
+		d, ok := byGateway[id]
+		if !ok {
+			d = &readmodel.Data{}
+			byGateway[id] = d
+		}
+		return d
+	}
+	for _, x := range consumers {
+		if x != nil {
+			b := bucket(x.GatewayID)
+			b.Consumers = append(b.Consumers, *x)
+		}
+	}
+	for _, x := range registries {
+		if x != nil {
+			b := bucket(x.GatewayID)
+			b.Registries = append(b.Registries, *x)
+		}
+	}
+	for _, x := range policies {
+		if x != nil {
+			b := bucket(x.GatewayID)
+			b.Policies = append(b.Policies, *x)
+		}
+	}
+	for _, x := range auths {
+		if x != nil {
+			b := bucket(x.GatewayID)
+			b.Auths = append(b.Auths, *x)
+		}
+	}
+	for _, x := range roles {
+		if x != nil {
+			b := bucket(x.GatewayID)
+			b.Roles = append(b.Roles, *x)
+		}
+	}
+	return byGateway, nil
+}
+
+// listAll pages one entity table to exhaustion via fetch(page).
+func listAll[T any](ctx context.Context, entity string, fetch func(ctx context.Context, page int) ([]T, int, error)) ([]T, error) {
+	out := make([]T, 0)
+	for page := 1; ; page++ {
+		items, _, err := fetch(ctx, page)
+		if err != nil {
+			if errors.Is(err, commonerrors.ErrNotFound) {
+				return out, nil
+			}
+			return nil, fmt.Errorf("configsnapshot: list %s: %w", entity, err)
+		}
+		out = append(out, items...)
+		if len(items) < compilerBulkPageSize {
+			return out, nil
+		}
+	}
+}
+
+// collectGatewaysEach loads each gateway's config concurrently, bounded by
+// compilerConcurrency. A nil entry marks a gateway skipped for corrupt
+// persisted config; any other collect error fails the whole compile. Callers
+// append the results in slice order, so the compiled snapshot stays
+// byte-identical to a serial collect and version hashes remain stable.
+func (c *Compiler) collectGatewaysEach(ctx context.Context, gateways []gatewaydomain.Gateway) ([]*readmodel.Data, error) {
 	results := make([]*readmodel.Data, len(gateways))
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(compilerConcurrency)

--- a/pkg/app/configsnapshot/compiler_test.go
+++ b/pkg/app/configsnapshot/compiler_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"testing"
 
 	appsnapshot "github.com/NeuralTrust/TrustGate/pkg/app/configsnapshot"
@@ -77,6 +78,21 @@ func (f fakeConsumers) ListByGateway(_ context.Context, gatewayID ids.GatewayID)
 	return f.byGateway[gatewayID.String()], nil
 }
 
+func (f fakeConsumers) List(_ context.Context, filter consumerdomain.ListFilter) ([]*consumerdomain.Consumer, int, error) {
+	if f.err != nil {
+		return nil, 0, f.err
+	}
+	if filter.Page > 1 {
+		return nil, 0, nil
+	}
+	if filter.GatewayID != (ids.GatewayID{}) {
+		items := f.byGateway[filter.GatewayID.String()]
+		return items, len(items), nil
+	}
+	items := flattenByGateway(f.byGateway)
+	return items, len(items), nil
+}
+
 type fakeRegistries struct {
 	byGateway    map[string][]*registrydomain.Registry
 	errByGateway map[string]error
@@ -86,6 +102,20 @@ type fakeRegistries struct {
 func (f fakeRegistries) List(_ context.Context, filter registrydomain.ListFilter) ([]*registrydomain.Registry, int, error) {
 	if f.err != nil {
 		return nil, 0, f.err
+	}
+	if filter.GatewayID == (ids.GatewayID{}) {
+		// Bulk scan across all gateways: a corrupt row anywhere fails the
+		// whole scan, mirroring the SQL repository.
+		for _, err := range f.errByGateway {
+			if err != nil {
+				return nil, 0, err
+			}
+		}
+		if filter.Page > 1 {
+			return nil, 0, nil
+		}
+		items := flattenByGateway(f.byGateway)
+		return items, len(items), nil
 	}
 	if err := f.errByGateway[filter.GatewayID.String()]; err != nil {
 		return nil, 0, err
@@ -109,6 +139,21 @@ func (f fakePolicies) ListByGateway(_ context.Context, gatewayID ids.GatewayID) 
 	return f.byGateway[gatewayID.String()], nil
 }
 
+func (f fakePolicies) List(_ context.Context, filter policydomain.ListFilter) ([]*policydomain.Policy, int, error) {
+	if f.err != nil {
+		return nil, 0, f.err
+	}
+	if filter.Page > 1 {
+		return nil, 0, nil
+	}
+	if filter.GatewayID != (ids.GatewayID{}) {
+		items := f.byGateway[filter.GatewayID.String()]
+		return items, len(items), nil
+	}
+	items := flattenByGateway(f.byGateway)
+	return items, len(items), nil
+}
+
 type fakeAuths struct {
 	byGateway map[string][]*authdomain.Auth
 	err       error
@@ -121,7 +166,11 @@ func (f fakeAuths) List(_ context.Context, filter authdomain.ListFilter) ([]*aut
 	if filter.Page > 1 {
 		return nil, 0, nil
 	}
-	items := f.byGateway[filter.GatewayID.String()]
+	if filter.GatewayID != (ids.GatewayID{}) {
+		items := f.byGateway[filter.GatewayID.String()]
+		return items, len(items), nil
+	}
+	items := flattenByGateway(f.byGateway)
 	return items, len(items), nil
 }
 
@@ -135,6 +184,36 @@ func (f fakeRoles) ListByGateway(_ context.Context, gatewayID ids.GatewayID) ([]
 		return nil, f.err
 	}
 	return f.byGateway[gatewayID.String()], nil
+}
+
+func (f fakeRoles) List(_ context.Context, filter roledomain.ListFilter) ([]*roledomain.Role, int, error) {
+	if f.err != nil {
+		return nil, 0, f.err
+	}
+	if filter.Page > 1 {
+		return nil, 0, nil
+	}
+	if filter.GatewayID != (ids.GatewayID{}) {
+		items := f.byGateway[filter.GatewayID.String()]
+		return items, len(items), nil
+	}
+	items := flattenByGateway(f.byGateway)
+	return items, len(items), nil
+}
+
+// flattenByGateway mirrors the SQL repos' zero-GatewayID List semantics for
+// the fakes: all gateways' rows in one deterministic (key-sorted) list.
+func flattenByGateway[T any](byGateway map[string][]T) []T {
+	keys := make([]string, 0, len(byGateway))
+	for k := range byGateway {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := make([]T, 0)
+	for _, k := range keys {
+		out = append(out, byGateway[k]...)
+	}
+	return out
 }
 
 type fakeCatalog struct {

--- a/pkg/app/configsnapshot/consumer_reader.go
+++ b/pkg/app/configsnapshot/consumer_reader.go
@@ -23,4 +23,7 @@ import (
 
 type ConsumerReader interface {
 	ListByGateway(ctx context.Context, gatewayID ids.GatewayID) ([]*consumerdomain.Consumer, error)
+	// List with a zero GatewayID pages across every gateway; the compiler's
+	// bulk collect path uses it to load all consumers in one scan.
+	List(ctx context.Context, filter consumerdomain.ListFilter) ([]*consumerdomain.Consumer, int, error)
 }

--- a/pkg/app/configsnapshot/policy_reader.go
+++ b/pkg/app/configsnapshot/policy_reader.go
@@ -23,4 +23,7 @@ import (
 
 type PolicyReader interface {
 	ListByGateway(ctx context.Context, gatewayID ids.GatewayID) ([]*policydomain.Policy, error)
+	// List with a zero GatewayID pages across every gateway; the compiler's
+	// bulk collect path uses it to load all policies in one scan.
+	List(ctx context.Context, filter policydomain.ListFilter) ([]*policydomain.Policy, int, error)
 }

--- a/pkg/app/configsnapshot/role_reader.go
+++ b/pkg/app/configsnapshot/role_reader.go
@@ -23,4 +23,7 @@ import (
 
 type RoleReader interface {
 	ListByGateway(ctx context.Context, gatewayID ids.GatewayID) ([]*roledomain.Role, error)
+	// List with a zero GatewayID pages across every gateway; the compiler's
+	// bulk collect path uses it to load all roles in one scan.
+	List(ctx context.Context, filter roledomain.ListFilter) ([]*roledomain.Role, int, error)
 }


### PR DESCRIPTION
…ries

Even collected concurrently, per-gateway collection costs five queries per gateway, so compile time grows with the tenant count and is dominated by database round-trips: measured ~18-20s per compile in deployments with many gateways, which was the entire config propagation delay to the data planes.

The compiler now loads the five gateway-scoped entity tables with one paged scan each (the List repositories already support a zero-GatewayID filter meaning all gateways) and groups rows by gateway in memory -- seven queries per compile regardless of tenant count. When a bulk scan hits corrupt persisted config it falls back to the per-gateway path, which still skips only the corrupt tenant. All snapshot data is sorted before encoding, so version hashes are unchanged.


Claude-Session: https://claude.ai/code/session_01Mn1tatcBxdsrBZmKAcvyct