### PR TITLE
fix(trustguard): read the MCP transform outcome from the envelope it …

### DIFF
--- a/pkg/infra/plugins/trustguard/mcp_rewrite.go
+++ b/pkg/infra/plugins/trustguard/mcp_rewrite.go
@@ -20,6 +20,48 @@ import (
 	"strings"
 )
 
+// mcpTransformedRequest lifts the masked tools/call arguments out of the
+// envelope TrustGuard echoes back for protocol=mcp — the same
+// {jsonrpc,id,method,params} shape mcpToolsCallPayload sent, with the detected
+// spans replaced. Nothing has to be re-split, so the structure survives exactly
+// as the detector left it.
+//
+// The tool name comes from the original call, never from the payload: routing
+// is the gateway's decision and must not be steered by a masking outcome.
+func mcpTransformedRequest(payload map[string]any, name string) ([]byte, bool) {
+	params, ok := payload["params"].(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	arguments, ok := params["arguments"]
+	if !ok {
+		return nil, false
+	}
+	raw, err := json.Marshal(arguments)
+	if err != nil {
+		return nil, false
+	}
+	out, err := json.Marshal(mcpToolCall{Name: name, Arguments: raw})
+	if err != nil {
+		return nil, false
+	}
+	return out, true
+}
+
+// mcpTransformedResult lifts the masked CallToolResult out of the JSON-RPC
+// result envelope mcpToolsResultPayload sent.
+func mcpTransformedResult(payload map[string]any) ([]byte, bool) {
+	result, ok := payload["result"]
+	if !ok {
+		return nil, false
+	}
+	out, err := json.Marshal(result)
+	if err != nil {
+		return nil, false
+	}
+	return out, true
+}
+
 // rewriteMCPRequest writes TrustGuard's masked text back into the tools/call
 // arguments, mirroring how the LLM path writes it back into the message
 // segments. The parts are rebuilt exactly as mcpInputText collected them so the
@@ -165,4 +207,13 @@ func rewriteMCPResponse(body []byte, masked string) ([]byte, bool) {
 		return nil, false
 	}
 	return out, true
+}
+
+// mcpToolName reads the tool name from the gateway's tools/call body.
+func mcpToolName(body []byte) string {
+	var call mcpToolCall
+	if err := json.Unmarshal(body, &call); err != nil {
+		return ""
+	}
+	return call.Name
 }

--- a/pkg/infra/plugins/trustguard/plugin.go
+++ b/pkg/infra/plugins/trustguard/plugin.go
@@ -190,6 +190,10 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 				return passThrough(), nil
 			}
 			reqBody := in.Request.Body
+			toolName := mcpToolName(reqBody)
+			tgt.applyPayload = func(payload map[string]any) ([]byte, bool) {
+				return mcpTransformedRequest(payload, toolName)
+			}
 			tgt.apply = func(masked string) ([]byte, bool) {
 				return rewriteMCPRequest(reqBody, masked)
 			}
@@ -212,6 +216,7 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 				return passThrough(), nil
 			}
 			respBody := in.Response.Body
+			tgt.applyPayload = mcpTransformedResult
 			tgt.apply = func(masked string) ([]byte, bool) {
 				return rewriteMCPResponse(respBody, masked)
 			}
@@ -364,6 +369,15 @@ func (p *Plugin) applyTransform(in appplugins.ExecInput, data guardData, resp *G
 		return passThrough(), nil
 	}
 
+	// A structured payload is preferred where the protocol has one: TrustGuard
+	// returns the masked MCP envelope whole, so the values are lifted out of it
+	// instead of being re-split from a joined string.
+	if tgt.applyPayload != nil {
+		if body, ok := tgt.applyPayload(resp.TransformedPayload); ok {
+			return p.transformApplied(in, data, tgt, body)
+		}
+	}
+
 	masked, ok := transformedInput(resp.TransformedPayload)
 	if !ok {
 		return p.transformDegraded(in, data, resp, reasonTransformNoPayload)
@@ -375,7 +389,12 @@ func (p *Plugin) applyTransform(in appplugins.ExecInput, data guardData, resp *G
 	if !ok {
 		return p.transformDegraded(in, data, resp, reasonTransformEncodeFailed)
 	}
+	return p.transformApplied(in, data, tgt, body)
+}
 
+// transformApplied records a successful rewrite and hands the masked body back
+// in the direction it belongs to.
+func (p *Plugin) transformApplied(in appplugins.ExecInput, data guardData, tgt transformTarget, body []byte) (*appplugins.Result, error) {
 	data.Decision = decisionTransformed
 	recordGuardOutcome(in.Event, data)
 	if tgt.isResponse {

--- a/pkg/infra/plugins/trustguard/plugin_test.go
+++ b/pkg/infra/plugins/trustguard/plugin_test.go
@@ -1502,3 +1502,74 @@ func TestExecuteBlocksOnlyOnFlaggedLeg(t *testing.T) {
 		t.Fatalf("expected *PluginError on response block, got %v", err)
 	}
 }
+
+// The real TrustGuard contract for protocol=mcp: transformed_payload is the
+// whole masked JSON-RPC envelope, not an {"input": "..."} string. Reading it as
+// a string found nothing and degraded to a block, which is what a DLP policy in
+// transform mode produced on a live tools/call.
+func TestExecuteMCPTransformUsesEnvelopePayload(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{response: GuardResponse{
+		Status: statusTransform,
+		TransformedPayload: map[string]any{
+			"id":      float64(1),
+			"jsonrpc": "2.0",
+			"method":  "tools/call",
+			"params": map[string]any{
+				"name": "notion-create-pages",
+				"arguments": map[string]any{
+					"pages": []any{map[string]any{
+						"content":    "## Datos de contacto\n\n- **Email:** [MASKED_EMAIL]\n- **Teléfono:** [MASKED_PHONE]",
+						"icon":       "👤",
+						"properties": map[string]any{"title": "Victor — Contacto"},
+					}},
+				},
+			},
+		},
+		TraceID: "trace-mcp-transform",
+	}}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	reqCtx := mcpRequestContext()
+	reqCtx.Body = []byte(`{"name":"notion-create-pages","arguments":{"pages":[{"content":"## Datos de contacto\n\n- **Email:** victor@neuraltrust.ai\n- **Teléfono:** 600123456","icon":"👤","properties":{"title":"Victor — Contacto"}}]}}`)
+
+	event, span := newEvent()
+	in := execInputWithEvent(policy.StagePreRequest, policy.ModeEnforce, settings(""), reqCtx, nil, event)
+	res, err := p.Execute(context.Background(), in)
+	if err != nil {
+		t.Fatalf("a transform outcome must not block, got %v", err)
+	}
+	if res == nil || res.RequestBody == nil {
+		t.Fatalf("expected the masked request body, got %+v", res)
+	}
+
+	var call mcpToolCall
+	if uerr := json.Unmarshal(res.RequestBody, &call); uerr != nil {
+		t.Fatalf("rewritten body is not a tools/call: %v", uerr)
+	}
+	if call.Name != "notion-create-pages" {
+		t.Fatalf("tool name = %q, want it preserved", call.Name)
+	}
+	args := string(call.Arguments)
+	if strings.Contains(args, "victor@neuraltrust.ai") || strings.Contains(args, "600123456") {
+		t.Fatalf("unmasked PII survived into the upstream arguments: %s", args)
+	}
+	if !strings.Contains(args, "[MASKED_EMAIL]") || !strings.Contains(args, "[MASKED_PHONE]") {
+		t.Fatalf("masked values missing from the arguments: %s", args)
+	}
+	// The structure the detector left must survive untouched.
+	if !strings.Contains(args, `"title":"Victor — Contacto"`) {
+		t.Fatalf("the rewrite lost non-masked structure: %s", args)
+	}
+
+	attrs := span.PluginAttrsCopy()
+	extras, ok := attrs.Extras.(guardData)
+	if !ok {
+		t.Fatalf("extras type = %T, want guardData", attrs.Extras)
+	}
+	if extras.Degraded || extras.Decision != decisionTransformed {
+		t.Fatalf("extras = %+v, want a clean transformed outcome", extras)
+	}
+}

--- a/pkg/infra/plugins/trustguard/rewrite.go
+++ b/pkg/infra/plugins/trustguard/rewrite.go
@@ -26,6 +26,12 @@ import (
 type transformTarget struct {
 	isResponse bool
 	apply      func(masked string) ([]byte, bool)
+	// applyPayload rebuilds the body from the structured payload TrustGuard
+	// echoes back. For protocol=mcp the transform outcome is the whole masked
+	// JSON-RPC envelope rather than a masked string, so there is nothing to
+	// re-split: the masked values are lifted straight out of it. Tried before
+	// apply, which stays as the fallback for a string-shaped payload.
+	applyPayload func(payload map[string]any) ([]byte, bool)
 }
 
 // transformedInput extracts the masked string TrustGuard returns for rewrite.


### PR DESCRIPTION
…arrives in

A DLP policy in transform mode blocked live MCP tool calls instead of masking them. For protocol=mcp TrustGuard returns transformed_payload as the whole masked JSON-RPC envelope — the {jsonrpc,id,method,params} shape the gateway sent, with the detected spans replaced — but the plugin only knew how to read a masked string under the "input" key. Finding none, it degraded to transform_no_payload and rejected the call, which surfaced to the agent as "request blocked due to a policy infraction" carrying status: transform.

Read the structured payload directly where the protocol provides one: the masked arguments and the masked CallToolResult are lifted out of the envelope as they are, with no re-splitting, so the structure the detector produced survives exactly. The tool name is taken from the original call rather than the payload — routing is the gateway's decision, not a masking outcome. The string path stays as the fallback for payloads shaped that way.


Claude-Session: https://claude.ai/code/session_01Ud4DKqxYxsgMEo5J6iE9L5