### PR TITLE
fix: Bedrock model family routing and token/cost accounting

### DIFF
--- a/pkg/app/catalog/slug.go
+++ b/pkg/app/catalog/slug.go
@@ -14,6 +14,15 @@
 
 package catalog
 
+import "strings"
+
+// inferenceProfilePrefixes are the geographies AWS puts in front of a Bedrock
+// model ID to name a cross-region inference profile, which is the only way to
+// invoke many newer models. The catalog stores the bare ID (and a "global."
+// twin), so a request routed through a regional profile finds no price — and
+// therefore no cost, and no dollar budget — unless the geography is dropped.
+var inferenceProfilePrefixes = []string{"us.", "eu.", "apac.", "us-gov.", "jp.", "au.", "ca."}
+
 func SlugCandidates(models ...string) []string {
 	var slugs []string
 	for _, model := range models {
@@ -26,11 +35,28 @@ func appendModelSlugs(dst []string, model string) []string {
 	if model == "" {
 		return dst
 	}
+	dst = appendDated(dst, model)
+	if bare := withoutInferenceProfile(model); bare != model {
+		dst = appendDated(dst, bare)
+	}
+	return dst
+}
+
+func appendDated(dst []string, model string) []string {
 	dst = append(dst, model)
 	if base := DeploymentCatalogSlug(model); base != model {
 		dst = append(dst, base)
 	}
 	return dst
+}
+
+func withoutInferenceProfile(model string) string {
+	for _, geography := range inferenceProfilePrefixes {
+		if strings.HasPrefix(model, geography) {
+			return model[len(geography):]
+		}
+	}
+	return model
 }
 
 func DeploymentCatalogSlug(model string) string {

--- a/pkg/app/catalog/slug_test.go
+++ b/pkg/app/catalog/slug_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package catalog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSlugCandidates(t *testing.T) {
+	tests := []struct {
+		name   string
+		models []string
+		want   []string
+	}{
+		{
+			name:   "a regional inference profile also tries the bare model",
+			models: []string{"eu.amazon.nova-lite-v1:0"},
+			want:   []string{"eu.amazon.nova-lite-v1:0", "amazon.nova-lite-v1:0"},
+		},
+		{
+			// Bedrock writes the date without separators, so only the
+			// geography comes off — the deployment-date rule needs dashes.
+			name:   "a dated Bedrock profile only loses its geography",
+			models: []string{"us.anthropic.claude-haiku-4-5-20251001-v1:0"},
+			want: []string{
+				"us.anthropic.claude-haiku-4-5-20251001-v1:0",
+				"anthropic.claude-haiku-4-5-20251001-v1:0",
+			},
+		},
+		{
+			name:   "a dated deployment still drops its date",
+			models: []string{"gpt-4o-2024-05-13"},
+			want:   []string{"gpt-4o-2024-05-13", "gpt-4o"},
+		},
+		{
+			name:   "a model that only looks prefixed keeps its name",
+			models: []string{"mistral.devstral-2-123b"},
+			want:   []string{"mistral.devstral-2-123b"},
+		},
+		{
+			name:   "duplicates across models collapse",
+			models: []string{"eu.amazon.nova-lite-v1:0", "amazon.nova-lite-v1:0", ""},
+			want:   []string{"eu.amazon.nova-lite-v1:0", "amazon.nova-lite-v1:0"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, SlugCandidates(tc.models...))
+		})
+	}
+}

--- a/pkg/infra/providers/adapter/bedrock_adapter.go
+++ b/pkg/infra/providers/adapter/bedrock_adapter.go
@@ -31,6 +31,7 @@ type BedrockAdapter struct {
 	titan   bedrockTitanAdapter
 	llama   bedrockLlamaAdapter
 	mistral bedrockMistralAdapter
+	nova    bedrockNovaAdapter
 }
 
 // ---------------------------------------------------------------------------
@@ -39,58 +40,123 @@ type BedrockAdapter struct {
 
 const (
 	bfClaude  = "claude"
-	bfOpenAI  = "openai" // DeepSeek, AI21 Jamba, etc.
+	bfOpenAI  = "openai" // DeepSeek, AI21 Jamba, newer Mistral, etc.
 	bfTitan   = "titan"
 	bfLlama   = "llama"
 	bfMistral = "mistral"
+	bfNova    = "nova"
 )
 
-// detectFamilyByModel returns the model family from a Bedrock model ID.
+// legacyMistralModels are the Mistral models whose Bedrock schema is the text
+// completion one (a single "prompt" string). Every other Mistral model — the
+// 2025 generation onwards: devstral, magistral, ministral 3, mistral large 3,
+// voxtral, pixtral — speaks the chat completions schema and answers "missing
+// field `messages`" if given a prompt. mistral-7b and mixtral are the mirror
+// image: they answer "Messages not supported for this model".
+var legacyMistralModels = []string{
+	"mistral-7b-instruct",
+	"mixtral-8x7b-instruct",
+	"mistral-large-2402",
+	"mistral-small-2402",
+}
+
+// openAICompatibleVendors are the Bedrock vendors whose InvokeModel schema is
+// the OpenAI chat completions one — {"messages":[…]} in, {"choices":[…]} out.
+// Each was invoked to confirm it, because the responses of all of them already
+// decode as OpenAI: leaving the request on the Claude fallback would encode and
+// decode the same model as two different families, and it is only accepted at
+// all because these endpoints tolerate the anthropic_version stowaway.
+var openAICompatibleVendors = []string{
+	"openai.", // gpt-oss
+	"qwen.",
+	"google.gemma",
+	"nvidia.",
+	"minimax.",
+	"zai.",
+	"deepseek",
+	"ai21.jamba",
+}
+
+// detectFamilyByModel returns the model family from a Bedrock model ID. The ID
+// may carry a geography prefix ("eu.", "us.") naming a cross-region inference
+// profile, so every match is a substring rather than an equality.
 func detectFamilyByModel(model string) string {
 	m := strings.ToLower(model)
 	switch {
 	case strings.Contains(m, "anthropic.claude"), strings.Contains(m, "claude"):
 		return bfClaude
-	case strings.Contains(m, "deepseek"), strings.Contains(m, "ai21.jamba"):
+	case strings.Contains(m, "amazon.nova"):
+		return bfNova
+	case containsAny(m, openAICompatibleVendors):
 		return bfOpenAI
 	case strings.Contains(m, "amazon.titan"):
 		return bfTitan
 	case strings.Contains(m, "meta.llama"), strings.Contains(m, "llama"):
 		return bfLlama
-	case strings.Contains(m, "mistral"):
-		return bfMistral
+	case strings.Contains(m, "mistral"), strings.Contains(m, "mixtral"):
+		if containsAny(m, legacyMistralModels) {
+			return bfMistral
+		}
+		return bfOpenAI
 	default:
-		return bfClaude // safe default
+		// Claude, because an unrecognised ID is as likely to be a provisioned
+		// or custom model ARN — which carries no family at all — as a vendor
+		// nobody has mapped yet.
+		return bfClaude
 	}
+}
+
+func containsAny(model string, needles []string) bool {
+	for _, needle := range needles {
+		if strings.Contains(model, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+// present records that a key was in the JSON without keeping its value, which
+// is all family detection needs. json.RawMessage would copy the whole subtree
+// instead, and detection runs once per streamed chunk — that is a copy per
+// token, on every provider.
+type present bool
+
+func (p *present) UnmarshalJSON([]byte) error {
+	*p = true
+	return nil
 }
 
 // detectFamilyFromRequestBody inspects the JSON body to determine the model
 // family heuristically.
 func detectFamilyFromRequestBody(body []byte) string {
 	var probe struct {
-		InputText        json.RawMessage `json:"inputText"`
-		Prompt           json.RawMessage `json:"prompt"`
-		Messages         json.RawMessage `json:"messages"`
-		MaxGenLen        json.RawMessage `json:"max_gen_len"`
-		System           json.RawMessage `json:"system"`
-		AnthropicVersion json.RawMessage `json:"anthropic_version"`
+		InputText        present         `json:"inputText"`
+		Prompt           present         `json:"prompt"`
+		Messages         present         `json:"messages"`
+		MaxGenLen        present         `json:"max_gen_len"`
+		System           json.RawMessage `json:"system"` // the value decides Claude vs OpenAI
+		AnthropicVersion present         `json:"anthropic_version"`
+		InferenceConfig  present         `json:"inferenceConfig"`
 	}
 	if json.Unmarshal(body, &probe) != nil {
 		return bfClaude
 	}
-	if probe.InputText != nil {
+	if probe.InferenceConfig {
+		return bfNova
+	}
+	if probe.InputText {
 		return bfTitan
 	}
-	if probe.Prompt != nil && probe.Messages == nil {
-		if probe.MaxGenLen != nil {
+	if probe.Prompt && !probe.Messages {
+		if probe.MaxGenLen {
 			return bfLlama
 		}
 		return bfMistral
 	}
 	// Has "messages" — distinguish Claude (Anthropic) from OpenAI-compat.
 	// Anthropic format has top-level "system" string or "anthropic_version".
-	if probe.Messages != nil {
-		if probe.AnthropicVersion != nil {
+	if probe.Messages {
+		if probe.AnthropicVersion {
 			return bfClaude
 		}
 		if probe.System != nil {
@@ -108,25 +174,29 @@ func detectFamilyFromRequestBody(body []byte) string {
 // detectFamilyFromResponseBody inspects the response JSON.
 func detectFamilyFromResponseBody(body []byte) string {
 	var probe struct {
-		Results    json.RawMessage `json:"results"`    // Titan
-		Generation json.RawMessage `json:"generation"` // Llama
-		Outputs    json.RawMessage `json:"outputs"`    // Mistral
-		Choices    json.RawMessage `json:"choices"`    // OpenAI-compat (DeepSeek, etc.)
-		Content    json.RawMessage `json:"content"`    // Claude (Anthropic)
+		Results    present `json:"results"`    // Titan
+		Generation present `json:"generation"` // Llama
+		Outputs    present `json:"outputs"`    // Mistral
+		Choices    present `json:"choices"`    // OpenAI-compat (DeepSeek, etc.)
+		Content    present `json:"content"`    // Claude (Anthropic)
+		Output     present `json:"output"`     // Nova
 	}
 	if json.Unmarshal(body, &probe) != nil {
 		return bfClaude
 	}
-	if probe.Results != nil {
+	if probe.Output {
+		return bfNova
+	}
+	if probe.Results {
 		return bfTitan
 	}
-	if probe.Generation != nil {
+	if probe.Generation {
 		return bfLlama
 	}
-	if probe.Outputs != nil {
+	if probe.Outputs {
 		return bfMistral
 	}
-	if probe.Choices != nil {
+	if probe.Choices {
 		return bfOpenAI
 	}
 	return bfClaude
@@ -135,26 +205,40 @@ func detectFamilyFromResponseBody(body []byte) string {
 // detectFamilyFromStreamChunk inspects a single streaming chunk.
 func detectFamilyFromStreamChunk(chunk []byte) string {
 	var probe struct {
-		OutputText json.RawMessage `json:"outputText"` // Titan
-		Generation json.RawMessage `json:"generation"` // Llama
-		Outputs    json.RawMessage `json:"outputs"`    // Mistral
-		Choices    json.RawMessage `json:"choices"`    // OpenAI-compat (DeepSeek)
-		Type       json.RawMessage `json:"type"`       // Claude/Anthropic
+		OutputText        present `json:"outputText"` // Titan
+		Generation        present `json:"generation"` // Llama
+		Outputs           present `json:"outputs"`    // Mistral
+		Choices           present `json:"choices"`    // OpenAI-compat (DeepSeek)
+		Type              present `json:"type"`       // Claude/Anthropic
+		MessageStart      present `json:"messageStart"`
+		ContentBlockDelta present `json:"contentBlockDelta"`
+		ContentBlockStop  present `json:"contentBlockStop"`
+		MessageStop       present `json:"messageStop"`
+		Metadata          present `json:"metadata"` // Nova, but too generic to lead with
 	}
 	if json.Unmarshal(chunk, &probe) != nil {
 		return bfClaude
 	}
-	if probe.OutputText != nil {
+	if probe.MessageStart || probe.ContentBlockDelta ||
+		probe.ContentBlockStop || probe.MessageStop {
+		return bfNova
+	}
+	if probe.OutputText {
 		return bfTitan
 	}
-	if probe.Generation != nil {
+	if probe.Generation {
 		return bfLlama
 	}
-	if probe.Outputs != nil {
+	if probe.Outputs {
 		return bfMistral
 	}
-	if probe.Choices != nil {
+	if probe.Choices {
 		return bfOpenAI
+	}
+	// The chunk that closes a Nova stream carries only usage, under a key
+	// generic enough that it is worth ruling out every other family first.
+	if probe.Metadata {
+		return bfNova
 	}
 	return bfClaude
 }
@@ -168,6 +252,8 @@ func (a *BedrockAdapter) DecodeRequest(body []byte) (*CanonicalRequest, error) {
 	switch family {
 	case bfOpenAI:
 		return a.openai.DecodeRequest(body)
+	case bfNova:
+		return a.nova.DecodeRequest(body)
 	case bfTitan:
 		return a.titan.DecodeRequest(body)
 	case bfLlama:
@@ -188,6 +274,8 @@ func (a *BedrockAdapter) EncodeRequest(req *CanonicalRequest) ([]byte, error) {
 	switch family {
 	case bfOpenAI:
 		return a.openai.EncodeRequest(req)
+	case bfNova:
+		return a.nova.EncodeRequest(req)
 	case bfTitan:
 		return a.titan.EncodeRequest(req)
 	case bfLlama:
@@ -227,6 +315,8 @@ func (a *BedrockAdapter) DecodeResponse(body []byte) (*CanonicalResponse, error)
 	switch family {
 	case bfOpenAI:
 		return a.openai.DecodeResponse(body)
+	case bfNova:
+		return a.nova.DecodeResponse(body)
 	case bfTitan:
 		return a.titan.DecodeResponse(body)
 	case bfLlama:
@@ -255,6 +345,8 @@ func (a *BedrockAdapter) DecodeStreamChunk(chunk []byte) (*CanonicalStreamChunk,
 	switch family {
 	case bfOpenAI:
 		return a.openai.DecodeStreamChunk(chunk)
+	case bfNova:
+		return a.nova.DecodeStreamChunk(chunk)
 	case bfTitan:
 		return a.titan.DecodeStreamChunk(chunk)
 	case bfLlama:
@@ -305,11 +397,12 @@ type titanResult struct {
 }
 
 type titanStreamChunk struct {
-	OutputText                string  `json:"outputText"`
-	TokenCount                int     `json:"tokenCount,omitempty"`
-	CompletionReason          *string `json:"completionReason,omitempty"`
-	InputTextTokenCount       int     `json:"inputTextTokenCount,omitempty"`
-	TotalOutputTextTokenCount int     `json:"totalOutputTextTokenCount,omitempty"`
+	OutputText                string                    `json:"outputText"`
+	TokenCount                int                       `json:"tokenCount,omitempty"`
+	CompletionReason          *string                   `json:"completionReason,omitempty"`
+	InputTextTokenCount       int                       `json:"inputTextTokenCount,omitempty"`
+	TotalOutputTextTokenCount int                       `json:"totalOutputTextTokenCount,omitempty"`
+	Metrics                   *bedrockInvocationMetrics `json:"amazon-bedrock-invocationMetrics"`
 }
 
 // Request ---------------------------------------------------------------------
@@ -361,6 +454,19 @@ func (t *bedrockTitanAdapter) EncodeRequest(req *CanonicalRequest) ([]byte, erro
 
 // Response --------------------------------------------------------------------
 
+// titanFinishReason maps a Titan completion reason onto the canonical
+// vocabulary, for both the buffered and the streamed path.
+func titanFinishReason(reason string) string {
+	switch reason {
+	case "FINISH", "":
+		return "stop"
+	case "LENGTH":
+		return "length"
+	default:
+		return reason
+	}
+}
+
 func (t *bedrockTitanAdapter) DecodeResponse(body []byte) (*CanonicalResponse, error) {
 	var resp titanResponse
 	if err := json.Unmarshal(body, &resp); err != nil {
@@ -370,14 +476,7 @@ func (t *bedrockTitanAdapter) DecodeResponse(body []byte) (*CanonicalResponse, e
 	if len(resp.Results) > 0 {
 		r := resp.Results[0]
 		cr.Content = r.OutputText
-		switch r.CompletionReason {
-		case "FINISH", "":
-			cr.FinishReason = "stop"
-		case "LENGTH":
-			cr.FinishReason = "length"
-		default:
-			cr.FinishReason = r.CompletionReason
-		}
+		cr.FinishReason = titanFinishReason(r.CompletionReason)
 		if r.Reasoning != "" {
 			cr.Reasoning = &CanonicalReasoning{ThinkingText: r.Reasoning}
 		}
@@ -393,22 +492,19 @@ func (t *bedrockTitanAdapter) DecodeStreamChunk(chunk []byte) (*CanonicalStreamC
 	if err := json.Unmarshal(chunk, &c); err != nil {
 		return nil, nil
 	}
-	sc := &CanonicalStreamChunk{Delta: c.OutputText}
+	var finishReason string
 	if c.CompletionReason != nil && *c.CompletionReason != "" {
-		switch *c.CompletionReason {
-		case "FINISH":
-			sc.FinishReason = "stop"
-		case "LENGTH":
-			sc.FinishReason = "length"
-		default:
-			sc.FinishReason = *c.CompletionReason
-		}
+		finishReason = titanFinishReason(*c.CompletionReason)
 	}
-	sc.Usage = mergeBedrockUsage(chunk, c.InputTextTokenCount, c.TotalOutputTextTokenCount)
-	if sc.Delta == "" && sc.FinishReason == "" && sc.Usage == nil {
+	usage := mergeParsedUsage(c.InputTextTokenCount, c.TotalOutputTextTokenCount, 0, c.Metrics)
+	if c.OutputText == "" && finishReason == "" && usage == nil {
 		return nil, nil
 	}
-	return sc, nil
+	return &CanonicalStreamChunk{
+		Delta:        c.OutputText,
+		FinishReason: finishReason,
+		Usage:        usage,
+	}, nil
 }
 
 // =========================================================================
@@ -437,10 +533,11 @@ type llamaResponse struct {
 }
 
 type llamaStreamChunk struct {
-	Generation           string  `json:"generation"`
-	PromptTokenCount     *int    `json:"prompt_token_count,omitempty"`
-	GenerationTokenCount *int    `json:"generation_token_count,omitempty"`
-	StopReason           *string `json:"stop_reason,omitempty"`
+	Generation           string                    `json:"generation"`
+	PromptTokenCount     *int                      `json:"prompt_token_count,omitempty"`
+	GenerationTokenCount *int                      `json:"generation_token_count,omitempty"`
+	StopReason           *string                   `json:"stop_reason,omitempty"`
+	Metrics              *bedrockInvocationMetrics `json:"amazon-bedrock-invocationMetrics"`
 }
 
 // Request ---------------------------------------------------------------------
@@ -473,24 +570,30 @@ func (l *bedrockLlamaAdapter) EncodeRequest(req *CanonicalRequest) ([]byte, erro
 
 // Response --------------------------------------------------------------------
 
+// llamaFinishReason maps a Llama stop reason onto the canonical vocabulary.
+// Both the buffered and the streamed path go through it: Bedrock reports
+// "length" on the last chunk exactly as it does on a whole answer, and a client
+// that only sees "stop" cannot tell a complete answer from a truncated one.
+func llamaFinishReason(stop string) string {
+	switch stop {
+	case "stop", "end_of_text", "":
+		return "stop"
+	case "length":
+		return "length"
+	default:
+		return stop
+	}
+}
+
 func (l *bedrockLlamaAdapter) DecodeResponse(body []byte) (*CanonicalResponse, error) {
 	var resp llamaResponse
 	if err := json.Unmarshal(body, &resp); err != nil {
 		return nil, err
 	}
-	var fr string
-	switch resp.StopReason {
-	case "stop", "end_of_text", "":
-		fr = "stop"
-	case "length":
-		fr = "length"
-	default:
-		fr = resp.StopReason
-	}
 	cr := &CanonicalResponse{
 		Role:         "assistant",
 		Content:      resp.Generation,
-		FinishReason: fr,
+		FinishReason: llamaFinishReason(resp.StopReason),
 	}
 	if resp.Reasoning != "" {
 		cr.Reasoning = &CanonicalReasoning{ThinkingText: resp.Reasoning}
@@ -506,9 +609,9 @@ func (l *bedrockLlamaAdapter) DecodeStreamChunk(chunk []byte) (*CanonicalStreamC
 	if err := json.Unmarshal(chunk, &c); err != nil {
 		return nil, nil
 	}
-	sc := &CanonicalStreamChunk{Delta: c.Generation}
+	var finishReason string
 	if c.StopReason != nil && *c.StopReason != "" {
-		sc.FinishReason = "stop"
+		finishReason = llamaFinishReason(*c.StopReason)
 	}
 	var in, out int
 	if c.PromptTokenCount != nil {
@@ -517,11 +620,15 @@ func (l *bedrockLlamaAdapter) DecodeStreamChunk(chunk []byte) (*CanonicalStreamC
 	if c.GenerationTokenCount != nil {
 		out = *c.GenerationTokenCount
 	}
-	sc.Usage = mergeBedrockUsage(chunk, in, out)
-	if sc.Delta == "" && sc.FinishReason == "" && sc.Usage == nil {
+	usage := mergeParsedUsage(in, out, 0, c.Metrics)
+	if c.Generation == "" && finishReason == "" && usage == nil {
 		return nil, nil
 	}
-	return sc, nil
+	return &CanonicalStreamChunk{
+		Delta:        c.Generation,
+		FinishReason: finishReason,
+		Usage:        usage,
+	}, nil
 }
 
 // =========================================================================
@@ -554,7 +661,8 @@ type mistralOutput struct {
 }
 
 type mistralStreamChunk struct {
-	Outputs []mistralOutput `json:"outputs,omitempty"`
+	Outputs []mistralOutput           `json:"outputs,omitempty"`
+	Metrics *bedrockInvocationMetrics `json:"amazon-bedrock-invocationMetrics"`
 }
 
 // Request ---------------------------------------------------------------------
@@ -591,6 +699,20 @@ func (m *bedrockMistralAdapter) EncodeRequest(req *CanonicalRequest) ([]byte, er
 
 // Response --------------------------------------------------------------------
 
+// mistralFinishReason maps a Mistral stop reason onto the canonical vocabulary.
+// Shared with the streamed path: the chunk that closes a truncated answer says
+// "length" just like the buffered body does.
+func mistralFinishReason(stop string) string {
+	switch stop {
+	case "stop", "end_turn", "":
+		return "stop"
+	case "length":
+		return "length"
+	default:
+		return stop
+	}
+}
+
 func (m *bedrockMistralAdapter) DecodeResponse(body []byte) (*CanonicalResponse, error) {
 	var resp mistralResponse
 	if err := json.Unmarshal(body, &resp); err != nil {
@@ -600,14 +722,7 @@ func (m *bedrockMistralAdapter) DecodeResponse(body []byte) (*CanonicalResponse,
 	if len(resp.Outputs) > 0 {
 		o := resp.Outputs[0]
 		cr.Content = o.Text
-		switch o.StopReason {
-		case "stop", "end_turn", "":
-			cr.FinishReason = "stop"
-		case "length":
-			cr.FinishReason = "length"
-		default:
-			cr.FinishReason = o.StopReason
-		}
+		cr.FinishReason = mistralFinishReason(o.StopReason)
 		if o.Reasoning != "" {
 			cr.Reasoning = &CanonicalReasoning{ThinkingText: o.Reasoning}
 		}
@@ -625,18 +740,240 @@ func (m *bedrockMistralAdapter) DecodeStreamChunk(chunk []byte) (*CanonicalStrea
 	if err := json.Unmarshal(chunk, &c); err != nil {
 		return nil, nil
 	}
-	sc := &CanonicalStreamChunk{}
+	var delta, finishReason string
 	if len(c.Outputs) > 0 {
-		sc.Delta = c.Outputs[0].Text
+		delta = c.Outputs[0].Text
 		if c.Outputs[0].StopReason != "" {
-			sc.FinishReason = "stop"
+			finishReason = mistralFinishReason(c.Outputs[0].StopReason)
 		}
 	}
-	sc.Usage = parseBedrockInvocationMetrics(chunk)
-	if sc.Delta == "" && sc.FinishReason == "" && sc.Usage == nil {
+	usage := mergeParsedUsage(0, 0, 0, c.Metrics)
+	if delta == "" && finishReason == "" && usage == nil {
 		return nil, nil
 	}
-	return sc, nil
+	return &CanonicalStreamChunk{
+		Delta:        delta,
+		FinishReason: finishReason,
+		Usage:        usage,
+	}, nil
+}
+
+// =========================================================================
+//
+//	NOVA  (Amazon Nova)
+//
+// =========================================================================
+
+// bedrockNovaAdapter speaks the Nova schema: content is a list of typed blocks
+// rather than a string, and the sampling knobs live under "inferenceConfig".
+// Nova rejects unknown top-level keys, so the Claude encoder's max_tokens and
+// anthropic_version make it answer "extraneous key [max_tokens] is not
+// permitted".
+type bedrockNovaAdapter struct{}
+
+// Typed structs ---------------------------------------------------------------
+
+type novaTextBlock struct {
+	Text string `json:"text"`
+}
+
+type novaMessage struct {
+	Role    string          `json:"role"`
+	Content []novaTextBlock `json:"content"`
+}
+
+type novaInferenceConfig struct {
+	MaxTokens     int      `json:"maxTokens,omitempty"`
+	Temperature   *float64 `json:"temperature,omitempty"`
+	TopP          *float64 `json:"topP,omitempty"`
+	TopK          *int     `json:"topK,omitempty"`
+	StopSequences []string `json:"stopSequences,omitempty"`
+}
+
+type novaRequest struct {
+	System          []novaTextBlock      `json:"system,omitempty"`
+	Messages        []novaMessage        `json:"messages"`
+	InferenceConfig *novaInferenceConfig `json:"inferenceConfig,omitempty"`
+}
+
+type novaUsage struct {
+	InputTokens  int `json:"inputTokens"`
+	OutputTokens int `json:"outputTokens"`
+	TotalTokens  int `json:"totalTokens"`
+}
+
+// The invocation metrics ride in the same JSON as the answer, so both response
+// and chunk parse them in the same pass: on a stream this runs per chunk, and a
+// second Unmarshal of every chunk just to look for a fallback is latency spent
+// on every token.
+type novaResponse struct {
+	Output struct {
+		Message novaMessage `json:"message"`
+	} `json:"output"`
+	StopReason string                    `json:"stopReason"`
+	Usage      *novaUsage                `json:"usage"`
+	Metrics    *bedrockInvocationMetrics `json:"amazon-bedrock-invocationMetrics"`
+}
+
+type novaStreamChunk struct {
+	ContentBlockDelta *struct {
+		Delta struct {
+			Text string `json:"text"`
+		} `json:"delta"`
+	} `json:"contentBlockDelta"`
+	MessageStop *struct {
+		StopReason string `json:"stopReason"`
+	} `json:"messageStop"`
+	Metadata *struct {
+		Usage *novaUsage `json:"usage"`
+	} `json:"metadata"`
+	Metrics *bedrockInvocationMetrics `json:"amazon-bedrock-invocationMetrics"`
+}
+
+// novaFinishReason maps a Nova stop reason onto the canonical vocabulary.
+func novaFinishReason(stop string) string {
+	switch stop {
+	case "end_turn", "stop_sequence", "":
+		return "stop"
+	case "max_tokens":
+		return "length"
+	default:
+		return stop
+	}
+}
+
+func novaText(blocks []novaTextBlock) string {
+	// A single block is the norm; joining it would copy the string for nothing.
+	switch len(blocks) {
+	case 0:
+		return ""
+	case 1:
+		return blocks[0].Text
+	}
+	var sb strings.Builder
+	for _, b := range blocks {
+		sb.WriteString(b.Text)
+	}
+	return sb.String()
+}
+
+// Request ---------------------------------------------------------------------
+
+func (n *bedrockNovaAdapter) DecodeRequest(body []byte) (*CanonicalRequest, error) {
+	var req novaRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, err
+	}
+	cr := &CanonicalRequest{
+		System:   novaText(req.System),
+		Messages: make([]CanonicalMessage, 0, len(req.Messages)),
+	}
+	for _, m := range req.Messages {
+		cr.Messages = append(cr.Messages, CanonicalMessage{
+			Role:    m.Role,
+			Content: novaText(m.Content),
+		})
+	}
+	if ic := req.InferenceConfig; ic != nil {
+		cr.MaxTokens = ic.MaxTokens
+		cr.Temperature = ic.Temperature
+		cr.TopP = ic.TopP
+		cr.TopK = ic.TopK
+		cr.Stop = ic.StopSequences
+	}
+	return cr, nil
+}
+
+func (n *bedrockNovaAdapter) EncodeRequest(req *CanonicalRequest) ([]byte, error) {
+	out := novaRequest{Messages: make([]novaMessage, 0, len(req.Messages))}
+	if req.System != "" {
+		out.System = []novaTextBlock{{Text: req.System}}
+	}
+	for _, m := range req.Messages {
+		// Nova only accepts user and assistant turns; a system message reaching
+		// here belongs in the dedicated field, not in the conversation.
+		if m.Role == "system" {
+			out.System = append(out.System, novaTextBlock{Text: m.Content})
+			continue
+		}
+		out.Messages = append(out.Messages, novaMessage{
+			Role:    m.Role,
+			Content: []novaTextBlock{{Text: m.Content}},
+		})
+	}
+
+	if req.MaxTokens > 0 || req.Temperature != nil || req.TopP != nil ||
+		req.TopK != nil || len(req.Stop) > 0 {
+		out.InferenceConfig = &novaInferenceConfig{
+			MaxTokens:     req.MaxTokens,
+			Temperature:   req.Temperature,
+			TopP:          req.TopP,
+			TopK:          req.TopK,
+			StopSequences: req.Stop,
+		}
+	}
+	return json.Marshal(out)
+}
+
+// Response --------------------------------------------------------------------
+
+func (n *bedrockNovaAdapter) DecodeResponse(body []byte) (*CanonicalResponse, error) {
+	var resp novaResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, err
+	}
+	cr := &CanonicalResponse{
+		Role:         "assistant",
+		Content:      novaText(resp.Output.Message.Content),
+		FinishReason: novaFinishReason(resp.StopReason),
+	}
+	if resp.Output.Message.Role != "" {
+		cr.Role = resp.Output.Message.Role
+	}
+	cr.Usage = novaCanonicalUsage(resp.Usage, resp.Metrics)
+	return cr, nil
+}
+
+// Stream ----------------------------------------------------------------------
+
+func (n *bedrockNovaAdapter) DecodeStreamChunk(chunk []byte) (*CanonicalStreamChunk, error) {
+	var c novaStreamChunk
+	if err := json.Unmarshal(chunk, &c); err != nil {
+		return nil, nil
+	}
+
+	var delta, finishReason string
+	if c.ContentBlockDelta != nil {
+		delta = c.ContentBlockDelta.Delta.Text
+	}
+	if c.MessageStop != nil {
+		finishReason = novaFinishReason(c.MessageStop.StopReason)
+	}
+	// Usage closes the stream in its own metadata chunk, which carries no text.
+	var usage *novaUsage
+	if c.Metadata != nil {
+		usage = c.Metadata.Usage
+	}
+	canonicalUsage := novaCanonicalUsage(usage, c.Metrics)
+
+	// Nova emits a contentBlockStop after every delta, so about half the chunks
+	// of a stream say nothing: they must not cost an allocation.
+	if delta == "" && finishReason == "" && canonicalUsage == nil {
+		return nil, nil
+	}
+	return &CanonicalStreamChunk{
+		Delta:        delta,
+		FinishReason: finishReason,
+		Usage:        canonicalUsage,
+	}, nil
+}
+
+func novaCanonicalUsage(usage *novaUsage, metrics *bedrockInvocationMetrics) *CanonicalUsage {
+	var in, out, total int
+	if usage != nil {
+		in, out, total = usage.InputTokens, usage.OutputTokens, usage.TotalTokens
+	}
+	return mergeParsedUsage(in, out, total, metrics)
 }
 
 // =========================================================================
@@ -700,16 +1037,19 @@ func formatMistralPrompt(system string, msgs []CanonicalMessage) string {
 		sysPrefix = system + "\n\n"
 	}
 
-	firstUser := true
 	for _, m := range msgs {
 		switch m.Role {
+		case "system":
+			// The template has no system turn, so it rides on the next user
+			// one. Dropping it would silently discard the instructions a
+			// caller put in the conversation instead of the system field.
+			sysPrefix += m.Content + "\n\n"
 		case "user":
 			content := m.Content
-			if firstUser && sysPrefix != "" {
+			if sysPrefix != "" {
 				content = sysPrefix + content
 				sysPrefix = ""
 			}
-			firstUser = false
 			fmt.Fprintf(&sb, "[INST] %s [/INST]", content)
 		case "assistant":
 			sb.WriteString(m.Content)
@@ -720,6 +1060,13 @@ func formatMistralPrompt(system string, msgs []CanonicalMessage) string {
 	return sb.String()
 }
 
+// bedrockInvocationMetrics is the cross-family usage block Bedrock appends
+// alongside the model's own answer.
+type bedrockInvocationMetrics struct {
+	InputTokenCount  int `json:"inputTokenCount"`
+	OutputTokenCount int `json:"outputTokenCount"`
+}
+
 // parseBedrockInvocationMetrics reads the cross-family
 // `amazon-bedrock-invocationMetrics` block as a fallback usage source. It
 // returns nil when the block is absent, both counts are zero, or the body
@@ -727,10 +1074,7 @@ func formatMistralPrompt(system string, msgs []CanonicalMessage) string {
 // callers must honor the nil-when-absent contract.
 func parseBedrockInvocationMetrics(body []byte) *CanonicalUsage {
 	var probe struct {
-		Metrics *struct {
-			InputTokenCount  int `json:"inputTokenCount"`
-			OutputTokenCount int `json:"outputTokenCount"`
-		} `json:"amazon-bedrock-invocationMetrics"`
+		Metrics *bedrockInvocationMetrics `json:"amazon-bedrock-invocationMetrics"`
 	}
 	if err := json.Unmarshal(body, &probe); err != nil {
 		return nil
@@ -739,6 +1083,22 @@ func parseBedrockInvocationMetrics(body []byte) *CanonicalUsage {
 		return nil
 	}
 	return newCanonicalUsage(probe.Metrics.InputTokenCount, probe.Metrics.OutputTokenCount, 0)
+}
+
+// mergeParsedUsage is mergeBedrockUsage over values a caller has already
+// decoded. The streaming decoders use it so a chunk is parsed once instead of
+// once for its own fields and again for the metrics — a saving paid per token.
+func mergeParsedUsage(familyIn, familyOut, familyTotal int, metrics *bedrockInvocationMetrics) *CanonicalUsage {
+	in, out := familyIn, familyOut
+	if metrics != nil {
+		if in == 0 {
+			in = metrics.InputTokenCount
+		}
+		if out == 0 {
+			out = metrics.OutputTokenCount
+		}
+	}
+	return newCanonicalUsage(in, out, familyTotal)
 }
 
 // mergeBedrockUsage applies the family-wins fallback: native family token counts

--- a/pkg/infra/providers/adapter/bedrock_adapter_test.go
+++ b/pkg/infra/providers/adapter/bedrock_adapter_test.go
@@ -155,9 +155,9 @@ func TestBedrock_Llama_StreamChunkDecode(t *testing.T) {
 // Bedrock Mistral: OpenAI → Bedrock (Mistral model)
 // ---------------------------------------------------------------------------
 
-func TestAdaptRequest_OpenAIToBedrockMistral(t *testing.T) {
+func TestAdaptRequest_OpenAIToBedrockLegacyMistral(t *testing.T) {
 	input := `{
-		"model": "mistral.mistral-large-2407-v1:0",
+		"model": "mistral.mistral-7b-instruct-v0:2",
 		"messages": [
 			{"role": "user", "content": "Explain AI"}
 		],
@@ -180,6 +180,36 @@ func TestAdaptRequest_OpenAIToBedrockMistral(t *testing.T) {
 	assert.Contains(t, result.Prompt, "Explain AI")
 	assert.Contains(t, result.Prompt, "[/INST]")
 	assert.Equal(t, 300, result.MaxTokens)
+}
+
+// Bedrock's Mistral models split across two schemas: the text completion API
+// (7B, Mixtral, Large and Small 24.02) takes a "prompt" string, everything from
+// Large 24.07 onwards takes "messages". Sending a prompt to the newer ones gets
+// "missing field `messages`" back, so unknown Mistral IDs default to messages:
+// the text completion list is closed, no new model joins it.
+func TestAdaptRequest_ModernMistralUsesMessages(t *testing.T) {
+	for _, model := range []string{
+		"mistral.mistral-large-2407-v1:0",
+		"mistral.devstral-2-123b",
+		"eu.mistral.pixtral-large-2502-v1:0",
+	} {
+		t.Run(model, func(t *testing.T) {
+			input := `{"model": "` + model + `", "messages": [{"role": "user", "content": "Explain AI"}], "max_tokens": 300}`
+
+			oa := &OpenAIAdapter{}
+			canonical, err := oa.DecodeRequest([]byte(input))
+			require.NoError(t, err)
+
+			adapter := &BedrockAdapter{}
+			out, err := adapter.EncodeRequest(canonical)
+			require.NoError(t, err)
+
+			var body map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal(out, &body))
+			assert.Contains(t, body, "messages")
+			assert.NotContains(t, body, "prompt")
+		})
+	}
 }
 
 func TestBedrock_Mistral_ResponseDecode(t *testing.T) {
@@ -455,4 +485,232 @@ func TestBedrock_InvocationMetricsFallback_MetricsAbsent(t *testing.T) {
 	cr, err := (&bedrockMistralAdapter{}).DecodeResponse(body)
 	require.NoError(t, err)
 	assert.Nil(t, cr.Usage, "Mistral with no metrics and no native counters must return nil")
+}
+
+// ---------------------------------------------------------------------------
+// Bedrock Nova (Amazon Nova)
+// ---------------------------------------------------------------------------
+
+func TestAdaptRequest_OpenAIToBedrockNova(t *testing.T) {
+	input := `{
+		"model": "eu.amazon.nova-lite-v1:0",
+		"messages": [
+			{"role": "system", "content": "You are helpful."},
+			{"role": "user", "content": "Hello, Nova!"}
+		],
+		"max_tokens": 256,
+		"temperature": 0.7
+	}`
+
+	oa := &OpenAIAdapter{}
+	canonical, err := oa.DecodeRequest([]byte(input))
+	require.NoError(t, err)
+
+	adapter := &BedrockAdapter{}
+	out, err := adapter.EncodeRequest(canonical)
+	require.NoError(t, err)
+
+	// Nova rejects unknown top-level keys outright, so the Claude encoder's
+	// max_tokens and anthropic_version are what "extraneous key [max_tokens]
+	// is not permitted" was complaining about.
+	var body map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(out, &body))
+	assert.NotContains(t, body, "max_tokens")
+	assert.NotContains(t, body, "anthropic_version")
+
+	var result novaRequest
+	require.NoError(t, json.Unmarshal(out, &result))
+	require.Len(t, result.System, 1)
+	assert.Equal(t, "You are helpful.", result.System[0].Text)
+	require.Len(t, result.Messages, 1)
+	assert.Equal(t, "user", result.Messages[0].Role)
+	require.Len(t, result.Messages[0].Content, 1)
+	assert.Equal(t, "Hello, Nova!", result.Messages[0].Content[0].Text)
+	require.NotNil(t, result.InferenceConfig)
+	assert.Equal(t, 256, result.InferenceConfig.MaxTokens)
+	assert.InDelta(t, 0.7, *result.InferenceConfig.Temperature, 0.001)
+}
+
+func TestBedrock_Nova_ResponseDecode(t *testing.T) {
+	body := `{"output":{"message":{"content":[{"text":"Ok."}],"role":"assistant"}},"stopReason":"max_tokens","usage":{"inputTokens":2,"outputTokens":16,"totalTokens":18}}`
+
+	adapter := &BedrockAdapter{}
+	cr, err := adapter.DecodeResponse([]byte(body))
+	require.NoError(t, err)
+	assert.Equal(t, "Ok.", cr.Content)
+	assert.Equal(t, "assistant", cr.Role)
+	assert.Equal(t, "length", cr.FinishReason)
+	require.NotNil(t, cr.Usage)
+	assert.Equal(t, 2, cr.Usage.InputTokens)
+	assert.Equal(t, 16, cr.Usage.OutputTokens)
+	assert.Equal(t, 18, cr.Usage.TotalTokens)
+}
+
+func TestBedrock_Nova_StreamChunkDecode(t *testing.T) {
+	adapter := &BedrockAdapter{}
+
+	sc, err := adapter.DecodeStreamChunk([]byte(`{"contentBlockDelta":{"delta":{"text":"Ok"},"contentBlockIndex":0}}`))
+	require.NoError(t, err)
+	require.NotNil(t, sc)
+	assert.Equal(t, "Ok", sc.Delta)
+
+	sc, err = adapter.DecodeStreamChunk([]byte(`{"messageStop":{"stopReason":"end_turn"}}`))
+	require.NoError(t, err)
+	require.NotNil(t, sc)
+	assert.Equal(t, "stop", sc.FinishReason)
+
+	// Usage closes the stream in its own chunk; miss it and the budget plugin
+	// never charges a streamed Nova answer.
+	sc, err = adapter.DecodeStreamChunk([]byte(`{"metadata":{"usage":{"inputTokens":2,"outputTokens":13}}}`))
+	require.NoError(t, err)
+	require.NotNil(t, sc)
+	require.NotNil(t, sc.Usage)
+	assert.Equal(t, 2, sc.Usage.InputTokens)
+	assert.Equal(t, 13, sc.Usage.OutputTokens)
+	assert.Equal(t, 15, sc.Usage.TotalTokens)
+
+	for _, empty := range []string{
+		`{"messageStart":{"role":"assistant"}}`,
+		`{"contentBlockStop":{"contentBlockIndex":0}}`,
+	} {
+		sc, err = adapter.DecodeStreamChunk([]byte(empty))
+		require.NoError(t, err)
+		assert.Nil(t, sc, "a chunk with no text, no stop reason and no usage carries nothing")
+	}
+}
+
+func TestBedrock_Nova_UsageFallsBackToInvocationMetrics(t *testing.T) {
+	adapter := &BedrockAdapter{}
+
+	sc, err := adapter.DecodeStreamChunk([]byte(`{"metadata":{"metrics":{}},"amazon-bedrock-invocationMetrics":{"inputTokenCount":7,"outputTokenCount":3}}`))
+	require.NoError(t, err)
+	require.NotNil(t, sc)
+	require.NotNil(t, sc.Usage)
+	assert.Equal(t, 7, sc.Usage.InputTokens)
+	assert.Equal(t, 3, sc.Usage.OutputTokens)
+
+	sc, err = adapter.DecodeStreamChunk([]byte(`{"metadata":{"usage":{"inputTokens":2,"outputTokens":13}},"amazon-bedrock-invocationMetrics":{"inputTokenCount":99,"outputTokenCount":99}}`))
+	require.NoError(t, err)
+	require.NotNil(t, sc)
+	require.NotNil(t, sc.Usage)
+	assert.Equal(t, 2, sc.Usage.InputTokens, "Nova's own counters must win over the invocation metrics")
+	assert.Equal(t, 13, sc.Usage.OutputTokens)
+}
+
+func TestBedrock_DecodeNovaRequest(t *testing.T) {
+	body := `{"system":[{"text":"Be brief."}],"messages":[{"role":"user","content":[{"text":"Hello Nova"}]}],"inferenceConfig":{"maxTokens":128,"temperature":0.5}}`
+	adapter := &BedrockAdapter{}
+	cr, err := adapter.DecodeRequest([]byte(body))
+	require.NoError(t, err)
+	assert.Equal(t, "Be brief.", cr.System)
+	require.Len(t, cr.Messages, 1)
+	assert.Equal(t, "Hello Nova", cr.Messages[0].Content)
+	assert.Equal(t, 128, cr.MaxTokens)
+	assert.InDelta(t, 0.5, *cr.Temperature, 0.001)
+}
+
+// Bedrock reports "length" on the last chunk of a truncated answer exactly as
+// it does on a whole one. Collapsing it to "stop" tells the client the model
+// finished when it was cut off. Both chunks below are verbatim from Bedrock.
+func TestBedrock_StreamKeepsTruncationReason(t *testing.T) {
+	cases := []struct {
+		name  string
+		chunk string
+	}{
+		{
+			name:  "llama",
+			chunk: `{"generation":",","prompt_token_count":null,"generation_token_count":8,"stop_reason":"length","amazon-bedrock-invocationMetrics":{"inputTokenCount":13,"outputTokenCount":8}}`,
+		},
+		{
+			name:  "mistral",
+			chunk: `{"outputs":[{"text":".","stop_reason":"length"}],"amazon-bedrock-invocationMetrics":{"inputTokenCount":12,"outputTokenCount":12}}`,
+		},
+		{
+			name:  "titan",
+			chunk: `{"outputText":".","completionReason":"LENGTH","inputTextTokenCount":12,"totalOutputTextTokenCount":12}`,
+		},
+		{
+			name:  "nova",
+			chunk: `{"messageStop":{"stopReason":"max_tokens"}}`,
+		},
+	}
+	adapter := &BedrockAdapter{}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sc, err := adapter.DecodeStreamChunk([]byte(tc.chunk))
+			require.NoError(t, err)
+			require.NotNil(t, sc)
+			assert.Equal(t, "length", sc.FinishReason)
+		})
+	}
+}
+
+func TestBedrock_StreamUsageStillReadsInvocationMetrics(t *testing.T) {
+	adapter := &BedrockAdapter{}
+	for _, tc := range []struct {
+		name  string
+		chunk string
+	}{
+		{"llama", `{"generation":"","stop_reason":"stop","amazon-bedrock-invocationMetrics":{"inputTokenCount":13,"outputTokenCount":8}}`},
+		{"mistral", `{"outputs":[{"text":"","stop_reason":"stop"}],"amazon-bedrock-invocationMetrics":{"inputTokenCount":13,"outputTokenCount":8}}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sc, err := adapter.DecodeStreamChunk([]byte(tc.chunk))
+			require.NoError(t, err)
+			require.NotNil(t, sc)
+			require.NotNil(t, sc.Usage)
+			assert.Equal(t, 13, sc.Usage.InputTokens)
+			assert.Equal(t, 8, sc.Usage.OutputTokens)
+			assert.Equal(t, 21, sc.Usage.TotalTokens)
+		})
+	}
+}
+
+// The Mistral template has no system turn, so a system message arriving in the
+// conversation (rather than in the dedicated field) used to vanish.
+func TestBedrock_MistralPromptKeepsSystemMessages(t *testing.T) {
+	prompt := formatMistralPrompt("", []CanonicalMessage{
+		{Role: "system", Content: "Answer in Catalan."},
+		{Role: "user", Content: "Explain AI"},
+	})
+	assert.Contains(t, prompt, "Answer in Catalan.")
+	assert.Contains(t, prompt, "Explain AI")
+}
+
+func TestBedrock_DetectFamilyByModel(t *testing.T) {
+	cases := []struct {
+		model string
+		want  string
+	}{
+		{"anthropic.claude-3-5-sonnet-20240620-v1:0", bfClaude},
+		{"eu.anthropic.claude-haiku-4-5-20251001-v1:0", bfClaude},
+		{"amazon.nova-lite-v1:0", bfNova},
+		{"eu.amazon.nova-lite-v1:0", bfNova},
+		{"amazon.titan-text-express-v1", bfTitan},
+		{"meta.llama3-70b-instruct-v1:0", bfLlama},
+		{"us.deepseek.deepseek-r1-v1:0", bfOpenAI},
+		{"mistral.mistral-7b-instruct-v0:2", bfMistral},
+		{"mistral.mixtral-8x7b-instruct-v0:1", bfMistral},
+		{"mistral.mistral-large-2402-v1:0", bfMistral},
+		{"mistral.mistral-large-2407-v1:0", bfOpenAI},
+		{"mistral.devstral-2-123b", bfOpenAI},
+		{"mistral.mistral-large-3-675b-instruct", bfOpenAI},
+		{"eu.mistral.pixtral-large-2502-v1:0", bfOpenAI},
+		// Vendors Bedrock added after the six original families, each invoked
+		// to confirm it answers the OpenAI chat completions schema.
+		{"openai.gpt-oss-20b-1:0", bfOpenAI},
+		{"qwen.qwen3-32b-v1:0", bfOpenAI},
+		{"google.gemma-3-4b-it", bfOpenAI},
+		{"nvidia.nemotron-nano-9b-v2", bfOpenAI},
+		{"minimax.minimax-m2", bfOpenAI},
+		{"zai.glm-4.7-flash", bfOpenAI},
+		// No vendor in the ID: a provisioned or custom model ARN keeps the
+		// incumbent fallback rather than erroring.
+		{"arn:aws:bedrock:eu-west-1:1234:provisioned-model/abcd", bfClaude},
+	}
+	for _, tc := range cases {
+		t.Run(tc.model, func(t *testing.T) {
+			assert.Equal(t, tc.want, detectFamilyByModel(tc.model))
+		})
+	}
 }

--- a/pkg/infra/providers/bedrock/client.go
+++ b/pkg/infra/providers/bedrock/client.go
@@ -15,12 +15,14 @@
 package bedrock
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"iter"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
@@ -29,6 +31,7 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/adapter"
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awsmiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
 	"github.com/aws/aws-sdk-go-v2/config"
 	awscredentials "github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
@@ -36,9 +39,18 @@ import (
 	bedrockTypes "github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	smithy "github.com/aws/smithy-go"
+	"github.com/aws/smithy-go/middleware"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 )
 
 const credentialsExpiryWindow = 5 * time.Minute
+
+// Bedrock reports the token counts of a buffered answer in these headers, for
+// every family, whether or not the body repeats them.
+const (
+	inputCountHeader  = "X-Amzn-Bedrock-Input-Token-Count"
+	outputCountHeader = "X-Amzn-Bedrock-Output-Token-Count"
+)
 
 type client struct {
 	clientPool    *sync.Map
@@ -76,7 +88,7 @@ func (c *client) Completions(
 		ModelId:     aws.String(model),
 		ContentType: aws.String("application/json"),
 		Body:        reqBody,
-	})
+	}, withRawResponse)
 	if err != nil {
 		if backendErr := newBedrockBackendError(err); backendErr != nil {
 			return nil, backendErr
@@ -84,7 +96,76 @@ func (c *client) Completions(
 		return nil, fmt.Errorf("failed to invoke model: %w", err)
 	}
 
-	return resp.Body, nil
+	return withHeaderTokenCounts(resp.Body, rawResponseHeaders(resp.ResultMetadata)), nil
+}
+
+// withRawResponse keeps the HTTP response reachable from the output metadata,
+// which is the only way to read the token-count headers: they are not modelled
+// in InvokeModelOutput. The SDK copies the options per call, so appending here
+// does not touch the pooled client.
+func withRawResponse(o *bedrockruntime.Options) {
+	o.APIOptions = append(o.APIOptions, awsmiddleware.AddRawResponseToMetadata)
+}
+
+func rawResponseHeaders(md middleware.Metadata) http.Header {
+	raw, ok := awsmiddleware.GetRawResponse(md).(*smithyhttp.Response)
+	if !ok || raw == nil || raw.Response == nil {
+		return nil
+	}
+	return raw.Header
+}
+
+// withHeaderTokenCounts splices the token counts Bedrock reports in headers into
+// the response body, under the same key the streaming path already carries them
+// in. Some families report usage nowhere else — a legacy Mistral answer is a
+// bare {"outputs":[…]} — so without this a buffered call looks free to every
+// plugin that charges for tokens.
+//
+// The counts go in first on purpose: a body that already carries real metrics
+// repeats the key, and the last occurrence is the one Go decodes, so the
+// upstream's own figures still win.
+func withHeaderTokenCounts(body []byte, headers http.Header) []byte {
+	if headers == nil {
+		return body
+	}
+	in := headerCount(headers, inputCountHeader)
+	out := headerCount(headers, outputCountHeader)
+	if in == 0 && out == 0 {
+		return body
+	}
+
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return body
+	}
+	rest := bytes.TrimLeft(trimmed[1:], " \t\r\n")
+	if len(rest) == 0 {
+		return body
+	}
+
+	metrics := fmt.Sprintf(
+		`"amazon-bedrock-invocationMetrics":{"inputTokenCount":%d,"outputTokenCount":%d}`,
+		in, out,
+	)
+	merged := make([]byte, 0, len(metrics)+len(trimmed)+1)
+	merged = append(merged, '{')
+	merged = append(merged, metrics...)
+	if rest[0] != '}' {
+		merged = append(merged, ',')
+	}
+	return append(merged, rest...)
+}
+
+func headerCount(headers http.Header, name string) int {
+	value := headers.Get(name)
+	if value == "" {
+		return 0
+	}
+	count, err := strconv.Atoi(value)
+	if err != nil || count < 0 {
+		return 0
+	}
+	return count
 }
 
 func (c *client) CompletionsStream(

--- a/pkg/infra/providers/bedrock/client_test.go
+++ b/pkg/infra/providers/bedrock/client_test.go
@@ -35,6 +35,71 @@ func TestNewBedrockClient(t *testing.T) {
 	assert.NotNil(t, NewBedrockClient())
 }
 
+// The body is verbatim from mistral-7b, which reports its token counts nowhere
+// else: without the headers a buffered answer costs zero.
+func TestWithHeaderTokenCounts(t *testing.T) {
+	counted := http.Header{
+		inputCountHeader:  []string{"11"},
+		outputCountHeader: []string{"16"},
+	}
+
+	t.Run("adds the counts a legacy Mistral body omits", func(t *testing.T) {
+		body := []byte(`{"outputs":[{"text":" OK.","stop_reason":"length"}]}`)
+
+		merged := withHeaderTokenCounts(body, counted)
+
+		var got struct {
+			Metrics struct {
+				InputTokenCount  int `json:"inputTokenCount"`
+				OutputTokenCount int `json:"outputTokenCount"`
+			} `json:"amazon-bedrock-invocationMetrics"`
+			Outputs []json.RawMessage `json:"outputs"`
+		}
+		require.NoError(t, json.Unmarshal(merged, &got))
+		assert.Equal(t, 11, got.Metrics.InputTokenCount)
+		assert.Equal(t, 16, got.Metrics.OutputTokenCount)
+		assert.Len(t, got.Outputs, 1)
+	})
+
+	t.Run("lets the body's own metrics win", func(t *testing.T) {
+		body := []byte(`{"amazon-bedrock-invocationMetrics":{"inputTokenCount":7,"outputTokenCount":3}}`)
+
+		merged := withHeaderTokenCounts(body, counted)
+
+		var got struct {
+			Metrics struct {
+				InputTokenCount int `json:"inputTokenCount"`
+			} `json:"amazon-bedrock-invocationMetrics"`
+		}
+		require.NoError(t, json.Unmarshal(merged, &got))
+		assert.Equal(t, 7, got.Metrics.InputTokenCount)
+	})
+
+	t.Run("leaves the body alone when there is nothing to add", func(t *testing.T) {
+		body := []byte(`{"outputs":[]}`)
+
+		assert.Equal(t, body, withHeaderTokenCounts(body, nil))
+		assert.Equal(t, body, withHeaderTokenCounts(body, http.Header{}))
+		assert.Equal(t, body, withHeaderTokenCounts(body, http.Header{
+			inputCountHeader: []string{"not a number"},
+		}))
+	})
+
+	t.Run("keeps malformed bodies untouched", func(t *testing.T) {
+		for _, body := range [][]byte{nil, []byte(""), []byte("not json"), []byte("{")} {
+			assert.Equal(t, body, withHeaderTokenCounts(body, counted))
+		}
+	})
+
+	t.Run("produces valid JSON for an empty object", func(t *testing.T) {
+		merged := withHeaderTokenCounts([]byte(`{ }`), counted)
+
+		var got map[string]any
+		require.NoError(t, json.Unmarshal(merged, &got))
+		assert.Contains(t, got, "amazon-bedrock-invocationMetrics")
+	})
+}
+
 func TestNewBedrockBackendError(t *testing.T) {
 	t.Run("converts AWS HTTP errors to backend errors", func(t *testing.T) {
 		err := &awshttp.ResponseError{


### PR DESCRIPTION
## Summary

Bedrock's InvokeModel schema is per model family, and the gateway picked the wrong one for several of them. Every finding here was reproduced against AWS with `bedrock-runtime`, and every fix re-verified the same way.

**Requests rejected outright**

- Amazon Nova had no case in the router and fell to the Claude fallback, which injects `max_tokens`: `Malformed input request: extraneous key [max_tokens] is not permitted`. It gets its own adapter for the messages-with-content-blocks shape.
- Every Mistral went to the text completion encoder, so `devstral` and the rest of the 2025 generation answered `missing field 'messages'`. Only the four models that really take a `prompt` string still do; anything newer takes messages.
- The vendors Bedrock added later (`gpt-oss`, `qwen`, `gemma`, `nemotron`, `minimax`, `glm`) were encoded as Claude and decoded as OpenAI — the same model read as two families. They work today only because those endpoints tolerate the `anthropic_version` stowaway. Each was invoked to confirm the schema before routing it.

**Usage silently lost**

Some families report a buffered answer's token counts nowhere but the HTTP headers — a legacy Mistral body is a bare `{"outputs":[…]}`. The client returned only the body, so those answers reached the usage-based plugins with no usage: the LLM Budget charged nothing and a one-token budget was never spent, which looks like the plugin being off rather than broken. The counts are now spliced into the body under the key the streaming path already uses, so every adapter reads them through the fallback it already has, and a body with its own usage still wins.

**Cost silently lost**

Many newer Bedrock models can only be invoked through a cross-region inference profile, which prefixes the ID with a geography — the client's own comments say that rewriting `eu.amazon.nova-lite-v1:0` to the bare ID makes AWS refuse the call. The catalog stores the bare ID, so the price lookup missed all of them: no cost in the metrics, and a **dollar budget that never charged**, on models that are otherwise priced and working. The geography now yields a second candidate slug, so the metrics builder, the cost plugin and its cap all pick the price up at once.

**Smaller correctness**

- A truncated streamed answer said `stop` instead of `length` for Llama and Mistral, so a cut-off answer looked complete. The buffered path always mapped it correctly.
- A `system` message arriving in the conversation vanished from the Mistral prompt, which has no system turn. It now rides on the next user turn, as Llama's formatter already did.

**Latency**

Family detection runs once per streamed chunk — a parse per token, on every provider. It no longer copies the JSON subtrees it only needs the presence of, and each chunk is parsed once instead of once for its own fields and again for the usage.

## Evidence

Verified end to end through the real encode → invoke → decode path in `eu-west-1`: `nova-lite`, `nova-micro`, `devstral`, `mistral-7b`, `gpt-oss-20b`, `qwen3-32b`, `gemma-3-4b`, `nemotron-nano-9b`, `minimax-m2`, `glm-4.7-flash`. The `mistral-7b` buffered answer went from no usage at all to `in=16 out=22 total=38`.

For the pricing gap, the production catalog carries `amazon.nova-lite-v1:0` with a price and no `eu.`/`us.` variant of anything — only `global.` twins — so every regional profile missed.

The gap is also covered from the outside: the LLM Budget provider sweep in [multi-agent-tests](https://github.com/NeuralTrust/multi-agent-tests) now exercises Bedrock with one model per encoding path, and its buffered rows are red against production until this ships.

## Test plan

- [x] `go test ./pkg/... -race`, `golangci-lint run`, gosec pre-commit hook
- [x] Live invocation of every model family above, before and after
- [ ] Re-run the provider sweep against a gateway carrying this branch: both Bedrock rows should go green
- [ ] Check a Bedrock request through a regional profile reports a cost in the metrics