### PR TITLE
feat(auth): expose non-secret api_key prefix and suffix

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -3532,6 +3532,13 @@ const docTemplate = `{
                 "id": {
                     "type": "string"
                 },
+                "key_prefix": {
+                    "description": "Non-secret recognition hint for api_key auths (e.g. \"ag_3dlXk\" + \"Rv8Q\").",
+                    "type": "string"
+                },
+                "key_suffix": {
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4349,6 +4349,13 @@
                     "id": {
                         "type": "string"
                     },
+                    "key_prefix": {
+                        "description": "Non-secret recognition hint for api_key auths (e.g. \"ag_3dlXk\" + \"Rv8Q\").",
+                        "type": "string"
+                    },
+                    "key_suffix": {
+                        "type": "string"
+                    },
                     "name": {
                         "type": "string"
                     },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -3525,6 +3525,13 @@
                 "id": {
                     "type": "string"
                 },
+                "key_prefix": {
+                    "description": "Non-secret recognition hint for api_key auths (e.g. \"ag_3dlXk\" + \"Rv8Q\").",
+                    "type": "string"
+                },
+                "key_suffix": {
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -123,6 +123,12 @@ definitions:
         type: string
       id:
         type: string
+      key_prefix:
+        description: Non-secret recognition hint for api_key auths (e.g. "ag_3dlXk"
+          + "Rv8Q").
+        type: string
+      key_suffix:
+        type: string
       name:
         type: string
       type:

--- a/pkg/api/handler/http/auth/response/auth_response.go
+++ b/pkg/api/handler/http/auth/response/auth_response.go
@@ -30,8 +30,11 @@ type AuthResponse struct {
 	Enabled   bool           `json:"enabled"`
 	Config    ConfigResponse `json:"config"`
 	APIKey    string         `json:"api_key,omitempty"` // #nosec G101
-	CreatedAt time.Time      `json:"created_at"`
-	UpdatedAt time.Time      `json:"updated_at"`
+	// Non-secret recognition hint for api_key auths (e.g. "ag_3dlXk" + "Rv8Q").
+	KeyPrefix string    `json:"key_prefix,omitempty"`
+	KeySuffix string    `json:"key_suffix,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 type ConfigResponse struct {
@@ -81,6 +84,8 @@ func FromAuth(a *domain.Auth) AuthResponse {
 		Type:      string(a.Type),
 		Enabled:   a.Enabled,
 		Config:    fromConfig(a.Config),
+		KeyPrefix: a.KeyPrefix,
+		KeySuffix: a.KeySuffix,
 		CreatedAt: a.CreatedAt,
 		UpdatedAt: a.UpdatedAt,
 	}

--- a/pkg/domain/auth/auth.go
+++ b/pkg/domain/auth/auth.go
@@ -30,6 +30,13 @@ const apiKeyPrefix = "ag_"
 
 const apiKeyEntropyBytes = 32
 
+// Non-secret preview of a generated api_key. Kept short so list/get can show
+// enough for operators to recognize a key without storing the plaintext.
+const (
+	apiKeyPreviewPrefixLen = 8 // includes the "ag_" marker, e.g. "ag_3dlXk"
+	apiKeyPreviewSuffixLen = 4
+)
+
 type Type string
 
 const (
@@ -67,9 +74,13 @@ type Auth struct {
 	Enabled   bool          `json:"enabled"`
 	Config    Config        `json:"config"`
 	KeyHash   string        `json:"-"`
-	RawKey    string        `json:"-"`
-	CreatedAt time.Time     `json:"created_at"`
-	UpdatedAt time.Time     `json:"updated_at"`
+	// KeyPrefix / KeySuffix are a non-secret recognition hint for api_key auths
+	// (e.g. "ag_3dlXk" + "Rv8Q"). Never used for authentication.
+	KeyPrefix string    `json:"-"`
+	KeySuffix string    `json:"-"`
+	RawKey    string    `json:"-"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 func NewAuth(gatewayID ids.GatewayID, name string, authType Type, enabled bool, config Config) (*Auth, error) {
@@ -105,6 +116,7 @@ func NewAPIKeyAuth(gatewayID ids.GatewayID, name string, enabled bool) (*Auth, e
 	}
 	a.RawKey = rawKey
 	a.KeyHash = HashAPIKey(rawKey)
+	a.KeyPrefix, a.KeySuffix = APIKeyPreview(rawKey)
 	return a, nil
 }
 
@@ -119,6 +131,15 @@ func GenerateAPIKey() (string, error) {
 func HashAPIKey(raw string) string {
 	sum := sha256.Sum256([]byte(raw))
 	return hex.EncodeToString(sum[:])
+}
+
+// APIKeyPreview returns the non-secret head and tail of a generated api key.
+// Empty strings are returned when the key is too short to split safely.
+func APIKeyPreview(raw string) (prefix, suffix string) {
+	if len(raw) < apiKeyPreviewPrefixLen+apiKeyPreviewSuffixLen {
+		return "", ""
+	}
+	return raw[:apiKeyPreviewPrefixLen], raw[len(raw)-apiKeyPreviewSuffixLen:]
 }
 
 func (a *Auth) Validate() error {

--- a/pkg/domain/auth/auth_test.go
+++ b/pkg/domain/auth/auth_test.go
@@ -78,8 +78,23 @@ func TestNewAPIKeyAuth_GeneratesKey(t *testing.T) {
 	if a.KeyHash != HashAPIKey(a.RawKey) {
 		t.Fatal("KeyHash must be the hash of RawKey")
 	}
+	wantPrefix, wantSuffix := APIKeyPreview(a.RawKey)
+	if a.KeyPrefix != wantPrefix || a.KeySuffix != wantSuffix {
+		t.Fatalf("preview = %q…%q, want %q…%q", a.KeyPrefix, a.KeySuffix, wantPrefix, wantSuffix)
+	}
 	if a.CreatedAt.IsZero() || a.UpdatedAt.IsZero() {
 		t.Fatal("expected timestamps to be set")
+	}
+}
+
+func TestAPIKeyPreview(t *testing.T) {
+	t.Parallel()
+	prefix, suffix := APIKeyPreview("ag_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcd")
+	if prefix != "ag_ABCDE" || suffix != "abcd" {
+		t.Fatalf("preview = %q…%q, want ag_ABCDE…abcd", prefix, suffix)
+	}
+	if p, s := APIKeyPreview("short"); p != "" || s != "" {
+		t.Fatalf("short key preview = %q…%q, want empty", p, s)
 	}
 }
 

--- a/pkg/infra/database/migrations/20260729120000_add_auth_key_preview.go
+++ b/pkg/infra/database/migrations/20260729120000_add_auth_key_preview.go
@@ -1,0 +1,47 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrations
+
+import (
+	"context"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/database"
+	"github.com/jackc/pgx/v5"
+)
+
+func init() {
+	database.RegisterMigration(database.Migration{
+		ID:   "20260729120000_add_auth_key_preview",
+		Name: "store non-secret api_key prefix/suffix for list/get recognition",
+		Up:   upAddAuthKeyPreview,
+		Down: downAddAuthKeyPreview,
+	})
+}
+
+func upAddAuthKeyPreview(ctx context.Context, tx pgx.Tx) error {
+	const ddl = `
+		ALTER TABLE auths ADD COLUMN IF NOT EXISTS key_prefix TEXT;
+		ALTER TABLE auths ADD COLUMN IF NOT EXISTS key_suffix TEXT;`
+	_, err := tx.Exec(ctx, ddl)
+	return err
+}
+
+func downAddAuthKeyPreview(ctx context.Context, tx pgx.Tx) error {
+	const ddl = `
+		ALTER TABLE auths DROP COLUMN IF EXISTS key_suffix;
+		ALTER TABLE auths DROP COLUMN IF EXISTS key_prefix;`
+	_, err := tx.Exec(ctx, ddl)
+	return err
+}

--- a/pkg/infra/repository/auth/repository.go
+++ b/pkg/infra/repository/auth/repository.go
@@ -68,11 +68,15 @@ func (r *Repository) Save(ctx context.Context, a *domain.Auth) error {
 		return fmt.Errorf("auth repository: marshal config: %w", err)
 	}
 	const query = `
-		INSERT INTO auths (id, gateway_id, name, type, enabled, config, key_hash, created_at, updated_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`
+		INSERT INTO auths (
+			id, gateway_id, name, type, enabled, config, key_hash, key_prefix, key_suffix, created_at, updated_at
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`
 	return r.withMarkedTx(ctx, func(tx pgx.Tx) error {
 		if _, err := tx.Exec(ctx, query,
-			a.ID, a.GatewayID, a.Name, string(a.Type), a.Enabled, configBytes, nullableString(a.KeyHash), a.CreatedAt, a.UpdatedAt,
+			a.ID, a.GatewayID, a.Name, string(a.Type), a.Enabled, configBytes,
+			nullableString(a.KeyHash), nullableString(a.KeyPrefix), nullableString(a.KeySuffix),
+			a.CreatedAt, a.UpdatedAt,
 		); err != nil {
 			return mapPgError(err)
 		}
@@ -125,7 +129,7 @@ func (r *Repository) Delete(ctx context.Context, gatewayID ids.GatewayID, id ids
 
 func (r *Repository) FindByID(ctx context.Context, id ids.AuthID) (*domain.Auth, error) {
 	const query = `
-		SELECT id, gateway_id, name, type, enabled, config, key_hash, created_at, updated_at
+		SELECT id, gateway_id, name, type, enabled, config, key_hash, key_prefix, key_suffix, created_at, updated_at
 		  FROM auths
 		 WHERE id = $1`
 	row := r.conn.Pool.QueryRow(ctx, query, id)
@@ -141,7 +145,7 @@ func (r *Repository) FindByID(ctx context.Context, id ids.AuthID) (*domain.Auth,
 
 func (r *Repository) FindByAPIKeyHash(ctx context.Context, keyHash string) (*domain.Auth, error) {
 	const query = `
-		SELECT id, gateway_id, name, type, enabled, config, key_hash, created_at, updated_at
+		SELECT id, gateway_id, name, type, enabled, config, key_hash, key_prefix, key_suffix, created_at, updated_at
 		  FROM auths
 		 WHERE key_hash = $1
 		   AND type = 'api_key'
@@ -162,7 +166,7 @@ func (r *Repository) FindByIDs(ctx context.Context, gatewayID ids.GatewayID, aut
 		return nil, nil
 	}
 	const query = `
-		SELECT id, gateway_id, name, type, enabled, config, key_hash, created_at, updated_at
+		SELECT id, gateway_id, name, type, enabled, config, key_hash, key_prefix, key_suffix, created_at, updated_at
 		  FROM auths
 		 WHERE gateway_id = $1
 		   AND id = ANY($2::uuid[])`
@@ -195,7 +199,7 @@ func (r *Repository) FindEnabledByTypes(ctx context.Context, types []domain.Type
 		typeNames = append(typeNames, string(t))
 	}
 	const query = `
-		SELECT id, gateway_id, name, type, enabled, config, key_hash, created_at, updated_at
+		SELECT id, gateway_id, name, type, enabled, config, key_hash, key_prefix, key_suffix, created_at, updated_at
 		  FROM auths
 		 WHERE enabled = TRUE
 		   AND type = ANY($1::text[])
@@ -226,7 +230,7 @@ func (r *Repository) ListEnabledByGatewayAndType(
 	authType domain.Type,
 ) ([]*domain.Auth, error) {
 	const query = `
-		SELECT id, gateway_id, name, type, enabled, config, key_hash, created_at, updated_at
+		SELECT id, gateway_id, name, type, enabled, config, key_hash, key_prefix, key_suffix, created_at, updated_at
 		  FROM auths
 		 WHERE gateway_id = $1
 		   AND type = $2
@@ -275,7 +279,7 @@ func (r *Repository) List(ctx context.Context, filter domain.ListFilter) ([]*dom
 	}
 
 	const listQuery = `
-		SELECT id, gateway_id, name, type, enabled, config, key_hash, created_at, updated_at
+		SELECT id, gateway_id, name, type, enabled, config, key_hash, key_prefix, key_suffix, created_at, updated_at
 		  FROM auths
 		 WHERE ($1::uuid IS NULL OR gateway_id = $1)
 		   AND ($2 = '' OR lower(name) LIKE '%' || lower($2) || '%')
@@ -311,10 +315,12 @@ func scanAuth(s rowScanner) (*domain.Auth, error) {
 		authType  string
 		configRaw []byte
 		keyHash   *string
+		keyPrefix *string
+		keySuffix *string
 	)
 	if err := s.Scan(
 		&a.ID, &a.GatewayID, &a.Name, &authType, &a.Enabled,
-		&configRaw, &keyHash,
+		&configRaw, &keyHash, &keyPrefix, &keySuffix,
 		&a.CreatedAt, &a.UpdatedAt,
 	); err != nil {
 		return nil, err
@@ -322,6 +328,12 @@ func scanAuth(s rowScanner) (*domain.Auth, error) {
 	a.Type = domain.Type(authType)
 	if keyHash != nil {
 		a.KeyHash = *keyHash
+	}
+	if keyPrefix != nil {
+		a.KeyPrefix = *keyPrefix
+	}
+	if keySuffix != nil {
+		a.KeySuffix = *keySuffix
 	}
 	if len(configRaw) > 0 {
 		if err := json.Unmarshal(configRaw, &a.Config); err != nil {

--- a/tests/functional/create_auth_test.go
+++ b/tests/functional/create_auth_test.go
@@ -31,6 +31,8 @@ func TestCreateAuth_Success_GeneratesKey(t *testing.T) {
 	key, ok := body["api_key"].(string)
 	require.True(t, ok, "create must surface the generated api_key: %v", body)
 	assert.True(t, strings.HasPrefix(key, "ag_"), "generated key must carry the ag_ prefix: %q", key)
+	assert.Equal(t, key[:8], body["key_prefix"], "key_prefix must match the head of the issued key")
+	assert.Equal(t, key[len(key)-4:], body["key_suffix"], "key_suffix must match the tail of the issued key")
 
 	// The secret never lives inside config: api_key auth carries no config block.
 	cfg, ok := body["config"].(map[string]any)

--- a/tests/functional/get_auth_test.go
+++ b/tests/functional/get_auth_test.go
@@ -26,9 +26,12 @@ func TestGetAuth_Success_NeverReturnsSecret(t *testing.T) {
 	assert.Equal(t, name, body["name"])
 
 	// The key is hash-only storage: GET never returns the plaintext, neither at
-	// the top level nor inside a config block.
+	// the top level nor inside a config block. A non-secret head/tail preview is
+	// returned so operators can recognize the key in the UI.
 	_, hasTopLevelKey := body["api_key"]
 	assert.False(t, hasTopLevelKey, "GET must not return the api_key (shown only once at creation): %v", body)
+	assert.NotEmpty(t, body["key_prefix"])
+	assert.NotEmpty(t, body["key_suffix"])
 	cfg, _ := body["config"].(map[string]any)
 	_, hasAPIKeyCfg := cfg["api_key"]
 	assert.False(t, hasAPIKeyCfg, "api_key auth must not carry a config.api_key block: %v", cfg)

--- a/tests/functional/repositories/auth/repository_test.go
+++ b/tests/functional/repositories/auth/repository_test.go
@@ -118,6 +118,10 @@ func TestRepository_SaveAndFindByID(t *testing.T) {
 	if got.KeyHash == "" || got.KeyHash != a.KeyHash {
 		t.Fatalf("key_hash round-trip lost data: got %q want %q", got.KeyHash, a.KeyHash)
 	}
+	if got.KeyPrefix != a.KeyPrefix || got.KeySuffix != a.KeySuffix {
+		t.Fatalf("key preview round-trip lost data: got %q…%q want %q…%q",
+			got.KeyPrefix, got.KeySuffix, a.KeyPrefix, a.KeySuffix)
+	}
 }
 
 func TestRepository_FindByAPIKeyHash(t *testing.T) {


### PR DESCRIPTION
Persist the head and last four characters of each generated api_key so list/get can show a recognition hint without storing the plaintext.