### PR TITLE
feat(auth): allow duplicate auth names per gateway

### DIFF
--- a/pkg/infra/database/migrations/20260729110000_drop_auths_gateway_name_unique.go
+++ b/pkg/infra/database/migrations/20260729110000_drop_auths_gateway_name_unique.go
@@ -1,0 +1,43 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrations
+
+import (
+	"context"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/database"
+	"github.com/jackc/pgx/v5"
+)
+
+func init() {
+	database.RegisterMigration(database.Migration{
+		ID:   "20260729110000_drop_auths_gateway_name_unique",
+		Name: "allow duplicate auth names per gateway; credentials resolve by id/key_hash",
+		Up:   upDropAuthsGatewayNameUnique,
+		Down: downDropAuthsGatewayNameUnique,
+	})
+}
+
+func upDropAuthsGatewayNameUnique(ctx context.Context, tx pgx.Tx) error {
+	const ddl = `ALTER TABLE auths DROP CONSTRAINT IF EXISTS auths_gateway_name_unique;`
+	_, err := tx.Exec(ctx, ddl)
+	return err
+}
+
+func downDropAuthsGatewayNameUnique(ctx context.Context, tx pgx.Tx) error {
+	const ddl = `ALTER TABLE auths ADD CONSTRAINT auths_gateway_name_unique UNIQUE (gateway_id, name);`
+	_, err := tx.Exec(ctx, ddl)
+	return err
+}

--- a/tests/functional/create_auth_test.go
+++ b/tests/functional/create_auth_test.go
@@ -88,18 +88,24 @@ func TestCreateAuth_OAuth2RequiresAudiences(t *testing.T) {
 	assert.Equal(t, "validation_failed", body["error"])
 }
 
-func TestCreateAuth_Conflict(t *testing.T) {
+func TestCreateAuth_DuplicateNameAllowed(t *testing.T) {
 	defer Track(t, "CreateAuth")()
 	gwID := CreateGateway(t, map[string]any{"slug": uniqueName("auth-dup")})
 	name := uniqueName("api-key")
-	_ = CreateAuth(t, gwID, validAuthPayload(name))
+	firstID := CreateAuth(t, gwID, validAuthPayload(name))
 
+	// Auth names are labels only — credentials resolve by id / key_hash, so two
+	// api_key auths on the same gateway may share a display name.
 	status, body := sendRequest(t, http.MethodPost,
 		fmt.Sprintf("%s/v1/gateways/%s/auths", AdminURL, gwID), nil,
 		validAuthPayload(name),
 	)
-	require.Equal(t, http.StatusConflict, status, "body=%v", body)
-	assert.Equal(t, "already_exists", body["error"])
+	require.Equal(t, http.StatusCreated, status, "body=%v", body)
+	secondID, ok := body["id"].(string)
+	require.True(t, ok, "create auth response missing id: %v", body)
+	assert.NotEqual(t, firstID, secondID)
+	assert.Equal(t, name, body["name"])
+	assert.NotEmpty(t, body["api_key"])
 }
 
 func TestCreateAuth_InvalidType(t *testing.T) {


### PR DESCRIPTION
Names are labels only; credentials resolve by id/key_hash. Drop auths_gateway_name_unique so consumers can mint multiple api_key auths that share a display name.