### PR TITLE
fix(mcp): return real HTTP status on gateway denials

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -6364,7 +6364,7 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "upstream_status": {
-                    "description": "Logical HTTP status of the MCP outcome (e.g. 200, 403). Wire HTTP may still be 200.",
+                    "description": "Logical HTTP status of the MCP outcome (e.g. 200, 403). Gateway denials also set the wire HTTP status and http.response.status_code.",
                     "type": "integer"
                 },
                 "upstream_tool": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7172,7 +7172,7 @@
                         "type": "integer"
                     },
                     "upstream_status": {
-                        "description": "Logical HTTP status of the MCP outcome (e.g. 200, 403). Wire HTTP may still be 200.",
+                        "description": "Logical HTTP status of the MCP outcome (e.g. 200, 403). Gateway denials also set the wire HTTP status and http.response.status_code.",
                         "type": "integer"
                     },
                     "upstream_tool": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -6357,7 +6357,7 @@
                     "type": "integer"
                 },
                 "upstream_status": {
-                    "description": "Logical HTTP status of the MCP outcome (e.g. 200, 403). Wire HTTP may still be 200.",
+                    "description": "Logical HTTP status of the MCP outcome (e.g. 200, 403). Gateway denials also set the wire HTTP status and http.response.status_code.",
                     "type": "integer"
                 },
                 "upstream_tool": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2056,7 +2056,7 @@ definitions:
       upstream_latency_ms:
         type: integer
       upstream_status:
-        description: Logical HTTP status of the MCP outcome (e.g. 200, 403). Wire HTTP may still be 200.
+        description: Logical HTTP status of the MCP outcome (e.g. 200, 403). Gateway denials also set the wire HTTP status and http.response.status_code.
         type: integer
       upstream_tool:
         type: string

--- a/docs/telemetry/otlp-metadata-contract.md
+++ b/docs/telemetry/otlp-metadata-contract.md
@@ -24,7 +24,7 @@ and — when an `otlp` exporter is declared under `exporters.raw[]` — also emi
 | Attribute | Event field |
 |-----------|-------------|
 | `http.request.method` | `request.method` |
-| `http.response.status_code` | `response.status_code` |
+| `http.response.status_code` | `response.status_code` (for MCP, aligned with `trustgate.mcp.upstream_status` / gateway denial outcome) |
 | `url.path` | `request.path` |
 
 ## GenAI semconv

--- a/pkg/api/handler/http/mcp/mcp_handler.go
+++ b/pkg/api/handler/http/mcp/mcp_handler.go
@@ -201,7 +201,7 @@ func writeAppError(c *fiber.Ctx, id json.RawMessage, err error) error {
 			middleware.SetOpsOutcome(c, o11y.OutcomeServerError)
 		}
 		applyRPCErrorHeaders(c, rpcErr)
-		return writeJSONStatus(c, httpStatusForRPCCode(rpcErr.Code), rpcResponse{
+		return writeJSONStatus(c, httpStatusForRPCError(rpcErr), rpcResponse{
 			JSONRPC: "2.0",
 			ID:      normalizeID(id),
 			Error:   &rpcError{Code: int(rpcErr.Code), Message: rpcErr.Message, Data: rpcErr.Data},
@@ -286,12 +286,17 @@ func writeJSONStatus(c *fiber.Ctx, status int, body any) error {
 	return c.Status(status).JSON(body)
 }
 
-func httpStatusForRPCCode(code int64) int {
-	switch code {
-	case appmcp.CodeRateLimited:
-		return fiber.StatusTooManyRequests
-	case appmcp.CodeUnavailable:
-		return fiber.StatusServiceUnavailable
+// httpStatusForRPCError maps gateway denials onto the wire HTTP status so
+// agents and telemetry see the real outcome. Upstream JSON-RPC errors stay on 200.
+func httpStatusForRPCError(err *appmcp.RPCError) int {
+	if err == nil {
+		return fiber.StatusOK
+	}
+	switch {
+	case appmcp.IsPolicyBlockedCode(err.Code),
+		err.Code == appmcp.CodeRateLimited,
+		err.Code == appmcp.CodeUnavailable:
+		return err.ResolvedHTTPStatus()
 	default:
 		return fiber.StatusOK
 	}

--- a/pkg/api/handler/http/mcp/rpc_dispatcher_test.go
+++ b/pkg/api/handler/http/mcp/rpc_dispatcher_test.go
@@ -201,7 +201,7 @@ func TestRPCGateway_ToolsCall_Allow_ReturnsResultUnchanged(t *testing.T) {
 	assert.Equal(t, string(raw), string(got))
 }
 
-func TestHandler_ToolsCall_PreRequestBlock_RendersJSONRPCErrorAt200(t *testing.T) {
+func TestHandler_ToolsCall_PreRequestBlock_RendersJSONRPCErrorAt403(t *testing.T) {
 	t.Parallel()
 	composer := mocks.NewComposer(t)
 	exec := pluginmocks.NewExecutor(t)
@@ -210,8 +210,8 @@ func TestHandler_ToolsCall_PreRequestBlock_RendersJSONRPCErrorAt200(t *testing.T
 	app := newAppWithRunner(t, composer, appmcp.NewPluginRunner(exec, discardLogger()), consumerdomain.TypeMCP, true)
 	status, body := rpcCall(t, app, `{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"echo"}}`)
 
-	if status != fiber.StatusOK {
-		t.Fatalf("JSON-RPC errors must ride on HTTP 200, got %d", status)
+	if status != fiber.StatusForbidden {
+		t.Fatalf("policy-blocked tools/call must return HTTP 403, got %d", status)
 	}
 	rpcErr := body["error"].(map[string]any)
 	if rpcErr["code"].(float64) != -32001 {

--- a/pkg/app/mcp/protocol.go
+++ b/pkg/app/mcp/protocol.go
@@ -151,7 +151,7 @@ type RPCError struct {
 	Code        int64
 	Message     string
 	Data        json.RawMessage
-	HTTPStatus  int // logical HTTP status for metrics; wire may still be 200
+	HTTPStatus  int // wire + metrics HTTP status for gateway denials; upstream RPC errors stay on 200
 	HTTPHeaders map[string][]string
 }
 
@@ -159,7 +159,7 @@ func (e *RPCError) Error() string {
 	return fmt.Sprintf("jsonrpc error %d: %s", e.Code, e.Message)
 }
 
-// ResolvedHTTPStatus returns the logical HTTP status for telemetry (not the wire status).
+// ResolvedHTTPStatus returns the HTTP status for gateway denials (wire + telemetry).
 func (e *RPCError) ResolvedHTTPStatus() int {
 	if e == nil {
 		return http.StatusBadGateway

--- a/pkg/app/metrics/builder.go
+++ b/pkg/app/metrics/builder.go
@@ -240,6 +240,14 @@ func (b *Builder) buildMCP(
 	b.fillRequest(evt, req, nil)
 	b.fillResponse(evt, resp, nil, totalMs)
 	b.fillStatus(evt, resp, nil, requestTrace)
+	// Prefer the logical MCP outcome over the wire status when they diverge
+	// (e.g. historical JSON-RPC denials that rode on HTTP 200).
+	if mcp != nil && mcp.UpstreamStatus != 0 {
+		evt.Response.StatusCode = mcp.UpstreamStatus
+		evt.Status.Code = mcp.UpstreamStatus
+		evt.Status.IsTimeout = mcp.UpstreamStatus == http.StatusRequestTimeout ||
+			mcp.UpstreamStatus == http.StatusGatewayTimeout
+	}
 	return evt
 }
 

--- a/pkg/app/metrics/builder_mcp_test.go
+++ b/pkg/app/metrics/builder_mcp_test.go
@@ -118,6 +118,8 @@ func TestBuilder_MCPFoldsPolicyChain(t *testing.T) {
 	require.NotNil(t, evt.MCP)
 	assert.Equal(t, http.StatusForbidden, evt.MCP.UpstreamStatus)
 	assert.Equal(t, -32001, evt.MCP.RPCErrorCode)
+	assert.Equal(t, http.StatusForbidden, evt.Response.StatusCode)
+	assert.Equal(t, http.StatusForbidden, evt.Status.Code)
 
 	require.Len(t, evt.PolicyChain, 1)
 	assert.Equal(t, "trustguard", evt.PolicyChain[0].Name)

--- a/pkg/infra/trace/span.go
+++ b/pkg/infra/trace/span.go
@@ -317,7 +317,7 @@ func (s *Span) SetMCPTargets(targets int) {
 	s.MCP.Targets = targets
 }
 
-// SetMCPStatus records the logical upstream HTTP status for metrics (wire may still be 200).
+// SetMCPStatus records the logical HTTP status for MCP metrics and http.response.status_code.
 func (s *Span) SetMCPStatus(httpStatus, rpcErrorCode int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/tests/functional/mcp_e2e_test.go
+++ b/tests/functional/mcp_e2e_test.go
@@ -138,9 +138,8 @@ func rpcResult(t *testing.T, status int, body map[string]any) map[string]any {
 
 func rpcErrorCode(t *testing.T, status int, body map[string]any) float64 {
 	t.Helper()
-	require.Equal(t, http.StatusOK, status, "expected rpc-level error: %v", body)
 	rpcErr, ok := body["error"].(map[string]any)
-	require.True(t, ok, "expected rpc error, got: %v", body)
+	require.True(t, ok, "expected rpc error (http %d), got: %v", status, body)
 	code, ok := rpcErr["code"].(float64)
 	require.True(t, ok, "rpc error missing code: %v", rpcErr)
 	return code

--- a/tests/functional/mcp_plugin_chain_test.go
+++ b/tests/functional/mcp_plugin_chain_test.go
@@ -5,6 +5,7 @@ package functional_test
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"sync/atomic"
 	"testing"
 
@@ -84,6 +85,7 @@ func TestMCPPluginChain_PreRequestEnforceBlockSkipsUpstream(t *testing.T) {
 		map[string]any{"name": "echo", "arguments": map[string]any{"message": "please run " + trustGuardBlockWord}})
 
 	require.Equal(t, rpcCodePolicyBlocked, rpcErrorCode(t, status, body))
+	require.Equal(t, http.StatusForbidden, status, "policy-blocked tools/call must return HTTP 403: %v", body)
 	require.Zero(t, atomic.LoadInt64(&calls), "upstream tool must not be invoked when PreRequest blocks")
 }
 
@@ -100,6 +102,7 @@ func TestMCPPluginChain_PreResponseEnforceBlockDiscardsResult(t *testing.T) {
 		map[string]any{"name": "leak", "arguments": map[string]any{"message": "benign"}})
 
 	require.Equal(t, rpcCodePolicyBlocked, rpcErrorCode(t, status, body))
+	require.Equal(t, http.StatusForbidden, status, "policy-blocked tools/call must return HTTP 403: %v", body)
 	require.Equal(t, int64(1), atomic.LoadInt64(&calls), "upstream tool must run once before PreResponse blocks its result")
 }
 

--- a/tests/functional/plugin_per_tool_rate_limiter_test.go
+++ b/tests/functional/plugin_per_tool_rate_limiter_test.go
@@ -239,6 +239,7 @@ func TestPluginE2E_PerToolRateLimiter_MCPToolCallDeny(t *testing.T) {
 	status, body = mcpRPC(t, gatewayID, consumerID, headers, "tools/call",
 		map[string]any{"name": "send_email", "arguments": map[string]any{}})
 	require.Equal(t, rpcCodePolicyBlocked, rpcErrorCode(t, status, body), "over-budget tools/call must be denied with -32001")
+	require.Equal(t, http.StatusTooManyRequests, status, "over-budget tools/call must return HTTP 429: %v", body)
 	require.Equal(t, int64(1), atomic.LoadInt64(&calls), "over-budget tools/call must not reach the upstream CallTool")
 }
 


### PR DESCRIPTION
## Summary
- MCP gateway denials (policy `-32001`, rate limit, unavailable) now set the **wire HTTP status** to the real outcome (`403` / `429` / `503`) instead of riding on `200` with only a JSON-RPC error.
- Metrics builder aligns `response.status_code` / `status.code` with `mcp.upstream_status`, so OTLP `http.response.status_code` matches `trustgate.mcp.upstream_status`.
- Upstream JSON-RPC errors (non-gateway) still return HTTP `200` (unchanged).

## Why
Agents and dashboards were seeing `trustgate.mcp.upstream_status:403` with `http.response.status_code:200`, which made denials look like successful transports and could let policy messages re-enter agent loops.

## Downstream impact
No code changes required in **app**, **DataCore**, or **data-plane-api** — they already treat `http_status >= 400` and/or `mcp.upstream_status >= 400` as errors. After this ships they become consistent.

## Test plan
- [x] `go test ./pkg/api/handler/http/mcp/... ./pkg/app/metrics/... ./pkg/app/mcp/... ./pkg/infra/telemetry/otlp/... ./pkg/infra/trace/... ./pkg/api/middleware/`
- [ ] `make test-functional` (MCP plugin chain + per-tool rate limiter expect `403` / `429`)
- [ ] Confirm OTLP sample: policy block → both `trustgate.mcp.upstream_status` and `http.response.status_code` are `403`