### PR TITLE
fix(oauth): claim dynamic client registration atomically across replicas

### DIFF
--- a/pkg/app/oauth/connect_test.go
+++ b/pkg/app/oauth/connect_test.go
@@ -61,6 +61,14 @@ func (m *memConnectStore) GetClient(_ context.Context, key string) (*oauth.Regis
 	return &c, nil
 }
 
+func (m *memConnectStore) SaveClientIfAbsent(_ context.Context, key string, c oauth.RegisteredClient) (*oauth.RegisteredClient, error) {
+	if existing, ok := m.clients[key]; ok {
+		return &existing, nil
+	}
+	m.clients[key] = c
+	return &c, nil
+}
+
 func (m *memConnectStore) SaveTicket(_ context.Context, id string, t oauth.ConnectTicket) error {
 	m.tickets[id] = t
 	return nil

--- a/pkg/app/oauth/ports.go
+++ b/pkg/app/oauth/ports.go
@@ -59,6 +59,13 @@ type RegisteredClient struct {
 type ClientStore interface {
 	SaveClient(ctx context.Context, key string, c RegisteredClient) error
 	GetClient(ctx context.Context, key string) (*RegisteredClient, error)
+	// SaveClientIfAbsent stores c only when no client is registered under key
+	// yet, and returns whichever client ends up stored — c when this caller won
+	// the claim, the incumbent when another replica got there first. Dynamic
+	// client registration is not idempotent: two replicas registering
+	// concurrently mint two client_ids, and the one that loses a last-write-wins
+	// save takes every refresh token issued to it down with it.
+	SaveClientIfAbsent(ctx context.Context, key string, c RegisteredClient) (*RegisteredClient, error)
 }
 
 //go:generate mockery --name=UpstreamRegistrar --dir=. --output=./mocks --filename=oauth_upstream_registrar_mock.go --case=underscore --with-expecter

--- a/pkg/infra/oauth/connect_store.go
+++ b/pkg/infra/oauth/connect_store.go
@@ -88,6 +88,34 @@ func (s *ConnectStore) SaveClient(ctx context.Context, key string, c appoauth.Re
 	return s.set(ctx, clientPrefix+key, c, 0)
 }
 
+// SaveClientIfAbsent claims the registration slot atomically (SETNX), so that
+// when several replicas register a dynamic client at the same moment exactly
+// one client_id survives and every replica converges on it.
+func (s *ConnectStore) SaveClientIfAbsent(ctx context.Context, key string, c appoauth.RegisteredClient) (*appoauth.RegisteredClient, error) {
+	raw, err := json.Marshal(c)
+	if err != nil {
+		return nil, fmt.Errorf("oauth connect store: encode client: %w", err)
+	}
+	won, err := s.rdb.SetNX(ctx, clientPrefix+key, raw, 0).Result()
+	if err != nil {
+		return nil, fmt.Errorf("oauth connect store: claim client: %w", err)
+	}
+	if won {
+		return &c, nil
+	}
+	incumbent, err := s.GetClient(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	if incumbent == nil {
+		// The winner's entry vanished between SETNX and the read (eviction or an
+		// explicit delete). Fall back to our own registration rather than
+		// reporting no client at all.
+		return &c, nil
+	}
+	return incumbent, nil
+}
+
 func (s *ConnectStore) GetClient(ctx context.Context, key string) (*appoauth.RegisteredClient, error) {
 	raw, err := s.rdb.Get(ctx, clientPrefix+key).Bytes()
 	if errors.Is(err, redis.Nil) {

--- a/pkg/infra/oauth/dcr_registrar.go
+++ b/pkg/infra/oauth/dcr_registrar.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -142,8 +143,17 @@ func (r *upstreamRegistrar) discover(ctx context.Context, upstreamURL string) (*
 }
 
 func (r *upstreamRegistrar) EnsureClient(ctx context.Context, key string, meta *appoauth.UpstreamAuthServer, redirectURI string) (*appoauth.RegisteredClient, error) {
-	if c, err := r.clients.GetClient(ctx, key); err == nil && c != nil && c.RedirectURI == redirectURI {
-		return c, nil
+	cached, cacheErr := r.clients.GetClient(ctx, key)
+	if cacheErr == nil && cached != nil && cached.RedirectURI == redirectURI {
+		return cached, nil
+	}
+	// A client is already registered but for a different redirect URI. Replacing
+	// it is deliberate, and it invalidates every refresh token the old client
+	// holds, so say so rather than losing those grants silently.
+	replacing := cacheErr == nil && cached != nil
+	if replacing {
+		slog.Warn("oauth dcr: re-registering upstream client because the redirect URI changed; grants held by the previous client can no longer be refreshed",
+			"key", key, "old_redirect_uri", cached.RedirectURI, "new_redirect_uri", redirectURI)
 	}
 	if meta.RegistrationEndpoint == "" {
 		return nil, fmt.Errorf("%w: authorization server has no registration_endpoint", appoauth.ErrUpstreamNotDiscoverable)
@@ -180,10 +190,26 @@ func (r *upstreamRegistrar) EnsureClient(ctx context.Context, key string, meta *
 		return nil, fmt.Errorf("oauth dcr: registration response has no client_id")
 	}
 	client := &appoauth.RegisteredClient{ClientID: doc.ClientID, ClientSecret: doc.ClientSecret, RedirectURI: redirectURI}
-	if err := r.clients.SaveClient(ctx, key, *client); err != nil {
+	if replacing {
+		if err := r.clients.SaveClient(ctx, key, *client); err != nil {
+			return nil, err
+		}
+		return client, nil
+	}
+	// First registration for this upstream. Other replicas may be registering
+	// at the same moment; claim the slot atomically so all of them converge on a
+	// single client_id. Overwriting here would strand the refresh tokens issued
+	// to the client that lost the race, which surfaces later as invalid_grant
+	// and drags the user back through consent.
+	stored, err := r.clients.SaveClientIfAbsent(ctx, key, *client)
+	if err != nil {
 		return nil, err
 	}
-	return client, nil
+	if stored.ClientID != client.ClientID {
+		slog.Info("oauth dcr: discarding duplicate client registration; another replica claimed this upstream first",
+			"key", key, "kept_client_id", stored.ClientID)
+	}
+	return stored, nil
 }
 
 func (r *upstreamRegistrar) CachedClient(ctx context.Context, key string) (*appoauth.RegisteredClient, error) {

--- a/pkg/infra/oauth/dcr_registrar_test.go
+++ b/pkg/infra/oauth/dcr_registrar_test.go
@@ -1,0 +1,154 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oauth_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	appoauth "github.com/NeuralTrust/TrustGate/pkg/app/oauth"
+	infraoauth "github.com/NeuralTrust/TrustGate/pkg/infra/oauth"
+	"github.com/stretchr/testify/require"
+)
+
+// claimStore models the shared registration slot: SaveClientIfAbsent is atomic,
+// as the Redis SETNX behind it is.
+type claimStore struct {
+	mu      sync.Mutex
+	clients map[string]appoauth.RegisteredClient
+}
+
+func newClaimStore() *claimStore {
+	return &claimStore{clients: map[string]appoauth.RegisteredClient{}}
+}
+
+func (s *claimStore) SaveClient(_ context.Context, key string, c appoauth.RegisteredClient) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.clients[key] = c
+	return nil
+}
+
+func (s *claimStore) GetClient(_ context.Context, key string) (*appoauth.RegisteredClient, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	c, ok := s.clients[key]
+	if !ok {
+		return nil, nil
+	}
+	return &c, nil
+}
+
+func (s *claimStore) SaveClientIfAbsent(_ context.Context, key string, c appoauth.RegisteredClient) (*appoauth.RegisteredClient, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if existing, ok := s.clients[key]; ok {
+		return &existing, nil
+	}
+	s.clients[key] = c
+	return &c, nil
+}
+
+// Dynamic client registration is not idempotent: every call mints a fresh
+// client_id. When several replicas register the same upstream at once they must
+// still converge on one client_id — a second one silently strands the refresh
+// tokens issued to the first, which resurfaces later as invalid_grant and drags
+// the user back through the consent screen.
+func TestEnsureClient_ConcurrentReplicasConvergeOnOneClientID(t *testing.T) {
+	t.Parallel()
+	var issued atomic.Int64
+	idp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := issued.Add(1)
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"client_id": fmt.Sprintf("client-%d", n),
+		})
+	}))
+	defer idp.Close()
+
+	store := newClaimStore()
+	meta := &appoauth.UpstreamAuthServer{RegistrationEndpoint: idp.URL}
+	const replicas = 8
+	const redirectURI = "https://gw.example.com/oauth/callback/com.notion/mcp"
+
+	results := make([]*appoauth.RegisteredClient, replicas)
+	errs := make([]error, replicas)
+	var wg sync.WaitGroup
+	for i := range replicas {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// A registrar per goroutine: each models a separate pod, so they share
+			// only the store — exactly as replicas do.
+			r := infraoauth.NewUpstreamRegistrar(store, idp.Client())
+			results[i], errs[i] = r.EnsureClient(context.Background(), "gw|reg", meta, redirectURI)
+		}()
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoError(t, err, "replica %d", i)
+		require.NotNil(t, results[i], "replica %d", i)
+	}
+	winner := results[0].ClientID
+	for i, got := range results {
+		require.Equal(t, winner, got.ClientID,
+			"replica %d returned a different client_id; grants issued to the others would be stranded", i)
+	}
+
+	stored, err := store.GetClient(context.Background(), "gw|reg")
+	require.NoError(t, err)
+	require.Equal(t, winner, stored.ClientID, "the stored client must be the one every replica uses")
+}
+
+// A genuine redirect-URI change is a deliberate replacement, not a race, and
+// must still overwrite the stored client.
+func TestEnsureClient_RedirectURIChangeReplacesClient(t *testing.T) {
+	t.Parallel()
+	var issued atomic.Int64
+	idp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := issued.Add(1)
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"client_id": fmt.Sprintf("client-%d", n)})
+	}))
+	defer idp.Close()
+
+	store := newClaimStore()
+	meta := &appoauth.UpstreamAuthServer{RegistrationEndpoint: idp.URL}
+	r := infraoauth.NewUpstreamRegistrar(store, idp.Client())
+	ctx := context.Background()
+
+	first, err := r.EnsureClient(ctx, "gw|reg", meta, "https://gw.example.com/oauth/callback/p")
+	require.NoError(t, err)
+
+	// Same redirect URI: reuses the registration, no new client_id.
+	again, err := r.EnsureClient(ctx, "gw|reg", meta, "https://gw.example.com/oauth/callback/p")
+	require.NoError(t, err)
+	require.Equal(t, first.ClientID, again.ClientID)
+
+	// Different redirect URI: deliberate re-registration.
+	moved, err := r.EnsureClient(ctx, "gw|reg", meta, "https://new.example.com/oauth/callback/p")
+	require.NoError(t, err)
+	require.NotEqual(t, first.ClientID, moved.ClientID)
+	stored, err := store.GetClient(ctx, "gw|reg")
+	require.NoError(t, err)
+	require.Equal(t, moved.ClientID, stored.ClientID)
+}


### PR DESCRIPTION
Dynamic client registration is not idempotent: every call to the upstream's registration endpoint mints a fresh client_id. EnsureClient registered without any coordination and stored the result with an unconditional SET, so two replicas hitting the same upstream at once minted two clients and the later save silently won. Every refresh token issued to the losing client_id was then stranded: the next refresh came back invalid_grant, the resolver fell through to consent, and the user was sent back to the connect page for a provider the vault still held a credential for — the loop reported against Notion and Linear on a multi-replica deployment.

Claim the registration slot with SETNX so all replicas converge on a single client_id, discarding the duplicate registration when another replica got there first. A redirect-URI change stays a deliberate replacement and still overwrites, but now logs a warning, since it invalidates the previous client's grants by design.


Claude-Session: https://claude.ai/code/session_01Ud4DKqxYxsgMEo5J6iE9L5