### PR TITLE
fix(oauth): stop the connect page reporting a dead grant as connected

### DIFF
--- a/pkg/api/handler/http/oauth/pages.go
+++ b/pkg/api/handler/http/oauth/pages.go
@@ -70,6 +70,8 @@ code{
 .reg{color:var(--faint);font-size:12px;margin-top:2px}
 .status{display:inline-flex;align-items:center;gap:6px;font-size:12.5px;color:var(--success)}
 .status .dot{width:7px;height:7px;border-radius:99px;background:var(--success);flex:none}
+.status.expired{color:var(--danger)}
+.status.expired .dot{background:var(--danger)}
 .actions{display:flex;align-items:center;gap:10px;flex:none}
 a.btn,button.btn{
   display:inline-block;border-radius:var(--radius);padding:8px 18px;font-size:13.5px;font-weight:600;
@@ -113,7 +115,10 @@ var connectPageTmpl = template.Must(template.New("connect").Parse(`<!doctype htm
 {{if not .Providers}}<p class="empty">No third-party providers are configured for this virtual MCP.</p>{{end}}
 {{range .Providers}}<div class="row">
   <div><div class="name">{{.Registry}}</div><div class="reg">{{.Provider}}</div></div>
-  <div class="actions">{{if .Linked}}
+  <div class="actions">{{if .NeedsReconnect}}
+    <span class="status expired"><span class="dot"></span>Expired</span>
+    <a class="btn" href="/oauth/connect/{{.Provider}}?ticket={{$.Ticket}}">Reconnect</a>
+  {{else if .Linked}}
     <span class="status"><span class="dot"></span>Connected</span>
     <form method="post" action="/oauth/disconnect/{{.Provider}}?ticket={{$.Ticket}}"><button class="btn revoke">Revoke</button></form>
   {{else}}

--- a/pkg/app/oauth/connect.go
+++ b/pkg/app/oauth/connect.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
+	"time"
 
 	appconsumer "github.com/NeuralTrust/TrustGate/pkg/app/consumer"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
@@ -64,6 +66,11 @@ func (s *connectService) mintTicket(ctx context.Context, t ConnectTicket) (strin
 	return id, nil
 }
 
+// credentialExpiryGrace mirrors the refresh skew the MCP credential resolver
+// applies, so the connect page and the downstream calls agree on when a stored
+// grant has run out.
+const credentialExpiryGrace = 60 * time.Second
+
 func (s *connectService) Page(ctx context.Context, ticketID string) (*ConnectPage, error) {
 	ticket, gatewayID, data, rc, err := s.resolve(ctx, ticketID)
 	if err != nil {
@@ -82,6 +89,11 @@ func (s *connectService) Page(ctx context.Context, ticketID string) (*ConnectPag
 			status.Linked = true
 			status.AccountRef = cred.AccountRef
 			status.ExpiresAt = cred.ExpiresAt
+			// A grant whose access token has expired and that carries no refresh
+			// token is dead: the resolver will demand consent on every call. Say so
+			// here instead of showing "Connected" while the agent is being told the
+			// opposite.
+			status.NeedsReconnect = cred.RefreshToken == "" && cred.Expired(credentialExpiryGrace)
 		case !errors.Is(err, vaultdomain.ErrNotFound):
 			return nil, fmt.Errorf("oauth connect: check linked credential: %w", err)
 		}
@@ -149,6 +161,17 @@ func (s *connectService) Callback(ctx context.Context, baseURL, provider, state,
 	if err != nil {
 		return st.TicketID, err
 	}
+	// Whether the provider handed us a refresh token decides everything that
+	// follows: without one the grant dies with its access token and every later
+	// call demands consent again. Record it at the moment of truth so that loop
+	// is diagnosable from the logs.
+	slog.Info("oauth connect: provider grant stored",
+		"provider", provider,
+		"subject", st.Ticket.PrincipalSub,
+		"gateway_id", gatewayID.String(),
+		"has_refresh_token", token.RefreshToken != "",
+		"expires_at", token.ExpiresAt,
+		"scopes", token.Scopes)
 	cred, err := vaultdomain.NewCredential(
 		gatewayID, st.Ticket.PrincipalSub, provider, "",
 		token.AccessToken, token.RefreshToken, token.Scopes, token.ExpiresAt,

--- a/pkg/app/oauth/connect_test.go
+++ b/pkg/app/oauth/connect_test.go
@@ -436,6 +436,52 @@ func TestConnectService_UnknownTicketAndProvider(t *testing.T) {
 	}
 }
 
+// A stored grant whose access token expired and that carries no refresh token
+// can never be renewed: the MCP resolver demands consent on every call. The
+// page must report that instead of a green "Connected" that contradicts what
+// the agent is being told.
+func TestConnectService_PageReportsDeadGrantAsNeedingReconnect(t *testing.T) {
+	t.Parallel()
+	svc, vault, gw := connectFixture(t, "https://unused")
+	ctx := context.Background()
+	ticket, err := svc.CreateTicket(ctx, gw, "alice", "/dev/mcp")
+	if err != nil {
+		t.Fatalf("CreateTicket: %v", err)
+	}
+
+	// Expired and unrefreshable.
+	dead, err := vaultdomain.NewCredential(gw, "alice", "github", "", "tok", "", nil, time.Now().Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("credential: %v", err)
+	}
+	if err := vault.Upsert(ctx, dead); err != nil {
+		t.Fatalf("vault: %v", err)
+	}
+	page, err := svc.Page(ctx, ticket)
+	if err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+	if !page.Providers[0].NeedsReconnect {
+		t.Fatalf("status = %+v, want NeedsReconnect for an expired grant with no refresh token", page.Providers[0])
+	}
+
+	// Expired but refreshable: still a live connection, the resolver renews it.
+	renewable, err := vaultdomain.NewCredential(gw, "alice", "github", "", "tok", "ref", nil, time.Now().Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("credential: %v", err)
+	}
+	if err := vault.Upsert(ctx, renewable); err != nil {
+		t.Fatalf("vault: %v", err)
+	}
+	page, err = svc.Page(ctx, ticket)
+	if err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+	if !page.Providers[0].Linked || page.Providers[0].NeedsReconnect {
+		t.Fatalf("status = %+v, want a refreshable grant to stay linked", page.Providers[0])
+	}
+}
+
 func TestConnectService_ChainURL(t *testing.T) {
 	t.Parallel()
 	svc, vault, gw := connectFixture(t, "https://unused")

--- a/pkg/app/oauth/connect_types.go
+++ b/pkg/app/oauth/connect_types.go
@@ -55,6 +55,11 @@ type ProviderStatus struct {
 	Linked     bool
 	AccountRef string
 	ExpiresAt  time.Time
+	// NeedsReconnect marks a stored grant that can never be renewed: its access
+	// token has expired and it carries no refresh token. Every downstream call
+	// against it demands consent, so the page must not advertise it as a live
+	// connection.
+	NeedsReconnect bool
 }
 
 type ConnectPage struct {


### PR DESCRIPTION
A stored grant whose access token has expired and that carries no refresh token can never be renewed: the MCP credential resolver returns consent_required on every call against it. The connect page nevertheless showed it as a green "Connected", so a user who had just linked a provider was told it was live while the agent kept being told to go and connect it — the loop reported against Notion and Linear.

Report that state as "Expired" with a Reconnect action. A grant that is expired but still refreshable stays linked, since the resolver renews it transparently.

Also log, at the moment the grant is stored, whether the provider returned a refresh token (plus expiry and scopes). Whether one was issued decides whether the connection survives its first token expiry, so this is the datum needed to tell a dead grant apart from a rejected refresh.


Claude-Session: https://claude.ai/code/session_01Ud4DKqxYxsgMEo5J6iE9L5