### PR TITLE
feat(mcp): fingerprint the tool surface in serverInfo.version

### DIFF
--- a/pkg/api/handler/http/mcp/mcp_handler.go
+++ b/pkg/api/handler/http/mcp/mcp_handler.go
@@ -15,9 +15,14 @@
 package mcp
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
+	"strings"
+	"time"
 
 	"github.com/NeuralTrust/TrustGate/pkg/api/middleware"
 	appauth "github.com/NeuralTrust/TrustGate/pkg/app/auth"
@@ -129,7 +134,7 @@ func (h *Handler) Handle(c *fiber.Ctx) error {
 	switch req.Method {
 	case "initialize":
 		h.recordInitialize(c)
-		return h.handleInitialize(c, req)
+		return h.handleInitialize(c, req, rc)
 	case "ping":
 		skipMetrics(c)
 		return writeRPCResult(c, req.ID, struct{}{})
@@ -166,7 +171,7 @@ type initializeParams struct {
 	ProtocolVersion string `json:"protocolVersion"`
 }
 
-func (h *Handler) handleInitialize(c *fiber.Ctx, req rpcRequest) error {
+func (h *Handler) handleInitialize(c *fiber.Ctx, req rpcRequest, rc *appconsumer.RoutableConsumer) error {
 	var params initializeParams
 	_ = json.Unmarshal(req.Params, &params)
 	version := latestProtocolVersion
@@ -182,9 +187,40 @@ func (h *Handler) handleInitialize(c *fiber.Ctx, req rpcRequest) error {
 		},
 		"serverInfo": fiber.Map{
 			"name":    serverName,
-			"version": serverVersion,
+			"version": serverVersion + "+" + surfaceFingerprint(rc),
 		},
 	})
+}
+
+// surfaceFingerprint summarises everything that decides which tools a virtual
+// MCP exposes: the bound MCP registries, when each was last changed, and the
+// toolkit that filters them. It rides in serverInfo.version as semver build
+// metadata, so a client that caches a server's tool list keyed on its reported
+// version re-lists after the consumer is reconfigured. Without it every virtual
+// MCP reports a constant "1.0" forever and a newly attached registry stays
+// invisible until the client is reinstalled.
+func surfaceFingerprint(rc *appconsumer.RoutableConsumer) string {
+	if rc == nil || rc.Consumer == nil {
+		return "0"
+	}
+	parts := make([]string, 0, len(rc.Registries))
+	for _, reg := range rc.Registries {
+		if reg == nil || !reg.IsMCP() {
+			continue
+		}
+		parts = append(parts, reg.ID.String()+"@"+reg.UpdatedAt.UTC().Format(time.RFC3339Nano))
+	}
+	entries := make([]string, 0, len(rc.Consumer.Toolkit()))
+	for _, e := range rc.Consumer.Toolkit() {
+		entries = append(entries, "tk:"+e.RegistryID.String()+"/"+e.Tool+"/"+e.Prompt+"/"+e.Resource+"/"+e.ExposeAs)
+	}
+	// Neither list has a guaranteed order across replicas or reloads — the
+	// role-derived toolkit is a union — so sort both: the same configuration
+	// must always fingerprint the same.
+	sort.Strings(parts)
+	sort.Strings(entries)
+	sum := sha256.Sum256([]byte(strings.Join(append(parts, entries...), "|")))
+	return hex.EncodeToString(sum[:6])
 }
 
 func writeAppError(c *fiber.Ctx, id json.RawMessage, err error) error {

--- a/pkg/api/handler/http/mcp/mcp_handler_test.go
+++ b/pkg/api/handler/http/mcp/mcp_handler_test.go
@@ -31,6 +31,7 @@ import (
 	approle "github.com/NeuralTrust/TrustGate/pkg/app/role"
 	consumerdomain "github.com/NeuralTrust/TrustGate/pkg/domain/consumer"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
+	registrydomain "github.com/NeuralTrust/TrustGate/pkg/domain/registry"
 	"github.com/gofiber/fiber/v2"
 	"github.com/stretchr/testify/mock"
 )
@@ -78,6 +79,40 @@ func newAppWithRunnerAndLimiter(t *testing.T, composer appmcp.Composer, plugins 
 	handler := mcphttp.NewHandler(mcphttp.NewRPCGateway(composer, plugins, limiter), appmcp.NewRoleScoper(approle.NewOIDCResolver()))
 	app.Post(mcpPath, handler.Handle)
 	app.Get(mcpPath, handler.MethodNotAllowed)
+	return app
+}
+
+// newAppWithRegistries builds an MCP consumer bound to the given registries, so
+// a test can observe how the initialize response reflects the tool surface.
+func newAppWithRegistries(t *testing.T, registries ...*registrydomain.Registry) *fiber.App {
+	t.Helper()
+	authID := ids.New[ids.AuthKind]()
+	gwID := ids.New[ids.GatewayKind]()
+	cons := &consumerdomain.Consumer{
+		ID:        ids.New[ids.ConsumerKind](),
+		GatewayID: gwID,
+		Name:      "virtual",
+		Type:      consumerdomain.TypeMCP,
+		Slug:      "virtual",
+		Active:    true,
+		AuthIDs:   []ids.AuthID{authID},
+	}
+	data := appconsumer.NewData(gwID, []appconsumer.RoutableConsumer{
+		{Consumer: cons, Registries: registries},
+	})
+
+	app := fiber.New()
+	app.Use(func(c *fiber.Ctx) error {
+		ctx := appconsumer.WithAuthID(c.UserContext(), authID)
+		ctx = appconsumer.WithData(ctx, data)
+		c.SetUserContext(ctx)
+		return c.Next()
+	})
+	handler := mcphttp.NewHandler(
+		mcphttp.NewRPCGateway(mocks.NewComposer(t), noopRunner(), nil),
+		appmcp.NewRoleScoper(approle.NewOIDCResolver()),
+	)
+	app.Post(mcpPath, handler.Handle)
 	return app
 }
 
@@ -244,6 +279,47 @@ func TestHandler_ToolsCall_ToolNotPermittedRidesOn200(t *testing.T) {
 	}
 	if msg, _ := rpcErr["message"].(string); !strings.Contains(msg, "not permitted") {
 		t.Fatalf("message = %q, want it to say the tool is not permitted", msg)
+	}
+}
+
+// serverInfo.version carries a fingerprint of the tool surface, so a client
+// that caches a server's tool list keyed on its reported version re-lists once
+// the consumer gains or loses a registry. A constant "1.0" left a newly
+// attached registry invisible no matter how often the client reconnected.
+func TestHandler_Initialize_VersionTracksTheToolSurface(t *testing.T) {
+	t.Parallel()
+	reg := func(name string) *registrydomain.Registry {
+		r, err := registrydomain.NewMCPRegistry(
+			ids.New[ids.GatewayKind](), name, "",
+			&registrydomain.MCPTarget{URL: "https://" + name + ".example.com/mcp"},
+		)
+		if err != nil {
+			t.Fatalf("registry: %v", err)
+		}
+		return r
+	}
+	notion, linear := reg("notion"), reg("linear")
+
+	versionFor := func(regs ...*registrydomain.Registry) string {
+		app := newAppWithRegistries(t, regs...)
+		_, body := rpcCall(t, app, `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`)
+		info := body["result"].(map[string]any)["serverInfo"].(map[string]any)
+		return info["version"].(string)
+	}
+
+	one := versionFor(notion)
+	if !strings.HasPrefix(one, "1.0+") {
+		t.Fatalf("version = %q, want the implementation version plus a fingerprint", one)
+	}
+	if again := versionFor(notion); again != one {
+		t.Fatalf("version is unstable for the same configuration: %q vs %q", one, again)
+	}
+	// Order must not matter, only the set.
+	if versionFor(notion, linear) != versionFor(linear, notion) {
+		t.Fatal("version must not depend on registry ordering")
+	}
+	if two := versionFor(notion, linear); two == one {
+		t.Fatalf("version %q did not change after attaching a registry", two)
 	}
 }
 


### PR DESCRIPTION
Every virtual MCP reported serverInfo.version "1.0" forever, so a client that caches a server's tool list keyed on its reported identity had no reason to re-list: attaching a registry to a consumer left the new tools invisible even across a full logout/login, because the initialize response looked identical.

Append a fingerprint of what actually decides the surface — the bound MCP registries with their last-changed timestamps, plus the toolkit that filters them — as semver build metadata ("1.0+<hash>"). Both lists are sorted first: the role-derived toolkit is a union and registry order is not stable across replicas, so the same configuration must always hash the same.

This is a cache-busting hint, not a push: clients that ignore serverInfo still need a reconnect. Telling them proactively needs tools.listChanged plus a server-to-client stream, which the gateway does not have — it answers GET with 405 and issues no Mcp-Session-Id, so clients treat it as stateless.


Claude-Session: https://claude.ai/code/session_01Ud4DKqxYxsgMEo5J6iE9L5