### PR TITLE
fix(token_rate_limiter): drop settings and headers that never took effect

### DIFF
--- a/docs/policies.json
+++ b/docs/policies.json
@@ -238,13 +238,6 @@
                 "description": "Target model used when behavior is downgrade_model. Must be on the same provider."
               },
               {
-                "key": "stream_usage_injection",
-                "label": "Stream Usage Injection",
-                "type": "boolean",
-                "description": "Request and inject usage on streaming responses so accrual works on streams.",
-                "default": false
-              },
-              {
                 "key": "count_cache_reads",
                 "label": "Count Cache Reads",
                 "type": "boolean",

--- a/pkg/app/plugins/catalog_metadata.go
+++ b/pkg/app/plugins/catalog_metadata.go
@@ -225,13 +225,6 @@ var pluginCatalogMeta = map[string]catalogMeta{
 					Description: "Target model used when behavior is downgrade_model. Must be on the same provider.",
 				},
 				{
-					Key:         "stream_usage_injection",
-					Label:       "Stream Usage Injection",
-					Type:        FieldTypeBoolean,
-					Description: "Request and inject usage on streaming responses so accrual works on streams.",
-					Default:     false,
-				},
-				{
 					Key:         "count_cache_reads",
 					Label:       "Count Cache Reads",
 					Type:        FieldTypeBoolean,

--- a/pkg/app/plugins/catalog_test.go
+++ b/pkg/app/plugins/catalog_test.go
@@ -246,10 +246,15 @@ func TestTokenRateLimiterSchema_BudgetTree(t *testing.T) {
 	assert.Equal(t, []string{"reject", "downgrade_model"}, enumValues(behavior.Enum))
 	assert.Equal(t, []string{"Reject", "Downgrade Model"}, enumLabels(behavior.Enum))
 
-	for _, k := range []string{"downgrade_to", "stream_usage_injection", "count_cache_reads", "custom_pricing", "group_by_header"} {
+	for _, k := range []string{"downgrade_to", "count_cache_reads", "custom_pricing", "group_by_header"} {
 		_, ok := fieldByKey(fields, k)
 		assert.Truef(t, ok, "missing top-level field %q", k)
 	}
+
+	// The proxy always asks OpenAI-format upstreams for streaming usage, so the
+	// budget has no switch of its own to offer.
+	_, ok = fieldByKey(fields, "stream_usage_injection")
+	assert.False(t, ok, "stream_usage_injection must not be advertised")
 
 	// Cost cap, the legacy window block, per_model and pricing_table moved out
 	// of the budget catalog schema even though their parsing is preserved.

--- a/pkg/infra/plugins/tokenratelimit/budget.go
+++ b/pkg/infra/plugins/tokenratelimit/budget.go
@@ -21,7 +21,6 @@ import (
 	"log/slog"
 	"math"
 	"net/http"
-	"strconv"
 
 	appplugins "github.com/NeuralTrust/TrustGate/pkg/app/plugins"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/policy"
@@ -293,6 +292,9 @@ func tokensRemaining(max float64, consumed int64) int {
 	return r
 }
 
+// accrue charges the windows once the answer is known. It reports through the
+// event only: the post-response stage runs after the response has been sent, so
+// any header it returned would be written to a snapshot nobody reads.
 func (p *Plugin) accrue(
 	ctx context.Context,
 	cfg *config,
@@ -335,8 +337,6 @@ func (p *Plugin) accrue(
 	if remaining < 0 {
 		remaining = 0
 	}
-	headers := rateLimitHeaders(limit, remaining, p.resetSeconds(ctx, primary.key, primary.windowSec))
-	headers["X-Tokens-Consumed"] = []string{strconv.Itoa(tokens)}
 
 	provider := ""
 	if req != nil {
@@ -353,7 +353,7 @@ func (p *Plugin) accrue(
 		TokensRemaining: remaining,
 		Model:           model,
 	})
-	return &appplugins.Result{StatusCode: http.StatusOK, Headers: headers}, nil
+	return &appplugins.Result{StatusCode: http.StatusOK}, nil
 }
 
 func (p *Plugin) accrueDollars(

--- a/pkg/infra/plugins/tokenratelimit/config.go
+++ b/pkg/infra/plugins/tokenratelimit/config.go
@@ -56,19 +56,18 @@ type aggregateConfig struct {
 }
 
 type config struct {
-	Unit                 string                         `mapstructure:"unit"`
-	PerModel             bool                           `mapstructure:"per_model"`
-	Counting             string                         `mapstructure:"counting"`
-	Rules                []budgetRule                   `mapstructure:"rules"`
-	Aggregate            *aggregateConfig               `mapstructure:"aggregate"`
-	BehaviorOnExceeded   string                         `mapstructure:"behavior_on_exceeded"`
-	DowngradeTo          string                         `mapstructure:"downgrade_to"`
-	StreamUsageInjection bool                           `mapstructure:"stream_usage_injection"`
-	CountCacheReads      bool                           `mapstructure:"count_cache_reads"`
-	CostCap              *llmcost.CapConfig             `mapstructure:"cost_cap"`
-	CustomPricing        map[string]llmcost.CustomPrice `mapstructure:"custom_pricing"`
-	Window               windowConfig                   `mapstructure:"window"`
-	GroupByHeader        string                         `mapstructure:"group_by_header"`
+	Unit               string                         `mapstructure:"unit"`
+	PerModel           bool                           `mapstructure:"per_model"`
+	Counting           string                         `mapstructure:"counting"`
+	Rules              []budgetRule                   `mapstructure:"rules"`
+	Aggregate          *aggregateConfig               `mapstructure:"aggregate"`
+	BehaviorOnExceeded string                         `mapstructure:"behavior_on_exceeded"`
+	DowngradeTo        string                         `mapstructure:"downgrade_to"`
+	CountCacheReads    bool                           `mapstructure:"count_cache_reads"`
+	CostCap            *llmcost.CapConfig             `mapstructure:"cost_cap"`
+	CustomPricing      map[string]llmcost.CustomPrice `mapstructure:"custom_pricing"`
+	Window             windowConfig                   `mapstructure:"window"`
+	GroupByHeader      string                         `mapstructure:"group_by_header"`
 }
 
 var validUnits = map[string]int{

--- a/pkg/infra/plugins/tokenratelimit/plugin_budget_test.go
+++ b/pkg/infra/plugins/tokenratelimit/plugin_budget_test.go
@@ -161,7 +161,10 @@ func TestPlugin_PerModel_CountingOutput(t *testing.T) {
 	reqA := &infracontext.RequestContext{Provider: "openai", SourceFormat: "openai", Body: []byte(`{"model":"model-a"}`)}
 	resp := &infracontext.ResponseContext{StatusCode: 200, Body: usageResponseBody()}
 
-	res, err := p.Execute(context.Background(), input(policy.StagePostResponse, settings, reqA, resp))
+	_, err := p.Execute(context.Background(), input(policy.StagePostResponse, settings, reqA, resp))
 	require.NoError(t, err)
-	assert.Equal(t, []string{"5"}, res.Headers["X-Tokens-Consumed"], "only output tokens are counted")
+
+	res, err := p.Execute(context.Background(), input(policy.StagePreRequest, settings, reqA, &infracontext.ResponseContext{}))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"1"}, res.Headers["X-Ratelimit-Remaining-Tokens"], "only output tokens are counted")
 }

--- a/pkg/infra/plugins/tokenratelimit/plugin_test.go
+++ b/pkg/infra/plugins/tokenratelimit/plugin_test.go
@@ -110,10 +110,8 @@ func TestPlugin_PostResponse_RecordsTokensAndPreRequestRejects(t *testing.T) {
 	body := []byte(`{"id":"x","model":"gpt","choices":[{"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`)
 	resp := &infracontext.ResponseContext{StatusCode: 200, Body: body}
 
-	res, err := p.Execute(context.Background(), input(policy.StagePostResponse, settings, req, resp))
+	_, err := p.Execute(context.Background(), input(policy.StagePostResponse, settings, req, resp))
 	require.NoError(t, err)
-	assert.Equal(t, []string{"15"}, res.Headers["X-Tokens-Consumed"])
-	assert.Equal(t, []string{"0"}, res.Headers["X-Ratelimit-Remaining-Tokens"])
 
 	// Now the next PreRequest must reject (15 consumed >= 10 limit).
 	_, err = p.Execute(context.Background(), input(policy.StagePreRequest, settings, req, &infracontext.ResponseContext{}))
@@ -152,9 +150,12 @@ func TestPlugin_PostResponse_StreamingUsesObservedUsage(t *testing.T) {
 	}
 	resp := &infracontext.ResponseContext{StatusCode: 200, Streaming: true}
 
-	res, err := p.Execute(context.Background(), input(policy.StagePostResponse, settings, req, resp))
+	_, err := p.Execute(context.Background(), input(policy.StagePostResponse, settings, req, resp))
 	require.NoError(t, err)
-	assert.Equal(t, []string{"42"}, res.Headers["X-Tokens-Consumed"])
+
+	res, err := p.Execute(context.Background(), input(policy.StagePreRequest, settings, req, &infracontext.ResponseContext{}))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"58"}, res.Headers["X-Ratelimit-Remaining-Tokens"], "the streamed usage must be charged")
 }
 
 func TestPlugin_PostResponse_NoTokensNoRecord(t *testing.T) {
@@ -163,9 +164,12 @@ func TestPlugin_PostResponse_NoTokensNoRecord(t *testing.T) {
 	req := &infracontext.RequestContext{Provider: "openai", SourceFormat: "openai"}
 	resp := &infracontext.ResponseContext{StatusCode: 200, Body: []byte(`{}`)}
 
-	res, err := p.Execute(context.Background(), input(policy.StagePostResponse, settings, req, resp))
+	_, err := p.Execute(context.Background(), input(policy.StagePostResponse, settings, req, resp))
 	require.NoError(t, err)
-	assert.Empty(t, res.Headers["X-Tokens-Consumed"])
+
+	res, err := p.Execute(context.Background(), input(policy.StagePreRequest, settings, req, &infracontext.ResponseContext{}))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"100"}, res.Headers["X-Ratelimit-Remaining-Tokens"], "a response without usage must charge nothing")
 }
 
 func scopedInput(stage policy.Stage, settings map[string]any, req *infracontext.RequestContext, resp *infracontext.ResponseContext, scope appplugins.RuntimeScope) appplugins.ExecInput {


### PR DESCRIPTION
## Summary

Two parts of the LLM Budget contract promised something the gateway never delivered. Both were found while building the plugin e2e suite in `multi-agent-tests`, which sweeps the whole option surface of `token_rate_limiter` against a real gateway.

**`stream_usage_injection` was a no-op setting.** It is advertised in the catalog (so it renders as a switch in the console) and parsed into the config, but nothing ever reads it. The behaviour it describes already happens unconditionally: `injectStreamIncludeUsage` forces `stream_options.include_usage: true` on every streaming request to an OpenAI-format upstream (`pkg/app/proxy/provider.go`). Turning the switch off did not disable anything. It is removed from the config struct, the catalog schema and `docs/policies.json`.

This is backward compatible. `pluginutil.Decode` runs with `ErrorUnused: false`, so policies whose settings still carry the key keep validating — the key is ignored, exactly as it already was in practice.

**The headers returned by `accrue()` could not reach a client.** `X-Tokens-Consumed`, plus the limit/remaining recomputed after the call, were built at the post-response stage. That stage runs in a goroutine after the answer has already been written, over a snapshot whose `Headers` field is explicitly set to `nil` and discarded when the stage ends (`snapshotResponse` in `pkg/app/proxy/plugin_runner.go`). The values died there. They are removed, and a note on `accrue` records the constraint so they do not come back.

Nothing observable is lost: the same counts already travel in the telemetry event as `TokensActual`, `TokensConsumed` and `TokensRemaining`, and the pre-request stage still reports `X-Ratelimit-*` / `X-Budget-*` to the caller as before.

`token_rate_limiter` was the only plugin affected — `trustguard` returns no headers, and every header-emitting result in `semanticcache` (`X-Cache`, `X-Cache-Status`) is produced at pre-request, so those still reach the client.

## Tests

Three unit tests asserted accrual through `X-Tokens-Consumed`, i.e. through an internal artifact that no client could see. They now assert the observable behaviour instead — that the next pre-request sees the counter charged:

- a streamed answer of 42 tokens leaves 58 of a 100 budget
- counting `output` charges 5 of a 6-token per-model rule, leaving 1
- a response with no usage charges nothing, leaving the budget at 100

## Test plan

- [x] `go build ./...`, `go vet ./pkg/...`
- [x] `go test ./pkg/infra/plugins/tokenratelimit/... ./pkg/app/plugins/...`
- [x] `golangci-lint run` on both packages — 0 issues
- [x] Full pre-commit suite (lint + gosec + tests)
- [ ] Console: confirm the budget form no longer shows the Stream Usage Injection switch
- [ ] Existing policy carrying `stream_usage_injection` still saves and runs

## Linear

No issue — found while writing the plugin e2e suite.

Made with [Cursor](https://cursor.com)