### PR TITLE
fix(trustguard): expose block reason fields for Playground (ENG-1161)

### DIFF
--- a/pkg/infra/plugins/trustguard/data.go
+++ b/pkg/infra/plugins/trustguard/data.go
@@ -139,6 +139,16 @@ func scoreLabelWorthy(decision string) bool {
 // confidence, falling back to the highest-confidence signal when nothing was
 // enforced. It returns ok=false when no finding carries a usable signal type.
 func primaryFinding(findings []GuardFinding) (label string, score float64, ok bool) {
+	chosen := selectPrimaryFinding(findings)
+	if chosen == nil || chosen.Signal == nil {
+		return "", 0, false
+	}
+	return chosen.Signal.Type, chosen.Signal.Confidence, true
+}
+
+// selectPrimaryFinding returns the enforced finding with the highest
+// confidence, or the highest-confidence signal when nothing was enforced.
+func selectPrimaryFinding(findings []GuardFinding) *GuardFinding {
 	var enforced, any *GuardFinding
 	for i := range findings {
 		f := &findings[i]
@@ -154,12 +164,8 @@ func primaryFinding(findings []GuardFinding) (label string, score float64, ok bo
 			}
 		}
 	}
-	chosen := enforced
-	if chosen == nil {
-		chosen = any
+	if enforced != nil {
+		return enforced
 	}
-	if chosen == nil {
-		return "", 0, false
-	}
-	return chosen.Signal.Type, chosen.Signal.Confidence, true
+	return any
 }

--- a/pkg/infra/plugins/trustguard/reject.go
+++ b/pkg/infra/plugins/trustguard/reject.go
@@ -67,13 +67,19 @@ func unavailableError(err *entitlementsUnavailableError) *appplugins.PluginError
 
 func blockBody(resp *GuardResponse) []byte {
 	body := struct {
-		Status    string `json:"status"`
-		Message   string `json:"message"`
-		TraceID   string `json:"trace_id,omitempty"`
-		RequestID string `json:"request_id,omitempty"`
+		Status       string `json:"status"`
+		Message      string `json:"message"`
+		Type         string `json:"type,omitempty"`
+		Reason       string `json:"reason,omitempty"`
+		Plugin       string `json:"plugin,omitempty"`
+		DetectorName string `json:"detector_name,omitempty"`
+		GateName     string `json:"gate_name,omitempty"`
+		TraceID      string `json:"trace_id,omitempty"`
+		RequestID    string `json:"request_id,omitempty"`
 	}{
 		Status:  statusBlock,
 		Message: blockMessage,
+		Type:    typeBlocked,
 	}
 	if resp != nil {
 		if resp.Status != "" {
@@ -81,10 +87,20 @@ func blockBody(resp *GuardResponse) []byte {
 		}
 		body.TraceID = resp.TraceID
 		body.RequestID = resp.RequestID
+		if finding := selectPrimaryFinding(resp.Findings); finding != nil {
+			if finding.Signal != nil {
+				body.Reason = finding.Signal.Type
+			}
+			if finding.Source != nil {
+				body.Plugin = finding.Source.Plugin
+				body.DetectorName = finding.Source.DetectorName
+				body.GateName = finding.Source.GateName
+			}
+		}
 	}
 	raw, err := json.Marshal(body)
 	if err != nil {
-		return []byte(`{"status":"block","message":"request blocked due to a policy infraction"}`)
+		return []byte(`{"status":"block","message":"request blocked due to a policy infraction","type":"trustguard_blocked"}`)
 	}
 	return raw
 }

--- a/pkg/infra/plugins/trustguard/reject_test.go
+++ b/pkg/infra/plugins/trustguard/reject_test.go
@@ -25,7 +25,11 @@ func TestBlockBodyOmitsFindingsFromClientResponse(t *testing.T) {
 	raw := blockBody(&GuardResponse{
 		Status: statusBlock,
 		Findings: []GuardFinding{{
-			Source:  &GuardFindingSource{Kind: "detector", Plugin: "prompt_guard"},
+			Source: &GuardFindingSource{
+				Kind:         "detector",
+				Plugin:       "prompt_guard",
+				DetectorName: "Jailbreak detector",
+			},
 			Signal:  &GuardFindingSignal{Type: "jailbreak", Confidence: 0.99},
 			Outcome: &GuardFindingOutcome{Action: "block"},
 			Evidence: map[string]any{
@@ -44,13 +48,28 @@ func TestBlockBodyOmitsFindingsFromClientResponse(t *testing.T) {
 	if _, ok := body["findings"]; ok {
 		t.Fatalf("client block body must not include findings, got %s", string(raw))
 	}
+	if _, ok := body["evidence"]; ok {
+		t.Fatalf("client block body must not include evidence, got %s", string(raw))
+	}
 
-	var status, message, traceID, requestID string
+	var status, message, blockType, reason, plugin, detectorName, traceID, requestID string
 	if err := json.Unmarshal(body["status"], &status); err != nil {
 		t.Fatalf("status: %v", err)
 	}
 	if err := json.Unmarshal(body["message"], &message); err != nil {
 		t.Fatalf("message: %v", err)
+	}
+	if err := json.Unmarshal(body["type"], &blockType); err != nil {
+		t.Fatalf("type: %v", err)
+	}
+	if err := json.Unmarshal(body["reason"], &reason); err != nil {
+		t.Fatalf("reason: %v", err)
+	}
+	if err := json.Unmarshal(body["plugin"], &plugin); err != nil {
+		t.Fatalf("plugin: %v", err)
+	}
+	if err := json.Unmarshal(body["detector_name"], &detectorName); err != nil {
+		t.Fatalf("detector_name: %v", err)
 	}
 	if err := json.Unmarshal(body["trace_id"], &traceID); err != nil {
 		t.Fatalf("trace_id: %v", err)
@@ -64,8 +83,45 @@ func TestBlockBodyOmitsFindingsFromClientResponse(t *testing.T) {
 	if message != blockMessage {
 		t.Fatalf("message = %q, want %q", message, blockMessage)
 	}
+	if blockType != typeBlocked {
+		t.Fatalf("type = %q, want %q", blockType, typeBlocked)
+	}
+	if reason != "jailbreak" {
+		t.Fatalf("reason = %q, want jailbreak", reason)
+	}
+	if plugin != "prompt_guard" {
+		t.Fatalf("plugin = %q, want prompt_guard", plugin)
+	}
+	if detectorName != "Jailbreak detector" {
+		t.Fatalf("detector_name = %q, want Jailbreak detector", detectorName)
+	}
 	if traceID != "trace-1" || requestID != "req-1" {
 		t.Fatalf("trace/request ids = %q / %q", traceID, requestID)
+	}
+}
+
+func TestBlockBodyIncludesGateName(t *testing.T) {
+	t.Parallel()
+
+	raw := blockBody(&GuardResponse{
+		Status: statusBlock,
+		Findings: []GuardFinding{{
+			Source:  &GuardFindingSource{Kind: "gate", GateName: "max_tokens"},
+			Signal:  &GuardFindingSignal{Type: "gate_block", Confidence: 1},
+			Outcome: &GuardFindingOutcome{Action: "block"},
+		}},
+	})
+
+	var body struct {
+		Type     string `json:"type"`
+		Reason   string `json:"reason"`
+		GateName string `json:"gate_name"`
+	}
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body.Type != typeBlocked || body.Reason != "gate_block" || body.GateName != "max_tokens" {
+		t.Fatalf("body = %+v", body)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Enrich TrustGuard client block bodies with safe structured fields (`type`, `reason`, `plugin`, `detector_name`, `gate_name`) from the primary finding.
- Keep full `findings` / `evidence` off the wire.
- Enables Playground (and other clients) to show what blocked a request instead of a generic policy message.

## Linear
ENG-1161 — https://linear.app/neuraltrust/issue/ENG-1161/bug-mensaje-playground

## Test plan
- [x] `go test ./pkg/infra/plugins/trustguard/...`
- [ ] Deploy/pair with app PR that maps these fields in Playground
- [ ] Manual: TrustGuard block still returns 403 without findings in JSON