### PR TITLE
fix(catalog): show Activity LLM cost for openai_compatible (ENG-1195)

### DIFF
--- a/pkg/api/middleware/mcp_pipeline_integration_test.go
+++ b/pkg/api/middleware/mcp_pipeline_integration_test.go
@@ -49,6 +49,8 @@ func (stubPricing) Resolve(context.Context, string, string) appcatalog.Pricing {
 	return appcatalog.Pricing{}
 }
 
+func (stubPricing) InvalidateCache() {}
+
 func TestMCPPipeline_ToolsCallBuildsMCPEvent(t *testing.T) {
 	worker := appmetricsmocks.NewWorker(t)
 

--- a/pkg/api/middleware/metrics_functional_test.go
+++ b/pkg/api/middleware/metrics_functional_test.go
@@ -125,6 +125,8 @@ func (zeroPricing) Resolve(_ context.Context, _ string, _ string) appcatalog.Pri
 	return appcatalog.Pricing{}
 }
 
+func (zeroPricing) InvalidateCache() {}
+
 func newMetricsApp(t *testing.T, gw *gatewaydomain.Gateway, rec *eventRecorder) *fiber.App {
 	t.Helper()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))

--- a/pkg/app/catalog/mocks/pricing_resolver_mock.go
+++ b/pkg/app/catalog/mocks/pricing_resolver_mock.go
@@ -40,6 +40,38 @@ func (_m *PricingResolver) Resolve(ctx context.Context, providerCode string, slu
 	return r0
 }
 
+// InvalidateCache provides a mock function with no fields
+func (_m *PricingResolver) InvalidateCache() {
+	_m.Called()
+}
+
+// PricingResolver_InvalidateCache_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'InvalidateCache'
+type PricingResolver_InvalidateCache_Call struct {
+	*mock.Call
+}
+
+// InvalidateCache is a helper method to define mock.On call
+func (_e *PricingResolver_Expecter) InvalidateCache() *PricingResolver_InvalidateCache_Call {
+	return &PricingResolver_InvalidateCache_Call{Call: _e.mock.On("InvalidateCache")}
+}
+
+func (_c *PricingResolver_InvalidateCache_Call) Run(run func()) *PricingResolver_InvalidateCache_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *PricingResolver_InvalidateCache_Call) Return() *PricingResolver_InvalidateCache_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *PricingResolver_InvalidateCache_Call) RunAndReturn(run func()) *PricingResolver_InvalidateCache_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // PricingResolver_Resolve_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Resolve'
 type PricingResolver_Resolve_Call struct {
 	*mock.Call

--- a/pkg/app/catalog/pricing.go
+++ b/pkg/app/catalog/pricing.go
@@ -23,6 +23,7 @@ import (
 	commonerrors "github.com/NeuralTrust/TrustGate/pkg/common/errors"
 	domain "github.com/NeuralTrust/TrustGate/pkg/domain/catalog"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/cache"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
 	"golang.org/x/sync/singleflight"
 )
 
@@ -36,6 +37,7 @@ type Pricing struct {
 //go:generate mockery --name=PricingResolver --dir=. --output=./mocks --filename=pricing_resolver_mock.go --case=underscore --with-expecter
 type PricingResolver interface {
 	Resolve(ctx context.Context, providerCode, slug string) Pricing
+	InvalidateCache()
 }
 
 var _ PricingResolver = (*pricingResolver)(nil)
@@ -67,9 +69,18 @@ func (r *pricingResolver) Resolve(ctx context.Context, providerCode, slug string
 		if cached, ok := r.cached(key); ok {
 			return cached, nil
 		}
-		return r.load(ctx, providerCode, slug, key), nil
+		p := r.load(ctx, providerCode, slug)
+		if !p.Found && providerCode == providers.ProviderOpenAICompatible {
+			p = r.load(ctx, providers.ProviderOpenAI, slug)
+		}
+		r.memoryCache.Set(key, p)
+		return p, nil
 	})
 	return v.(Pricing)
+}
+
+func (r *pricingResolver) InvalidateCache() {
+	r.memoryCache.Clear()
 }
 
 func (r *pricingResolver) cached(key string) (Pricing, bool) {
@@ -85,7 +96,7 @@ func (r *pricingResolver) cached(key string) (Pricing, bool) {
 	return p, true
 }
 
-func (r *pricingResolver) load(ctx context.Context, providerCode, slug, key string) Pricing {
+func (r *pricingResolver) load(ctx context.Context, providerCode, slug string) Pricing {
 	model, err := r.repo.FindModel(ctx, providerCode, slug)
 	if err != nil {
 		if !errors.Is(err, commonerrors.ErrNotFound) {
@@ -94,18 +105,17 @@ func (r *pricingResolver) load(ctx context.Context, providerCode, slug, key stri
 				slog.String("model", slug),
 				slog.String("error", err.Error()))
 		}
-		p := Pricing{}
-		r.memoryCache.Set(key, p)
-		return p
+		return Pricing{}
 	}
-	p := Pricing{
+	if model.InputPrice == "" && model.OutputPrice == "" {
+		return Pricing{}
+	}
+	return Pricing{
 		ModelLabel:  model.DisplayName,
 		InputPrice:  parsePrice(model.InputPrice),
 		OutputPrice: parsePrice(model.OutputPrice),
 		Found:       true,
 	}
-	r.memoryCache.Set(key, p)
-	return p
 }
 
 func parsePrice(raw string) float64 {

--- a/pkg/app/catalog/pricing_test.go
+++ b/pkg/app/catalog/pricing_test.go
@@ -23,24 +23,35 @@ import (
 	commonerrors "github.com/NeuralTrust/TrustGate/pkg/common/errors"
 	domain "github.com/NeuralTrust/TrustGate/pkg/domain/catalog"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/cache"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 type priceRepo struct {
 	*fakeRepo
-	model *domain.Model
+	byKey map[string]*domain.Model
 	err   error
 	calls int
 }
 
-func (p *priceRepo) FindModel(_ context.Context, _ string, _ string) (*domain.Model, error) {
+func (p *priceRepo) FindModel(_ context.Context, providerCode string, slug string) (*domain.Model, error) {
 	p.calls++
-	return p.model, p.err
+	if p.err != nil {
+		return nil, p.err
+	}
+	if p.byKey != nil {
+		if m, ok := p.byKey[providerCode+":"+slug]; ok {
+			return m, nil
+		}
+		return nil, commonerrors.ErrNotFound
+	}
+	return nil, commonerrors.ErrNotFound
 }
 
 func newPricingResolver(repo domain.Repository) PricingResolver {
 	mgr := cache.NewTTLMapManager(cache.CatalogModelCacheTTL)
+	mgr.CreateTTLMap(cache.CatalogModelTTLName, cache.CatalogModelCacheTTL)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	return NewPricingResolver(repo, mgr, logger)
 }
@@ -48,10 +59,12 @@ func newPricingResolver(repo domain.Repository) PricingResolver {
 func TestPricingResolver_ComputesPriceAndCachesLookup(t *testing.T) {
 	repo := &priceRepo{
 		fakeRepo: newFakeRepo(),
-		model: &domain.Model{
-			DisplayName: "GPT-4o",
-			InputPrice:  "0.0000025",
-			OutputPrice: "0.00001",
+		byKey: map[string]*domain.Model{
+			"openai:gpt-4o": {
+				DisplayName: "GPT-4o",
+				InputPrice:  "0.0000025",
+				OutputPrice: "0.00001",
+			},
 		},
 	}
 	resolver := newPricingResolver(repo)
@@ -86,6 +99,70 @@ func TestPricingResolver_EmptyKeySkipsLookup(t *testing.T) {
 	assert.False(t, resolver.Resolve(context.Background(), "", "gpt-4o").Found)
 	assert.False(t, resolver.Resolve(context.Background(), "openai", "").Found)
 	assert.Equal(t, 0, repo.calls)
+}
+
+func TestPricingResolver_OpenAICompatibleFallsBackToOpenAIPrices(t *testing.T) {
+	repo := &priceRepo{
+		fakeRepo: newFakeRepo(),
+		byKey: map[string]*domain.Model{
+			"openai:gpt-4o": {
+				DisplayName: "GPT-4o",
+				InputPrice:  "0.0000025",
+				OutputPrice: "0.00001",
+			},
+		},
+	}
+	resolver := newPricingResolver(repo)
+
+	got := resolver.Resolve(context.Background(), providers.ProviderOpenAICompatible, "gpt-4o")
+	require.True(t, got.Found)
+	assert.Equal(t, "GPT-4o", got.ModelLabel)
+	assert.InDelta(t, 0.0000025, got.InputPrice, 1e-12)
+	assert.InDelta(t, 0.00001, got.OutputPrice, 1e-12)
+	assert.Equal(t, 2, repo.calls, "compatible miss then openai hit")
+
+	cached := resolver.Resolve(context.Background(), providers.ProviderOpenAICompatible, "gpt-4o")
+	assert.Equal(t, got, cached)
+	assert.Equal(t, 2, repo.calls, "compatible hit must stay cached under openai_compatible key")
+}
+
+func TestPricingResolver_EmptyPricesAreNotFound(t *testing.T) {
+	repo := &priceRepo{
+		fakeRepo: newFakeRepo(),
+		byKey: map[string]*domain.Model{
+			"openai:free-model": {
+				DisplayName: "Free",
+				InputPrice:  "",
+				OutputPrice: "",
+			},
+		},
+	}
+	resolver := newPricingResolver(repo)
+
+	got := resolver.Resolve(context.Background(), "openai", "free-model")
+	assert.False(t, got.Found)
+}
+
+func TestPricingResolver_InvalidateCacheDropsNegativeAndPositiveEntries(t *testing.T) {
+	repo := &priceRepo{
+		fakeRepo: newFakeRepo(),
+		byKey: map[string]*domain.Model{
+			"openai:gpt-4o": {
+				DisplayName: "GPT-4o",
+				InputPrice:  "0.0000025",
+				OutputPrice: "0.00001",
+			},
+		},
+	}
+	resolver := newPricingResolver(repo)
+
+	require.True(t, resolver.Resolve(context.Background(), "openai", "gpt-4o").Found)
+	assert.Equal(t, 1, repo.calls)
+
+	resolver.InvalidateCache()
+
+	require.True(t, resolver.Resolve(context.Background(), "openai", "gpt-4o").Found)
+	assert.Equal(t, 2, repo.calls, "after invalidate the next resolve must hit the repository again")
 }
 
 func TestParsePrice(t *testing.T) {

--- a/pkg/app/catalog/signal_test.go
+++ b/pkg/app/catalog/signal_test.go
@@ -47,7 +47,7 @@ func TestSyncer_Sync_SignalsOnSuccess(t *testing.T) {
 	defer srv.Close()
 
 	signaler := &configsynctest.FakeSignaler{}
-	s := NewSyncer(newFakeRepo(), modelsdev.NewClient(srv.URL), newSignalTestLogger(), signaler)
+	s := NewSyncer(newFakeRepo(), modelsdev.NewClient(srv.URL), newSignalTestLogger(), signaler, nil)
 
 	if err := s.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync error: %v", err)
@@ -65,7 +65,7 @@ func TestSyncer_Sync_DoesNotSignalOnFailure(t *testing.T) {
 	defer srv.Close()
 
 	signaler := &configsynctest.FakeSignaler{}
-	s := NewSyncer(newFakeRepo(), modelsdev.NewClient(srv.URL), newSignalTestLogger(), signaler)
+	s := NewSyncer(newFakeRepo(), modelsdev.NewClient(srv.URL), newSignalTestLogger(), signaler, nil)
 
 	if err := s.Sync(context.Background()); err == nil {
 		t.Fatal("expected error from failing client")

--- a/pkg/app/catalog/sync.go
+++ b/pkg/app/catalog/sync.go
@@ -156,10 +156,11 @@ type syncer struct {
 	client   *modelsdev.Client
 	logger   *slog.Logger
 	signaler configsyncport.SnapshotSignaler
+	pricing  PricingResolver
 }
 
-func NewSyncer(repo domain.Repository, client *modelsdev.Client, logger *slog.Logger, signaler configsyncport.SnapshotSignaler) Syncer {
-	return &syncer{repo: repo, client: client, logger: logger, signaler: signaler}
+func NewSyncer(repo domain.Repository, client *modelsdev.Client, logger *slog.Logger, signaler configsyncport.SnapshotSignaler, pricing PricingResolver) Syncer {
+	return &syncer{repo: repo, client: client, logger: logger, signaler: signaler, pricing: pricing}
 }
 
 func (s *syncer) Sync(ctx context.Context) error {
@@ -224,6 +225,9 @@ func (s *syncer) Sync(ctx context.Context) error {
 	s.logger.Info(bootlog.CatalogSyncCompleted,
 		slog.Int("providers", len(seedProviders)),
 		slog.Int("models", len(models)))
+	if s.pricing != nil {
+		s.pricing.InvalidateCache()
+	}
 	if s.signaler != nil {
 		s.signaler.Signal(ctx)
 	}

--- a/pkg/app/catalog/sync_test.go
+++ b/pkg/app/catalog/sync_test.go
@@ -114,7 +114,7 @@ func TestSyncer_Sync(t *testing.T) {
 	repo := newFakeRepo()
 	client := modelsdev.NewClient(srv.URL)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	s := NewSyncer(repo, client, logger, nil)
+	s := NewSyncer(repo, client, logger, nil, nil)
 
 	if err := s.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync error: %v", err)
@@ -179,7 +179,7 @@ func TestSyncer_Sync_SkipsBedrockModelsOnAlternativeEndpoints(t *testing.T) {
 	defer srv.Close()
 
 	repo := newFakeRepo()
-	s := NewSyncer(repo, modelsdev.NewClient(srv.URL), slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	s := NewSyncer(repo, modelsdev.NewClient(srv.URL), slog.New(slog.NewTextHandler(io.Discard, nil)), nil, nil)
 	if err := s.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync error: %v", err)
 	}
@@ -220,7 +220,7 @@ func TestSyncer_Sync_SkipsGeographyScopedBedrockProfiles(t *testing.T) {
 	defer srv.Close()
 
 	repo := newFakeRepo()
-	s := NewSyncer(repo, modelsdev.NewClient(srv.URL), slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	s := NewSyncer(repo, modelsdev.NewClient(srv.URL), slog.New(slog.NewTextHandler(io.Discard, nil)), nil, nil)
 	if err := s.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync error: %v", err)
 	}
@@ -250,9 +250,35 @@ func TestSyncer_Sync_PropagatesClientError(t *testing.T) {
 	repo := newFakeRepo()
 	client := modelsdev.NewClient(srv.URL)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	s := NewSyncer(repo, client, logger, nil)
+	s := NewSyncer(repo, client, logger, nil, nil)
 
 	if err := s.Sync(context.Background()); err == nil {
 		t.Fatal("expected error from failing client")
+	}
+}
+
+type pricingCacheSpy struct {
+	invalidations int
+}
+
+func (p *pricingCacheSpy) Resolve(context.Context, string, string) Pricing { return Pricing{} }
+
+func (p *pricingCacheSpy) InvalidateCache() { p.invalidations++ }
+
+func TestSyncer_Sync_InvalidatesPricingCache(t *testing.T) {
+	t.Parallel()
+	const payload = `{"openai":{"id":"openai","name":"OpenAI","models":{"gpt-4o":{"id":"gpt-4o","name":"GPT-4o"}}}}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, payload)
+	}))
+	defer srv.Close()
+
+	pricing := &pricingCacheSpy{}
+	s := NewSyncer(newFakeRepo(), modelsdev.NewClient(srv.URL), slog.New(slog.NewTextHandler(io.Discard, nil)), nil, pricing)
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync error: %v", err)
+	}
+	if pricing.invalidations != 1 {
+		t.Fatalf("InvalidateCache calls = %d, want 1", pricing.invalidations)
 	}
 }

--- a/pkg/app/metrics/builder_test.go
+++ b/pkg/app/metrics/builder_test.go
@@ -41,6 +41,8 @@ func (s stubPricing) Resolve(_ context.Context, providerCode, slug string) appca
 	return s.price
 }
 
+func (stubPricing) InvalidateCache() {}
+
 func newBuilder(price appcatalog.Pricing) *Builder {
 	return NewBuilder(adapter.NewRegistry(), stubPricing{price: price})
 }

--- a/pkg/app/metrics/worker_test.go
+++ b/pkg/app/metrics/worker_test.go
@@ -80,6 +80,8 @@ func (s stubPricingResolver) Resolve(_ context.Context, _ string, _ string) appc
 	return s.price
 }
 
+func (stubPricingResolver) InvalidateCache() {}
+
 // TestWorker_PublishesConsolidatedEvent exercises the full path: Process ->
 // pipeline -> builder -> exporter, asserting that a single consolidated event
 // with the expected shape reaches the exporter.

--- a/pkg/container/modules/catalog.go
+++ b/pkg/container/modules/catalog.go
@@ -56,12 +56,12 @@ func provideCatalogServices(c *container.Container) error {
 	if err := c.Provide(appcatalog.NewService); err != nil {
 		return err
 	}
-	if err := c.Provide(func(repo domain.Repository, client *modelsdev.Client, logger *slog.Logger, sig snapshotSignalParams) appcatalog.Syncer {
-		return appcatalog.NewSyncer(repo, client, logger, sig.Signaler)
-	}); err != nil {
+	if err := c.Provide(appcatalog.NewPricingResolver); err != nil {
 		return err
 	}
-	if err := c.Provide(appcatalog.NewPricingResolver); err != nil {
+	if err := c.Provide(func(repo domain.Repository, client *modelsdev.Client, logger *slog.Logger, sig snapshotSignalParams, pricing appcatalog.PricingResolver) appcatalog.Syncer {
+		return appcatalog.NewSyncer(repo, client, logger, sig.Signaler, pricing)
+	}); err != nil {
 		return err
 	}
 	if err := c.Provide(cataloghttp.NewListProvidersHandler); err != nil {

--- a/tests/functional/mcp_plugin_chain_test.go
+++ b/tests/functional/mcp_plugin_chain_test.go
@@ -85,7 +85,7 @@ func TestMCPPluginChain_PreRequestEnforceBlockSkipsUpstream(t *testing.T) {
 		map[string]any{"name": "echo", "arguments": map[string]any{"message": "please run " + trustGuardBlockWord}})
 
 	require.Equal(t, rpcCodePolicyBlocked, rpcErrorCode(t, status, body))
-	require.Equal(t, http.StatusForbidden, status, "policy-blocked tools/call must return HTTP 403: %v", body)
+	require.Equal(t, http.StatusOK, status, "policy-blocked tools/call must stay on HTTP 200 with JSON-RPC error (non-2xx drops MCP sessions): %v", body)
 	require.Zero(t, atomic.LoadInt64(&calls), "upstream tool must not be invoked when PreRequest blocks")
 }
 
@@ -102,7 +102,7 @@ func TestMCPPluginChain_PreResponseEnforceBlockDiscardsResult(t *testing.T) {
 		map[string]any{"name": "leak", "arguments": map[string]any{"message": "benign"}})
 
 	require.Equal(t, rpcCodePolicyBlocked, rpcErrorCode(t, status, body))
-	require.Equal(t, http.StatusForbidden, status, "policy-blocked tools/call must return HTTP 403: %v", body)
+	require.Equal(t, http.StatusOK, status, "policy-blocked tools/call must stay on HTTP 200 with JSON-RPC error (non-2xx drops MCP sessions): %v", body)
 	require.Equal(t, int64(1), atomic.LoadInt64(&calls), "upstream tool must run once before PreResponse blocks its result")
 }
 

--- a/tests/functional/plugin_per_tool_rate_limiter_test.go
+++ b/tests/functional/plugin_per_tool_rate_limiter_test.go
@@ -239,7 +239,7 @@ func TestPluginE2E_PerToolRateLimiter_MCPToolCallDeny(t *testing.T) {
 	status, body = mcpRPC(t, gatewayID, consumerID, headers, "tools/call",
 		map[string]any{"name": "send_email", "arguments": map[string]any{}})
 	require.Equal(t, rpcCodePolicyBlocked, rpcErrorCode(t, status, body), "over-budget tools/call must be denied with -32001")
-	require.Equal(t, http.StatusTooManyRequests, status, "over-budget tools/call must return HTTP 429: %v", body)
+	require.Equal(t, http.StatusOK, status, "over-budget tools/call must stay on HTTP 200 with JSON-RPC error (non-2xx drops MCP sessions): %v", body)
 	require.Equal(t, int64(1), atomic.LoadInt64(&calls), "over-budget tools/call must not reach the upstream CallTool")
 }
 


### PR DESCRIPTION
## Summary
- Fall back `openai_compatible` pricing lookups to `openai` catalog prices for the same model slug
- Treat empty catalog prices as a miss (`Found:false`) instead of emitting fake `$0`
- Invalidate the pricing cache after catalog sync so negative lookups do not stick for 24h

Part of [ENG-1195](https://linear.app/neuraltrust/issue/ENG-1195/bug-trustgate-activity-coste-cost-no-se-muestra-en-muchas-requests-llm).

Companion PRs: DataCore (omit unpriced cost JSON) + app (`hasCost` requires `currency === USD`).

## Test plan
- [x] `go test ./pkg/app/catalog/ ./pkg/app/metrics/`
- [ ] Smoke: LLM request via `openai_compatible` registry with a priced openai slug → Activity Cost populated
- [ ] Confirm catalog sync clears previously cached misses