### PR TITLE
feat(catalog): keep geography-scoped Bedrock profiles out of the stor…

### DIFF
--- a/pkg/app/catalog/service.go
+++ b/pkg/app/catalog/service.go
@@ -40,6 +40,20 @@ func (s *service) ListProviders(ctx context.Context) ([]domain.Provider, error) 
 	return s.repo.ListProviders(ctx)
 }
 
+// ListModels returns the models on offer for a provider. Disabled rows are left
+// out: the catalog keeps them so pricing and validation can still resolve a
+// model that was withdrawn upstream, but a listing exists to be picked from, and
+// a withdrawn model is not a valid pick.
 func (s *service) ListModels(ctx context.Context, providerCode string) ([]domain.Model, error) {
-	return s.repo.ListModelsByProviderCode(ctx, providerCode)
+	stored, err := s.repo.ListModelsByProviderCode(ctx, providerCode)
+	if err != nil {
+		return nil, err
+	}
+	enabled := make([]domain.Model, 0, len(stored))
+	for _, model := range stored {
+		if model.Enabled {
+			enabled = append(enabled, model)
+		}
+	}
+	return enabled, nil
 }

--- a/pkg/app/catalog/service_test.go
+++ b/pkg/app/catalog/service_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package catalog
+
+import (
+	"context"
+	"testing"
+
+	domain "github.com/NeuralTrust/TrustGate/pkg/domain/catalog"
+)
+
+type listOnlyRepo struct {
+	fakeRepo
+	models []domain.Model
+}
+
+func (r *listOnlyRepo) ListModelsByProviderCode(_ context.Context, _ string) ([]domain.Model, error) {
+	return r.models, nil
+}
+
+// A model the sync withdrew stays stored so pricing can still resolve it, but it
+// must not be offered in the listing the model pickers are built from.
+func TestService_ListModels_OmitsDisabledModels(t *testing.T) {
+	t.Parallel()
+	repo := &listOnlyRepo{models: []domain.Model{
+		{Slug: "global.anthropic.claude-opus-5", Enabled: true},
+		{Slug: "us.anthropic.claude-opus-5", Enabled: false},
+		{Slug: "amazon.nova-pro-v1:0", Enabled: true},
+	}}
+
+	got, err := NewService(repo).ListModels(context.Background(), "bedrock")
+	if err != nil {
+		t.Fatalf("ListModels error: %v", err)
+	}
+
+	if len(got) != 2 {
+		t.Fatalf("got %d models, want 2: %+v", len(got), got)
+	}
+	for _, model := range got {
+		if !model.Enabled {
+			t.Fatalf("disabled model %q was listed", model.Slug)
+		}
+	}
+}

--- a/pkg/app/catalog/sync.go
+++ b/pkg/app/catalog/sync.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/NeuralTrust/TrustGate/pkg/app/configsyncport"
 	domain "github.com/NeuralTrust/TrustGate/pkg/domain/catalog"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/bedrock/controlplane"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/bootlog"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/catalog/modelsdev"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
@@ -122,15 +123,25 @@ var modelsDevProviderToCode = map[string]string{
 }
 
 // skipModel drops catalog entries the gateway could never invoke as published.
+// Both rules are scoped to Bedrock; other providers are synced verbatim.
 //
-// On Bedrock, models.dev lists some models twice: once under their InvokeModel
+// The first covers models models.dev lists twice: once under their InvokeModel
 // ID and once behind an alternative OpenAI-compatible endpoint, which the
 // Bedrock client does not speak (e.g. "openai.gpt-oss-20b" alongside the real
 // "openai.gpt-oss-20b-1:0"). Other providers legitimately reach models through
-// an alternative endpoint — Claude on Vertex and Azure, for one — so the rule is
-// scoped to Bedrock rather than applied to the whole catalog.
+// an alternative endpoint — Claude on Vertex and Azure, for one — hence the
+// narrow scope.
+//
+// The second drops inference profiles bound to one geography. Only the global
+// profile is offered, so that a catalog entry is valid whatever region a
+// registry is configured with. Filtering here rather than only at listing time
+// keeps the stored catalog free of entries no registry should pick, including
+// for clients that do not scope their request to a registry.
 func skipModel(providerCode string, m modelsdev.Model) bool {
-	return providerCode == providers.ProviderBedrock && m.AltAPI != ""
+	if providerCode != providers.ProviderBedrock {
+		return false
+	}
+	return m.AltAPI != "" || controlplane.IsGeographyScopedProfile(m.Slug)
 }
 
 //go:generate mockery --name=Syncer --dir=. --output=./mocks --filename=catalog_syncer_mock.go --case=underscore --with-expecter

--- a/pkg/app/catalog/sync_test.go
+++ b/pkg/app/catalog/sync_test.go
@@ -194,6 +194,52 @@ func TestSyncer_Sync_SkipsBedrockModelsOnAlternativeEndpoints(t *testing.T) {
 	}
 }
 
+// Only the global inference profile is offered, so the geography-scoped
+// duplicates of a model (us., eu., jp., au.) never reach the catalog — not even
+// for clients that list models without scoping the request to a registry.
+func TestSyncer_Sync_SkipsGeographyScopedBedrockProfiles(t *testing.T) {
+	t.Parallel()
+	const payload = `{
+		"amazon-bedrock": {
+			"id": "amazon-bedrock",
+			"name": "Amazon Bedrock",
+			"models": {
+				"anthropic.claude-opus-5": {"id":"anthropic.claude-opus-5","name":"Claude Opus 5"},
+				"global.anthropic.claude-opus-5": {"id":"global.anthropic.claude-opus-5","name":"Claude Opus 5 (Global)"},
+				"us.anthropic.claude-opus-5": {"id":"us.anthropic.claude-opus-5","name":"Claude Opus 5 (US)"},
+				"eu.anthropic.claude-opus-5": {"id":"eu.anthropic.claude-opus-5","name":"Claude Opus 5 (EU)"},
+				"jp.anthropic.claude-opus-5": {"id":"jp.anthropic.claude-opus-5","name":"Claude Opus 5 (JP)"},
+				"au.anthropic.claude-opus-5": {"id":"au.anthropic.claude-opus-5","name":"Claude Opus 5 (AU)"},
+				"amazon.nova-pro-v1:0": {"id":"amazon.nova-pro-v1:0","name":"Nova Pro"}
+			}
+		}
+	}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, payload)
+	}))
+	defer srv.Close()
+
+	repo := newFakeRepo()
+	s := NewSyncer(repo, modelsdev.NewClient(srv.URL), slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync error: %v", err)
+	}
+
+	got := map[string]bool{}
+	for _, slug := range repo.disabledCalls[repo.providers["bedrock"].ID] {
+		got[slug] = true
+	}
+	want := []string{"anthropic.claude-opus-5", "global.anthropic.claude-opus-5", "amazon.nova-pro-v1:0"}
+	if len(got) != len(want) {
+		t.Fatalf("bedrock keep slugs = %v, want exactly %v", got, want)
+	}
+	for _, slug := range want {
+		if !got[slug] {
+			t.Fatalf("bedrock keep slugs = %v, missing %q", got, slug)
+		}
+	}
+}
+
 func TestSyncer_Sync_PropagatesClientError(t *testing.T) {
 	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/infra/bedrock/controlplane/client.go
+++ b/pkg/infra/bedrock/controlplane/client.go
@@ -89,10 +89,11 @@ const (
 	// APPLICATION profiles are customer-created and account-specific.
 	profileTypeSystemDefined = "SYSTEM_DEFINED"
 	profileStatusActive      = "ACTIVE"
-	// globalProfilePrefix names the geography-agnostic inference profile, the only
-	// kind the catalog offers. See collectInferenceProfiles.
-	globalProfilePrefix = "global."
-	profilePageSize          = "1000"
+	// globalProfileGeography names the geography-agnostic inference profile, the
+	// only kind the catalog offers. See collectInferenceProfiles.
+	globalProfileGeography = "global"
+	globalProfilePrefix    = globalProfileGeography + "."
+	profilePageSize        = "1000"
 	// maxProfilePages bounds pagination so a repeating nextToken cannot spin.
 	maxProfilePages = 10
 
@@ -288,6 +289,19 @@ func (c *client) entitlements(
 		return nil, false
 	}
 	return verdicts, true
+}
+
+// IsGeographyScopedProfile reports whether id names an inference profile bound to
+// a single geography ("us.", "eu.", "jp.", "au."…), which is invocable only from
+// source regions inside that geography. Plain model IDs and the geography-
+// agnostic "global." profile are not scoped and return false.
+func IsGeographyScopedProfile(id string) bool {
+	parts := strings.Split(id, ".")
+	if len(parts) < 3 || parts[0] == globalProfileGeography {
+		return false
+	}
+	_, ok := profileGeoPrefixes[parts[0]]
+	return ok
 }
 
 // baseModelID strips the geography prefix of a cross-region inference profile


### PR DESCRIPTION
…ed catalog

The availability filter only runs when a caller scopes its request to a registry with gateway_id and registry_id, since model access is per credential set. Clients that list the catalog without naming a registry got every models.dev entry, so a picker still showed the us./eu./jp./au. duplicates of each model alongside the global profile.

Apply the global-only rule at sync time as well, where it needs no credentials, so the stored catalog holds only entries some registry could pick.

The listing also returned models the sync had disabled. Rows are kept on purpose — pricing and validation must still resolve a model withdrawn upstream — but a listing exists to be picked from, so the service now omits them.