### PR TITLE
fix(metrics): include policy_chain on MCP request events

### DIFF
--- a/pkg/app/metrics/builder.go
+++ b/pkg/app/metrics/builder.go
@@ -222,12 +222,19 @@ func (b *Builder) buildMCP(
 	}
 	evt.MCP = mcp
 
+	chain, pluginsMs, flagged, security := b.foldPluginSpans(requestTrace)
+	evt.PolicyChain = chain
+	evt.IsFlagged = flagged
+	evt.Security = security
+
 	totalMs := endTime.Sub(startTime).Milliseconds()
-	gatewayMs := maxInt64(0, totalMs-upstreamMs)
+	routingMs := maxInt64(0, totalMs-upstreamMs-pluginsMs)
 	evt.Latency = events.Latency{
 		TotalMs:    totalMs,
 		ProviderMs: upstreamMs,
-		GatewayMs:  gatewayMs,
+		PoliciesMs: pluginsMs,
+		RoutingMs:  routingMs,
+		GatewayMs:  pluginsMs + routingMs,
 	}
 
 	b.fillRequest(evt, req, nil)

--- a/pkg/app/metrics/builder_mcp_test.go
+++ b/pkg/app/metrics/builder_mcp_test.go
@@ -36,7 +36,7 @@ func mcpSpan(name string, attrs *trace.MCPAttrs, latency time.Duration) *trace.S
 func TestBuilder_MCPFoldsUpstreamAndLatency(t *testing.T) {
 	rt := trace.New("trace-mcp", trace.Metadata{
 		GatewayID:    "gw-1",
-		TenantID:       "team-9",
+		TenantID:     "team-9",
 		ConsumerID:   "c-1",
 		ConsumerName: "agent",
 		Kind:         events.KindMCP,
@@ -76,12 +76,60 @@ func TestBuilder_MCPFoldsUpstreamAndLatency(t *testing.T) {
 
 	assert.Equal(t, int64(200), evt.Latency.TotalMs)
 	assert.Equal(t, int64(120), evt.Latency.ProviderMs)
+	assert.Equal(t, int64(0), evt.Latency.PoliciesMs)
+	assert.Equal(t, int64(80), evt.Latency.RoutingMs)
 	assert.Equal(t, int64(80), evt.Latency.GatewayMs)
 
 	assert.Nil(t, evt.Usage)
 	assert.Nil(t, evt.Cost)
 	assert.Empty(t, evt.Attempts)
 	assert.Empty(t, evt.PolicyChain)
+	assert.False(t, evt.IsFlagged)
+	assert.Empty(t, evt.Security)
+}
+
+func TestBuilder_MCPFoldsPolicyChain(t *testing.T) {
+	rt := trace.New("trace-mcp-policy", trace.Metadata{
+		GatewayID:  "gw-1",
+		TenantID:   "team-9",
+		ConsumerID: "c-1",
+		Kind:       events.KindMCP,
+	})
+	_ = rt.AddSpan(pluginSpan("trustguard",
+		&trace.PluginAttrs{Stage: "pre_request", Decision: "block", ScoreLabel: "jailbreak"},
+		403, 31*time.Millisecond, ""))
+	_ = rt.AddSpan(mcpSpan("tools/call", &trace.MCPAttrs{
+		Method:         "tools/call",
+		Operation:      "tool",
+		Tool:           "list_projects",
+		UpstreamStatus: "error",
+		RPCErrorCode:   -32001,
+	}, 3*time.Millisecond))
+
+	req := &infracontext.RequestContext{GatewayID: "gw-1", Method: "POST", Path: "/mcp"}
+	resp := &infracontext.ResponseContext{StatusCode: 200}
+	start := time.UnixMilli(2_000_000)
+	end := start.Add(34 * time.Millisecond)
+
+	evt := newBuilder(appcatalog.Pricing{}).Build(context.Background(), rt, req, resp, start, end)
+
+	assert.Equal(t, events.KindMCP, evt.Kind)
+	require.NotNil(t, evt.MCP)
+	assert.Equal(t, -32001, evt.MCP.RPCErrorCode)
+
+	require.Len(t, evt.PolicyChain, 1)
+	assert.Equal(t, "trustguard", evt.PolicyChain[0].Name)
+	assert.Equal(t, "pre_request", evt.PolicyChain[0].Stage)
+	assert.Equal(t, "block", evt.PolicyChain[0].Decision)
+	assert.True(t, evt.PolicyChain[0].Flagged)
+	assert.True(t, evt.IsFlagged)
+	assert.Equal(t, []string{"jailbreak"}, evt.Security)
+
+	assert.Equal(t, int64(34), evt.Latency.TotalMs)
+	assert.Equal(t, int64(3), evt.Latency.ProviderMs)
+	assert.Equal(t, int64(31), evt.Latency.PoliciesMs)
+	assert.Equal(t, int64(0), evt.Latency.RoutingMs)
+	assert.Equal(t, int64(31), evt.Latency.GatewayMs)
 }
 
 func TestBuilder_LLMKindDefault(t *testing.T) {


### PR DESCRIPTION
## Summary
- MCP metrics builder now folds plugin spans into `policy_chain`, `is_flagged`, `security`, and `latency.policies_ms` (same as LLM).
- Fixes empty `policy_chain` on MCP events when policies block (`rpc_error_code: -32001`) or allow.

## Test plan
- [x] `go test ./pkg/app/metrics/...`
- [ ] Deploy Gate and call MCP `tools/call` with TrustGuard attached; confirm Activity/DataCore `policy_chain` is non-empty
- [ ] Confirm a blocked call still shows `-32001` and a flagged trustguard entry