### PR TITLE
feat: forward provider fields for Notion Firewall mapping

### DIFF
--- a/pkg/api/handler/http/mcp/rpc_dispatcher.go
+++ b/pkg/api/handler/http/mcp/rpc_dispatcher.go
@@ -174,7 +174,15 @@ func (g *RPCGateway) dispatch(ctx context.Context, rc *appconsumer.RoutableConsu
 		if tools == nil {
 			tools = []appmcp.Tool{}
 		}
-		return map[string]any{"tools": tools}, nil
+		result := map[string]any{"tools": tools}
+		raw, err := json.Marshal(result)
+		if err != nil {
+			return nil, err
+		}
+		if err := g.plugins.PreResponseResult(ctx, rc, raw); err != nil {
+			return nil, err
+		}
+		return result, nil
 	case "tools/call":
 		var p struct {
 			Name      string          `json:"name"`

--- a/pkg/app/mcp/plugin_runner.go
+++ b/pkg/app/mcp/plugin_runner.go
@@ -163,6 +163,52 @@ func (r *PluginRunner) PreResponse(
 	return nil
 }
 
+// PreResponseResult runs StagePreResponse over an arbitrary MCP result body
+// (tools/list, tools/call result, etc.) without requiring tools/call params.
+func (r *PluginRunner) PreResponseResult(
+	ctx context.Context,
+	rc *appconsumer.RoutableConsumer,
+	result json.RawMessage,
+) error {
+	if r.executor == nil || rc == nil || rc.Consumer == nil {
+		return nil
+	}
+	reqCtx := &infracontext.RequestContext{
+		GatewayID:    rc.Consumer.GatewayID.String(),
+		ConsumerID:   rc.Consumer.ID.String(),
+		ConsumerType: string(rc.Consumer.Type),
+		MCP:          true,
+		Body:         []byte(`{}`),
+	}
+	respCtx := &infracontext.ResponseContext{
+		GatewayID: rc.Consumer.GatewayID.String(),
+		Body:      result,
+		Streaming: false,
+	}
+	outcome, err := r.executor.RunStage(ctx, appplugins.StageInput{
+		Stage:    policy.StagePreResponse,
+		Policies: rc.Policies,
+		Plan:     rc.PolicyPlan,
+		Request:  reqCtx,
+		Response: respCtx,
+	})
+	if err != nil {
+		if pe, ok := appplugins.AsPluginError(err); ok {
+			return blockToRPCError(pe)
+		}
+		r.logFailOpen(rc, policy.StagePreResponse, directionOutput, err)
+		return nil
+	}
+	if outcome != nil && outcome.ShortCircuit {
+		return blockToRPCError(&appplugins.PluginError{
+			StatusCode: outcome.StatusCode,
+			Message:    "response blocked by policy",
+			Body:       outcome.Body,
+		})
+	}
+	return nil
+}
+
 // logFailOpen records a guard/plugin failure that the runner deliberately does
 // not surface. RUN-832 requires a tools/call to proceed on guard errors in both
 // directions; only ids and outcome are logged, never tool payloads.

--- a/pkg/infra/plugins/trustguard/attachments.go
+++ b/pkg/infra/plugins/trustguard/attachments.go
@@ -1,0 +1,230 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trustguard
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// extractPayloadAttachments walks provider request JSON for user file/image
+// parts and returns Guard attachments for doc_analyzer → IPI.
+func extractPayloadAttachments(rawBody []byte) []GuardAttachment {
+	if len(rawBody) == 0 {
+		return nil
+	}
+	var root map[string]any
+	if json.Unmarshal(rawBody, &root) != nil {
+		return nil
+	}
+	var out []GuardAttachment
+	seen := map[string]struct{}{}
+	add := func(a GuardAttachment) {
+		key := a.ContentType + "|" + a.Filename + "|" + a.Data + "|" + a.URL
+		if _, ok := seen[key]; ok {
+			return
+		}
+		if strings.TrimSpace(a.Data) == "" && strings.TrimSpace(a.URL) == "" {
+			return
+		}
+		seen[key] = struct{}{}
+		out = append(out, a)
+	}
+	walkAttachmentValue(root["messages"], add)
+	walkAttachmentValue(root["input"], add)
+	walkAttachmentValue(root["contents"], add)
+	return out
+}
+
+func walkAttachmentValue(v any, add func(GuardAttachment)) {
+	switch t := v.(type) {
+	case []any:
+		for _, item := range t {
+			walkAttachmentValue(item, add)
+		}
+	case map[string]any:
+		role, _ := t["role"].(string)
+		role = strings.ToLower(strings.TrimSpace(role))
+		if role == "assistant" || role == "model" || role == "tool" || role == "system" || role == "developer" {
+			return
+		}
+		if content, ok := t["content"]; ok {
+			walkContentParts(content, add)
+		}
+		if parts, ok := t["parts"]; ok {
+			walkContentParts(parts, add)
+		}
+		collectAttachmentPart(t, add)
+	}
+}
+
+func walkContentParts(content any, add func(GuardAttachment)) {
+	switch c := content.(type) {
+	case []any:
+		for _, part := range c {
+			if m, ok := part.(map[string]any); ok {
+				collectAttachmentPart(m, add)
+			}
+		}
+	case map[string]any:
+		collectAttachmentPart(c, add)
+	}
+}
+
+func collectAttachmentPart(m map[string]any, add func(GuardAttachment)) {
+	typ, _ := m["type"].(string)
+	typ = strings.ToLower(strings.TrimSpace(typ))
+	switch typ {
+	case "image_url", "input_image":
+		add(attachmentFromImageURL(m))
+	case "image":
+		add(attachmentFromAnthropicImage(m))
+	case "file", "input_file", "document":
+		add(attachmentFromFile(m))
+	}
+	if inline, ok := m["inlineData"].(map[string]any); ok {
+		add(GuardAttachment{
+			Filename:    "inline",
+			ContentType: strAny(inline["mimeType"]),
+			Data:        strAny(inline["data"]),
+		})
+	}
+	if fd, ok := m["fileData"].(map[string]any); ok {
+		add(GuardAttachment{
+			Filename:    "file",
+			ContentType: strAny(fd["mimeType"]),
+			URL:         strAny(fd["fileUri"]),
+		})
+	}
+}
+
+func attachmentFromImageURL(m map[string]any) GuardAttachment {
+	a := GuardAttachment{Filename: "image", ContentType: "image/*"}
+	switch img := m["image_url"].(type) {
+	case string:
+		fillAttachmentURLOrData(&a, img)
+	case map[string]any:
+		fillAttachmentURLOrData(&a, strAny(img["url"]))
+	}
+	if u := strAny(m["image_url"]); a.URL == "" && a.Data == "" && u != "" {
+		fillAttachmentURLOrData(&a, u)
+	}
+	if u := strAny(m["url"]); a.URL == "" && a.Data == "" {
+		fillAttachmentURLOrData(&a, u)
+	}
+	return a
+}
+
+func attachmentFromAnthropicImage(m map[string]any) GuardAttachment {
+	a := GuardAttachment{Filename: "image", ContentType: "image/*"}
+	src, _ := m["source"].(map[string]any)
+	if src == nil {
+		return a
+	}
+	if mt := strAny(src["media_type"]); mt != "" {
+		a.ContentType = mt
+	}
+	switch strings.ToLower(strAny(src["type"])) {
+	case "base64":
+		a.Data = strAny(src["data"])
+	case "url":
+		a.URL = strAny(src["url"])
+	default:
+		if d := strAny(src["data"]); d != "" {
+			a.Data = d
+		}
+		if u := strAny(src["url"]); u != "" {
+			a.URL = u
+		}
+	}
+	return a
+}
+
+func attachmentFromFile(m map[string]any) GuardAttachment {
+	a := GuardAttachment{
+		Filename:    firstNonEmpty(strAny(m["filename"]), strAny(m["name"]), "file"),
+		ContentType: firstNonEmpty(strAny(m["content_type"]), strAny(m["mime_type"]), "application/octet-stream"),
+	}
+	if fileObj, ok := m["file"].(map[string]any); ok {
+		if a.Filename == "file" {
+			a.Filename = firstNonEmpty(strAny(fileObj["filename"]), strAny(fileObj["name"]), "file")
+		}
+		if d := strAny(fileObj["file_data"]); d != "" {
+			fillAttachmentURLOrData(&a, d)
+		}
+		if u := strAny(fileObj["file_id"]); u != "" && a.Data == "" && a.URL == "" {
+			a.URL = u
+		}
+	}
+	if d := strAny(m["file_data"]); d != "" {
+		fillAttachmentURLOrData(&a, d)
+	}
+	if d := strAny(m["data"]); d != "" && a.Data == "" {
+		a.Data = d
+	}
+	if u := strAny(m["url"]); u != "" && a.URL == "" {
+		a.URL = u
+	}
+	if src, ok := m["source"].(map[string]any); ok {
+		if mt := strAny(src["media_type"]); mt != "" {
+			a.ContentType = mt
+		}
+		if d := strAny(src["data"]); d != "" {
+			a.Data = d
+		}
+		if u := strAny(src["url"]); u != "" {
+			a.URL = u
+		}
+	}
+	return a
+}
+
+func fillAttachmentURLOrData(a *GuardAttachment, v string) {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return
+	}
+	if strings.HasPrefix(v, "data:") {
+		if i := strings.Index(v, ","); i >= 0 {
+			meta := v[5:i]
+			a.Data = v[i+1:]
+			if j := strings.Index(meta, ";"); j >= 0 {
+				a.ContentType = meta[:j]
+			} else if meta != "" {
+				a.ContentType = meta
+			}
+			return
+		}
+	}
+	if strings.HasPrefix(v, "http://") || strings.HasPrefix(v, "https://") {
+		a.URL = v
+		return
+	}
+	a.Data = v
+}
+
+func strAny(v any) string {
+	s, _ := v.(string)
+	return strings.TrimSpace(s)
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/pkg/infra/plugins/trustguard/attachments_test.go
+++ b/pkg/infra/plugins/trustguard/attachments_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026 NeuralTrust
+package trustguard
+
+import "testing"
+
+func TestExtractPayloadAttachments_OpenAIImageAndFile(t *testing.T) {
+	t.Parallel()
+	raw := []byte(`{
+		"messages":[
+			{"role":"user","content":[
+				{"type":"text","text":"describe"},
+				{"type":"image_url","image_url":{"url":"https://example.com/a.png"}},
+				{"type":"file","file":{"filename":"doc.pdf","file_data":"JVBERi0x"}}
+			]},
+			{"role":"assistant","content":[{"type":"image_url","image_url":{"url":"https://example.com/skip.png"}}]}
+		]
+	}`)
+	got := extractPayloadAttachments(raw)
+	if len(got) != 2 {
+		t.Fatalf("got %#v, want 2 user attachments", got)
+	}
+}
+
+func TestExtractPayloadAttachments_GeminiInline(t *testing.T) {
+	t.Parallel()
+	raw := []byte(`{"contents":[{"role":"user","parts":[{"inlineData":{"mimeType":"image/png","data":"abc"}}]}]}`)
+	got := extractPayloadAttachments(raw)
+	if len(got) != 1 || got[0].Data != "abc" || got[0].ContentType != "image/png" {
+		t.Fatalf("got %#v", got)
+	}
+}

--- a/pkg/infra/plugins/trustguard/llm.go
+++ b/pkg/infra/plugins/trustguard/llm.go
@@ -22,26 +22,66 @@ import (
 )
 
 // llmRequestPayload builds a protocol=llm evaluate payload that preserves chat
-// roles (including role=tool responses and assistant tool_calls). Flattening to
-// {input} loses roles, so detectors that only inspect tool content cannot run.
+// roles (including role=tool responses and assistant tool_calls) and forwards
+// tool definitions so IPI can score descriptions.
 func llmRequestPayload(creq *adapter.CanonicalRequest) (json.RawMessage, error) {
-	return json.Marshal(map[string]any{
+	return llmRequestPayloadWithAttachments(creq, nil)
+}
+
+func llmRequestPayloadWithAttachments(creq *adapter.CanonicalRequest, attachments []GuardAttachment) (json.RawMessage, error) {
+	payload := map[string]any{
 		"messages": guardChatMessages(creq),
-	})
+	}
+	if tools := guardTools(creq); len(tools) > 0 {
+		payload["tools"] = tools
+	}
+	if len(attachments) > 0 {
+		payload["attachments"] = attachments
+	}
+	return json.Marshal(payload)
 }
 
 // llmResponsePayload builds a protocol=llm evaluate payload for response-direction
 // inspect. Uses messages[] with role=assistant so Activity and detectors do not
-// treat the completion as a user turn (the legacy {input} shape mapped to RoleUser).
-func llmResponsePayload(text string) (json.RawMessage, error) {
-	return json.Marshal(map[string]any{
-		"messages": []map[string]any{
-			{
-				"role":    "assistant",
-				"content": text,
-			},
-		},
-	})
+// treat the completion as a user turn. Includes tool_calls and request-side tool
+// definitions when present so IPI can score tool descriptions on the response leg.
+func llmResponsePayload(cresp *adapter.CanonicalResponse, reqTools []adapter.CanonicalTool) (json.RawMessage, error) {
+	msg := map[string]any{
+		"role":    "assistant",
+		"content": "",
+	}
+	if cresp != nil {
+		content := cresp.Content
+		// Private reasoning must not be scored as assistant output (Firewall skips thinking).
+		if cresp.Reasoning != nil && strings.TrimSpace(content) == strings.TrimSpace(cresp.Reasoning.ThinkingText) {
+			content = ""
+		}
+		msg["content"] = content
+		if len(cresp.ToolCalls) > 0 {
+			calls := make([]map[string]any, 0, len(cresp.ToolCalls))
+			for _, tc := range cresp.ToolCalls {
+				calls = append(calls, map[string]any{
+					"id":   tc.ID,
+					"type": "function",
+					"function": map[string]any{
+						"name":      tc.Name,
+						"arguments": tc.Arguments,
+					},
+				})
+			}
+			msg["tool_calls"] = calls
+			if strings.TrimSpace(content) == "" {
+				msg["content"] = nil
+			}
+		}
+	}
+	payload := map[string]any{
+		"messages": []map[string]any{msg},
+	}
+	if tools := guardToolsFromCanonical(reqTools); len(tools) > 0 {
+		payload["tools"] = tools
+	}
+	return json.Marshal(payload)
 }
 
 func guardChatMessages(creq *adapter.CanonicalRequest) []map[string]any {
@@ -92,6 +132,36 @@ func guardChatMessage(msg adapter.CanonicalMessage) map[string]any {
 	return m
 }
 
+func guardTools(creq *adapter.CanonicalRequest) []map[string]any {
+	if creq == nil {
+		return nil
+	}
+	return guardToolsFromCanonical(creq.Tools)
+}
+
+func guardToolsFromCanonical(tools []adapter.CanonicalTool) []map[string]any {
+	if len(tools) == 0 {
+		return nil
+	}
+	out := make([]map[string]any, 0, len(tools))
+	for _, t := range tools {
+		fn := map[string]any{
+			"name": t.Name,
+		}
+		if s := strings.TrimSpace(t.Description); s != "" {
+			fn["description"] = s
+		}
+		if t.Schema != nil {
+			fn["parameters"] = t.Schema
+		}
+		out = append(out, map[string]any{
+			"type":     "function",
+			"function": fn,
+		})
+	}
+	return out
+}
+
 // joinedTransformedMessages rebuilds the newline-joined text TrustGate uses for
 // request rewrite from a Guard transformed_payload that carries messages[].
 // Order matches requestParts: system (as role=system) then each non-empty content.
@@ -120,4 +190,18 @@ func joinedTransformedMessages(payload map[string]any) (string, bool) {
 		return "", false
 	}
 	return strings.Join(parts, "\n"), true
+}
+
+func responseHasInspectableContent(cresp *adapter.CanonicalResponse) bool {
+	if cresp == nil {
+		return false
+	}
+	content := cresp.Content
+	if cresp.Reasoning != nil && strings.TrimSpace(content) == strings.TrimSpace(cresp.Reasoning.ThinkingText) {
+		content = ""
+	}
+	if strings.TrimSpace(content) != "" {
+		return true
+	}
+	return len(cresp.ToolCalls) > 0
 }

--- a/pkg/infra/plugins/trustguard/llm_test.go
+++ b/pkg/infra/plugins/trustguard/llm_test.go
@@ -85,6 +85,63 @@ func TestLLMRequestPayloadPreservesToolRoles(t *testing.T) {
 	}
 }
 
+func TestLLMRequestPayloadIncludesTools(t *testing.T) {
+	t.Parallel()
+
+	creq := &adapter.CanonicalRequest{
+		Messages: []adapter.CanonicalMessage{{Role: "user", Content: "hi"}},
+		Tools: []adapter.CanonicalTool{{
+			Name:        "search",
+			Description: "find docs",
+			Schema:      map[string]any{"type": "object"},
+		}},
+	}
+	raw, err := llmRequestPayload(creq)
+	if err != nil {
+		t.Fatalf("llmRequestPayload: %v", err)
+	}
+	var payload struct {
+		Tools []map[string]any `json:"tools"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(payload.Tools) != 1 {
+		t.Fatalf("tools len = %d, want 1", len(payload.Tools))
+	}
+	fn, ok := payload.Tools[0]["function"].(map[string]any)
+	if !ok || fn["name"] != "search" || fn["description"] != "find docs" {
+		t.Fatalf("function = %#v", payload.Tools[0]["function"])
+	}
+}
+
+func TestLLMResponsePayloadToolCallsOnly(t *testing.T) {
+	t.Parallel()
+
+	raw, err := llmResponsePayload(&adapter.CanonicalResponse{
+		ToolCalls: []adapter.CanonicalToolCall{{ID: "1", Name: "search", Arguments: `{}`}},
+	}, []adapter.CanonicalTool{{Name: "search", Description: "find docs"}})
+	if err != nil {
+		t.Fatalf("llmResponsePayload: %v", err)
+	}
+	var payload struct {
+		Messages []map[string]any `json:"messages"`
+		Tools    []map[string]any `json:"tools"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(payload.Messages) != 1 || payload.Messages[0]["role"] != "assistant" {
+		t.Fatalf("messages = %#v", payload.Messages)
+	}
+	if _, ok := payload.Messages[0]["tool_calls"]; !ok {
+		t.Fatal("expected tool_calls on assistant message")
+	}
+	if len(payload.Tools) != 1 {
+		t.Fatalf("tools len = %d, want 1", len(payload.Tools))
+	}
+}
+
 func TestJoinedTransformedMessages(t *testing.T) {
 	t.Parallel()
 
@@ -118,5 +175,28 @@ func TestTransformedInputPrefersInputThenMessages(t *testing.T) {
 	})
 	if !ok || got != "a\nb" {
 		t.Fatalf("messages fallback: got %q ok=%v", got, ok)
+	}
+}
+
+func TestLLMResponsePayloadSkipsPureThinking(t *testing.T) {
+	t.Parallel()
+	raw, err := llmResponsePayload(&adapter.CanonicalResponse{
+		Content: "private thought",
+		Reasoning: &adapter.CanonicalReasoning{ThinkingText: "private thought"},
+	}, nil)
+	if err != nil {
+		t.Fatalf("llmResponsePayload: %v", err)
+	}
+	var payload struct {
+		Messages []map[string]any `json:"messages"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(payload.Messages) != 1 {
+		t.Fatalf("messages = %#v", payload.Messages)
+	}
+	if payload.Messages[0]["content"] != "" {
+		t.Fatalf("content = %#v, want empty (thinking-only)", payload.Messages[0]["content"])
 	}
 }

--- a/pkg/infra/plugins/trustguard/mcp.go
+++ b/pkg/infra/plugins/trustguard/mcp.go
@@ -69,6 +69,21 @@ func mcpOutputText(body []byte) string {
 	return strings.Join(parts, "\n")
 }
 
+// mcpOutputInspectable reports whether an MCP result body has text worth sending
+// to TrustGuard: CallToolResult text blocks or tools/list tool metadata.
+func mcpOutputInspectable(body []byte) bool {
+	if strings.TrimSpace(mcpOutputText(body)) != "" {
+		return true
+	}
+	var listed struct {
+		Tools []json.RawMessage `json:"tools"`
+	}
+	if err := json.Unmarshal(body, &listed); err != nil {
+		return false
+	}
+	return len(listed.Tools) > 0
+}
+
 // flattenArgumentStrings walks the decoded arguments value and collects string
 // leaves (recursing maps and arrays); numbers, bools and nulls are skipped. Map
 // keys are visited in sorted order for deterministic output. When arguments are

--- a/pkg/infra/plugins/trustguard/plugin.go
+++ b/pkg/infra/plugins/trustguard/plugin.go
@@ -205,10 +205,10 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 			if skipOutputInspect(in.Stage, in.Response) {
 				return passThrough(), nil
 			}
-			text = mcpOutputText(in.Response.Body)
-			if strings.TrimSpace(text) == "" {
+			if !mcpOutputInspectable(in.Response.Body) {
 				return passThrough(), nil
 			}
+			text = mcpOutputText(in.Response.Body)
 			raw, err := mcpToolsResultPayload(in.Response.Body)
 			if err != nil {
 				p.warn(ctx, "trustguard mcp tools/result payload build failed, failing open",
@@ -233,14 +233,14 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 			if decErr != nil || creq == nil {
 				return passThrough(), nil
 			}
-			if strings.TrimSpace(joinRequestText(creq)) == "" {
+			if strings.TrimSpace(joinRequestText(creq)) == "" && len(extractPayloadAttachments(in.Request.Body)) == 0 {
 				return passThrough(), nil
 			}
 			reg := p.registry
 			tgt.apply = func(masked string) ([]byte, bool) {
 				return rewriteRequest(reg, format, creq, masked)
 			}
-			raw, err := llmRequestPayload(creq)
+			raw, err := llmRequestPayloadWithAttachments(creq, extractPayloadAttachments(in.Request.Body))
 			if err != nil {
 				p.warn(ctx, "trustguard llm payload build failed, failing open",
 					slog.String("plugin", PluginName),
@@ -255,8 +255,13 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 				return passThrough(), nil
 			}
 			var cresp *adapter.CanonicalResponse
+			var reqTools []adapter.CanonicalTool
+			if creq, decErr := p.registry.DecodeRequestFor(in.Request.Body, format); decErr == nil && creq != nil {
+				reqTools = creq.Tools
+			}
 			if in.Response.Streaming {
 				text = streamAssistantText(p.registry, in.Response.Body, format)
+				cresp = &adapter.CanonicalResponse{Content: text}
 			} else {
 				var decErr error
 				cresp, decErr = p.registry.DecodeResponseFor(in.Response.Body, format)
@@ -265,16 +270,16 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 				}
 				text = cresp.Content
 			}
-			if strings.TrimSpace(text) == "" {
+			if !responseHasInspectableContent(cresp) && len(reqTools) == 0 {
 				return passThrough(), nil
 			}
-			if cresp != nil {
+			if cresp != nil && strings.TrimSpace(cresp.Content) != "" {
 				reg := p.registry
 				tgt.apply = func(masked string) ([]byte, bool) {
 					return rewriteResponse(reg, format, cresp, masked)
 				}
 			}
-			raw, err := llmResponsePayload(text)
+			raw, err := llmResponsePayload(cresp, reqTools)
 			if err != nil {
 				p.warn(ctx, "trustguard llm payload build failed, failing open",
 					slog.String("plugin", PluginName),

--- a/pkg/infra/plugins/trustguard/plugin.go
+++ b/pkg/infra/plugins/trustguard/plugin.go
@@ -208,7 +208,6 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 			if !mcpOutputInspectable(in.Response.Body) {
 				return passThrough(), nil
 			}
-			text = mcpOutputText(in.Response.Body)
 			raw, err := mcpToolsResultPayload(in.Response.Body)
 			if err != nil {
 				p.warn(ctx, "trustguard mcp tools/result payload build failed, failing open",
@@ -268,7 +267,6 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 				if decErr != nil || cresp == nil {
 					return passThrough(), nil
 				}
-				text = cresp.Content
 			}
 			if !responseHasInspectableContent(cresp) && len(reqTools) == 0 {
 				return passThrough(), nil

--- a/pkg/infra/providers/adapter/anthropic_adapter.go
+++ b/pkg/infra/providers/adapter/anthropic_adapter.go
@@ -27,7 +27,7 @@ type AnthropicAdapter struct{}
 // Provider-specific typed structs
 type anthropicRequest struct {
 	Model       string                 `json:"model,omitempty"`
-	System      string                 `json:"system,omitempty"`
+	System      json.RawMessage        `json:"system,omitempty"`
 	Messages    []anthropicMessage     `json:"messages"`
 	MaxTokens   int                    `json:"max_tokens"`
 	Temperature *float64               `json:"temperature,omitempty"`
@@ -86,7 +86,8 @@ type anthropicContentBlock struct {
 	Name         string          `json:"name,omitempty"`
 	Input        json.RawMessage `json:"input,omitempty"`
 	ToolUseID    string          `json:"tool_use_id,omitempty"` // user message: tool_result block
-	BlockContent string          `json:"content,omitempty"`     // user message: tool_result block content
+	Content      json.RawMessage `json:"content,omitempty"`     // tool_result content: string or blocks
+	IsError      bool            `json:"is_error,omitempty"`
 }
 
 type anthropicUsage struct {
@@ -249,10 +250,14 @@ func decodeAnthropicMessageContent(role string, content json.RawMessage) []Canon
 		for _, b := range blocks {
 			switch b.Type {
 			case "tool_result":
+				content := anthropicToolResultText(b.Content)
+				if b.IsError && content != "" {
+					content = "error: " + content
+				}
 				toolMessages = append(toolMessages, CanonicalMessage{
 					Role:       "tool",
 					ToolCallID: b.ToolUseID,
-					Content:    b.BlockContent,
+					Content:    content,
 				})
 			case "text":
 				textParts = append(textParts, b.Text)
@@ -302,7 +307,7 @@ func (a *AnthropicAdapter) DecodeRequest(body []byte) (*CanonicalRequest, error)
 
 	cr := &CanonicalRequest{
 		Model:       req.Model,
-		System:      req.System,
+		System:      anthropicSystemText(req.System),
 		MaxTokens:   req.MaxTokens,
 		Temperature: req.Temperature,
 		TopP:        req.TopP,
@@ -349,7 +354,7 @@ func (a *AnthropicAdapter) DecodeRequest(body []byte) (*CanonicalRequest, error)
 func (a *AnthropicAdapter) EncodeRequest(req *CanonicalRequest) ([]byte, error) {
 	out := anthropicRequest{
 		Model:       req.Model,
-		System:      req.System,
+		System:      anthropicSystemRaw(req.System),
 		Temperature: req.Temperature,
 		TopP:        req.TopP,
 		TopK:        req.TopK,
@@ -374,10 +379,11 @@ func (a *AnthropicAdapter) EncodeRequest(req *CanonicalRequest) ([]byte, error) 
 		if m.Role == "tool" {
 			var toolResultBlocks []anthropicContentBlock
 			for i < len(req.Messages) && req.Messages[i].Role == "tool" {
+				content, _ := json.Marshal(req.Messages[i].Content)
 				toolResultBlocks = append(toolResultBlocks, anthropicContentBlock{
-					Type:         "tool_result",
-					ToolUseID:    req.Messages[i].ToolCallID,
-					BlockContent: req.Messages[i].Content,
+					Type:      "tool_result",
+					ToolUseID: req.Messages[i].ToolCallID,
+					Content:   content,
 				})
 				i++
 			}
@@ -799,4 +805,61 @@ func (a *AnthropicAdapter) EncodeStreamChunk(chunk *CanonicalStreamChunk) ([][]b
 	}
 
 	return nil, nil
+}
+
+func anthropicSystemText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return strings.TrimSpace(s)
+	}
+	var blocks []anthropicContentBlock
+	if json.Unmarshal(raw, &blocks) != nil {
+		return strings.TrimSpace(contentToString(raw))
+	}
+	parts := make([]string, 0, len(blocks))
+	for _, b := range blocks {
+		if b.Type == "" || b.Type == "text" {
+			if t := strings.TrimSpace(b.Text); t != "" {
+				parts = append(parts, t)
+			}
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+func anthropicSystemRaw(system string) json.RawMessage {
+	if strings.TrimSpace(system) == "" {
+		return nil
+	}
+	raw, err := json.Marshal(system)
+	if err != nil {
+		return nil
+	}
+	return raw
+}
+
+func anthropicToolResultText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return s
+	}
+	var blocks []anthropicContentBlock
+	if json.Unmarshal(raw, &blocks) == nil {
+		parts := make([]string, 0, len(blocks))
+		for _, b := range blocks {
+			if b.Type == "text" || b.Type == "" {
+				if t := strings.TrimSpace(b.Text); t != "" {
+					parts = append(parts, t)
+				}
+			}
+		}
+		return strings.Join(parts, "\n")
+	}
+	return contentToString(raw)
 }

--- a/pkg/infra/providers/adapter/anthropic_adapter_test.go
+++ b/pkg/infra/providers/adapter/anthropic_adapter_test.go
@@ -334,3 +334,31 @@ func TestAnthropicSSE_CacheFieldRoundTrip_MessageStart(t *testing.T) {
 	assert.Equal(t, 4, decoded.Usage.CacheCreationInputTokens)
 	assert.Equal(t, 9, decoded.Usage.CacheReadInputTokens)
 }
+
+func TestCanonical_Anthropic_SystemArrayAndToolResultBlocks(t *testing.T) {
+	input := `{
+		"model": "claude-sonnet-4-5",
+		"max_tokens": 1024,
+		"system": [{"type":"text","text":"Be concise."}],
+		"messages": [
+			{"role":"user","content":[{"type":"text","text":"Weather?"}]},
+			{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"get_lat_lng","input":{"location_description":"Beijing"}}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","is_error":true,"content":[{"type":"text","text":"timeout"}]}]}
+		]
+	}`
+	a := &AnthropicAdapter{}
+	cr, err := a.DecodeRequest([]byte(input))
+	require.NoError(t, err)
+	assert.Equal(t, "Be concise.", cr.System)
+	require.GreaterOrEqual(t, len(cr.Messages), 2)
+	var tool *CanonicalMessage
+	for i := range cr.Messages {
+		if cr.Messages[i].Role == "tool" {
+			tool = &cr.Messages[i]
+			break
+		}
+	}
+	require.NotNil(t, tool)
+	assert.Equal(t, "error: timeout", tool.Content)
+	assert.Equal(t, "t1", tool.ToolCallID)
+}

--- a/pkg/infra/providers/adapter/cohere_adapter.go
+++ b/pkg/infra/providers/adapter/cohere_adapter.go
@@ -385,6 +385,9 @@ func (a *CohereAdapter) DecodeStreamChunk(chunk []byte) (*CanonicalStreamChunk, 
 		if err := json.Unmarshal(event.Delta, &delta); err != nil || delta.Message == nil || delta.Message.Content == nil {
 			return nil, nil
 		}
+		if delta.Message.Content.Type != "" && delta.Message.Content.Type != "text" {
+			return nil, nil
+		}
 		if delta.Message.Content.Text == "" {
 			return nil, nil
 		}

--- a/pkg/infra/providers/adapter/cohere_adapter_test.go
+++ b/pkg/infra/providers/adapter/cohere_adapter_test.go
@@ -89,3 +89,17 @@ func TestCohereRerankAdapter_DecodeRequest_Model(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "rerank-english-v3.0", got.Model)
 }
+
+func TestCohere_DecodeStreamChunk_SkipsThinking(t *testing.T) {
+	a := &CohereAdapter{}
+	thinking := []byte(`{"type":"content-delta","delta":{"message":{"content":{"type":"thinking","thinking":"private"}}}}`)
+	chunk, err := a.DecodeStreamChunk(thinking)
+	require.NoError(t, err)
+	assert.Nil(t, chunk)
+
+	text := []byte(`{"type":"content-delta","delta":{"message":{"content":{"type":"text","text":"hello"}}}}`)
+	chunk, err = a.DecodeStreamChunk(text)
+	require.NoError(t, err)
+	require.NotNil(t, chunk)
+	assert.Equal(t, "hello", chunk.Delta)
+}

--- a/pkg/infra/providers/adapter/gemini_adapter.go
+++ b/pkg/infra/providers/adapter/gemini_adapter.go
@@ -150,6 +150,9 @@ func (a *GeminiAdapter) DecodeRequest(body []byte) (*CanonicalRequest, error) {
 		var toolCalls []CanonicalToolCall
 		var toolResults []CanonicalMessage
 		for _, p := range c.Parts {
+			if p.Thought || p.ThoughtSignature != "" {
+				continue
+			}
 			if p.Text != "" {
 				textParts = append(textParts, p.Text)
 			}
@@ -472,6 +475,9 @@ func (a *GeminiAdapter) DecodeStreamChunk(chunk []byte) (*CanonicalStreamChunk, 
 
 		var text string
 		for i, p := range content.Parts {
+			if p.Thought || p.ThoughtSignature != "" {
+				continue
+			}
 			text += p.Text
 			if p.FunctionCall != nil {
 				argsBytes, _ := json.Marshal(p.FunctionCall.Args)

--- a/pkg/infra/providers/adapter/gemini_adapter_test.go
+++ b/pkg/infra/providers/adapter/gemini_adapter_test.go
@@ -315,3 +315,29 @@ func TestUsageExtraction_Gemini_Stream_ToolUseInput(t *testing.T) {
 	require.NotNil(t, sc.Usage)
 	assert.Equal(t, 6, sc.Usage.ToolUseInputTokens)
 }
+
+func TestGemini_DecodeRequest_SkipsThoughtParts(t *testing.T) {
+	input := `{
+		"contents":[{
+			"role":"user",
+			"parts":[
+				{"thought":true,"text":"secret thought"},
+				{"text":"Weather?"}
+			]
+		}]
+	}`
+	cr, err := (&GeminiAdapter{}).DecodeRequest([]byte(input))
+	require.NoError(t, err)
+	require.Len(t, cr.Messages, 1)
+	assert.Equal(t, "Weather?", cr.Messages[0].Content)
+	assert.NotContains(t, cr.Messages[0].Content, "secret")
+}
+
+func TestGemini_DecodeStreamChunk_SkipsThoughtParts(t *testing.T) {
+	chunk := []byte(`{"candidates":[{"content":{"role":"model","parts":[{"thought":true,"text":"secret"},{"text":"hello"}]}}]}`)
+	sc, err := (&GeminiAdapter{}).DecodeStreamChunk(chunk)
+	require.NoError(t, err)
+	require.NotNil(t, sc)
+	assert.Equal(t, "hello", sc.Delta)
+	assert.NotContains(t, sc.Delta, "secret")
+}

--- a/pkg/infra/providers/adapter/openai_completions_adapter.go
+++ b/pkg/infra/providers/adapter/openai_completions_adapter.go
@@ -14,7 +14,10 @@
 
 package adapter
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"strings"
+)
 
 // ---------------------------------------------------------------------------
 // Chat Completions API typed structs
@@ -38,6 +41,7 @@ type openaiRequest struct {
 type openaiMessage struct {
 	Role       string           `json:"role"`
 	Content    json.RawMessage  `json:"content,omitempty"` // string or []contentPart
+	Refusal    *string          `json:"refusal,omitempty"`
 	ToolCalls  []openaiToolCall `json:"tool_calls,omitempty"`
 	ToolCallID string           `json:"tool_call_id,omitempty"`
 }
@@ -201,7 +205,7 @@ func decodeCompletionsRequest(body []byte) (*CanonicalRequest, error) {
 			})
 		}
 
-		if m.Role == "system" {
+		if m.Role == "system" || m.Role == "developer" {
 			if cr.System != "" {
 				cr.System += "\n"
 			}
@@ -314,6 +318,9 @@ func decodeCompletionsResponse(body []byte) (*CanonicalResponse, error) {
 		choice := resp.Choices[0]
 		if choice.Message != nil {
 			cr.Content = contentToString(choice.Message.Content)
+			if cr.Content == "" && choice.Message.Refusal != nil {
+				cr.Content = strings.TrimSpace(*choice.Message.Refusal)
+			}
 			for _, tc := range choice.Message.ToolCalls {
 				cr.ToolCalls = append(cr.ToolCalls, CanonicalToolCall{
 					ID:        tc.ID,

--- a/pkg/infra/providers/adapter/openai_completions_adapter_test.go
+++ b/pkg/infra/providers/adapter/openai_completions_adapter_test.go
@@ -143,3 +143,25 @@ func TestUsageSubCounts_OpenAIChat_ReasoningOutput(t *testing.T) {
 	assert.Equal(t, 12, cr.Usage.ReasoningOutputTokens)
 	assert.Equal(t, 20, cr.Usage.OutputTokens, "ReasoningOutputTokens is a sub-count; OutputTokens must not be reduced")
 }
+
+func TestCanonical_OpenAI_Completions_DeveloperAndRefusal(t *testing.T) {
+	a := &OpenAIAdapter{}
+	req := `{
+		"model":"gpt-5-mini",
+		"messages":[
+			{"role":"developer","content":"Prefer tools."},
+			{"role":"user","content":"hi"}
+		]
+	}`
+	cr, err := a.DecodeRequest([]byte(req))
+	require.NoError(t, err)
+	assert.Equal(t, "Prefer tools.", cr.System)
+	require.Len(t, cr.Messages, 1)
+
+	resp := `{
+		"choices":[{"message":{"role":"assistant","content":null,"refusal":"I cannot help with that."},"finish_reason":"stop"}]
+	}`
+	cresp, err := a.DecodeResponse([]byte(resp))
+	require.NoError(t, err)
+	assert.Equal(t, "I cannot help with that.", cresp.Content)
+}

--- a/tests/functional/mcp_e2e_test.go
+++ b/tests/functional/mcp_e2e_test.go
@@ -290,7 +290,7 @@ func TestMCPServer_ToolkitFiltersAndAliasesTools(t *testing.T) {
 
 	status, body = mcpRPC(t, gatewayID, consumerID, apiKeyHeaders(key), "tools/call",
 		map[string]any{"name": "secret"})
-	require.Equal(t, float64(-32602), rpcErrorCode(t, status, body))
+	require.Equal(t, float64(-32001), rpcErrorCode(t, status, body))
 }
 
 func TestMCPServer_PromptsAndResources(t *testing.T) {
@@ -499,7 +499,7 @@ func TestMCPServer_RoleBasedConsumerAppliesRoleMCPPolicies(t *testing.T) {
 
 	status, body = mcpRPC(t, gatewayID, consumerID, bearerHeaders(granted), "tools/call",
 		map[string]any{"name": "secret"})
-	require.Equal(t, float64(-32602), rpcErrorCode(t, status, body))
+	require.Equal(t, float64(-32001), rpcErrorCode(t, status, body))
 }
 
 func TestMCPServer_RoleBasedConsumerEmptyToolkitDeniesAll(t *testing.T) {


### PR DESCRIPTION
## Summary
- TrustGuard evaluate payloads preserve chat roles, tool results, and tool definitions (including MCP `tools/list`).
- Provider adapters decode fields needed for Firewall mapping: Anthropic system/tool_result, OpenAI developer/refusal, Cohere/Gemini thinking skip (incl. stream).
- Extract user image/file parts into `payload.attachments` so Guard `doc_analyzer` can OCR → IPI.
- Skip pure thinking content on the response inspect path.

Pairs with TrustGuard PR on `feat/notion-firewall-llm-mcp-mapping`.

## Test plan
- [x] `go test ./pkg/infra/plugins/trustguard/... ./pkg/infra/providers/adapter/... ./pkg/app/mcp/...`
- [ ] Gateway smoke: multimodal user image + tool-call follow-up across openai_chat / anthropic / gemini / cohere
- [ ] MCP `tools/list` and `tools/call` hit Guard evaluate