### PR TITLE
fix(metrics): keep large Gemini/LLM bodies for Activity

### DIFF
--- a/pkg/infra/metrics/events/sanitize.go
+++ b/pkg/infra/metrics/events/sanitize.go
@@ -346,8 +346,14 @@ func shrinkJSONMap(m map[string]any, maxBytes int) bool {
 			return true
 		}
 	}
+	if contents, ok := m["contents"].([]any); ok && len(contents) > 0 {
+		m["contents"] = shrinkGeminiContents(contents, maxBytes, m)
+		if fitsJSON(m, maxBytes) {
+			return true
+		}
+	}
 	// Drop bulky non-essential keys after messages are already minimized.
-	for _, key := range []string{"tools", "functions", "tool_choice", "function_call"} {
+	for _, key := range []string{"tools", "functions", "tool_choice", "function_call", "toolsConfig", "generationConfig", "safetySettings"} {
 		if _, ok := m[key]; ok {
 			delete(m, key)
 			m["_nt_truncated"] = true
@@ -393,6 +399,30 @@ func shrinkMessages(msgs []any, maxBytes int, parent map[string]any) []any {
 
 func fitsJSONWithMessages(parent map[string]any, msgs []any, maxBytes int) bool {
 	parent["messages"] = msgs
+	return fitsJSON(parent, maxBytes)
+}
+
+// shrinkGeminiContents keeps the first content turn and the newest tail, like
+// shrinkMessages, so Activity can still parse Gemini generateContent bodies.
+func shrinkGeminiContents(contents []any, maxBytes int, parent map[string]any) []any {
+	if len(contents) == 0 {
+		return contents
+	}
+	out := append([]any(nil), contents...)
+	for len(out) > 2 && !fitsJSONWithContents(parent, out, maxBytes) {
+		out = append(out[:1], out[2:]...)
+	}
+	for len(out) > 1 && !fitsJSONWithContents(parent, out, maxBytes) {
+		out = out[1:]
+	}
+	if !fitsJSONWithContents(parent, out, maxBytes) {
+		truncateStringLeaves(out, maxBytes)
+	}
+	return out
+}
+
+func fitsJSONWithContents(parent map[string]any, contents []any, maxBytes int) bool {
+	parent["contents"] = contents
 	return fitsJSON(parent, maxBytes)
 }
 

--- a/pkg/infra/metrics/events/sanitize_test.go
+++ b/pkg/infra/metrics/events/sanitize_test.go
@@ -124,6 +124,52 @@ func TestSanitizeBody_JSONSafeCapKeepsParseableMessages(t *testing.T) {
 	assert.Contains(t, last["content"], "neuraltrust.ai")
 }
 
+func TestSanitizeBody_JSONSafeCapKeepsParseableGeminiContents(t *testing.T) {
+	contents := make([]map[string]any, 0, 40)
+	contents = append(contents, map[string]any{
+		"role":  "user",
+		"parts": []any{map[string]any{"text": "system-like first turn"}},
+	})
+	for i := 0; i < 38; i++ {
+		contents = append(contents, map[string]any{
+			"role":  "user",
+			"parts": []any{map[string]any{"text": strings.Repeat("y", 2500) + "-" + string(rune('a'+i%26))}},
+		})
+	}
+	contents = append(contents, map[string]any{
+		"role":  "user",
+		"parts": []any{map[string]any{"text": "Summarize https://neuraltrust.ai"}},
+	})
+
+	raw, err := json.Marshal(map[string]any{
+		"model":    "gemini-2.0-flash",
+		"contents": contents,
+	})
+	require.NoError(t, err)
+	require.Greater(t, len(raw), 64*1024)
+
+	got := events.SanitizeBody(raw, map[string][]string{"Content-Type": {"application/json"}})
+	require.LessOrEqual(t, len(got), 64*1024)
+	require.True(t, json.Valid([]byte(got)), "sanitized body must stay valid JSON")
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(got), &parsed))
+	require.Equal(t, true, parsed["_nt_truncated"])
+
+	outContents, ok := parsed["contents"].([]any)
+	require.True(t, ok)
+	require.NotEmpty(t, outContents)
+
+	last, ok := outContents[len(outContents)-1].(map[string]any)
+	require.True(t, ok)
+	parts, ok := last["parts"].([]any)
+	require.True(t, ok)
+	require.NotEmpty(t, parts)
+	part, ok := parts[0].(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, part["text"], "neuraltrust.ai")
+}
+
 func TestSanitizeBody_JSONSafeCapNonJSONFallsBackToByteTruncate(t *testing.T) {
 	body := []byte(strings.Repeat("plain-", 20_000))
 	got := events.SanitizeBody(body, map[string][]string{"Content-Type": {"text/plain"}})

--- a/pkg/infra/telemetry/otlp/settings.go
+++ b/pkg/infra/telemetry/otlp/settings.go
@@ -49,7 +49,9 @@ const (
 	defaultSignal       = SignalLogs
 	defaultCompression  = compressionGzip
 	defaultTimeout      = 10 * time.Second
-	defaultMaxBodyBytes = 4096
+	// Keep Activity raw request/response bodies intact past the 64KiB sanitize
+	// cap; the previous 4KiB OTel attribute limit mid-cut JSON and blanked UI.
+	defaultMaxBodyBytes = 256 * 1024
 )
 
 // TLSSettings configures mutual or server-only TLS for the OTLP transport.


### PR DESCRIPTION
## Summary
- Raise OTLP `max_body_bytes` default from 4KiB → 256KiB so raw request/response attributes are not mid-cut into invalid JSON.
- JSON-safe sanitize now shrinks Gemini `contents[]` (like OpenAI `messages[]`) so Activity can still parse large Gemini traces.

## Why
Activity showed empty request/response for large OpenAI/Gemini traces (`trace_id` e.g. `c4eae580-…`): OTel attribute length limit truncated bodies mid-JSON.

## Test plan
- [x] `go test ./pkg/infra/metrics/events/ ./pkg/infra/telemetry/otlp/`
- [ ] After deploy: open a large Gemini/OpenAI Activity row and confirm Request/Response bodies render