### PR TITLE
fix(trustguard): inspect and mask structuredContent on MCP tool results

### DIFF
--- a/pkg/infra/plugins/trustguard/mcp.go
+++ b/pkg/infra/plugins/trustguard/mcp.go
@@ -26,8 +26,9 @@ type mcpToolCall struct {
 }
 
 type mcpToolResult struct {
-	Content []mcpContentBlock `json:"content"`
-	IsError bool              `json:"isError"`
+	Content           []mcpContentBlock `json:"content"`
+	StructuredContent json.RawMessage   `json:"structuredContent"`
+	IsError           bool              `json:"isError"`
 }
 
 type mcpContentBlock struct {
@@ -51,21 +52,30 @@ func mcpInputText(body []byte) string {
 	return strings.Join(parts, "\n")
 }
 
-// mcpOutputText concatenates the text of every text content block in a
-// CallToolResult, ignoring non-text blocks (image/audio/resource). The isError
-// flag does not change extraction. It returns "" when there is no text.
+// mcpOutputText concatenates the inspectable text of a CallToolResult: the text
+// of every text content block (ignoring image/audio/resource blocks) followed by
+// every string leaf of structuredContent, in the order rewriteMCPResponse writes
+// them back. The isError flag does not change extraction. It returns "" when
+// there is nothing to inspect.
+//
+// structuredContent is included because a tool may return its payload there
+// instead of, or in addition to, text blocks — it reaches the agent all the
+// same. This value gates whether the guard is called at all, so leaving
+// structuredContent out let a result whose PII lived only in structuredContent
+// skip inspection entirely and reach the caller unmasked.
 func mcpOutputText(body []byte) string {
 	var result mcpToolResult
 	if err := json.Unmarshal(body, &result); err != nil {
 		return ""
 	}
-	parts := make([]string, 0, len(result.Content))
+	parts := make([]string, 0, len(result.Content)+1)
 	for _, block := range result.Content {
 		if !blockIsText(block) || strings.TrimSpace(block.Text) == "" {
 			continue
 		}
 		parts = append(parts, block.Text)
 	}
+	parts = append(parts, flattenArgumentStrings(result.StructuredContent)...)
 	return strings.Join(parts, "\n")
 }
 

--- a/pkg/infra/plugins/trustguard/mcp_rewrite.go
+++ b/pkg/infra/plugins/trustguard/mcp_rewrite.go
@@ -159,39 +159,53 @@ func replaceArgumentStrings(value any, masked []string, idx *int) (any, bool) {
 	}
 }
 
-// rewriteMCPResponse writes the masked text back into the text content blocks of
-// a CallToolResult. The result is patched in place on a generic decode rather
-// than re-encoded from a typed struct, so fields the gateway does not model
-// (structuredContent, _meta, annotations) survive the rewrite.
+// rewriteMCPResponse writes the masked text back into a CallToolResult: first the
+// text content blocks, then the string leaves of structuredContent, in the exact
+// order mcpOutputText collected them. The result is patched in place on a generic
+// decode rather than re-encoded from a typed struct, so fields the gateway does
+// not model (_meta, annotations) survive the rewrite.
+//
+// This is the string-payload fallback; the structured applyPayload path
+// (mcpTransformedResult) is tried first and lifts the whole masked envelope. It
+// still has to cover structuredContent so a result whose only inspectable data
+// lives there is masked here rather than degrading to a block.
 func rewriteMCPResponse(body []byte, masked string) ([]byte, bool) {
 	var generic map[string]any
 	if err := json.Unmarshal(body, &generic); err != nil {
 		return nil, false
 	}
-	blocks, ok := generic["content"].([]any)
-	if !ok {
-		return nil, false
-	}
 
 	// Same selection as mcpOutputText: text blocks with non-blank text, in order.
-	targets := make([]map[string]any, 0, len(blocks))
-	parts := make([]string, 0, len(blocks))
-	for _, raw := range blocks {
-		block, ok := raw.(map[string]any)
-		if !ok {
-			continue
+	textBlocks := make([]map[string]any, 0)
+	parts := make([]string, 0)
+	if blocks, ok := generic["content"].([]any); ok {
+		for _, raw := range blocks {
+			block, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			text, ok := block["text"].(string)
+			if !ok || strings.TrimSpace(text) == "" {
+				continue
+			}
+			if kind, ok := block["type"].(string); ok && kind != "" && kind != "text" {
+				continue
+			}
+			textBlocks = append(textBlocks, block)
+			parts = append(parts, text)
 		}
-		text, ok := block["text"].(string)
-		if !ok || strings.TrimSpace(text) == "" {
-			continue
-		}
-		if kind, ok := block["type"].(string); ok && kind != "" && kind != "text" {
-			continue
-		}
-		targets = append(targets, block)
-		parts = append(parts, text)
 	}
-	if len(targets) == 0 {
+
+	// Then structuredContent string leaves, sorted-key order, matching
+	// flattenArgumentStrings/collectStrings so the masked halves line up.
+	structured, hasStructured := generic["structuredContent"]
+	var structuredLeaves int
+	if hasStructured {
+		leaves := collectStrings(structured, nil)
+		structuredLeaves = len(leaves)
+		parts = append(parts, leaves...)
+	}
+	if len(parts) == 0 {
 		return nil, false
 	}
 
@@ -199,8 +213,16 @@ func rewriteMCPResponse(body []byte, masked string) ([]byte, bool) {
 	if !ok {
 		return nil, false
 	}
-	for i, block := range targets {
+	for i, block := range textBlocks {
 		block["text"] = maskedParts[i]
+	}
+	if structuredLeaves > 0 {
+		idx := 0
+		patched, ok := replaceArgumentStrings(structured, maskedParts[len(textBlocks):], &idx)
+		if !ok || idx != structuredLeaves {
+			return nil, false
+		}
+		generic["structuredContent"] = patched
 	}
 	out, err := json.Marshal(generic)
 	if err != nil {

--- a/pkg/infra/plugins/trustguard/mcp_test.go
+++ b/pkg/infra/plugins/trustguard/mcp_test.go
@@ -118,6 +118,21 @@ func TestMCPOutputText(t *testing.T) {
 			want: "",
 		},
 		{
+			name: "structuredContent only, no text blocks",
+			body: `{"content":[],"structuredContent":{"email":"jane@acme.io"}}`,
+			want: "jane@acme.io",
+		},
+		{
+			name: "structuredContent appended after text blocks in sorted-key order",
+			body: `{"content":[{"type":"text","text":"body"}],"structuredContent":{"b":"second","a":"first"}}`,
+			want: "body\nfirst\nsecond",
+		},
+		{
+			name: "structuredContent numbers and bools skipped",
+			body: `{"content":[],"structuredContent":{"count":3,"ok":true,"name":"Jane"}}`,
+			want: "Jane",
+		},
+		{
 			name: "malformed json",
 			body: `{"content":`,
 			want: "",
@@ -132,6 +147,66 @@ func TestMCPOutputText(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRewriteMCPResponseMasksStructuredContent(t *testing.T) {
+	t.Parallel()
+
+	t.Run("text block and structuredContent leaves together", func(t *testing.T) {
+		t.Parallel()
+		body := `{"content":[{"type":"text","text":"contact"}],"structuredContent":{"b":"second","a":"first"},"isError":false}`
+		// Same order mcpOutputText builds: text block, then structured leaves
+		// sorted by key (a before b). TrustGuard returns the joined masked text.
+		masked := "CONTACT\nONE\nTWO"
+
+		out, ok := rewriteMCPResponse([]byte(body), masked)
+		if !ok {
+			t.Fatal("rewriteMCPResponse returned false")
+		}
+		var got mcpToolResult
+		if err := json.Unmarshal(out, &got); err != nil {
+			t.Fatalf("unmarshal rewritten body: %v", err)
+		}
+		if len(got.Content) != 1 || got.Content[0].Text != "CONTACT" {
+			t.Fatalf("content not rewritten: %+v", got.Content)
+		}
+		var sc map[string]string
+		if err := json.Unmarshal(got.StructuredContent, &sc); err != nil {
+			t.Fatalf("unmarshal structuredContent: %v", err)
+		}
+		if sc["a"] != "ONE" || sc["b"] != "TWO" {
+			t.Fatalf("structuredContent not rewritten: %+v", sc)
+		}
+	})
+
+	t.Run("structuredContent only", func(t *testing.T) {
+		t.Parallel()
+		body := `{"content":[],"structuredContent":{"email":"jane@acme.io"}}`
+		masked := "[MASKED_EMAIL]"
+
+		out, ok := rewriteMCPResponse([]byte(body), masked)
+		if !ok {
+			t.Fatal("rewriteMCPResponse returned false")
+		}
+		var got map[string]any
+		if err := json.Unmarshal(out, &got); err != nil {
+			t.Fatalf("unmarshal rewritten body: %v", err)
+		}
+		sc, _ := got["structuredContent"].(map[string]any)
+		if sc["email"] != "[MASKED_EMAIL]" {
+			t.Fatalf("structuredContent email not masked: %+v", sc)
+		}
+	})
+
+	t.Run("line-count mismatch fails closed", func(t *testing.T) {
+		t.Parallel()
+		body := `{"content":[],"structuredContent":{"email":"jane@acme.io"}}`
+		// Masked text has an extra line the original never had: the mapping is
+		// ambiguous, so the rewrite must refuse rather than corrupt the body.
+		if _, ok := rewriteMCPResponse([]byte(body), "one\ntwo"); ok {
+			t.Fatal("expected rewriteMCPResponse to fail on a line-count mismatch")
+		}
+	})
 }
 
 func TestFlattenArgumentStrings(t *testing.T) {


### PR DESCRIPTION
The MCP response guard gated inspection on text content blocks alone, so a CallToolResult that carried its payload in structuredContent (with no text block, or with the sensitive data only in the structured field) was never sent to TrustGuard and reached the agent unmasked.

mcpOutputText now also flattens the string leaves of structuredContent — the value only gates whether the guard runs; the guard already receives the whole result envelope — and the string-payload fallback rewriteMCPResponse writes the masked halves back into both the text blocks and the structuredContent leaves, in the same order, so a structuredContent-bearing result is masked rather than degrading to a block.


Claude-Session: https://claude.ai/code/session_01Ud4DKqxYxsgMEo5J6iE9L5