### PR TITLE
fix(mcp): use 403 for a pending upstream consent, not 401

### DIFF
--- a/pkg/api/handler/http/mcp/mcp_handler.go
+++ b/pkg/api/handler/http/mcp/mcp_handler.go
@@ -213,13 +213,13 @@ func writeAppError(c *fiber.Ctx, id json.RawMessage, err error) error {
 			"provider":    consentErr.Provider,
 			"connect_url": connectURL,
 		})
-		// 401 rather than a transport-level success: the call failed because the
-		// user has not authorized this upstream, which reads as an auth problem
-		// in clients and logs alike. No WWW-Authenticate is set on purpose —
-		// the caller's credentials for the gateway are valid, and advertising a
-		// challenge here would send MCP clients back through the gateway's own
-		// OAuth flow instead of to the connect page carried in the payload.
-		return writeJSONStatus(c, fiber.StatusUnauthorized, rpcResponse{
+		// 403, not 401: the caller's credentials for the gateway are valid, it is
+		// the upstream account that is unlinked. MCP clients read any 401 on this
+		// endpoint as "your token is stale", refresh it successfully, retry, get
+		// the same 401 and give up with "server returned 401 after successful
+		// authentication" — the consent URL in the payload never gets a chance.
+		// 403 states the request is refused as it stands without inviting a retry.
+		return writeJSONStatus(c, fiber.StatusForbidden, rpcResponse{
 			JSONRPC: "2.0",
 			ID:      normalizeID(id),
 			Error: &rpcError{

--- a/pkg/api/handler/http/mcp/mcp_handler_test.go
+++ b/pkg/api/handler/http/mcp/mcp_handler_test.go
@@ -192,11 +192,11 @@ func TestHandler_ToolsCall_PassesUpstreamRPCErrorThrough(t *testing.T) {
 	}
 }
 
-// Calling a tool on an upstream the user has not connected is an authorization
-// gap, so it answers 401 and carries the connect URL. No WWW-Authenticate is
-// advertised: the caller's gateway credentials are fine, and a challenge here
-// would push MCP clients back through the gateway's own OAuth flow.
-func TestHandler_ToolsCall_ConsentRequiredIsUnauthorized(t *testing.T) {
+// Calling a tool on an upstream the user has not connected answers 403 and
+// carries the connect URL. Not 401: MCP clients read that as a stale gateway
+// token, refresh it, retry, and fail with "401 after successful
+// authentication" without ever surfacing the consent URL.
+func TestHandler_ToolsCall_ConsentRequiredIsForbidden(t *testing.T) {
 	t.Parallel()
 	composer := mocks.NewComposer(t)
 	composer.EXPECT().CallTool(mock.Anything, mock.Anything, "notion-search", mock.Anything).
@@ -207,8 +207,8 @@ func TestHandler_ToolsCall_ConsentRequiredIsUnauthorized(t *testing.T) {
 
 	status, body := rpcCall(t, app,
 		`{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"notion-search"}}`)
-	if status != fiber.StatusUnauthorized {
-		t.Fatalf("status = %d, want 401 for an unconnected upstream", status)
+	if status != fiber.StatusForbidden {
+		t.Fatalf("status = %d, want 403 for an unconnected upstream", status)
 	}
 	rpcErr := body["error"].(map[string]any)
 	if rpcErr["code"].(float64) != -32003 {

--- a/pkg/api/handler/http/mcp/rpc_dispatcher.go
+++ b/pkg/api/handler/http/mcp/rpc_dispatcher.go
@@ -87,8 +87,9 @@ func (g *RPCGateway) finishSpan(span *trace.Span, err error) {
 	case errors.As(err, &consentErr):
 		// An upstream the user has not connected yet is an authorization gap,
 		// not a broken gateway; recording it as 502 buried real upstream
-		// failures under routine consent prompts.
-		span.SetMCPStatus(http.StatusUnauthorized, codeConsentRequired)
+		// failures under routine consent prompts. Mirrors the 403 sent on the
+		// wire — 401 makes MCP clients retry the gateway's own OAuth forever.
+		span.SetMCPStatus(http.StatusForbidden, codeConsentRequired)
 	case errors.Is(err, appmcp.ErrToolNotFound), errors.Is(err, appmcp.ErrPromptNotFound),
 		errors.Is(err, appmcp.ErrResourceNotFound):
 		span.SetMCPStatus(http.StatusNotFound, 0)

--- a/pkg/api/handler/http/mcp/rpc_dispatcher_span_test.go
+++ b/pkg/api/handler/http/mcp/rpc_dispatcher_span_test.go
@@ -106,7 +106,7 @@ func TestRPCGateway_Dispatch_RecordsPolicyBlockedHTTPStatus(t *testing.T) {
 // An upstream the user has not connected yet is an authorization gap, not a
 // broken gateway: recording it as 502 hid real upstream failures among routine
 // consent prompts.
-func TestRPCGateway_Dispatch_RecordsConsentAsUnauthorized(t *testing.T) {
+func TestRPCGateway_Dispatch_RecordsConsentAsForbidden(t *testing.T) {
 	t.Parallel()
 	composer := mocks.NewComposer(t)
 	composer.EXPECT().
@@ -125,7 +125,7 @@ func TestRPCGateway_Dispatch_RecordsConsentAsUnauthorized(t *testing.T) {
 
 	attrs, ok := rt.Spans()[0].MCPAttrsCopy()
 	require.True(t, ok)
-	assert.Equal(t, http.StatusUnauthorized, attrs.UpstreamStatus)
+	assert.Equal(t, http.StatusForbidden, attrs.UpstreamStatus)
 	assert.Equal(t, -32003, attrs.RPCErrorCode)
 }
 


### PR DESCRIPTION
401 sent MCP clients into a dead end: Cursor reads any 401 on the MCP endpoint as a stale gateway token, refreshes it successfully, retries, gets the same 401 and gives up with "Server returned 401 after successful authentication". The connect URL in the payload never reaches the user, and the tool call fails hard.

The caller's credentials for the gateway are valid — it is the upstream account that is unlinked — so 403 is both accurate and inert: it states the request is refused as it stands without inviting an authentication retry. The -32003 payload with provider and connect_url is unchanged, and the span records 403 to match, so consent stays distinguishable from a toolkit denial (-32001) by its JSON-RPC code.


Claude-Session: https://claude.ai/code/session_01Ud4DKqxYxsgMEo5J6iE9L5