### PR TITLE
fix(mcp): keep tool-call refusals on HTTP 200 so MCP clients can read…

### DIFF
--- a/pkg/api/handler/http/mcp/mcp_handler.go
+++ b/pkg/api/handler/http/mcp/mcp_handler.go
@@ -56,6 +56,9 @@ const (
 const (
 	codeConsentRequired  = -32003
 	codeResourceNotFound = -32002
+	// codePolicyBlocked mirrors the app-layer policy-denial code, so a toolkit
+	// denial is classified alongside plugin blocks.
+	codePolicyBlocked = -32001
 )
 
 type Handler struct {
@@ -188,6 +191,7 @@ func writeAppError(c *fiber.Ctx, id json.RawMessage, err error) error {
 	var (
 		rpcErr        *appmcp.RPCError
 		consentErr    *appmcp.ConsentRequiredError
+		notPermitted  *appmcp.ToolNotPermittedError
 		invalidParams *InvalidParamsError
 	)
 	switch {
@@ -213,13 +217,13 @@ func writeAppError(c *fiber.Ctx, id json.RawMessage, err error) error {
 			"provider":    consentErr.Provider,
 			"connect_url": connectURL,
 		})
-		// 403, not 401: the caller's credentials for the gateway are valid, it is
-		// the upstream account that is unlinked. MCP clients read any 401 on this
-		// endpoint as "your token is stale", refresh it successfully, retry, get
-		// the same 401 and give up with "server returned 401 after successful
-		// authentication" — the consent URL in the payload never gets a chance.
-		// 403 states the request is refused as it stands without inviting a retry.
-		return writeJSONStatus(c, fiber.StatusForbidden, rpcResponse{
+		// HTTP 200 carrying a JSON-RPC error, not a 4xx. MCP streamable-HTTP
+		// clients treat any non-2xx on this endpoint as a transport failure: they
+		// drop the connection and restart authentication instead of reading the
+		// body, so the connect URL never reaches the user. The refusal is
+		// reported to the agent through the JSON-RPC error, and the semantic
+		// status (403) is recorded on the span for metrics and traces.
+		return writeJSON(c, rpcResponse{
 			JSONRPC: "2.0",
 			ID:      normalizeID(id),
 			Error: &rpcError{
@@ -227,6 +231,17 @@ func writeAppError(c *fiber.Ctx, id json.RawMessage, err error) error {
 				Message: fmt.Sprintf("user consent required: open %s to connect %s", connectURL, consentErr.Provider),
 				Data:    data,
 			},
+		})
+	case errors.As(err, &notPermitted):
+		// A denial the agent should read and act on, so it rides on HTTP 200 for
+		// the same transport reason as the consent case above; the span records
+		// it as forbidden. Written inline rather than through writeRPCError,
+		// which would reclassify the outcome as a generic client error.
+		middleware.SetOpsOutcome(c, o11y.OutcomeDeniedPolicy)
+		return writeJSON(c, rpcResponse{
+			JSONRPC: "2.0",
+			ID:      normalizeID(id),
+			Error:   &rpcError{Code: codePolicyBlocked, Message: notPermitted.Error()},
 		})
 	case errors.As(err, &invalidParams):
 		return writeRPCError(c, id, codeInvalidParams, invalidParams.Reason)

--- a/pkg/api/handler/http/mcp/mcp_handler_test.go
+++ b/pkg/api/handler/http/mcp/mcp_handler_test.go
@@ -192,11 +192,11 @@ func TestHandler_ToolsCall_PassesUpstreamRPCErrorThrough(t *testing.T) {
 	}
 }
 
-// Calling a tool on an upstream the user has not connected answers 403 and
-// carries the connect URL. Not 401: MCP clients read that as a stale gateway
-// token, refresh it, retry, and fail with "401 after successful
-// authentication" without ever surfacing the consent URL.
-func TestHandler_ToolsCall_ConsentRequiredIsForbidden(t *testing.T) {
+// The consent refusal must reach the agent, so it rides on HTTP 200 carrying
+// the JSON-RPC error and the connect URL. Any 4xx here is read by MCP clients
+// as a transport failure: they drop the connection and restart authentication
+// without ever parsing the body.
+func TestHandler_ToolsCall_ConsentRequiredRidesOn200(t *testing.T) {
 	t.Parallel()
 	composer := mocks.NewComposer(t)
 	composer.EXPECT().CallTool(mock.Anything, mock.Anything, "notion-search", mock.Anything).
@@ -207,8 +207,8 @@ func TestHandler_ToolsCall_ConsentRequiredIsForbidden(t *testing.T) {
 
 	status, body := rpcCall(t, app,
 		`{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"notion-search"}}`)
-	if status != fiber.StatusForbidden {
-		t.Fatalf("status = %d, want 403 for an unconnected upstream", status)
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200 so the client parses the JSON-RPC error", status)
 	}
 	rpcErr := body["error"].(map[string]any)
 	if rpcErr["code"].(float64) != -32003 {
@@ -221,6 +221,29 @@ func TestHandler_ToolsCall_ConsentRequiredIsForbidden(t *testing.T) {
 	connectURL, _ := data["connect_url"].(string)
 	if !strings.Contains(connectURL, "/virtual/mcp/connect?ticket=tk") {
 		t.Fatalf("connect_url = %q, want the consumer's connect page", connectURL)
+	}
+}
+
+// A tool the toolkit forbids is reported to the agent as a policy denial over
+// HTTP 200, so the client surfaces the reason instead of failing the transport.
+func TestHandler_ToolsCall_ToolNotPermittedRidesOn200(t *testing.T) {
+	t.Parallel()
+	composer := mocks.NewComposer(t)
+	composer.EXPECT().CallTool(mock.Anything, mock.Anything, "notion-search", mock.Anything).
+		Return(nil, &appmcp.ToolNotPermittedError{Tool: "notion-search"}).Once()
+	app := newApp(t, composer, consumerdomain.TypeMCP, true)
+
+	status, body := rpcCall(t, app,
+		`{"jsonrpc":"2.0","id":11,"method":"tools/call","params":{"name":"notion-search"}}`)
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200 so the client parses the JSON-RPC error", status)
+	}
+	rpcErr := body["error"].(map[string]any)
+	if rpcErr["code"].(float64) != -32001 {
+		t.Fatalf("code = %v, want the policy-blocked code", rpcErr["code"])
+	}
+	if msg, _ := rpcErr["message"].(string); !strings.Contains(msg, "not permitted") {
+		t.Fatalf("message = %q, want it to say the tool is not permitted", msg)
 	}
 }
 

--- a/pkg/api/handler/http/mcp/rpc_dispatcher.go
+++ b/pkg/api/handler/http/mcp/rpc_dispatcher.go
@@ -78,18 +78,22 @@ func (g *RPCGateway) finishSpan(span *trace.Span, err error) {
 	}
 	span.SetError(err.Error())
 	var (
-		rpcErr     *appmcp.RPCError
-		consentErr *appmcp.ConsentRequiredError
+		rpcErr       *appmcp.RPCError
+		consentErr   *appmcp.ConsentRequiredError
+		notPermitted *appmcp.ToolNotPermittedError
 	)
 	switch {
 	case errors.As(err, &rpcErr):
 		span.SetMCPStatus(rpcErr.ResolvedHTTPStatus(), int(rpcErr.Code))
 	case errors.As(err, &consentErr):
-		// An upstream the user has not connected yet is an authorization gap,
-		// not a broken gateway; recording it as 502 buried real upstream
-		// failures under routine consent prompts. Mirrors the 403 sent on the
-		// wire — 401 makes MCP clients retry the gateway's own OAuth forever.
+		// Both of these answer HTTP 200 on the wire so MCP clients parse the
+		// JSON-RPC error instead of tearing down the transport. The status the
+		// refusal *means* belongs in telemetry, which is what this records:
+		// otherwise an unconnected upstream showed up as a 502 and buried real
+		// upstream failures among routine consent prompts.
 		span.SetMCPStatus(http.StatusForbidden, codeConsentRequired)
+	case errors.As(err, &notPermitted):
+		span.SetMCPStatus(http.StatusForbidden, codePolicyBlocked)
 	case errors.Is(err, appmcp.ErrToolNotFound), errors.Is(err, appmcp.ErrPromptNotFound),
 		errors.Is(err, appmcp.ErrResourceNotFound):
 		span.SetMCPStatus(http.StatusNotFound, 0)

--- a/pkg/api/handler/http/mcp/rpc_dispatcher_span_test.go
+++ b/pkg/api/handler/http/mcp/rpc_dispatcher_span_test.go
@@ -103,9 +103,10 @@ func TestRPCGateway_Dispatch_RecordsPolicyBlockedHTTPStatus(t *testing.T) {
 	assert.Equal(t, -32001, attrs.RPCErrorCode)
 }
 
-// An upstream the user has not connected yet is an authorization gap, not a
-// broken gateway: recording it as 502 hid real upstream failures among routine
-// consent prompts.
+// The wire answers 200 so MCP clients parse the error, but telemetry must still
+// say what the refusal means: an upstream the user has not connected is an
+// authorization gap, not a broken gateway. Recording it as 502 hid real
+// upstream failures among routine consent prompts.
 func TestRPCGateway_Dispatch_RecordsConsentAsForbidden(t *testing.T) {
 	t.Parallel()
 	composer := mocks.NewComposer(t)

--- a/pkg/app/mcp/composer.go
+++ b/pkg/app/mcp/composer.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"net/http"
 	"net/url"
 	"time"
 
@@ -111,11 +110,7 @@ func (c *composer) CallTool(ctx context.Context, rc *appconsumer.RoutableConsume
 	// forbidden tool sends the user off to an authorization flow that cannot
 	// grant it.
 	if _, forbidden := comp.denied[name]; forbidden {
-		return nil, &RPCError{
-			Code:       codePolicyBlocked,
-			Message:    fmt.Sprintf("tool %q is not permitted for this consumer", name),
-			HTTPStatus: http.StatusForbidden,
-		}
+		return nil, &ToolNotPermittedError{Tool: name}
 	}
 	// No reachable upstream exposes this tool. If another upstream is still
 	// awaiting consent it may be the one that owns the tool, so the consent

--- a/pkg/app/mcp/composer_test.go
+++ b/pkg/app/mcp/composer_test.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
-	"net/http"
 	"sync"
 	"testing"
 
@@ -458,15 +457,12 @@ func TestComposer_CallTool_ToolkitDeniedIsForbidden(t *testing.T) {
 	}, notion)
 
 	_, err := c.CallTool(context.Background(), rc, "notion-search", nil)
-	var rpcErr *RPCError
-	if !errors.As(err, &rpcErr) {
-		t.Fatalf("error = %v, want an RPCError policy denial", err)
+	var denied *ToolNotPermittedError
+	if !errors.As(err, &denied) {
+		t.Fatalf("error = %v, want ToolNotPermittedError", err)
 	}
-	if rpcErr.ResolvedHTTPStatus() != http.StatusForbidden {
-		t.Fatalf("status = %d, want 403", rpcErr.ResolvedHTTPStatus())
-	}
-	if !IsPolicyBlockedCode(rpcErr.Code) {
-		t.Fatalf("code = %d, want the policy-blocked code", rpcErr.Code)
+	if denied.Tool != "notion-search" {
+		t.Fatalf("tool = %q, want notion-search", denied.Tool)
 	}
 	if up.lastCall != "" {
 		t.Fatalf("upstream was invoked with %q for a denied tool", up.lastCall)
@@ -505,9 +501,9 @@ func TestComposer_CallTool_DeniedToolBeatsPendingConsent(t *testing.T) {
 	if errors.As(err, &consent) {
 		t.Fatal("a forbidden tool must not send the user through a consent flow")
 	}
-	var rpcErr *RPCError
-	if !errors.As(err, &rpcErr) || rpcErr.ResolvedHTTPStatus() != http.StatusForbidden {
-		t.Fatalf("error = %v, want 403 policy denial", err)
+	var denied *ToolNotPermittedError
+	if !errors.As(err, &denied) {
+		t.Fatalf("error = %v, want a policy denial", err)
 	}
 }
 

--- a/pkg/app/mcp/errors.go
+++ b/pkg/app/mcp/errors.go
@@ -27,3 +27,15 @@ var (
 	ErrNoMCPRegistries     = fmt.Errorf("mcp: no MCP registries attached to consumer: %w", commonerrors.ErrValidation)
 	ErrUpstreamUnavailable = fmt.Errorf("mcp: upstream unavailable")
 )
+
+// ToolNotPermittedError reports a tool the upstream offers but the consumer's
+// toolkit excludes. It is a denial, not a missing tool and not an upstream
+// failure, so it carries its own type: the handler answers it as a policy block
+// the agent can read, while telemetry records it as forbidden.
+type ToolNotPermittedError struct {
+	Tool string
+}
+
+func (e *ToolNotPermittedError) Error() string {
+	return fmt.Sprintf("mcp: tool %q is not permitted for this consumer", e.Tool)
+}


### PR DESCRIPTION
… them

Cursor treats any non-2xx on the MCP endpoint as a transport failure: it never parses the body, drops the connection ("connection:transport_error"), and restarts authentication. The 403 introduced for a pending upstream consent therefore replaced the earlier 401 loop with a dead transport — the connect URL sitting in the payload was never surfaced to the user either way.

Send both refusals — consent required and a tool the toolkit forbids — as JSON-RPC errors over HTTP 200, which is how the transport is meant to carry them, and record the status they *mean* (403) on the span instead. The dashboard keeps showing the refusal as forbidden, distinguishable by code (-32003 consent, -32001 policy), while the agent actually receives the message and can act on it.

The toolkit denial gets its own error type rather than an RPCError so it does not inherit the gateway-denial status mapping used by plugin blocks, which must keep answering 403.


Claude-Session: https://claude.ai/code/session_01Ud4DKqxYxsgMEo5J6iE9L5