### PR TITLE
fix(oauth): surface IdP token-endpoint errors returned with HTTP 200

### DIFF
--- a/pkg/app/oauth/idp_transport.go
+++ b/pkg/app/oauth/idp_transport.go
@@ -81,13 +81,24 @@ func (t *idpTransport) tokenCall(ctx context.Context, endpoint string, form url.
 	if err != nil {
 		return nil, fmt.Errorf("oauth: unparseable IdP token response (status %d)", res.StatusCode)
 	}
-	if res.StatusCode != http.StatusOK {
-		code, _ := doc["error"].(string)
+	// Some identity providers — notably GitHub — report token-endpoint failures
+	// with HTTP 200 and an `error` field in the body rather than a 4xx status.
+	// Surface that embedded error regardless of the status code; otherwise the
+	// empty access_token flows downstream and the failure resurfaces as a
+	// misleading "fetch userinfo: unexpected status 401" instead of the real
+	// cause (e.g. redirect_uri_mismatch, bad_verification_code).
+	if code, _ := doc["error"].(string); code != "" {
 		desc, _ := doc["error_description"].(string)
-		if code == "" {
-			code = "server_error"
-		}
 		return nil, oauthErr(code, desc)
+	}
+	if res.StatusCode != http.StatusOK {
+		return nil, oauthErr("server_error",
+			fmt.Sprintf("identity provider token endpoint returned status %d", res.StatusCode))
+	}
+	// A 200 with no error and no access_token is equally unusable: fail loudly
+	// here rather than letting an empty bearer reach the userinfo/subject step.
+	if token, _ := doc["access_token"].(string); token == "" {
+		return nil, oauthErr("server_error", "identity provider returned no access token")
 	}
 	return doc, nil
 }

--- a/pkg/app/oauth/idp_transport_test.go
+++ b/pkg/app/oauth/idp_transport_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oauth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// GitHub reports token-endpoint failures with HTTP 200 and an `error` field in
+// a form-encoded body rather than a 4xx status. The transport must surface that
+// as an OAuth error instead of returning an empty access_token that later
+// resurfaces as a misleading "fetch userinfo: 401".
+func TestIDPTokenCall_GitHubStyleErrorWithHTTP200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("error=bad_verification_code&error_description=The+code+passed+is+incorrect"))
+	}))
+	defer srv.Close()
+
+	tr := &idpTransport{client: srv.Client()}
+	_, err := tr.tokenCall(context.Background(), srv.URL, url.Values{"code": {"x"}})
+
+	var oe *OAuthError
+	require.ErrorAs(t, err, &oe)
+	require.Equal(t, "bad_verification_code", oe.Code)
+}
+
+// A 200 response with neither an error nor an access_token is unusable and must
+// fail loudly at the transport rather than propagating an empty bearer.
+func TestIDPTokenCall_EmptyAccessTokenIsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"token_type":"bearer"}`))
+	}))
+	defer srv.Close()
+
+	tr := &idpTransport{client: srv.Client()}
+	_, err := tr.tokenCall(context.Background(), srv.URL, url.Values{})
+
+	var oe *OAuthError
+	require.ErrorAs(t, err, &oe)
+	require.Equal(t, "server_error", oe.Code)
+}
+
+// A well-formed GitHub-style (form-encoded) success is returned verbatim.
+func TestIDPTokenCall_FormEncodedSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
+		_, _ = w.Write([]byte("access_token=gho_ok&token_type=bearer&scope=read:user"))
+	}))
+	defer srv.Close()
+
+	tr := &idpTransport{client: srv.Client()}
+	doc, err := tr.tokenCall(context.Background(), srv.URL, url.Values{})
+
+	require.NoError(t, err)
+	require.Equal(t, "gho_ok", doc["access_token"])
+}


### PR DESCRIPTION
GitHub (and other providers) report token-endpoint failures with HTTP 200 and an `error` field in the body instead of a 4xx status. idpTransport.tokenCall only treated a non-200 status as failure, so a GitHub error (e.g. redirect_uri_mismatch, bad_verification_code) slipped through as a "successful" response with an empty access_token. The empty bearer then reached the subject-capture step and the whole flow failed with a misleading "oauth: fetch userinfo: unexpected status 401".

Treat an embedded `error` field — or a missing access_token — as a failure regardless of the HTTP status, so the real IdP error surfaces at the callback.


Claude-Session: https://claude.ai/code/session_01Ud4DKqxYxsgMEo5J6iE9L5