### PR TITLE
feat: accept gateway api key via Authorization and x-api-key

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -3269,7 +3269,7 @@ const docTemplate = `{
         },
         "/{consumer_slug}/v1/chat/completions": {
             "post": {
-                "description": "Forwards an OpenAI Chat Completions request to the selected provider. Proxy plane route: /{consumer_slug}/v1/chat/completions. Other fixed routes include /v1/messages (Anthropic) and /v1/responses (OpenAI Responses).",
+                "description": "Forwards an OpenAI Chat Completions request to the selected provider. Proxy plane route: /{consumer_slug}/v1/chat/completions. Other fixed routes include /v1/messages (Anthropic) and /v1/responses (OpenAI Responses). Inline consumers may authenticate with an api key via X-AG-API-Key, x-api-key, or Authorization: Bearer ag_….",
                 "consumes": [
                     "application/json"
                 ],
@@ -3296,7 +3296,13 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Bearer token for OAuth2 or OIDC consumers",
+                        "description": "API key for inline consumers (Anthropic-compatible clients)",
+                        "name": "x-api-key",
+                        "in": "header"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Bearer ag_… for inline api-key auth, or Bearer JWT for OAuth2/OIDC consumers",
                         "name": "Authorization",
                         "in": "header"
                     },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -3262,7 +3262,7 @@
         },
         "/{consumer_slug}/v1/chat/completions": {
             "post": {
-                "description": "Forwards an OpenAI Chat Completions request to the selected provider. Proxy plane route: /{consumer_slug}/v1/chat/completions. Other fixed routes include /v1/messages (Anthropic) and /v1/responses (OpenAI Responses).",
+                "description": "Forwards an OpenAI Chat Completions request to the selected provider. Proxy plane route: /{consumer_slug}/v1/chat/completions. Other fixed routes include /v1/messages (Anthropic) and /v1/responses (OpenAI Responses). Inline consumers may authenticate with an api key via X-AG-API-Key, x-api-key, or Authorization: Bearer ag_….",
                 "consumes": [
                     "application/json"
                 ],
@@ -3289,7 +3289,13 @@
                     },
                     {
                         "type": "string",
-                        "description": "Bearer token for OAuth2 or OIDC consumers",
+                        "description": "API key for inline consumers (Anthropic-compatible clients)",
+                        "name": "x-api-key",
+                        "in": "header"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Bearer ag_… for inline api-key auth, or Bearer JWT for OAuth2/OIDC consumers",
                         "name": "Authorization",
                         "in": "header"
                     },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2265,7 +2265,9 @@ paths:
       - application/json
       description: 'Forwards an OpenAI Chat Completions request to the selected provider.
         Proxy plane route: /{consumer_slug}/v1/chat/completions. Other fixed routes
-        include /v1/messages (Anthropic) and /v1/responses (OpenAI Responses).'
+        include /v1/messages (Anthropic) and /v1/responses (OpenAI Responses). Inline
+        consumers may authenticate with an api key via X-AG-API-Key, x-api-key, or
+        Authorization: Bearer ag_….'
       parameters:
       - description: Consumer slug
         in: path
@@ -2276,7 +2278,12 @@ paths:
         in: header
         name: X-AG-API-Key
         type: string
-      - description: Bearer token for OAuth2 or OIDC consumers
+      - description: API key for inline consumers (Anthropic-compatible clients)
+        in: header
+        name: x-api-key
+        type: string
+      - description: Bearer ag_… for inline api-key auth, or Bearer JWT for OAuth2/OIDC
+          consumers
         in: header
         name: Authorization
         type: string

--- a/pkg/api/handler/http/proxy/proxy_handler.go
+++ b/pkg/api/handler/http/proxy/proxy_handler.go
@@ -84,13 +84,14 @@ func NewForwardedHandler(forwarder appproxy.Forwarder) *ForwardedHandler {
 
 // Handle godoc
 // @Summary      Proxy chat completion
-// @Description  Forwards an OpenAI Chat Completions request to the selected provider. Proxy plane route: /{consumer_slug}/v1/chat/completions. Other fixed routes include /v1/messages (Anthropic) and /v1/responses (OpenAI Responses).
+// @Description  Forwards an OpenAI Chat Completions request to the selected provider. Proxy plane route: /{consumer_slug}/v1/chat/completions. Other fixed routes include /v1/messages (Anthropic) and /v1/responses (OpenAI Responses). Inline consumers may authenticate with an api key via X-AG-API-Key, x-api-key, or Authorization: Bearer ag_….
 // @Tags         proxy
 // @Accept       json
 // @Produce      json
 // @Param        consumer_slug      path   string  true   "Consumer slug"
 // @Param        X-AG-API-Key       header string  false  "API key for inline consumers"
-// @Param        Authorization      header string  false  "Bearer token for OAuth2 or OIDC consumers"
+// @Param        x-api-key          header string  false  "API key for inline consumers (Anthropic-compatible clients)"
+// @Param        Authorization      header string  false  "Bearer ag_… for inline api-key auth, or Bearer JWT for OAuth2/OIDC consumers"
 // @Param        X-AG-Gateway-Slug  header string  false  "Gateway slug when using header-based gateway discovery"
 // @Param        body               body   object  true   "OpenAI Chat Completions request body"
 // @Success      200                {object}  map[string]interface{}

--- a/pkg/api/middleware/auth.go
+++ b/pkg/api/middleware/auth.go
@@ -83,7 +83,7 @@ func (m *AuthMiddleware) Middleware() fiber.Handler {
 				slog.String("gateway_slug", gw.Slug),
 				slog.String("consumer_slug", route.ConsumerSlug),
 				slog.String("error", err.Error()))
-			if errors.Is(err, resolver.ErrUnauthenticated) && apiKeyAttachedElsewhere(c.Get(resolver.HeaderAPIKey), data, rc) {
+			if errors.Is(err, resolver.ErrUnauthenticated) && apiKeyAttachedElsewhere(resolver.APIKeyFromRequest(c), data, rc) {
 				return forbidden(c, resolver.ErrForbidden)
 			}
 			return writeAuthError(c, err)

--- a/pkg/api/middleware/auth_resolver_test.go
+++ b/pkg/api/middleware/auth_resolver_test.go
@@ -129,6 +129,91 @@ func TestAuthMiddleware_APIKeyInlineSuccess(t *testing.T) {
 	require.Equal(t, fiber.StatusOK, resp.StatusCode)
 }
 
+func TestAuthMiddleware_APIKeyBearerInlineSuccess(t *testing.T) {
+	t.Parallel()
+	gw, rc, rawKey := inlineConsumerWithAPIKey(t)
+	app := newAuthTestApp(t, gw, appconsumer.NewData(gw.ID, []appconsumer.RoutableConsumer{rc}), fakeOAuth2Verifier{}, fakeOIDCVerifier{}, nil)
+
+	req := httptest.NewRequest(fiber.MethodPost, "/cons1234/v1/chat/completions", nil)
+	req.Host = "acme.gw.neuraltrust.ai"
+	req.Header.Set(fiber.HeaderAuthorization, "Bearer "+rawKey)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+}
+
+func TestAuthMiddleware_APIKeyCompatHeaderInlineSuccess(t *testing.T) {
+	t.Parallel()
+	gw, rc, rawKey := inlineConsumerWithAPIKey(t)
+	app := newAuthTestApp(t, gw, appconsumer.NewData(gw.ID, []appconsumer.RoutableConsumer{rc}), fakeOAuth2Verifier{}, fakeOIDCVerifier{}, nil)
+
+	req := httptest.NewRequest(fiber.MethodPost, "/cons1234/v1/chat/completions", nil)
+	req.Host = "acme.gw.neuraltrust.ai"
+	req.Header.Set(resolver.HeaderAPIKeyCompat, rawKey)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+}
+
+func TestAuthMiddleware_APIKeyBearerUnknownUnauthorized(t *testing.T) {
+	t.Parallel()
+	gw, rc, _ := inlineConsumerWithAPIKey(t)
+	app := newAuthTestApp(t, gw, appconsumer.NewData(gw.ID, []appconsumer.RoutableConsumer{rc}), fakeOAuth2Verifier{}, fakeOIDCVerifier{}, nil)
+
+	req := httptest.NewRequest(fiber.MethodPost, "/cons1234/v1/chat/completions", nil)
+	req.Host = "acme.gw.neuraltrust.ai"
+	req.Header.Set(fiber.HeaderAuthorization, "Bearer ag_unknown")
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestAuthMiddleware_APIKeyBearerValidElsewhereForbidden(t *testing.T) {
+	t.Parallel()
+	gw, rc, _ := inlineConsumerWithAPIKey(t)
+	otherRawKey := "ag_other"
+	otherAuthID := ids.New[ids.AuthKind]()
+	otherRC := appconsumer.RoutableConsumer{
+		Consumer: &consumerdomain.Consumer{
+			ID:          ids.New[ids.ConsumerKind](),
+			GatewayID:   gw.ID,
+			Slug:        "other123",
+			RoutingMode: consumerdomain.RoutingModeInline,
+			Active:      true,
+			AuthIDs:     []ids.AuthID{otherAuthID},
+		},
+		Auths: []*authdomain.Auth{{
+			ID:        otherAuthID,
+			GatewayID: gw.ID,
+			Type:      authdomain.TypeAPIKey,
+			Enabled:   true,
+			KeyHash:   authdomain.HashAPIKey(otherRawKey),
+		}},
+	}
+	data := appconsumer.NewData(gw.ID, []appconsumer.RoutableConsumer{rc, otherRC})
+	app := newAuthTestApp(t, gw, data, fakeOAuth2Verifier{}, fakeOIDCVerifier{}, nil)
+
+	req := httptest.NewRequest(fiber.MethodPost, "/cons1234/v1/chat/completions", nil)
+	req.Host = "acme.gw.neuraltrust.ai"
+	req.Header.Set(fiber.HeaderAuthorization, "Bearer "+otherRawKey)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusForbidden, resp.StatusCode)
+}
+
+func TestAuthMiddleware_APIKeyBearerRoleBasedForbidden(t *testing.T) {
+	t.Parallel()
+	gw, rc, rawKey := roleBasedConsumerWithAPIKey(t)
+	app := newAuthTestApp(t, gw, appconsumer.NewData(gw.ID, []appconsumer.RoutableConsumer{rc}), fakeOAuth2Verifier{}, fakeOIDCVerifier{}, nil)
+
+	req := httptest.NewRequest(fiber.MethodPost, "/cons1234/v1/chat/completions", nil)
+	req.Host = "acme.gw.neuraltrust.ai"
+	req.Header.Set(fiber.HeaderAuthorization, "Bearer "+rawKey)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusForbidden, resp.StatusCode)
+}
+
 func TestAuthMiddleware_APIKeyValidElsewhereForbidden(t *testing.T) {
 	t.Parallel()
 	gw, rc, _ := inlineConsumerWithAPIKey(t)
@@ -430,6 +515,31 @@ func inlineConsumerWithAPIKey(t *testing.T) (*gatewaydomain.Gateway, appconsumer
 			GatewayID:   gw.ID,
 			Slug:        "cons1234",
 			RoutingMode: consumerdomain.RoutingModeInline,
+			Active:      true,
+			AuthIDs:     []ids.AuthID{authID},
+		},
+		Auths: []*authdomain.Auth{{
+			ID:        authID,
+			GatewayID: gw.ID,
+			Type:      authdomain.TypeAPIKey,
+			Enabled:   true,
+			KeyHash:   authdomain.HashAPIKey(rawKey),
+		}},
+	}
+	return gw, rc, rawKey
+}
+
+func roleBasedConsumerWithAPIKey(t *testing.T) (*gatewaydomain.Gateway, appconsumer.RoutableConsumer, string) {
+	t.Helper()
+	gw := &gatewaydomain.Gateway{ID: ids.New[ids.GatewayKind](), Slug: "acme"}
+	authID := ids.New[ids.AuthKind]()
+	rawKey := "ag_secret"
+	rc := appconsumer.RoutableConsumer{
+		Consumer: &consumerdomain.Consumer{
+			ID:          ids.New[ids.ConsumerKind](),
+			GatewayID:   gw.ID,
+			Slug:        "cons1234",
+			RoutingMode: consumerdomain.RoutingModeRoleBased,
 			Active:      true,
 			AuthIDs:     []ids.AuthID{authID},
 		},

--- a/pkg/api/resolver/api_key_resolver.go
+++ b/pkg/api/resolver/api_key_resolver.go
@@ -34,7 +34,7 @@ func (r *APIKeyIdentityResolver) Resolve(
 	gw *gatewaydomain.Gateway,
 	rc *appconsumer.RoutableConsumer,
 ) (*appauth.AuthContext, error) {
-	rawKey := c.Get(HeaderAPIKey)
+	rawKey := APIKeyFromRequest(c)
 	if rawKey == "" {
 		return nil, ErrUnauthenticated
 	}

--- a/pkg/api/resolver/api_key_source.go
+++ b/pkg/api/resolver/api_key_source.go
@@ -1,0 +1,48 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolver
+
+import (
+	"strings"
+
+	authdomain "github.com/NeuralTrust/TrustGate/pkg/domain/auth"
+	"github.com/gofiber/fiber/v2"
+)
+
+// HeaderAPIKeyCompat is the Anthropic-style header some OpenAI-compatible
+// clients (Claude Code, etc.) use when they can only send an api key and not
+// custom headers.
+const HeaderAPIKeyCompat = "x-api-key"
+
+// APIKeyFromRequest returns the gateway api key presented by the caller, or
+// an empty string when none is present. Precedence is X-AG-API-Key, then
+// x-api-key, then Authorization: Bearer when the token carries the TrustGate
+// api-key prefix. A bearer without that prefix is left for OAuth2/OIDC.
+func APIKeyFromRequest(c *fiber.Ctx) string {
+	if key := strings.TrimSpace(c.Get(HeaderAPIKey)); key != "" {
+		return key
+	}
+	if key := strings.TrimSpace(c.Get(HeaderAPIKeyCompat)); key != "" {
+		return key
+	}
+	token, err := bearerToken(c.Get(fiber.HeaderAuthorization))
+	if err != nil {
+		return ""
+	}
+	if !authdomain.HasAPIKeyPrefix(token) {
+		return ""
+	}
+	return token
+}

--- a/pkg/api/resolver/chained_resolver.go
+++ b/pkg/api/resolver/chained_resolver.go
@@ -54,7 +54,7 @@ func (r ChainedIdentityResolver) Resolve(
 	if c.Get(HeaderPlaygroundToken) != "" {
 		return r.playground.Resolve(c, gw, rc)
 	}
-	if c.Get(HeaderAPIKey) != "" {
+	if APIKeyFromRequest(c) != "" {
 		return r.apiKey.Resolve(c, gw, rc)
 	}
 	if strings.TrimSpace(c.Get(fiber.HeaderAuthorization)) == "" {

--- a/pkg/domain/auth/auth.go
+++ b/pkg/domain/auth/auth.go
@@ -133,6 +133,13 @@ func HashAPIKey(raw string) string {
 	return hex.EncodeToString(sum[:])
 }
 
+// HasAPIKeyPrefix reports whether raw looks like a generated TrustGate api key
+// (the "ag_" marker). Used by the proxy to tell api keys apart from JWTs when
+// both travel in Authorization: Bearer.
+func HasAPIKeyPrefix(raw string) bool {
+	return strings.HasPrefix(raw, apiKeyPrefix)
+}
+
 // APIKeyPreview returns the non-secret head and tail of a generated api key.
 // Empty strings are returned when the key is too short to split safely.
 func APIKeyPreview(raw string) (prefix, suffix string) {

--- a/pkg/domain/auth/auth_test.go
+++ b/pkg/domain/auth/auth_test.go
@@ -136,6 +136,19 @@ func TestHashAPIKey_Deterministic(t *testing.T) {
 	}
 }
 
+func TestHasAPIKeyPrefix(t *testing.T) {
+	t.Parallel()
+	if !HasAPIKeyPrefix("ag_secret") {
+		t.Fatal("generated api keys must match the prefix")
+	}
+	if HasAPIKeyPrefix("eyJhbGciOiJIUzI1NiJ9.payload.sig") {
+		t.Fatal("JWTs must not match the api-key prefix")
+	}
+	if HasAPIKeyPrefix("") {
+		t.Fatal("empty string must not match the prefix")
+	}
+}
+
 func TestNewAuth_Validation(t *testing.T) {
 	t.Parallel()
 	gwID := ids.New[ids.GatewayKind]()

--- a/tests/functional/proxy_e2e_test.go
+++ b/tests/functional/proxy_e2e_test.go
@@ -26,6 +26,7 @@ type fakeUpstream struct {
 	hits     int64
 	mu       sync.Mutex
 	lastBody []byte
+	lastAuth string
 }
 
 func (u *fakeUpstream) URL() string { return u.server.URL }
@@ -38,11 +39,18 @@ func (u *fakeUpstream) LastBody() []byte {
 	return u.lastBody
 }
 
+func (u *fakeUpstream) LastAuth() string {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return u.lastAuth
+}
+
 func (u *fakeUpstream) record(r *http.Request) {
 	atomic.AddInt64(&u.hits, 1)
 	body, _ := io.ReadAll(r.Body)
 	u.mu.Lock()
 	u.lastBody = body
+	u.lastAuth = r.Header.Get("Authorization")
 	u.mu.Unlock()
 }
 
@@ -174,16 +182,23 @@ func expectedAttempts() int {
 // status, response headers and the full (buffered or streamed) body.
 func proxyPost(t *testing.T, apiKey, path string, body any) (int, http.Header, []byte) {
 	t.Helper()
+	return proxyPostWithAuth(t, apiKey, path, body, proxyAPIKeyHeader, apiKey)
+}
+
+// proxyPostWithAuth is like proxyPost but lets the caller choose which header
+// carries the gateway api key (X-AG-API-Key, Authorization, or x-api-key).
+func proxyPostWithAuth(t *testing.T, hostKey, path string, body any, authHeader, authValue string) (int, http.Header, []byte) {
+	t.Helper()
 	buf, err := json.Marshal(body)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodPost, ProxyURL+path, bytes.NewReader(buf))
 	require.NoError(t, err)
-	host, ok := proxyHosts.Load(apiKey)
+	host, ok := proxyHosts.Load(hostKey)
 	require.True(t, ok, "proxy host missing for api key")
 	req.Host = host.(string)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set(proxyAPIKeyHeader, apiKey)
+	req.Header.Set(authHeader, authValue)
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
@@ -241,6 +256,36 @@ func TestProxyE2E_NonStreaming_NoLB(t *testing.T) {
 		assert.Equal(t, http.StatusInternalServerError, status, "the final upstream error is relayed, body: %s", body)
 		assert.Equal(t, expectedAttempts(), up.Hits(), "every attempt (first + retries) must reach the upstream")
 	})
+}
+
+// TestProxyE2E_APIKeyAuthHeaders checks that the same gateway api key authenticates
+// when presented via X-AG-API-Key, Authorization: Bearer, or x-api-key, and that
+// the registry credential (not the gateway key) is what reaches the upstream.
+func TestProxyE2E_APIKeyAuthHeaders(t *testing.T) {
+	defer Track(t, "ProxyE2E")()
+
+	up := newJSONUpstream(t, "auth-header-ok")
+	apiKey, path := setupRoute(t, "", up)
+
+	cases := []struct {
+		name   string
+		header string
+		value  string
+	}{
+		{name: "X-AG-API-Key", header: proxyAPIKeyHeader, value: apiKey},
+		{name: "Authorization Bearer", header: "Authorization", value: "Bearer " + apiKey},
+		{name: "x-api-key", header: "x-api-key", value: apiKey},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			status, _, body := proxyPostWithAuth(t, apiKey, path, chatRequest(false), tc.header, tc.value)
+			assert.Equal(t, http.StatusOK, status, "body: %s", body)
+			assert.Contains(t, string(body), "auth-header-ok")
+			assert.Equal(t, "Bearer sk-test", up.LastAuth(),
+				"upstream must receive the registry credential, not the gateway api key")
+		})
+	}
+	assert.Equal(t, len(cases), up.Hits())
 }
 
 func TestProxyE2E_Streaming_NoLB(t *testing.T) {


### PR DESCRIPTION
## Summary

Clients like Cursor or Claude can override the OpenAI base URL but cannot send custom headers — only an api key field, which becomes `Authorization: Bearer <key>` (OpenAI-style) or `x-api-key` (Anthropic-style). TrustGate previously only accepted the gateway api key via `X-AG-API-Key`, so those clients could not authenticate against the proxy.

The proxy LLM plane now accepts the same TrustGate api key from three headers, with explicit precedence:

1. `X-AG-API-Key`
2. `x-api-key`
3. `Authorization: Bearer ag_…`

Bearer values without the `ag_` prefix still go to OAuth2/OIDC, so existing JWT consumers are unchanged. Validation (hash match against attached auths, rejection on `role_based`) is identical.

## Test plan

- [x] Unit tests for bearer / `x-api-key` success, unknown key → 401, key of another consumer → 403, `role_based` → 403
- [x] Existing OAuth2/OIDC middleware tests still pass (no JWT regression)
- [x] Functional `TestProxyE2E_APIKeyAuthHeaders`: same request authenticated via all three headers; upstream receives the registry credential (`Bearer sk-test`), not the gateway api key
- [x] `golangci-lint` clean on touched packages

Made with [Cursor](https://cursor.com)