### PR TITLE
fix(trustguard): inspect streamed responses after drain (ENG-1176)

### DIFF
--- a/pkg/app/plugins/catalog_metadata.go
+++ b/pkg/app/plugins/catalog_metadata.go
@@ -857,7 +857,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 	"trustguard": {
 		name:        "TrustGuard",
 		group:       groupGuardrails,
-		description: "Inspect request or response content with TrustGuard, block flagged material, and apply data-masking. Fails open on guard errors; streaming is not inspected live.",
+		description: "Inspect request or response content with TrustGuard, block flagged material, and apply data-masking. Fails open on guard errors. Streaming responses are inspected after the stream completes (post_response), not live.",
 		schema: SettingsSchema{
 			Fields: []Field{
 				{

--- a/pkg/infra/plugins/trustguard/config.go
+++ b/pkg/infra/plugins/trustguard/config.go
@@ -84,9 +84,11 @@ func (s Settings) selectsStage(stage policy.Stage) bool {
 	case inspectRequest:
 		return stage == policy.StagePreRequest
 	case inspectResponse:
-		return stage == policy.StagePreResponse
+		return stage == policy.StagePreResponse || stage == policy.StagePostResponse
 	case inspectRequestResponse:
-		return stage == policy.StagePreRequest || stage == policy.StagePreResponse
+		return stage == policy.StagePreRequest ||
+			stage == policy.StagePreResponse ||
+			stage == policy.StagePostResponse
 	default:
 		return false
 	}

--- a/pkg/infra/plugins/trustguard/config_test.go
+++ b/pkg/infra/plugins/trustguard/config_test.go
@@ -93,20 +93,22 @@ func TestParseConfig(t *testing.T) {
 
 func TestSelectsStage(t *testing.T) {
 	tests := []struct {
-		name            string
-		inspect         string
-		wantPreRequest  bool
-		wantPreResponse bool
+		name             string
+		inspect          string
+		wantPreRequest   bool
+		wantPreResponse  bool
+		wantPostResponse bool
 	}{
-		{name: "request", inspect: inspectRequest, wantPreRequest: true, wantPreResponse: false},
-		{name: "response", inspect: inspectResponse, wantPreRequest: false, wantPreResponse: true},
-		{name: "request_response", inspect: inspectRequestResponse, wantPreRequest: true, wantPreResponse: true},
+		{name: "request", inspect: inspectRequest, wantPreRequest: true, wantPreResponse: false, wantPostResponse: false},
+		{name: "response", inspect: inspectResponse, wantPreRequest: false, wantPreResponse: true, wantPostResponse: true},
+		{name: "request_response", inspect: inspectRequestResponse, wantPreRequest: true, wantPreResponse: true, wantPostResponse: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := Settings{Inspect: tt.inspect}
 			assert.Equal(t, tt.wantPreRequest, s.selectsStage(policy.StagePreRequest))
 			assert.Equal(t, tt.wantPreResponse, s.selectsStage(policy.StagePreResponse))
+			assert.Equal(t, tt.wantPostResponse, s.selectsStage(policy.StagePostResponse))
 		})
 	}
 }

--- a/pkg/infra/plugins/trustguard/llm.go
+++ b/pkg/infra/plugins/trustguard/llm.go
@@ -30,6 +30,20 @@ func llmRequestPayload(creq *adapter.CanonicalRequest) (json.RawMessage, error) 
 	})
 }
 
+// llmResponsePayload builds a protocol=llm evaluate payload for response-direction
+// inspect. Uses messages[] with role=assistant so Activity and detectors do not
+// treat the completion as a user turn (the legacy {input} shape mapped to RoleUser).
+func llmResponsePayload(text string) (json.RawMessage, error) {
+	return json.Marshal(map[string]any{
+		"messages": []map[string]any{
+			{
+				"role":    "assistant",
+				"content": text,
+			},
+		},
+	})
+}
+
 func guardChatMessages(creq *adapter.CanonicalRequest) []map[string]any {
 	if creq == nil {
 		return nil

--- a/pkg/infra/plugins/trustguard/plugin.go
+++ b/pkg/infra/plugins/trustguard/plugin.go
@@ -91,11 +91,13 @@ func New(registry *adapter.Registry, baseURL string, timeout time.Duration, clie
 func (p *Plugin) Name() string { return PluginName }
 
 func (p *Plugin) MandatoryStages() []policy.Stage {
-	return []policy.Stage{policy.StagePreRequest, policy.StagePreResponse}
+	// PostResponse is mandatory so streamed responses are buffered and inspected
+	// after the client drain (PreResponse sees Streaming=true and cannot inspect).
+	return []policy.Stage{policy.StagePreRequest, policy.StagePreResponse, policy.StagePostResponse}
 }
 
 func (p *Plugin) SupportedStages() []policy.Stage {
-	return []policy.Stage{policy.StagePreRequest, policy.StagePreResponse}
+	return []policy.Stage{policy.StagePreRequest, policy.StagePreResponse, policy.StagePostResponse}
 }
 
 func (p *Plugin) SupportedProtocols() []appplugins.Protocol {
@@ -163,7 +165,7 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 	}
 
 	direction := directionInput
-	if in.Stage == policy.StagePreResponse {
+	if in.Stage == policy.StagePreResponse || in.Stage == policy.StagePostResponse {
 		direction = directionOutput
 	}
 
@@ -200,7 +202,7 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 			}
 			payload = raw
 		} else {
-			if in.Response == nil || in.Response.Streaming || len(in.Response.Body) == 0 {
+			if skipOutputInspect(in.Stage, in.Response) {
 				return passThrough(), nil
 			}
 			text = mcpOutputText(in.Response.Body)
@@ -249,22 +251,30 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 			}
 			payload = raw
 		} else {
-			if in.Response == nil || in.Response.Streaming || len(in.Response.Body) == 0 {
+			if skipOutputInspect(in.Stage, in.Response) {
 				return passThrough(), nil
 			}
-			cresp, decErr := p.registry.DecodeResponseFor(in.Response.Body, format)
-			if decErr != nil || cresp == nil {
-				return passThrough(), nil
+			var cresp *adapter.CanonicalResponse
+			if in.Response.Streaming {
+				text = streamAssistantText(p.registry, in.Response.Body, format)
+			} else {
+				var decErr error
+				cresp, decErr = p.registry.DecodeResponseFor(in.Response.Body, format)
+				if decErr != nil || cresp == nil {
+					return passThrough(), nil
+				}
+				text = cresp.Content
 			}
-			text = cresp.Content
 			if strings.TrimSpace(text) == "" {
 				return passThrough(), nil
 			}
-			reg := p.registry
-			tgt.apply = func(masked string) ([]byte, bool) {
-				return rewriteResponse(reg, format, cresp, masked)
+			if cresp != nil {
+				reg := p.registry
+				tgt.apply = func(masked string) ([]byte, bool) {
+					return rewriteResponse(reg, format, cresp, masked)
+				}
 			}
-			raw, err := llmPayload(text)
+			raw, err := llmResponsePayload(text)
 			if err != nil {
 				p.warn(ctx, "trustguard llm payload build failed, failing open",
 					slog.String("plugin", PluginName),
@@ -480,6 +490,23 @@ func protocolFor(consumerType string) string {
 		return protocolA2A
 	default:
 		return protocolLLM
+	}
+}
+
+// skipOutputInspect reports whether this stage should skip response inspection.
+// PreResponse defers streaming bodies to PostResponse (body is empty until drain);
+// PostResponse skips non-streaming bodies already inspected at PreResponse.
+func skipOutputInspect(stage policy.Stage, resp *infracontext.ResponseContext) bool {
+	if resp == nil || len(resp.Body) == 0 {
+		return true
+	}
+	switch stage {
+	case policy.StagePreResponse:
+		return resp.Streaming
+	case policy.StagePostResponse:
+		return !resp.Streaming
+	default:
+		return true
 	}
 }
 

--- a/pkg/infra/plugins/trustguard/plugin_test.go
+++ b/pkg/infra/plugins/trustguard/plugin_test.go
@@ -440,9 +440,7 @@ func TestExecutePreResponseBlockReturns403(t *testing.T) {
 	if got.Direction != directionOutput {
 		t.Fatalf("direction = %q, want %q", got.Direction, directionOutput)
 	}
-	if llmPayloadInput(t, got.Payload) != "the answer" {
-		t.Fatalf("input = %q, want %q", llmPayloadInput(t, got.Payload), "the answer")
-	}
+	assertLLMRequestMessages(t, got.Payload, []string{"assistant"}, []string{"the answer"})
 }
 
 func TestExecuteObserveModeOnBlockPassesThrough(t *testing.T) {
@@ -570,7 +568,57 @@ func TestExecuteStreamingResponsePassThrough(t *testing.T) {
 		t.Fatalf("expected pass-through, got %+v", res)
 	}
 	if f.count() != 0 {
-		t.Fatalf("expected guard not called for streaming, got %d hits", f.count())
+		t.Fatalf("expected guard not called for streaming pre_response, got %d hits", f.count())
+	}
+}
+
+func TestExecutePostResponseStreamingInspects(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: GuardResponse{Status: "allowed", TraceID: "trace-stream"}}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	sse := "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"the \"}}]}\n" +
+		"data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"answer\"}}]}\n" +
+		"data: [DONE]\n"
+	resp := &infracontext.ResponseContext{StatusCode: 200, Streaming: true, Body: []byte(sse)}
+	in := execInput(policy.StagePostResponse, policy.ModeObserve, settings(""), requestContext(), resp)
+	res, err := p.Execute(context.Background(), in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res == nil || res.StatusCode != http.StatusOK {
+		t.Fatalf("expected pass-through, got %+v", res)
+	}
+	if f.count() != 1 {
+		t.Fatalf("expected guard called once for streamed post_response, got %d", f.count())
+	}
+	got := f.captured()
+	if got.Direction != directionOutput {
+		t.Fatalf("direction = %q, want %q", got.Direction, directionOutput)
+	}
+	assertLLMRequestMessages(t, got.Payload, []string{"assistant"}, []string{"the answer"})
+}
+
+func TestExecutePostResponseNonStreamingPassThrough(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: GuardResponse{Status: statusBlock}}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	resp := &infracontext.ResponseContext{StatusCode: 200, Streaming: false, Body: openAIResponseBody()}
+	in := execInput(policy.StagePostResponse, policy.ModeEnforce, settings(""), requestContext(), resp)
+	res, err := p.Execute(context.Background(), in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res == nil || res.StatusCode != http.StatusOK {
+		t.Fatalf("expected pass-through, got %+v", res)
+	}
+	if f.count() != 0 {
+		t.Fatalf("expected no guard call for non-stream post_response, got %d", f.count())
 	}
 }
 

--- a/pkg/infra/plugins/trustguard/stream_text.go
+++ b/pkg/infra/plugins/trustguard/stream_text.go
@@ -1,0 +1,49 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trustguard
+
+import (
+	"strings"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/adapter"
+)
+
+// streamAssistantText reassembles assistant text from a buffered SSE body using
+// per-chunk DecodeStreamChunk. Returns empty when the body is not SSE or yields
+// no text deltas (caller should fall back to DecodeResponse).
+func streamAssistantText(reg *adapter.Registry, body []byte, format adapter.Format) string {
+	if reg == nil || len(body) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, line := range strings.Split(strings.ReplaceAll(string(body), "\r\n", "\n"), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if payload == "" || payload == "[DONE]" {
+			continue
+		}
+		chunk, err := reg.DecodeStreamChunkFor([]byte(payload), format)
+		if err != nil || chunk == nil {
+			continue
+		}
+		if d := strings.TrimSpace(chunk.Delta); d != "" {
+			b.WriteString(chunk.Delta)
+		}
+	}
+	return b.String()
+}

--- a/pkg/infra/plugins/trustguard/stream_text_test.go
+++ b/pkg/infra/plugins/trustguard/stream_text_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trustguard
+
+import (
+	"testing"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/adapter"
+)
+
+func TestStreamAssistantTextOpenAICompletions(t *testing.T) {
+	t.Parallel()
+
+	reg := adapter.NewRegistry()
+	sse := "data: {\"id\":\"c1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hel\"}}]}\n" +
+		"data: {\"id\":\"c1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"lo\"}}]}\n" +
+		"data: [DONE]\n"
+	got := streamAssistantText(reg, []byte(sse), adapter.FormatOpenAI)
+	if got != "hello" {
+		t.Fatalf("streamAssistantText = %q, want %q", got, "hello")
+	}
+}
+
+func TestStreamAssistantTextEmpty(t *testing.T) {
+	t.Parallel()
+
+	reg := adapter.NewRegistry()
+	if got := streamAssistantText(reg, nil, adapter.FormatOpenAI); got != "" {
+		t.Fatalf("got %q, want empty", got)
+	}
+	if got := streamAssistantText(nil, []byte("data: {}\n"), adapter.FormatOpenAI); got != "" {
+		t.Fatalf("nil registry got %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Run TrustGuard response inspect on `post_response` after streamed bodies are buffered (playground uses `stream: true`).
- Reassemble OpenAI chat SSE into assistant text for output evaluate.
- Send output evaluate as `messages[{role:assistant}]` instead of `{input}` so Activity/detectors do not treat completions as user turns.
- Non-streaming path unchanged: still inspected at `pre_response`; `post_response` passes through for non-stream.

## Linear
ENG-1176 — https://linear.app/neuraltrust/issue/ENG-1176/trustguard-response-detection-error

## Test plan
- [x] `go test ./pkg/infra/plugins/trustguard/ ./pkg/app/plugins/`
- [ ] Manual: playground streaming + TrustGuard `request_response` → output evaluate appears in Activity
- [ ] Manual: non-stream chat → still one output evaluate at pre_response (no duplicate post_response call)