### PR TITLE
feat: accept registries on consumer update to unblock routing mode switches

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -814,7 +814,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Updates an existing consumer.",
+                "description": "Updates an existing consumer. The optional ` + "`" + `registries` + "`" + ` field replaces the whole registry association set, so switching a role_based consumer to inline routing and attaching its registries happens in a single atomic request.",
                 "consumes": [
                     "application/json"
                 ],
@@ -3095,7 +3095,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Returns the catalog of supported models, optionally filtered by provider.",
+                "description": "Returns the catalog of supported models, optionally filtered by provider. When gateway_id and registry_id are supplied for an AWS Bedrock registry, the list is narrowed to the models those credentials can invoke serverless (on-demand base models and system-defined inference profiles), excluding Bedrock Marketplace, Provisioned Throughput and custom models. Malformed ids and unreachable AWS endpoints are ignored and yield the full catalog.",
                 "produces": [
                     "application/json"
                 ],
@@ -3108,6 +3108,20 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Filter by provider id",
                         "name": "provider",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Gateway of the registry to scope availability to",
+                        "name": "gateway_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Registry whose credentials decide model availability",
+                        "name": "registry_id",
                         "in": "query"
                     }
                 ],
@@ -3990,6 +4004,9 @@ const docTemplate = `{
                 },
                 "pool_alias": {
                     "type": "string"
+                },
+                "smart_routing": {
+                    "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_request.SmartRoutingConfigRequest"
                 }
             }
         },
@@ -4056,6 +4073,28 @@ const docTemplate = `{
                 }
             }
         },
+        "github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_request.SmartRoutingConfigRequest": {
+            "type": "object",
+            "properties": {
+                "tiers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_request.SmartRoutingTierRequest"
+                    }
+                }
+            }
+        },
+        "github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_request.SmartRoutingTierRequest": {
+            "type": "object",
+            "properties": {
+                "min_score": {
+                    "type": "number"
+                },
+                "registry_id": {
+                    "type": "string"
+                }
+            }
+        },
         "github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_request.ToolkitEntryRequest": {
             "type": "object",
             "properties": {
@@ -4105,6 +4144,13 @@ const docTemplate = `{
                 },
                 "name": {
                     "type": "string"
+                },
+                "registries": {
+                    "description": "Registries replaces the whole registry association set: registries absent\nfrom the list are detached. Omit the field to leave the associations as\nthey are; send an empty list to detach every registry.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_request.RegistryBindingRequest"
+                    }
                 },
                 "routing_mode": {
                     "type": "string"
@@ -4295,6 +4341,9 @@ const docTemplate = `{
                 },
                 "pool_alias": {
                     "type": "string"
+                },
+                "smart_routing": {
+                    "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_response.SmartRoutingConfigResponse"
                 }
             }
         },
@@ -4357,6 +4406,28 @@ const docTemplate = `{
                 },
                 "weight": {
                     "type": "integer"
+                }
+            }
+        },
+        "github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_response.SmartRoutingConfigResponse": {
+            "type": "object",
+            "properties": {
+                "tiers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_response.SmartRoutingTierResponse"
+                    }
+                }
+            }
+        },
+        "github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_response.SmartRoutingTierResponse": {
+            "type": "object",
+            "properties": {
+                "min_score": {
+                    "type": "number"
+                },
+                "registry_id": {
+                    "type": "string"
                 }
             }
         },
@@ -6371,7 +6442,6 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "upstream_status": {
-                    "description": "Logical HTTP status of the MCP outcome (e.g. 200, 403). Gateway denials also set the wire HTTP status and http.response.status_code.",
                     "type": "integer"
                 },
                 "upstream_tool": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -807,7 +807,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Updates an existing consumer.",
+                "description": "Updates an existing consumer. The optional `registries` field replaces the whole registry association set, so switching a role_based consumer to inline routing and attaching its registries happens in a single atomic request.",
                 "consumes": [
                     "application/json"
                 ],
@@ -3088,7 +3088,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Returns the catalog of supported models, optionally filtered by provider.",
+                "description": "Returns the catalog of supported models, optionally filtered by provider. When gateway_id and registry_id are supplied for an AWS Bedrock registry, the list is narrowed to the models those credentials can invoke serverless (on-demand base models and system-defined inference profiles), excluding Bedrock Marketplace, Provisioned Throughput and custom models. Malformed ids and unreachable AWS endpoints are ignored and yield the full catalog.",
                 "produces": [
                     "application/json"
                 ],
@@ -3101,6 +3101,20 @@
                         "type": "string",
                         "description": "Filter by provider id",
                         "name": "provider",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Gateway of the registry to scope availability to",
+                        "name": "gateway_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Registry whose credentials decide model availability",
+                        "name": "registry_id",
                         "in": "query"
                     }
                 ],
@@ -3983,6 +3997,9 @@
                 },
                 "pool_alias": {
                     "type": "string"
+                },
+                "smart_routing": {
+                    "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_request.SmartRoutingConfigRequest"
                 }
             }
         },
@@ -4049,6 +4066,28 @@
                 }
             }
         },
+        "github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_request.SmartRoutingConfigRequest": {
+            "type": "object",
+            "properties": {
+                "tiers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_request.SmartRoutingTierRequest"
+                    }
+                }
+            }
+        },
+        "github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_request.SmartRoutingTierRequest": {
+            "type": "object",
+            "properties": {
+                "min_score": {
+                    "type": "number"
+                },
+                "registry_id": {
+                    "type": "string"
+                }
+            }
+        },
         "github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_request.ToolkitEntryRequest": {
             "type": "object",
             "properties": {
@@ -4098,6 +4137,13 @@
                 },
                 "name": {
                     "type": "string"
+                },
+                "registries": {
+                    "description": "Registries replaces the whole registry association set: registries absent\nfrom the list are detached. Omit the field to leave the associations as\nthey are; send an empty list to detach every registry.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_request.RegistryBindingRequest"
+                    }
                 },
                 "routing_mode": {
                     "type": "string"
@@ -4288,6 +4334,9 @@
                 },
                 "pool_alias": {
                     "type": "string"
+                },
+                "smart_routing": {
+                    "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_response.SmartRoutingConfigResponse"
                 }
             }
         },
@@ -4350,6 +4399,28 @@
                 },
                 "weight": {
                     "type": "integer"
+                }
+            }
+        },
+        "github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_response.SmartRoutingConfigResponse": {
+            "type": "object",
+            "properties": {
+                "tiers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_response.SmartRoutingTierResponse"
+                    }
+                }
+            }
+        },
+        "github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_response.SmartRoutingTierResponse": {
+            "type": "object",
+            "properties": {
+                "min_score": {
+                    "type": "number"
+                },
+                "registry_id": {
+                    "type": "string"
                 }
             }
         },
@@ -6364,7 +6435,6 @@
                     "type": "integer"
                 },
                 "upstream_status": {
-                    "description": "Logical HTTP status of the MCP outcome (e.g. 200, 403). Gateway denials also set the wire HTTP status and http.response.status_code.",
                     "type": "integer"
                 },
                 "upstream_tool": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -433,6 +433,8 @@ definitions:
         type: array
       pool_alias:
         type: string
+      smart_routing:
+        $ref: '#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_request.SmartRoutingConfigRequest'
     type: object
   github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_request.LBPoolMemberRequest:
     properties:
@@ -477,6 +479,20 @@ definitions:
       default:
         type: string
     type: object
+  github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_request.SmartRoutingConfigRequest:
+    properties:
+      tiers:
+        items:
+          $ref: '#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_request.SmartRoutingTierRequest'
+        type: array
+    type: object
+  github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_request.SmartRoutingTierRequest:
+    properties:
+      min_score:
+        type: number
+      registry_id:
+        type: string
+    type: object
   github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_request.ToolkitEntryRequest:
     properties:
       expose_as:
@@ -510,6 +526,14 @@ definitions:
         type: array
       name:
         type: string
+      registries:
+        description: |-
+          Registries replaces the whole registry association set: registries absent
+          from the list are detached. Omit the field to leave the associations as
+          they are; send an empty list to detach every registry.
+        items:
+          $ref: '#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_request.RegistryBindingRequest'
+        type: array
       routing_mode:
         type: string
       toolkit:
@@ -635,6 +659,8 @@ definitions:
         type: array
       pool_alias:
         type: string
+      smart_routing:
+        $ref: '#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_response.SmartRoutingConfigResponse'
     type: object
   github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_response.LBPoolMemberResponse:
     properties:
@@ -675,6 +701,20 @@ definitions:
         type: string
       weight:
         type: integer
+    type: object
+  github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_response.SmartRoutingConfigResponse:
+    properties:
+      tiers:
+        items:
+          $ref: '#/definitions/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_response.SmartRoutingTierResponse'
+        type: array
+    type: object
+  github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_response.SmartRoutingTierResponse:
+    properties:
+      min_score:
+        type: number
+      registry_id:
+        type: string
     type: object
   github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_response.ToolkitEntryResponse:
     properties:
@@ -2062,7 +2102,6 @@ definitions:
       upstream_latency_ms:
         type: integer
       upstream_status:
-        description: Logical HTTP status of the MCP outcome (e.g. 200, 403). Gateway denials also set the wire HTTP status and http.response.status_code.
         type: integer
       upstream_tool:
         type: string
@@ -2835,7 +2874,9 @@ paths:
     put:
       consumes:
       - application/json
-      description: Updates an existing consumer.
+      description: Updates an existing consumer. The optional `registries` field replaces
+        the whole registry association set, so switching a role_based consumer to
+        inline routing and attaching its registries happens in a single atomic request.
       parameters:
       - description: Gateway id
         format: uuid
@@ -4312,11 +4353,25 @@ paths:
   /v1/models-catalog:
     get:
       description: Returns the catalog of supported models, optionally filtered by
-        provider.
+        provider. When gateway_id and registry_id are supplied for an AWS Bedrock
+        registry, the list is narrowed to the models those credentials can invoke
+        serverless (on-demand base models and system-defined inference profiles),
+        excluding Bedrock Marketplace, Provisioned Throughput and custom models. Malformed
+        ids and unreachable AWS endpoints are ignored and yield the full catalog.
       parameters:
       - description: Filter by provider id
         in: query
         name: provider
+        type: string
+      - description: Gateway of the registry to scope availability to
+        format: uuid
+        in: query
+        name: gateway_id
+        type: string
+      - description: Registry whose credentials decide model availability
+        format: uuid
+        in: query
+        name: registry_id
         type: string
       produces:
       - application/json

--- a/pkg/api/handler/http/consumer/request/create_consumer_request.go
+++ b/pkg/api/handler/http/consumer/request/create_consumer_request.go
@@ -246,35 +246,52 @@ func (r CreateConsumerRequest) ToRegistryBindings() ([]ids.RegistryID, map[ids.R
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	if len(r.Registries) == 0 {
+	bindings, policies, err := parseRegistryBindings(r.Registries, policies)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if bindings == nil {
 		return nil, nil, policies, nil
 	}
-	registryIDs := make([]ids.RegistryID, 0, len(r.Registries))
-	weights := make(map[ids.RegistryID]int, len(r.Registries))
-	seen := make(map[ids.RegistryID]struct{}, len(r.Registries))
-	for i, binding := range r.Registries {
+	return bindings.IDs, bindings.Weights, policies, nil
+}
+
+// parseRegistryBindings turns the wire registry bindings into the domain
+// association set and merges every per-binding model policy into policies,
+// which may be nil. An empty list yields a nil binding set.
+func parseRegistryBindings(
+	raw []RegistryBindingRequest,
+	policies domain.ModelPolicies,
+) (*domain.RegistryBindings, domain.ModelPolicies, error) {
+	if len(raw) == 0 {
+		return nil, policies, nil
+	}
+	bindings := &domain.RegistryBindings{
+		IDs:     make([]ids.RegistryID, 0, len(raw)),
+		Weights: make(map[ids.RegistryID]int, len(raw)),
+	}
+	for i, binding := range raw {
 		id, err := ids.Parse[ids.RegistryKind](binding.ID)
 		if err != nil {
-			return nil, nil, nil, fmt.Errorf("registries[%d]: invalid id %q: %w", i, binding.ID, commonerrors.ErrValidation)
+			return nil, nil, fmt.Errorf("registries[%d]: invalid id %q: %w", i, binding.ID, commonerrors.ErrValidation)
 		}
-		if _, dup := seen[id]; dup {
-			return nil, nil, nil, fmt.Errorf("registries[%d]: duplicate id %q: %w", i, binding.ID, commonerrors.ErrValidation)
+		if _, dup := bindings.Weights[id]; dup {
+			return nil, nil, fmt.Errorf("registries[%d]: duplicate id %q: %w", i, binding.ID, commonerrors.ErrValidation)
 		}
-		seen[id] = struct{}{}
-		registryIDs = append(registryIDs, id)
 		weight, err := normalizeBindingWeight(binding.Weight)
 		if err != nil {
-			return nil, nil, nil, fmt.Errorf("registries[%d]: %w", i, err)
+			return nil, nil, fmt.Errorf("registries[%d]: %w", i, err)
 		}
-		weights[id] = weight
+		bindings.IDs = append(bindings.IDs, id)
+		bindings.Weights[id] = weight
 		if binding.ModelPolicies == nil {
 			continue
 		}
 		if policies == nil {
-			policies = make(domain.ModelPolicies, len(r.Registries))
+			policies = make(domain.ModelPolicies, len(raw))
 		}
 		if _, dup := policies[id]; dup {
-			return nil, nil, nil, fmt.Errorf(
+			return nil, nil, fmt.Errorf(
 				"registries[%d]: model policy for %q already declared in model_policies: %w",
 				i, binding.ID, commonerrors.ErrValidation,
 			)
@@ -284,7 +301,7 @@ func (r CreateConsumerRequest) ToRegistryBindings() ([]ids.RegistryID, map[ids.R
 			Default: binding.ModelPolicies.Default,
 		}
 	}
-	return registryIDs, weights, policies, nil
+	return bindings, policies, nil
 }
 
 func normalizeBindingWeight(weight *int) (int, error) {

--- a/pkg/api/handler/http/consumer/request/update_consumer_request.go
+++ b/pkg/api/handler/http/consumer/request/update_consumer_request.go
@@ -23,16 +23,20 @@ import (
 )
 
 type UpdateConsumerRequest struct {
-	Name          *string                `json:"name,omitempty"`
-	Type          *string                `json:"type,omitempty"`
-	RoutingMode   *string                `json:"routing_mode,omitempty"`
-	LBConfig      *LBConfigRequest       `json:"lb_config,omitempty"`
-	Headers       *map[string]string     `json:"headers,omitempty"`
-	Active        *bool                  `json:"active,omitempty"`
-	Fallback      *FallbackRequest       `json:"fallback,omitempty"`
-	ModelPolicies *[]ModelPolicyRequest  `json:"model_policies,omitempty"`
-	Toolkit       *[]ToolkitEntryRequest `json:"toolkit,omitempty"`
-	FailMode      *string                `json:"fail_mode,omitempty"`
+	Name        *string            `json:"name,omitempty"`
+	Type        *string            `json:"type,omitempty"`
+	RoutingMode *string            `json:"routing_mode,omitempty"`
+	LBConfig    *LBConfigRequest   `json:"lb_config,omitempty"`
+	Headers     *map[string]string `json:"headers,omitempty"`
+	Active      *bool              `json:"active,omitempty"`
+	Fallback    *FallbackRequest   `json:"fallback,omitempty"`
+	// Registries replaces the whole registry association set: registries absent
+	// from the list are detached. Omit the field to leave the associations as
+	// they are; send an empty list to detach every registry.
+	Registries    *[]RegistryBindingRequest `json:"registries,omitempty"`
+	ModelPolicies *[]ModelPolicyRequest     `json:"model_policies,omitempty"`
+	Toolkit       *[]ToolkitEntryRequest    `json:"toolkit,omitempty"`
+	FailMode      *string                   `json:"fail_mode,omitempty"`
 }
 
 func (r UpdateConsumerRequest) Validate() error {
@@ -42,6 +46,17 @@ func (r UpdateConsumerRequest) Validate() error {
 		}
 		if len(*r.Name) > 255 {
 			return fmt.Errorf("name too long (max 255): %w", commonerrors.ErrValidation)
+		}
+	}
+	if r.Registries == nil {
+		return nil
+	}
+	for i, binding := range *r.Registries {
+		if binding.ModelPolicies != nil {
+			return fmt.Errorf(
+				"registries[%d].model_policies is not supported on update, declare them in model_policies: %w",
+				i, commonerrors.ErrValidation,
+			)
 		}
 	}
 	return nil
@@ -69,6 +84,22 @@ func (r UpdateConsumerRequest) ToLBConfig() (*domain.LBConfig, error) {
 
 func (r UpdateConsumerRequest) ToFallback() (*domain.Fallback, error) {
 	return r.Fallback.ToFallback()
+}
+
+// ToRegistryBindings parses the optional registries block. A nil result means
+// the caller did not send the field and the current associations must be kept.
+func (r UpdateConsumerRequest) ToRegistryBindings() (*domain.RegistryBindings, error) {
+	if r.Registries == nil {
+		return nil, nil
+	}
+	bindings, _, err := parseRegistryBindings(*r.Registries, nil)
+	if err != nil {
+		return nil, err
+	}
+	if bindings == nil {
+		return &domain.RegistryBindings{}, nil
+	}
+	return bindings, nil
 }
 
 func (r UpdateConsumerRequest) ToModelPolicies() (*domain.ModelPolicies, error) {

--- a/pkg/api/handler/http/consumer/request/update_consumer_request_test.go
+++ b/pkg/api/handler/http/consumer/request/update_consumer_request_test.go
@@ -15,9 +15,12 @@
 package request
 
 import (
+	"errors"
 	"testing"
 
+	commonerrors "github.com/NeuralTrust/TrustGate/pkg/common/errors"
 	domain "github.com/NeuralTrust/TrustGate/pkg/domain/consumer"
+	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
 )
 
 func strPtr(v string) *string { return &v }
@@ -44,6 +47,84 @@ func TestUpdateConsumerRequest_ToType(t *testing.T) {
 				t.Fatalf("ToType() = %q, want %q", *got, *tc.want)
 			}
 		})
+	}
+}
+
+func TestUpdateConsumerRequest_ToRegistryBindings(t *testing.T) {
+	t.Parallel()
+	first := ids.New[ids.RegistryKind]()
+	second := ids.New[ids.RegistryKind]()
+	weight := 40
+
+	t.Run("omitted keeps current associations", func(t *testing.T) {
+		t.Parallel()
+		got, err := UpdateConsumerRequest{}.ToRegistryBindings()
+		if err != nil {
+			t.Fatalf("ToRegistryBindings() error: %v", err)
+		}
+		if got != nil {
+			t.Fatalf("ToRegistryBindings() = %+v, want nil", got)
+		}
+	})
+
+	t.Run("empty list detaches every registry", func(t *testing.T) {
+		t.Parallel()
+		got, err := UpdateConsumerRequest{Registries: &[]RegistryBindingRequest{}}.ToRegistryBindings()
+		if err != nil {
+			t.Fatalf("ToRegistryBindings() error: %v", err)
+		}
+		if got == nil || len(got.IDs) != 0 {
+			t.Fatalf("ToRegistryBindings() = %+v, want empty binding set", got)
+		}
+	})
+
+	t.Run("preserves order and weights", func(t *testing.T) {
+		t.Parallel()
+		got, err := UpdateConsumerRequest{Registries: &[]RegistryBindingRequest{
+			{ID: first.String(), Weight: &weight},
+			{ID: second.String()},
+		}}.ToRegistryBindings()
+		if err != nil {
+			t.Fatalf("ToRegistryBindings() error: %v", err)
+		}
+		if len(got.IDs) != 2 || got.IDs[0] != first || got.IDs[1] != second {
+			t.Fatalf("IDs = %v, want [%s %s]", got.IDs, first, second)
+		}
+		if got.Weights[first] != weight || got.Weights[second] != domain.DefaultRegistryWeight {
+			t.Fatalf("Weights = %v", got.Weights)
+		}
+	})
+
+	t.Run("rejects duplicates", func(t *testing.T) {
+		t.Parallel()
+		_, err := UpdateConsumerRequest{Registries: &[]RegistryBindingRequest{
+			{ID: first.String()},
+			{ID: first.String()},
+		}}.ToRegistryBindings()
+		if !errors.Is(err, commonerrors.ErrValidation) {
+			t.Fatalf("err = %v, want ErrValidation", err)
+		}
+	})
+
+	t.Run("rejects out of range weight", func(t *testing.T) {
+		t.Parallel()
+		tooBig := domain.MaxRegistryWeight + 1
+		_, err := UpdateConsumerRequest{Registries: &[]RegistryBindingRequest{
+			{ID: first.String(), Weight: &tooBig},
+		}}.ToRegistryBindings()
+		if !errors.Is(err, commonerrors.ErrValidation) {
+			t.Fatalf("err = %v, want ErrValidation", err)
+		}
+	})
+}
+
+func TestUpdateConsumerRequest_Validate_RejectsPerBindingModelPolicies(t *testing.T) {
+	t.Parallel()
+	req := UpdateConsumerRequest{Registries: &[]RegistryBindingRequest{
+		{ID: ids.New[ids.RegistryKind]().String(), ModelPolicies: &RegistryModelPolicyRequest{Default: "gpt-4o"}},
+	}}
+	if err := req.Validate(); !errors.Is(err, commonerrors.ErrValidation) {
+		t.Fatalf("err = %v, want ErrValidation", err)
 	}
 }
 

--- a/pkg/api/handler/http/consumer/update_consumer_handler.go
+++ b/pkg/api/handler/http/consumer/update_consumer_handler.go
@@ -36,7 +36,7 @@ func NewUpdateConsumerHandler(updater appconsumer.Updater) *UpdateConsumerHandle
 
 // Handle godoc
 // @Summary      Update a consumer
-// @Description  Updates an existing consumer.
+// @Description  Updates an existing consumer. The optional `registries` field replaces the whole registry association set, so switching a role_based consumer to inline routing and attaching its registries happens in a single atomic request.
 // @Tags         consumers
 // @Accept       json
 // @Produce      json
@@ -80,6 +80,10 @@ func (h *UpdateConsumerHandler) Handle(c *fiber.Ctx) error {
 	if err != nil {
 		return httpio.WriteError(c, err)
 	}
+	registries, err := req.ToRegistryBindings()
+	if err != nil {
+		return httpio.WriteError(c, err)
+	}
 
 	cons, err := h.updater.Update(c.UserContext(), appconsumer.UpdateInput{
 		ID:            id,
@@ -91,6 +95,7 @@ func (h *UpdateConsumerHandler) Handle(c *fiber.Ctx) error {
 		Headers:       req.Headers,
 		Active:        req.Active,
 		Fallback:      fallback,
+		Registries:    registries,
 		ModelPolicies: modelPolicies,
 		Toolkit:       toolkit,
 		FailMode:      req.ToFailMode(),

--- a/pkg/app/consumer/associator.go
+++ b/pkg/app/consumer/associator.go
@@ -91,7 +91,10 @@ func (a *associator) AttachRegistry(ctx context.Context, gatewayID ids.GatewayID
 		return err
 	}
 	if cons.RoutingMode == domain.RoutingModeRoleBased {
-		return commonerrors.ErrConflict
+		return fmt.Errorf(
+			"%w: consumer %s routes by role, registries can only be attached in inline routing;"+
+				" send routing_mode and registries together in PUT /v1/gateways/{gateway_id}/consumers/{id}",
+			commonerrors.ErrConflict, consumerID)
 	}
 	reg, err := a.registryInGateway(ctx, gatewayID, registryID)
 	if err != nil {
@@ -123,7 +126,10 @@ func (a *associator) AttachRole(ctx context.Context, gatewayID ids.GatewayID, co
 		return err
 	}
 	if cons.RoutingMode == domain.RoutingModeInline {
-		return commonerrors.ErrConflict
+		return fmt.Errorf(
+			"%w: consumer %s routes inline, roles can only be attached in role_based routing;"+
+				" send routing_mode in PUT /v1/gateways/{gateway_id}/consumers/{id} first",
+			commonerrors.ErrConflict, consumerID)
 	}
 	if err := a.roleInGateway(ctx, gatewayID, roleID); err != nil {
 		return err

--- a/pkg/app/consumer/creator.go
+++ b/pkg/app/consumer/creator.go
@@ -105,7 +105,7 @@ func (c *creator) Create(ctx context.Context, in CreateInput) (*domain.Consumer,
 	if err := validateRegistryRefsAssociated(cons); err != nil {
 		return nil, err
 	}
-	if err := c.ensureRegistriesInGateway(ctx, in.GatewayID, in.RegistryIDs); err != nil {
+	if err := ensureRegistriesInGateway(ctx, c.registryRepo, in.GatewayID, in.RegistryIDs); err != nil {
 		return nil, err
 	}
 	if err := c.ensureRolesInGateway(ctx, in.GatewayID, in.RoleIDs); err != nil {
@@ -136,11 +136,16 @@ func (c *creator) saveWithSlugRetry(ctx context.Context, cons *domain.Consumer) 
 	}
 }
 
-func (c *creator) ensureRegistriesInGateway(ctx context.Context, gatewayID ids.GatewayID, registryIDs []ids.RegistryID) error {
+func ensureRegistriesInGateway(
+	ctx context.Context,
+	registryRepo registrydomain.Repository,
+	gatewayID ids.GatewayID,
+	registryIDs []ids.RegistryID,
+) error {
 	if len(registryIDs) == 0 {
 		return nil
 	}
-	found, err := c.registryRepo.FindByIDs(ctx, gatewayID, registryIDs)
+	found, err := registryRepo.FindByIDs(ctx, gatewayID, registryIDs)
 	if err != nil {
 		return err
 	}

--- a/pkg/app/consumer/updater.go
+++ b/pkg/app/consumer/updater.go
@@ -30,15 +30,18 @@ import (
 )
 
 type UpdateInput struct {
-	ID            ids.ConsumerID
-	GatewayID     ids.GatewayID
-	Name          *string
-	Type          *domain.Type
-	RoutingMode   *domain.RoutingMode
-	LBConfig      *domain.LBConfig
-	Headers       *map[string]string
-	Active        *bool
-	Fallback      *domain.Fallback
+	ID          ids.ConsumerID
+	GatewayID   ids.GatewayID
+	Name        *string
+	Type        *domain.Type
+	RoutingMode *domain.RoutingMode
+	LBConfig    *domain.LBConfig
+	Headers     *map[string]string
+	Active      *bool
+	Fallback    *domain.Fallback
+	// Registries replaces the whole registry association set. A nil value keeps
+	// the associations the consumer already has.
+	Registries    *domain.RegistryBindings
 	ModelPolicies *domain.ModelPolicies
 	Toolkit       *domain.Toolkit
 	FailMode      *domain.FailMode
@@ -52,16 +55,18 @@ type Updater interface {
 var _ Updater = (*updater)(nil)
 
 type updater struct {
-	repo        domain.Repository
-	authRepo    authdomain.Repository
-	memoryCache *cache.TTLMap
-	publisher   cache.EventPublisher
-	logger      *slog.Logger
-	signaler    configsyncport.SnapshotSignaler
+	repo         domain.Repository
+	registryRepo registrydomain.Repository
+	authRepo     authdomain.Repository
+	memoryCache  *cache.TTLMap
+	publisher    cache.EventPublisher
+	logger       *slog.Logger
+	signaler     configsyncport.SnapshotSignaler
 }
 
 func NewUpdater(
 	repo domain.Repository,
+	registryRepo registrydomain.Repository,
 	authRepo authdomain.Repository,
 	manager *cache.TTLMapManager,
 	publisher cache.EventPublisher,
@@ -69,12 +74,13 @@ func NewUpdater(
 	signaler configsyncport.SnapshotSignaler,
 ) Updater {
 	return &updater{
-		repo:        repo,
-		authRepo:    authRepo,
-		memoryCache: manager.GetTTLMap(cache.ConsumerTTLName),
-		publisher:   publisher,
-		logger:      logger,
-		signaler:    signaler,
+		repo:         repo,
+		registryRepo: registryRepo,
+		authRepo:     authRepo,
+		memoryCache:  manager.GetTTLMap(cache.ConsumerTTLName),
+		publisher:    publisher,
+		logger:       logger,
+		signaler:     signaler,
 	}
 }
 
@@ -118,6 +124,12 @@ func (u *updater) Update(ctx context.Context, in UpdateInput) (*domain.Consumer,
 	if previousMode != existing.RoutingMode {
 		cleanIncompatibleModeConfig(existing)
 	}
+	// Applied after the mode cleanup so that sending registries alongside
+	// routing_mode=role_based is rejected by Validate instead of silently dropped.
+	if in.Registries != nil {
+		existing.RegistryIDs = in.Registries.IDs
+		existing.RegistryWeights = in.Registries.Weights
+	}
 	existing.UpdatedAt = time.Now().UTC()
 	if err := validateRegistryRefsAssociated(existing); err != nil {
 		return nil, err
@@ -125,10 +137,15 @@ func (u *updater) Update(ctx context.Context, in UpdateInput) (*domain.Consumer,
 	if err := existing.Validate(); err != nil {
 		return nil, err
 	}
+	if in.Registries != nil {
+		if err := ensureRegistriesInGateway(ctx, u.registryRepo, existing.GatewayID, existing.RegistryIDs); err != nil {
+			return nil, err
+		}
+	}
 	if err := u.revalidateAuthsForTransition(ctx, existing, previousType, previousMode); err != nil {
 		return nil, err
 	}
-	if err := u.repo.Update(ctx, existing); err != nil {
+	if err := u.repo.Update(ctx, existing, requestedRegistryBindings(existing, in.Registries)); err != nil {
 		return nil, err
 	}
 	u.memoryCache.Set(existing.ID.String(), existing)
@@ -137,6 +154,17 @@ func (u *updater) Update(ctx context.Context, in UpdateInput) (*domain.Consumer,
 		u.signaler.Signal(ctx)
 	}
 	return existing, nil
+}
+
+// requestedRegistryBindings returns the association set the repository must
+// persist, or nil when the caller did not ask to change it. It reads the
+// validated aggregate rather than the input so a switch to role_based, which
+// drops every registry, is reflected.
+func requestedRegistryBindings(c *domain.Consumer, requested *domain.RegistryBindings) *domain.RegistryBindings {
+	if requested == nil {
+		return nil
+	}
+	return &domain.RegistryBindings{IDs: c.RegistryIDs, Weights: c.RegistryWeights}
 }
 
 func (u *updater) revalidateAuthsForTransition(
@@ -225,6 +253,7 @@ func cleanIncompatibleModeConfig(c *domain.Consumer) {
 	switch c.RoutingMode {
 	case domain.RoutingModeRoleBased:
 		c.RegistryIDs = nil
+		c.RegistryWeights = nil
 		c.Fallback = nil
 		c.LBConfig = nil
 		c.ModelPolicies = nil

--- a/pkg/app/consumer/updater_test.go
+++ b/pkg/app/consumer/updater_test.go
@@ -28,6 +28,7 @@ import (
 	repomocks "github.com/NeuralTrust/TrustGate/pkg/domain/consumer/mocks"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
 	registrydomain "github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	registrymocks "github.com/NeuralTrust/TrustGate/pkg/domain/registry/mocks"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/cache/cachetest"
 	"github.com/stretchr/testify/mock"
 )
@@ -62,11 +63,11 @@ func TestUpdater_Update_Success(t *testing.T) {
 		Update(mock.Anything, mock.MatchedBy(func(c *domain.Consumer) bool {
 			return c.ID == existing.ID && c.Name == "new" && c.Type == domain.TypeMCP &&
 				len(c.RegistryIDs) == 1 && c.RegistryIDs[0] == beID
-		})).
+		}), mock.Anything).
 		Return(nil).
 		Once()
 
-	updater := appconsumer.NewUpdater(repo, authmocks.NewRepository(t), newCacheManager(), cachetest.NoopPublisher(), newTestLogger(), nil)
+	updater := appconsumer.NewUpdater(repo, registrymocks.NewRepository(t), authmocks.NewRepository(t), newCacheManager(), cachetest.NoopPublisher(), newTestLogger(), nil)
 	got, err := updater.Update(context.Background(), appconsumer.UpdateInput{
 		ID:        existing.ID,
 		GatewayID: gwID,
@@ -94,11 +95,11 @@ func TestUpdater_Update_Partial_PreservesFieldsAndAssociations(t *testing.T) {
 			return c.Name == "renamed" && c.Slug == "X84Yhsy8" &&
 				c.RoutingMode == domain.RoutingModeInline && c.Type == domain.TypeLLM &&
 				len(c.RegistryIDs) == 1 && c.RegistryIDs[0] == beID
-		})).
+		}), (*domain.RegistryBindings)(nil)).
 		Return(nil).
 		Once()
 
-	updater := appconsumer.NewUpdater(repo, authmocks.NewRepository(t), newCacheManager(), cachetest.NoopPublisher(), newTestLogger(), nil)
+	updater := appconsumer.NewUpdater(repo, registrymocks.NewRepository(t), authmocks.NewRepository(t), newCacheManager(), cachetest.NoopPublisher(), newTestLogger(), nil)
 	got, err := updater.Update(context.Background(), appconsumer.UpdateInput{
 		ID:        existing.ID,
 		GatewayID: gwID,
@@ -120,7 +121,7 @@ func TestUpdater_Update_NotFound(t *testing.T) {
 	repo := repomocks.NewRepository(t)
 	repo.EXPECT().FindByID(mock.Anything, mock.Anything).Return(nil, domain.ErrNotFound).Once()
 
-	updater := appconsumer.NewUpdater(repo, authmocks.NewRepository(t), newCacheManager(), cachetest.NoopPublisher(), newTestLogger(), nil)
+	updater := appconsumer.NewUpdater(repo, registrymocks.NewRepository(t), authmocks.NewRepository(t), newCacheManager(), cachetest.NoopPublisher(), newTestLogger(), nil)
 
 	_, err := updater.Update(context.Background(), appconsumer.UpdateInput{
 		ID: ids.New[ids.ConsumerKind](),
@@ -139,7 +140,7 @@ func TestUpdater_Update_RejectsModelPolicyForUnassociatedRegistry(t *testing.T) 
 	repo := repomocks.NewRepository(t)
 	repo.EXPECT().FindByID(mock.Anything, existing.ID).Return(existing, nil).Once()
 
-	updater := appconsumer.NewUpdater(repo, authmocks.NewRepository(t), newCacheManager(), cachetest.NoopPublisher(), newTestLogger(), nil)
+	updater := appconsumer.NewUpdater(repo, registrymocks.NewRepository(t), authmocks.NewRepository(t), newCacheManager(), cachetest.NoopPublisher(), newTestLogger(), nil)
 
 	_, err := updater.Update(context.Background(), appconsumer.UpdateInput{
 		ID:        existing.ID,
@@ -163,9 +164,9 @@ func TestUpdater_Update_AllowsModelPolicyForAssociatedRegistry(t *testing.T) {
 
 	repo := repomocks.NewRepository(t)
 	repo.EXPECT().FindByID(mock.Anything, existing.ID).Return(existing, nil).Once()
-	repo.EXPECT().Update(mock.Anything, mock.Anything).Return(nil).Once()
+	repo.EXPECT().Update(mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
-	updater := appconsumer.NewUpdater(repo, authmocks.NewRepository(t), newCacheManager(), cachetest.NoopPublisher(), newTestLogger(), nil)
+	updater := appconsumer.NewUpdater(repo, registrymocks.NewRepository(t), authmocks.NewRepository(t), newCacheManager(), cachetest.NoopPublisher(), newTestLogger(), nil)
 
 	_, err := updater.Update(context.Background(), appconsumer.UpdateInput{
 		ID:        existing.ID,
@@ -191,7 +192,7 @@ func TestUpdater_Update_RejectsLBConfigForUnassociatedRegistry(t *testing.T) {
 	repo := repomocks.NewRepository(t)
 	repo.EXPECT().FindByID(mock.Anything, existing.ID).Return(existing, nil).Once()
 
-	updater := appconsumer.NewUpdater(repo, authmocks.NewRepository(t), newCacheManager(), cachetest.NoopPublisher(), newTestLogger(), nil)
+	updater := appconsumer.NewUpdater(repo, registrymocks.NewRepository(t), authmocks.NewRepository(t), newCacheManager(), cachetest.NoopPublisher(), newTestLogger(), nil)
 
 	_, err := updater.Update(context.Background(), appconsumer.UpdateInput{
 		ID:        existing.ID,
@@ -232,11 +233,11 @@ func TestUpdater_Update_DisabledObjectsClearFallbackAndLBConfig(t *testing.T) {
 		Update(mock.Anything, mock.MatchedBy(func(c *domain.Consumer) bool {
 			return c.Fallback != nil && !c.Fallback.Enabled && len(c.Fallback.Chain) == 0 &&
 				c.LBConfig != nil && !c.LBConfig.Enabled && len(c.LBConfig.Members) == 0
-		})).
+		}), mock.Anything).
 		Return(nil).
 		Once()
 
-	updater := appconsumer.NewUpdater(repo, authmocks.NewRepository(t), newCacheManager(), cachetest.NoopPublisher(), newTestLogger(), nil)
+	updater := appconsumer.NewUpdater(repo, registrymocks.NewRepository(t), authmocks.NewRepository(t), newCacheManager(), cachetest.NoopPublisher(), newTestLogger(), nil)
 	_, err := updater.Update(context.Background(), appconsumer.UpdateInput{
 		ID:        existing.ID,
 		GatewayID: gwID,
@@ -267,11 +268,11 @@ func TestUpdater_Update_SwitchToRoleBasedCleansInlineConfig(t *testing.T) {
 				c.Fallback == nil &&
 				c.LBConfig == nil &&
 				len(c.ModelPolicies) == 0
-		})).
+		}), mock.Anything).
 		Return(nil).
 		Once()
 
-	updater := appconsumer.NewUpdater(repo, authmocks.NewRepository(t), newCacheManager(), cachetest.NoopPublisher(), newTestLogger(), nil)
+	updater := appconsumer.NewUpdater(repo, registrymocks.NewRepository(t), authmocks.NewRepository(t), newCacheManager(), cachetest.NoopPublisher(), newTestLogger(), nil)
 	if _, err := updater.Update(context.Background(), appconsumer.UpdateInput{
 		ID:          existing.ID,
 		GatewayID:   gwID,
@@ -304,11 +305,11 @@ func TestUpdater_Update_SwitchToInlineClearsRoles(t *testing.T) {
 	repo.EXPECT().
 		Update(mock.Anything, mock.MatchedBy(func(c *domain.Consumer) bool {
 			return c.RoutingMode == domain.RoutingModeInline && len(c.RoleIDs) == 0
-		})).
+		}), mock.Anything).
 		Return(nil).
 		Once()
 
-	updater := appconsumer.NewUpdater(repo, authmocks.NewRepository(t), newCacheManager(), cachetest.NoopPublisher(), newTestLogger(), nil)
+	updater := appconsumer.NewUpdater(repo, registrymocks.NewRepository(t), authmocks.NewRepository(t), newCacheManager(), cachetest.NoopPublisher(), newTestLogger(), nil)
 	if _, err := updater.Update(context.Background(), appconsumer.UpdateInput{
 		ID:          existing.ID,
 		GatewayID:   gwID,
@@ -333,7 +334,7 @@ func TestUpdater_Update_RejectsIdPAuthOnSwitchToMCP(t *testing.T) {
 	authRepo.EXPECT().FindByIDs(mock.Anything, gwID, existing.AuthIDs).
 		Return([]*authdomain.Auth{{ID: authID, GatewayID: gwID, Type: authdomain.TypeOIDC}}, nil).Once()
 
-	updater := appconsumer.NewUpdater(repo, authRepo, newCacheManager(), cachetest.NoopPublisher(), newTestLogger(), nil)
+	updater := appconsumer.NewUpdater(repo, registrymocks.NewRepository(t), authRepo, newCacheManager(), cachetest.NoopPublisher(), newTestLogger(), nil)
 	_, err := updater.Update(context.Background(), appconsumer.UpdateInput{
 		ID:        existing.ID,
 		GatewayID: gwID,
@@ -360,7 +361,7 @@ func TestUpdater_Update_RejectsNonIdPAuthOnSwitchToRoleBased(t *testing.T) {
 	authRepo.EXPECT().FindByIDs(mock.Anything, gwID, existing.AuthIDs).
 		Return([]*authdomain.Auth{{ID: authID, GatewayID: gwID, Type: authdomain.TypeAPIKey}}, nil).Once()
 
-	updater := appconsumer.NewUpdater(repo, authRepo, newCacheManager(), cachetest.NoopPublisher(), newTestLogger(), nil)
+	updater := appconsumer.NewUpdater(repo, registrymocks.NewRepository(t), authRepo, newCacheManager(), cachetest.NoopPublisher(), newTestLogger(), nil)
 	_, err := updater.Update(context.Background(), appconsumer.UpdateInput{
 		ID:          existing.ID,
 		GatewayID:   gwID,
@@ -381,13 +382,13 @@ func TestUpdater_Update_AllowsOAuth2AuthOnSwitchToMCP(t *testing.T) {
 
 	repo := repomocks.NewRepository(t)
 	repo.EXPECT().FindByID(mock.Anything, existing.ID).Return(existing, nil).Once()
-	repo.EXPECT().Update(mock.Anything, mock.Anything).Return(nil).Once()
+	repo.EXPECT().Update(mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
 	authRepo := authmocks.NewRepository(t)
 	authRepo.EXPECT().FindByIDs(mock.Anything, gwID, existing.AuthIDs).
 		Return([]*authdomain.Auth{{ID: authID, GatewayID: gwID, Type: authdomain.TypeOAuth2}}, nil).Once()
 
-	updater := appconsumer.NewUpdater(repo, authRepo, newCacheManager(), cachetest.NoopPublisher(), newTestLogger(), nil)
+	updater := appconsumer.NewUpdater(repo, registrymocks.NewRepository(t), authRepo, newCacheManager(), cachetest.NoopPublisher(), newTestLogger(), nil)
 	if _, err := updater.Update(context.Background(), appconsumer.UpdateInput{
 		ID:        existing.ID,
 		GatewayID: gwID,
@@ -408,7 +409,7 @@ func TestUpdater_Update_RejectsMultipleAuthsOnSwitchToRoleBased(t *testing.T) {
 	repo := repomocks.NewRepository(t)
 	repo.EXPECT().FindByID(mock.Anything, existing.ID).Return(existing, nil).Once()
 
-	updater := appconsumer.NewUpdater(repo, authmocks.NewRepository(t), newCacheManager(), cachetest.NoopPublisher(), newTestLogger(), nil)
+	updater := appconsumer.NewUpdater(repo, registrymocks.NewRepository(t), authmocks.NewRepository(t), newCacheManager(), cachetest.NoopPublisher(), newTestLogger(), nil)
 	_, err := updater.Update(context.Background(), appconsumer.UpdateInput{
 		ID:          existing.ID,
 		GatewayID:   gwID,
@@ -416,6 +417,142 @@ func TestUpdater_Update_RejectsMultipleAuthsOnSwitchToRoleBased(t *testing.T) {
 	})
 	if !errors.Is(err, domain.ErrInvalidRoutingMode) {
 		t.Fatalf("err = %v, want ErrInvalidRoutingMode (role_based allows at most one auth)", err)
+	}
+}
+
+func roleBasedConsumer(gwID ids.GatewayID) *domain.Consumer {
+	now := time.Now().UTC()
+	return domain.Rehydrate(domain.RehydrateParams{
+		ID:          ids.New[ids.ConsumerKind](),
+		GatewayID:   gwID,
+		Name:        "old",
+		Type:        domain.TypeLLM,
+		Slug:        "X84Yhsy8",
+		RoutingMode: domain.RoutingModeRoleBased,
+		Active:      true,
+		RoleIDs:     []ids.RoleID{ids.New[ids.RoleKind]()},
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	})
+}
+
+func TestUpdater_Update_SwitchToInlineAttachesRegistries(t *testing.T) {
+	t.Parallel()
+	gwID := ids.New[ids.GatewayKind]()
+	beID := ids.New[ids.RegistryKind]()
+	existing := roleBasedConsumer(gwID)
+	mode := domain.RoutingModeInline
+
+	repo := repomocks.NewRepository(t)
+	repo.EXPECT().FindByID(mock.Anything, existing.ID).Return(existing, nil).Once()
+	repo.EXPECT().
+		Update(mock.Anything, mock.MatchedBy(func(c *domain.Consumer) bool {
+			return c.RoutingMode == domain.RoutingModeInline &&
+				len(c.RoleIDs) == 0 &&
+				len(c.RegistryIDs) == 1 && c.RegistryIDs[0] == beID &&
+				c.WeightFor(beID) == 30
+		}), mock.MatchedBy(func(b *domain.RegistryBindings) bool {
+			return b != nil && len(b.IDs) == 1 && b.IDs[0] == beID && b.Weights[beID] == 30
+		})).
+		Return(nil).
+		Once()
+
+	registryRepo := registrymocks.NewRepository(t)
+	registryRepo.EXPECT().
+		FindByIDs(mock.Anything, gwID, []ids.RegistryID{beID}).
+		Return([]*registrydomain.Registry{{ID: beID, GatewayID: gwID}}, nil).
+		Once()
+
+	updater := appconsumer.NewUpdater(repo, registryRepo, authmocks.NewRepository(t), newCacheManager(), cachetest.NoopPublisher(), newTestLogger(), nil)
+	got, err := updater.Update(context.Background(), appconsumer.UpdateInput{
+		ID:          existing.ID,
+		GatewayID:   gwID,
+		RoutingMode: &mode,
+		Registries: &domain.RegistryBindings{
+			IDs:     []ids.RegistryID{beID},
+			Weights: map[ids.RegistryID]int{beID: 30},
+		},
+		ModelPolicies: ptr(domain.ModelPolicies{beID: {Allowed: []string{"gpt-4o"}}}),
+	})
+	if err != nil {
+		t.Fatalf("Update error: %v", err)
+	}
+	if len(got.RegistryIDs) != 1 || got.RegistryIDs[0] != beID {
+		t.Fatalf("RegistryIDs = %v, want [%s]", got.RegistryIDs, beID)
+	}
+}
+
+func TestUpdater_Update_EmptyRegistriesDetachesAll(t *testing.T) {
+	t.Parallel()
+	gwID := ids.New[ids.GatewayKind]()
+	beID := ids.New[ids.RegistryKind]()
+	existing := existingConsumer(gwID, beID)
+
+	repo := repomocks.NewRepository(t)
+	repo.EXPECT().FindByID(mock.Anything, existing.ID).Return(existing, nil).Once()
+	repo.EXPECT().
+		Update(mock.Anything, mock.MatchedBy(func(c *domain.Consumer) bool {
+			return len(c.RegistryIDs) == 0
+		}), mock.MatchedBy(func(b *domain.RegistryBindings) bool {
+			return b != nil && len(b.IDs) == 0
+		})).
+		Return(nil).
+		Once()
+
+	updater := appconsumer.NewUpdater(repo, registrymocks.NewRepository(t), authmocks.NewRepository(t), newCacheManager(), cachetest.NoopPublisher(), newTestLogger(), nil)
+	if _, err := updater.Update(context.Background(), appconsumer.UpdateInput{
+		ID:         existing.ID,
+		GatewayID:  gwID,
+		Registries: &domain.RegistryBindings{},
+	}); err != nil {
+		t.Fatalf("Update error: %v", err)
+	}
+}
+
+func TestUpdater_Update_RejectsRegistriesInRoleBasedMode(t *testing.T) {
+	t.Parallel()
+	gwID := ids.New[ids.GatewayKind]()
+	beID := ids.New[ids.RegistryKind]()
+	existing := roleBasedConsumer(gwID)
+
+	repo := repomocks.NewRepository(t)
+	repo.EXPECT().FindByID(mock.Anything, existing.ID).Return(existing, nil).Once()
+
+	updater := appconsumer.NewUpdater(repo, registrymocks.NewRepository(t), authmocks.NewRepository(t), newCacheManager(), cachetest.NoopPublisher(), newTestLogger(), nil)
+	_, err := updater.Update(context.Background(), appconsumer.UpdateInput{
+		ID:         existing.ID,
+		GatewayID:  gwID,
+		Registries: &domain.RegistryBindings{IDs: []ids.RegistryID{beID}},
+	})
+	if !errors.Is(err, domain.ErrInvalidRoutingMode) {
+		t.Fatalf("err = %v, want ErrInvalidRoutingMode (registries need inline routing)", err)
+	}
+}
+
+func TestUpdater_Update_RejectsRegistriesOutsideGateway(t *testing.T) {
+	t.Parallel()
+	gwID := ids.New[ids.GatewayKind]()
+	beID := ids.New[ids.RegistryKind]()
+	foreignID := ids.New[ids.RegistryKind]()
+	existing := existingConsumer(gwID, beID)
+
+	repo := repomocks.NewRepository(t)
+	repo.EXPECT().FindByID(mock.Anything, existing.ID).Return(existing, nil).Once()
+
+	registryRepo := registrymocks.NewRepository(t)
+	registryRepo.EXPECT().
+		FindByIDs(mock.Anything, gwID, []ids.RegistryID{foreignID}).
+		Return(nil, nil).
+		Once()
+
+	updater := appconsumer.NewUpdater(repo, registryRepo, authmocks.NewRepository(t), newCacheManager(), cachetest.NoopPublisher(), newTestLogger(), nil)
+	_, err := updater.Update(context.Background(), appconsumer.UpdateInput{
+		ID:         existing.ID,
+		GatewayID:  gwID,
+		Registries: &domain.RegistryBindings{IDs: []ids.RegistryID{foreignID}},
+	})
+	if !errors.Is(err, registrydomain.ErrInvalidRegistryID) {
+		t.Fatalf("err = %v, want ErrInvalidRegistryID", err)
 	}
 }
 
@@ -428,7 +565,7 @@ func TestUpdater_Update_RejectsCrossGateway(t *testing.T) {
 	repo := repomocks.NewRepository(t)
 	repo.EXPECT().FindByID(mock.Anything, existing.ID).Return(existing, nil).Once()
 
-	updater := appconsumer.NewUpdater(repo, authmocks.NewRepository(t), newCacheManager(), cachetest.NoopPublisher(), newTestLogger(), nil)
+	updater := appconsumer.NewUpdater(repo, registrymocks.NewRepository(t), authmocks.NewRepository(t), newCacheManager(), cachetest.NoopPublisher(), newTestLogger(), nil)
 
 	_, err := updater.Update(context.Background(), appconsumer.UpdateInput{
 		ID:        existing.ID,

--- a/pkg/container/modules/consumer.go
+++ b/pkg/container/modules/consumer.go
@@ -67,8 +67,8 @@ func provideConsumerServices(c *container.Container) error {
 	}); err != nil {
 		return err
 	}
-	if err := c.Provide(func(repo domain.Repository, authRepo authdomain.Repository, manager *cache.TTLMapManager, publisher cache.EventPublisher, logger *slog.Logger, sig snapshotSignalParams) appconsumer.Updater {
-		return appconsumer.NewUpdater(repo, authRepo, manager, publisher, logger, sig.Signaler)
+	if err := c.Provide(func(repo domain.Repository, registryRepo registrydomain.Repository, authRepo authdomain.Repository, manager *cache.TTLMapManager, publisher cache.EventPublisher, logger *slog.Logger, sig snapshotSignalParams) appconsumer.Updater {
+		return appconsumer.NewUpdater(repo, registryRepo, authRepo, manager, publisher, logger, sig.Signaler)
 	}); err != nil {
 		return err
 	}

--- a/pkg/domain/consumer/consumer.go
+++ b/pkg/domain/consumer/consumer.go
@@ -74,6 +74,13 @@ const (
 	MaxRegistryWeight = 100
 )
 
+// RegistryBindings is a complete desired registry association set for a
+// consumer, with the weight to apply to each member.
+type RegistryBindings struct {
+	IDs     []ids.RegistryID
+	Weights map[ids.RegistryID]int
+}
+
 type Consumer struct {
 	ID              ids.ConsumerID         `json:"id"`
 	GatewayID       ids.GatewayID          `json:"gateway_id"`

--- a/pkg/domain/consumer/mocks/consumer_repository_mock.go
+++ b/pkg/domain/consumer/mocks/consumer_repository_mock.go
@@ -866,17 +866,17 @@ func (_c *Repository_Save_Call) RunAndReturn(run func(context.Context, *consumer
 	return _c
 }
 
-// Update provides a mock function with given fields: ctx, c
-func (_m *Repository) Update(ctx context.Context, c *consumer.Consumer) error {
-	ret := _m.Called(ctx, c)
+// Update provides a mock function with given fields: ctx, c, registries
+func (_m *Repository) Update(ctx context.Context, c *consumer.Consumer, registries *consumer.RegistryBindings) error {
+	ret := _m.Called(ctx, c, registries)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Update")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *consumer.Consumer) error); ok {
-		r0 = rf(ctx, c)
+	if rf, ok := ret.Get(0).(func(context.Context, *consumer.Consumer, *consumer.RegistryBindings) error); ok {
+		r0 = rf(ctx, c, registries)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -892,13 +892,14 @@ type Repository_Update_Call struct {
 // Update is a helper method to define mock.On call
 //   - ctx context.Context
 //   - c *consumer.Consumer
-func (_e *Repository_Expecter) Update(ctx interface{}, c interface{}) *Repository_Update_Call {
-	return &Repository_Update_Call{Call: _e.mock.On("Update", ctx, c)}
+//   - registries *consumer.RegistryBindings
+func (_e *Repository_Expecter) Update(ctx interface{}, c interface{}, registries interface{}) *Repository_Update_Call {
+	return &Repository_Update_Call{Call: _e.mock.On("Update", ctx, c, registries)}
 }
 
-func (_c *Repository_Update_Call) Run(run func(ctx context.Context, c *consumer.Consumer)) *Repository_Update_Call {
+func (_c *Repository_Update_Call) Run(run func(ctx context.Context, c *consumer.Consumer, registries *consumer.RegistryBindings)) *Repository_Update_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*consumer.Consumer))
+		run(args[0].(context.Context), args[1].(*consumer.Consumer), args[2].(*consumer.RegistryBindings))
 	})
 	return _c
 }
@@ -908,7 +909,7 @@ func (_c *Repository_Update_Call) Return(_a0 error) *Repository_Update_Call {
 	return _c
 }
 
-func (_c *Repository_Update_Call) RunAndReturn(run func(context.Context, *consumer.Consumer) error) *Repository_Update_Call {
+func (_c *Repository_Update_Call) RunAndReturn(run func(context.Context, *consumer.Consumer, *consumer.RegistryBindings) error) *Repository_Update_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/domain/consumer/repository.go
+++ b/pkg/domain/consumer/repository.go
@@ -39,7 +39,10 @@ type Reader interface {
 // Writer persists consumer aggregate lifecycle changes.
 type Writer interface {
 	Save(ctx context.Context, c *Consumer) error
-	Update(ctx context.Context, c *Consumer) error
+	// Update persists the consumer row and, when registries is non-nil, replaces
+	// its registry association set in the same transaction. A nil registries
+	// leaves the existing links untouched.
+	Update(ctx context.Context, c *Consumer, registries *RegistryBindings) error
 	Delete(ctx context.Context, gatewayID ids.GatewayID, id ids.ConsumerID) error
 }
 

--- a/pkg/infra/repository/consumer/repository.go
+++ b/pkg/infra/repository/consumer/repository.go
@@ -143,7 +143,7 @@ func (r *Repository) Save(ctx context.Context, c *domain.Consumer) error {
 	})
 }
 
-func (r *Repository) Update(ctx context.Context, c *domain.Consumer) error {
+func (r *Repository) Update(ctx context.Context, c *domain.Consumer, registries *domain.RegistryBindings) error {
 	if c == nil {
 		return errors.New("consumer repository: nil consumer")
 	}
@@ -181,11 +181,11 @@ func (r *Repository) Update(ctx context.Context, c *domain.Consumer) error {
 		       active           = $11,
 		       updated_at       = $12
 		 WHERE id = $1 AND gateway_id = $13`
+	// The consumers row is written before the registry links because the
+	// routing-mode DB guard rejects registry rows on a role_based consumer: a
+	// role_based → inline switch has to land the new mode first.
 	return r.withMarkedTx(ctx, func(tx pgx.Tx) error {
 		if err := lockConsumerRow(ctx, tx, c.ID); err != nil {
-			return err
-		}
-		if err := ensureRegistryRefsAssociated(ctx, tx, c); err != nil {
 			return err
 		}
 		if err := cleanupIncompatibleRelations(ctx, tx, c); err != nil {
@@ -201,8 +201,38 @@ func (r *Repository) Update(ctx context.Context, c *domain.Consumer) error {
 		if cmd.RowsAffected() == 0 {
 			return domain.ErrNotFound
 		}
-		return nil
+		if err := replaceRegistryLinks(ctx, tx, c, registries); err != nil {
+			return err
+		}
+		return ensureRegistryRefsAssociated(ctx, tx, c)
 	})
+}
+
+// replaceRegistryLinks makes consumer_registry match the requested set,
+// detaching the links that are gone and upserting the rest with their weight and
+// their position in the set. A role_based consumer holds no links at all;
+// cleanupIncompatibleRelations already removed them.
+func replaceRegistryLinks(ctx context.Context, tx pgx.Tx, c *domain.Consumer, registries *domain.RegistryBindings) error {
+	if registries == nil || c.RoutingMode == domain.RoutingModeRoleBased {
+		return nil
+	}
+	const detachRemoved = `
+		DELETE FROM consumer_registry
+		 WHERE consumer_id = $1
+		   AND registry_id <> ALL($2::uuid[])`
+	if _, err := tx.Exec(ctx, detachRemoved, c.ID, ids.ToUUIDs(registries.IDs)); err != nil {
+		return mapPgError(err)
+	}
+	const upsertLink = `
+		INSERT INTO consumer_registry (consumer_id, registry_id, weight, position) VALUES ($1, $2, $3, $4)
+		ON CONFLICT (consumer_id, registry_id) DO UPDATE SET weight = EXCLUDED.weight, position = EXCLUDED.position`
+	for position, registryID := range registries.IDs {
+		weight := clampRegistryWeight(registries.Weights[registryID])
+		if _, err := tx.Exec(ctx, upsertLink, c.ID, registryID, weight, position); err != nil {
+			return mapPgError(err)
+		}
+	}
+	return nil
 }
 
 func cleanupIncompatibleRelations(ctx context.Context, tx pgx.Tx, c *domain.Consumer) error {

--- a/pkg/runtimeconfig/snapshot/adapters/adapters_test.go
+++ b/pkg/runtimeconfig/snapshot/adapters/adapters_test.go
@@ -167,7 +167,7 @@ func TestConsumerAdapter(t *testing.T) {
 	assert.Len(t, byAuth, 1)
 
 	assert.ErrorIs(t, repo.Save(ctx, &consumerdomain.Consumer{}), configsync.ErrReadOnly)
-	assert.ErrorIs(t, repo.Update(ctx, &consumerdomain.Consumer{}), configsync.ErrReadOnly)
+	assert.ErrorIs(t, repo.Update(ctx, &consumerdomain.Consumer{}, nil), configsync.ErrReadOnly)
 	assert.ErrorIs(t, repo.Delete(ctx, f.gateway.ID, ids.New[ids.ConsumerKind]()), configsync.ErrReadOnly)
 	assert.ErrorIs(t, repo.AttachAuth(ctx, ids.New[ids.ConsumerKind](), f.auth.ID), configsync.ErrReadOnly)
 	assert.ErrorIs(t, repo.DetachAuth(ctx, ids.New[ids.ConsumerKind](), f.auth.ID), configsync.ErrReadOnly)

--- a/pkg/runtimeconfig/snapshot/adapters/consumer_repository.go
+++ b/pkg/runtimeconfig/snapshot/adapters/consumer_repository.go
@@ -75,7 +75,7 @@ func (r *consumerRepository) Save(_ context.Context, _ *domain.Consumer) error {
 	return configsync.ErrReadOnly
 }
 
-func (r *consumerRepository) Update(_ context.Context, _ *domain.Consumer) error {
+func (r *consumerRepository) Update(_ context.Context, _ *domain.Consumer, _ *domain.RegistryBindings) error {
 	return configsync.ErrReadOnly
 }
 

--- a/tests/functional/repositories/consumer/repository_test.go
+++ b/tests/functional/repositories/consumer/repository_test.go
@@ -223,6 +223,90 @@ func TestRepository_SavePreservesRegistryOrder(t *testing.T) {
 	}
 }
 
+// TestRepository_UpdateSwitchesRoleBasedToInlineWithRegistries pins the write
+// order the routing-mode DB guard imposes: the consumers row has to leave
+// role_based before any registry link can be inserted.
+func TestRepository_UpdateSwitchesRoleBasedToInlineWithRegistries(t *testing.T) {
+	f := setupRepo(t)
+	ctx := context.Background()
+	gwID := seedGateway(t, f.gw, "rb-to-inline")
+	beID := seedRegistry(t, f.be, gwID, "rb-to-inline-be")
+	roleID := seedRole(t, f.roles, gwID, "rb-to-inline-role")
+
+	c, err := domain.New(domain.CreateParams{
+		GatewayID:   gwID,
+		Name:        "rb-consumer",
+		Type:        domain.TypeLLM,
+		RoutingMode: domain.RoutingModeRoleBased,
+		RoleIDs:     []ids.RoleID{roleID},
+	})
+	if err != nil {
+		t.Fatalf("consumer domain.New: %v", err)
+	}
+	if err := f.repo.Save(ctx, c); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	c.RoutingMode = domain.RoutingModeInline
+	c.RoleIDs = nil
+	c.RegistryIDs = []ids.RegistryID{beID}
+	c.RegistryWeights = map[ids.RegistryID]int{beID: 40}
+	bindings := &domain.RegistryBindings{IDs: c.RegistryIDs, Weights: c.RegistryWeights}
+	if err := f.repo.Update(ctx, c, bindings); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	got, err := f.repo.FindByID(ctx, c.ID)
+	if err != nil {
+		t.Fatalf("FindByID: %v", err)
+	}
+	if got.RoutingMode != domain.RoutingModeInline {
+		t.Fatalf("RoutingMode = %q, want %q", got.RoutingMode, domain.RoutingModeInline)
+	}
+	if len(got.RegistryIDs) != 1 || got.RegistryIDs[0] != beID {
+		t.Fatalf("RegistryIDs = %v, want [%s]", got.RegistryIDs, beID)
+	}
+	if got.WeightFor(beID) != 40 {
+		t.Fatalf("WeightFor(%s) = %d, want 40", beID, got.WeightFor(beID))
+	}
+	if len(got.RoleIDs) != 0 {
+		t.Fatalf("RoleIDs = %v, want none", got.RoleIDs)
+	}
+}
+
+// TestRepository_UpdateReplacesRegistryLinks asserts Update persists the whole
+// association set: dropped registries are detached and order is rewritten.
+func TestRepository_UpdateReplacesRegistryLinks(t *testing.T) {
+	f := setupRepo(t)
+	ctx := context.Background()
+	gwID := seedGateway(t, f.gw, "replace-links")
+	first := seedRegistry(t, f.be, gwID, "replace-be-first")
+	second := seedRegistry(t, f.be, gwID, "replace-be-second")
+	third := seedRegistry(t, f.be, gwID, "replace-be-third")
+
+	c := validConsumer(t, gwID, "replace-consumer", first, second)
+	saveWithRegistries(t, f, c)
+
+	c.RegistryIDs = []ids.RegistryID{third, second}
+	if err := f.repo.Update(ctx, c, &domain.RegistryBindings{IDs: c.RegistryIDs}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	got, err := f.repo.FindByID(ctx, c.ID)
+	if err != nil {
+		t.Fatalf("FindByID: %v", err)
+	}
+	want := []ids.RegistryID{third, second}
+	if len(got.RegistryIDs) != len(want) {
+		t.Fatalf("RegistryIDs = %v, want %v", got.RegistryIDs, want)
+	}
+	for i := range want {
+		if got.RegistryIDs[i] != want[i] {
+			t.Fatalf("RegistryIDs = %v, want %v", got.RegistryIDs, want)
+		}
+	}
+}
+
 func TestRepository_SaveAndFindByID_RoundTripsFallback(t *testing.T) {
 	f := setupRepo(t)
 	ctx := context.Background()
@@ -603,7 +687,7 @@ func TestRepository_Update_RejectsRegistryReferenceAfterDetach(t *testing.T) {
 
 	c.ModelPolicies = domain.ModelPolicies{beID: {Allowed: []string{"gpt-4o"}}}
 	c.UpdatedAt = time.Now().UTC()
-	err := f.repo.Update(ctx, c)
+	err := f.repo.Update(ctx, c, nil)
 	if !errors.Is(err, registrydomain.ErrInvalidRegistryID) {
 		t.Fatalf("err = %v, want ErrInvalidRegistryID", err)
 	}
@@ -614,7 +698,7 @@ func TestRepository_Update_NotFound(t *testing.T) {
 	gwID := seedGateway(t, f.gw, "pool-u2")
 	beID := seedRegistry(t, f.be, gwID, "be-u2")
 	c := validConsumer(t, gwID, "ghost", beID)
-	err := f.repo.Update(context.Background(), c)
+	err := f.repo.Update(context.Background(), c, nil)
 	if !errors.Is(err, domain.ErrNotFound) {
 		t.Fatalf("err = %v, want ErrNotFound", err)
 	}

--- a/tests/functional/update_consumer_test.go
+++ b/tests/functional/update_consumer_test.go
@@ -153,6 +153,108 @@ func TestUpdateConsumer_Partial_EmptyTypePreservesExisting(t *testing.T) {
 	assert.Equal(t, "MCP", body["type"], "empty type must be treated as no-change, not reset to LLM")
 }
 
+// TestUpdateConsumer_SwitchRoleBasedToInlineWithRegistries covers the routing
+// switch a UI performs in one step: the registry links cannot be created before
+// the consumer leaves role_based mode, so they travel in the update body.
+func TestUpdateConsumer_SwitchRoleBasedToInlineWithRegistries(t *testing.T) {
+	defer Track(t, "UpdateConsumer")()
+	gwID := CreateGateway(t, map[string]any{"slug": uniqueName("co-upd-rb2inline-gw")})
+	beID := CreateRegistry(t, gwID, validRegistryPayload(uniqueName("co-upd-rb2inline-be")))
+	roleID := CreateRole(t, gwID, map[string]any{"name": uniqueName("co-upd-rb2inline-role")})
+	name := uniqueName("co-upd-rb2inline")
+	coID := CreateConsumer(t, gwID, map[string]any{
+		"name":         name,
+		"routing_mode": "role_based",
+		"roles":        []string{roleID},
+	})
+
+	// Attaching through the association endpoint is what fails while the
+	// consumer is still role_based.
+	status, body := sendRequest(t, http.MethodPost,
+		fmt.Sprintf("%s/v1/gateways/%s/consumers/%s/registries/%s", AdminURL, gwID, coID, beID),
+		nil, nil,
+	)
+	require.Equal(t, http.StatusConflict, status, "body=%v", body)
+
+	status, body = sendRequest(t, http.MethodPut,
+		fmt.Sprintf("%s/v1/gateways/%s/consumers/%s", AdminURL, gwID, coID),
+		nil, map[string]any{
+			"name":           name,
+			"routing_mode":   "inline",
+			"registries":     []map[string]any{{"id": beID, "weight": 40}},
+			"model_policies": []map[string]any{{"registry_id": beID, "default": "gpt-4o-mini"}},
+		},
+	)
+	require.Equal(t, http.StatusOK, status, "body=%v", body)
+
+	got := getConsumer(t, gwID, coID)
+	assert.Equal(t, "inline", got["routing_mode"])
+	assert.Empty(t, idSet(t, got, "role_ids"), "roles must be dropped on the switch to inline")
+	registries := idSet(t, got, "registry_ids")
+	require.Len(t, registries, 1)
+	assert.Contains(t, registries, beID)
+}
+
+// TestUpdateConsumer_RegistriesReplaceAssociationSet asserts the field is a full
+// replacement: registries missing from the list are detached.
+func TestUpdateConsumer_RegistriesReplaceAssociationSet(t *testing.T) {
+	defer Track(t, "UpdateConsumer")()
+	gwID := CreateGateway(t, map[string]any{"slug": uniqueName("co-upd-replace-gw")})
+	be1 := CreateRegistry(t, gwID, validRegistryPayload(uniqueName("co-upd-replace-be1")))
+	be2 := CreateRegistry(t, gwID, validRegistryPayload(uniqueName("co-upd-replace-be2")))
+	name := uniqueName("co-upd-replace")
+	coID := CreateConsumerWithRegistries(t, gwID, name, be1, be2)
+
+	status, body := sendRequest(t, http.MethodPut,
+		fmt.Sprintf("%s/v1/gateways/%s/consumers/%s", AdminURL, gwID, coID),
+		nil, map[string]any{"name": name, "registries": []map[string]any{{"id": be2}}},
+	)
+	require.Equal(t, http.StatusOK, status, "body=%v", body)
+
+	got := idSet(t, getConsumer(t, gwID, coID), "registry_ids")
+	require.Len(t, got, 1)
+	assert.Contains(t, got, be2)
+}
+
+// TestUpdateConsumer_RejectsRegistriesInRoleBasedMode keeps the invariant that a
+// role_based consumer never holds registry links.
+func TestUpdateConsumer_RejectsRegistriesInRoleBasedMode(t *testing.T) {
+	defer Track(t, "UpdateConsumer")()
+	gwID := CreateGateway(t, map[string]any{"slug": uniqueName("co-upd-rb-reg-gw")})
+	beID := CreateRegistry(t, gwID, validRegistryPayload(uniqueName("co-upd-rb-reg-be")))
+	name := uniqueName("co-upd-rb-reg")
+	coID := CreateConsumer(t, gwID, validConsumerPayload(name))
+
+	status, body := sendRequest(t, http.MethodPut,
+		fmt.Sprintf("%s/v1/gateways/%s/consumers/%s", AdminURL, gwID, coID),
+		nil, map[string]any{
+			"name":         name,
+			"routing_mode": "role_based",
+			"registries":   []map[string]any{{"id": beID}},
+		},
+	)
+	require.Equal(t, http.StatusUnprocessableEntity, status, "body=%v", body)
+	assert.Equal(t, "validation_failed", body["error"])
+}
+
+// TestUpdateConsumer_RejectsRegistryFromAnotherGateway keeps the association set
+// inside the gateway boundary.
+func TestUpdateConsumer_RejectsRegistryFromAnotherGateway(t *testing.T) {
+	defer Track(t, "UpdateConsumer")()
+	gwA := CreateGateway(t, map[string]any{"slug": uniqueName("co-upd-xgw-a")})
+	gwB := CreateGateway(t, map[string]any{"slug": uniqueName("co-upd-xgw-b")})
+	foreign := CreateRegistry(t, gwB, validRegistryPayload(uniqueName("co-upd-xgw-be")))
+	name := uniqueName("co-upd-xgw")
+	coID := CreateConsumer(t, gwA, validConsumerPayload(name))
+
+	status, body := sendRequest(t, http.MethodPut,
+		fmt.Sprintf("%s/v1/gateways/%s/consumers/%s", AdminURL, gwA, coID),
+		nil, map[string]any{"name": name, "registries": []map[string]any{{"id": foreign}}},
+	)
+	require.Equal(t, http.StatusUnprocessableEntity, status, "body=%v", body)
+	assert.Equal(t, "validation_failed", body["error"])
+}
+
 func TestUpdateConsumer_NotFound(t *testing.T) {
 	defer Track(t, "UpdateConsumer")()
 	gwID := CreateGateway(t, map[string]any{"slug": uniqueName("co-upd-missing-gw")})


### PR DESCRIPTION
## Summary

Switching a consumer between static (`inline`) and identity-based (`role_based`) routing returned `409 resource conflict`. The two halves of the change had to happen in separate requests and each order was rejected: `POST /consumers/{id}/registries/{registry_id}` refuses to attach while the consumer is still `role_based` (both in `associator.AttachRegistry` and in the `enforce_consumer_routing_mode` DB trigger), while switching the mode first drops the existing links.

`PUT /v1/gateways/{gateway_id}/consumers/{id}` now accepts an optional `registries` field, mirroring create, so the mode change and the association set land in a single transaction.

- Omitting `registries` leaves the current associations untouched; sending an empty list detaches every registry.
- Inside the transaction the `consumers` row is written **before** `consumer_registry`, because the routing-mode guard rejects registry rows while the consumer is still `role_based`.
- `Writer.Update` now takes the binding set explicitly. A `nil` value means "do not touch the links", which stops an unrelated update from silently re-attaching a registry that a concurrent detach had removed (this is what `TestRepository_Update_RejectsRegistryReferenceAfterDetach` guards).
- The two bare `ErrConflict` returns in `associator.go` now say which invariant broke and point at the atomic `PUT`. The original report was a log line that only said `resource conflict`.

## Notes for the reviewer

The diff is above the 400-line budget, but the production code is roughly 170 lines. The rest is tests (~450) and regenerated Swagger (~210). `docs/` was already stale on `develop`, so `make swagger` also picks up unrelated `smart_routing` fields. Happy to move the regeneration to its own PR if you prefer.

## Test plan

- [x] `go test ./pkg/...` — full unit suite green
- [x] `golangci-lint run ./pkg/...` — 0 issues
- [x] Repository integration tests against a real Postgres, covering the `role_based` → `inline` switch with registries and full replacement of the association set (this is where the DB trigger ordering is exercised)
- [x] Functional HTTP tests: the reported scenario (409 through the association endpoint, then 200 via the atomic PUT), full replacement, rejection of `registries` in `role_based` mode, and rejection of a registry from another gateway

Unrelated finding: the consumer functional suite cannot run end to end locally. `CreateGateway` puts every gateway under `tenant_id: functional-tenant` with `max_instances: 5`, so from the sixth gateway on the tests fail with `ratelimit: instance limit reached`. Reproduced on a clean `develop` checkout, so it predates this branch; the new tests were run in batches under that cap.

Made with [Cursor](https://cursor.com)