### PR TITLE
fix: suppress CodeQL false positive on HashAPIKey

### DIFF
--- a/pkg/domain/auth/auth.go
+++ b/pkg/domain/auth/auth.go
@@ -128,8 +128,14 @@ func GenerateAPIKey() (string, error) {
 	return apiKeyPrefix + base64.RawURLEncoding.EncodeToString(buf), nil
 }
 
+// HashAPIKey returns a deterministic SHA-256 hex digest of an opaque api key for
+// exact-match storage and lookup. This is not password hashing: callers present
+// the full key and we look up by digest, so a slow KDF (bcrypt/scrypt/argon2)
+// would break authentication without improving the threat model.
+//
+// codeql[go/weak-sensitive-data-hashing]
 func HashAPIKey(raw string) string {
-	sum := sha256.Sum256([]byte(raw))
+	sum := sha256.Sum256([]byte(raw)) // codeql[go/weak-sensitive-data-hashing]
 	return hex.EncodeToString(sum[:])
 }
 


### PR DESCRIPTION
## Summary

[PR #365](https://github.com/NeuralTrust/TrustGate/pull/365) (develop → main) failed CodeQL on `pkg/domain/auth/auth.go`: `go/weak-sensitive-data-hashing` against `HashAPIKey`.

That function hashes opaque API keys for exact-match lookup, not passwords. A slow KDF would break auth without improving the threat model. The alert was dismissed as a false positive on the security advisory; this PR documents the rationale and adds an inline CodeQL suppression so future touches of the file do not reopen the failure.

## Test plan

- [x] Alert #16 dismissed as false positive
- [x] PR #365 checks already green after dismissal
- [ ] CodeQL on this PR stays clean

Made with [Cursor](https://cursor.com)