### PR TITLE
Encode the shared catalog once per compile and raise dev admin CPU

### DIFF
--- a/k8s/overlays/dev/patches/resources-patch.yaml
+++ b/k8s/overlays/dev/patches/resources-patch.yaml
@@ -7,12 +7,15 @@ spec:
     spec:
       containers:
       - name: admin
+        # The admin compiles and proto-encodes the full config snapshot on
+        # every write; at 100m that CPU work was throttled ~10x and showed up
+        # as ~20s of config propagation latency to the data planes.
         resources:
           limits:
-            cpu: 100m
+            cpu: "1"
             memory: 1Gi
           requests:
-            cpu: 50m
+            cpu: 250m
             memory: 512Mi
 ---
 apiVersion: apps/v1

--- a/pkg/app/configsnapshot/compiler.go
+++ b/pkg/app/configsnapshot/compiler.go
@@ -131,15 +131,21 @@ func (c *Compiler) CompileFor(ctx context.Context, scope string) (*readmodel.Sna
 	return readmodel.Build(data), nil
 }
 
-func (c *Compiler) CompileAll(ctx context.Context) (*readmodel.Snapshot, map[string]*readmodel.Snapshot, error) {
+// CompileAll compiles the global snapshot, one tenant-only snapshot per
+// gateway scope, and the shared catalog as its own snapshot. The catalog
+// (providers + models, usually the bulk of the encoded bytes) is deliberately
+// NOT merged into the global or scoped snapshots: the dispatcher encodes it
+// once and appends the encoded bytes to every snapshot it publishes, instead
+// of re-encoding the same catalog per gateway on every compile.
+func (c *Compiler) CompileAll(ctx context.Context) (*readmodel.Snapshot, map[string]*readmodel.Snapshot, *readmodel.Snapshot, error) {
 	gateways, err := c.listGateways(ctx)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	collected, err := c.collectGateways(ctx, gateways)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	global := readmodel.Data{}
@@ -162,24 +168,25 @@ func (c *Compiler) CompileAll(ctx context.Context) (*readmodel.Snapshot, map[str
 	}
 
 	if skipped > 0 && len(global.Gateways) == 0 {
-		return nil, nil, fmt.Errorf("configsnapshot: every gateway (%d) skipped due to corrupt persisted config; refusing to publish empty snapshot: %w", skipped, commonerrors.ErrCorruptData)
+		return nil, nil, nil, fmt.Errorf("configsnapshot: every gateway (%d) skipped due to corrupt persisted config; refusing to publish empty snapshot: %w", skipped, commonerrors.ErrCorruptData)
 	}
 
 	cat, err := c.collectCatalogData(ctx)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
+	catData := readmodel.Data{}
+	mergeCatalog(&catData, cat)
+	sortData(&catData)
 
-	mergeCatalog(&global, cat)
 	sortData(&global)
 
 	scoped := make(map[string]*readmodel.Snapshot, len(buckets))
 	for scope, bucket := range buckets {
-		mergeCatalog(bucket, cat)
 		sortData(bucket)
 		scoped[scope] = readmodel.Build(*bucket)
 	}
-	return readmodel.Build(global), scoped, nil
+	return readmodel.Build(global), scoped, readmodel.Build(catData), nil
 }
 
 func appendGatewayData(dst *readmodel.Data, gateway gatewaydomain.Gateway, gwData readmodel.Data) {

--- a/pkg/app/configsnapshot/dispatcher.go
+++ b/pkg/app/configsnapshot/dispatcher.go
@@ -40,8 +40,15 @@ type SnapshotCompiler interface {
 	Compile(ctx context.Context) (*readmodel.Snapshot, error)
 }
 
+// PartitionedCompiler compiles the global snapshot, tenant-only scoped
+// snapshots, and the shared catalog separately, so the dispatcher can encode
+// the catalog once and append the encoded bytes to every published snapshot.
+// Protobuf wire format merges concatenated messages (repeated fields append),
+// so tenant bytes + catalog bytes decode as one full snapshot on the data
+// plane; both halves use deterministic marshaling, keeping version hashes
+// stable across replicas.
 type PartitionedCompiler interface {
-	CompileAll(ctx context.Context) (*readmodel.Snapshot, map[string]*readmodel.Snapshot, error)
+	CompileAll(ctx context.Context) (global *readmodel.Snapshot, scoped map[string]*readmodel.Snapshot, catalog *readmodel.Snapshot, err error)
 }
 
 // DispatcherConfig tunes the debounce/backstop cadence and the outbox safety bound.
@@ -270,19 +277,25 @@ func (d *Dispatcher) dispatch(ctx context.Context) error {
 
 func (d *Dispatcher) compile(ctx context.Context) (raw []byte, version string, scoped map[string]ScopedSnapshot, err error) {
 	if partitioned, ok := d.compiler.(PartitionedCompiler); ok {
-		global, scopedSnaps, cerr := partitioned.CompileAll(ctx)
+		global, scopedSnaps, catalog, cerr := partitioned.CompileAll(ctx)
 		if cerr != nil {
 			return nil, "", nil, fmt.Errorf("configsnapshot: compile: %w", cerr)
 		}
-		raw, version, err = d.encode(global)
+		// The catalog is usually the bulk of the encoded bytes and identical in
+		// every snapshot, so encode it once and append the bytes per snapshot.
+		catalogRaw, eerr := d.codec.Encode(catalog)
+		if eerr != nil {
+			return nil, "", nil, fmt.Errorf("configsnapshot: encode catalog: %w", eerr)
+		}
+		raw, version, err = d.encodeWithCatalog(global, catalogRaw)
 		if err != nil {
 			return nil, "", nil, err
 		}
 		scoped = make(map[string]ScopedSnapshot, len(scopedSnaps))
 		for scope, snap := range scopedSnaps {
-			scopedRaw, scopedVersion, eerr := d.encode(snap)
-			if eerr != nil {
-				return nil, "", nil, eerr
+			scopedRaw, scopedVersion, serr := d.encodeWithCatalog(snap, catalogRaw)
+			if serr != nil {
+				return nil, "", nil, serr
 			}
 			scoped[scope] = ScopedSnapshot{Raw: scopedRaw, Version: scopedVersion}
 		}
@@ -298,6 +311,20 @@ func (d *Dispatcher) compile(ctx context.Context) (raw []byte, version string, s
 		return nil, "", nil, err
 	}
 	return raw, version, nil, nil
+}
+
+// encodeWithCatalog encodes a tenant-only snapshot and appends the
+// pre-encoded catalog bytes. Protobuf unmarshal merges the concatenation into
+// one full snapshot; the version hashes the exact bytes served.
+func (d *Dispatcher) encodeWithCatalog(snapshot *readmodel.Snapshot, catalogRaw []byte) ([]byte, string, error) {
+	tenantRaw, err := d.codec.Encode(snapshot)
+	if err != nil {
+		return nil, "", fmt.Errorf("configsnapshot: encode: %w", err)
+	}
+	raw := make([]byte, 0, len(tenantRaw)+len(catalogRaw))
+	raw = append(raw, tenantRaw...)
+	raw = append(raw, catalogRaw...)
+	return raw, d.codec.Version(raw), nil
 }
 
 func (d *Dispatcher) encode(snapshot *readmodel.Snapshot) ([]byte, string, error) {

--- a/pkg/app/configsnapshot/scope_test.go
+++ b/pkg/app/configsnapshot/scope_test.go
@@ -27,6 +27,7 @@ import (
 	policydomain "github.com/NeuralTrust/TrustGate/pkg/domain/policy"
 	registrydomain "github.com/NeuralTrust/TrustGate/pkg/domain/registry"
 	roledomain "github.com/NeuralTrust/TrustGate/pkg/domain/role"
+	infrasnapshot "github.com/NeuralTrust/TrustGate/pkg/infra/configsnapshot"
 )
 
 func gatewayWithTeam(id ids.GatewayID, team string) *gatewaydomain.Gateway {
@@ -94,7 +95,7 @@ func TestCompilerCompileAllPartitionsAndIsolates(t *testing.T) {
 
 	compiler := twoTenantCompiler(t, acme, globex, acmeConsumer, globexConsumer)
 
-	global, scoped, err := compiler.CompileAll(context.Background())
+	global, scoped, catalog, err := compiler.CompileAll(context.Background())
 	if err != nil {
 		t.Fatalf("compile all: %v", err)
 	}
@@ -116,12 +117,55 @@ func TestCompilerCompileAllPartitionsAndIsolates(t *testing.T) {
 			t.Fatal("globex consumer leaked into acme scope")
 		}
 	}
-	if len(acmeSnap.Data().Providers) != 1 {
-		t.Fatalf("expected shared catalog in acme scope, got %d", len(acmeSnap.Data().Providers))
+	if len(acmeSnap.Data().Providers) != 0 {
+		t.Fatalf("scoped snapshots must be tenant-only; the dispatcher appends the catalog bytes, got %d providers", len(acmeSnap.Data().Providers))
+	}
+	if len(catalog.Data().Providers) != 1 {
+		t.Fatalf("expected the shared catalog as its own snapshot, got %d providers", len(catalog.Data().Providers))
 	}
 	globexSnap := scoped[globex.String()]
 	if gws := globexSnap.Data().Gateways; len(gws) != 1 || gws[0].ID != globex {
 		t.Fatalf("globex scope leaked other gateways: %+v", gws)
+	}
+}
+
+// TestScopedBytesConcatenatedWithCatalogDecodeAsOneSnapshot locks in the wire
+// property the dispatcher relies on: a tenant-only snapshot encoding followed
+// by the catalog encoding unmarshals as one merged snapshot on the data plane.
+func TestScopedBytesConcatenatedWithCatalogDecodeAsOneSnapshot(t *testing.T) {
+	acme := mustGatewayID(t, "11111111-1111-1111-1111-111111111111")
+	globex := mustGatewayID(t, "22222222-2222-2222-2222-222222222222")
+	acmeConsumer := mustConsumerID(t, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+	globexConsumer := mustConsumerID(t, "cccccccc-cccc-cccc-cccc-cccccccccccc")
+
+	compiler := twoTenantCompiler(t, acme, globex, acmeConsumer, globexConsumer)
+	_, scoped, catalog, err := compiler.CompileAll(context.Background())
+	if err != nil {
+		t.Fatalf("compile all: %v", err)
+	}
+
+	codec := infrasnapshot.NewCodec()
+	tenantRaw, err := codec.Encode(scoped[acme.String()])
+	if err != nil {
+		t.Fatalf("encode tenant: %v", err)
+	}
+	catalogRaw, err := codec.Encode(catalog)
+	if err != nil {
+		t.Fatalf("encode catalog: %v", err)
+	}
+	merged, err := codec.Decode(append(append([]byte{}, tenantRaw...), catalogRaw...))
+	if err != nil {
+		t.Fatalf("decode concatenated snapshot: %v", err)
+	}
+	data := merged.Data()
+	if len(data.Gateways) != 1 || data.Gateways[0].ID != acme {
+		t.Fatalf("merged snapshot must keep the tenant data, got %+v", data.Gateways)
+	}
+	if len(data.Consumers) != 1 || data.Consumers[0].ID != acmeConsumer {
+		t.Fatalf("merged snapshot must keep the tenant consumers, got %+v", data.Consumers)
+	}
+	if len(data.Providers) != 1 {
+		t.Fatalf("merged snapshot must contain the catalog, got %d providers", len(data.Providers))
 	}
 }
 


### PR DESCRIPTION
The compile duration logged in production (~19-20s) was CPU, not I/O: CompileAll merged the model catalog into the global snapshot and every per-gateway scoped snapshot, then JSON+proto encoded it N+1 times per dispatch -- the catalog is the bulk of the ~800KB snapshot -- all under a 100m CPU limit on the admin container (a ~10x throttle).

CompileAll now returns tenant-only global/scoped snapshots plus the catalog as its own snapshot; the dispatcher encodes the catalog once and appends the bytes to each published snapshot. Protobuf wire format merges concatenated messages (repeated fields append, and the snapshot message sets no scalar fields), so the data plane decodes tenant bytes + catalog bytes as one full snapshot; both halves use deterministic marshaling, keeping version hashes stable across replicas.

The dev admin CPU limit goes from 100m to 1 (requests 50m -> 250m) so the remaining encode work is not throttled.


Claude-Session: https://claude.ai/code/session_01Mn1tatcBxdsrBZmKAcvyct