### PR TITLE
fix(prompt_template): refuse ambiguous references and report silent rewrites

### DIFF
--- a/pkg/app/plugins/catalog_metadata.go
+++ b/pkg/app/plugins/catalog_metadata.go
@@ -552,7 +552,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 					Label:       "Template Engine",
 					Type:        FieldTypeEnum,
 					Description: "Placeholder rendering engine. Only mustache is supported in v1.",
-					Enum:        enumOptions("mustache", "jinja2_subset"),
+					Enum:        enumOptions("mustache"),
 					Default:     "mustache",
 				},
 				{

--- a/pkg/app/plugins/catalog_test.go
+++ b/pkg/app/plugins/catalog_test.go
@@ -664,7 +664,8 @@ func TestPromptTemplateSchema_Tree(t *testing.T) {
 	engineField, ok := fieldByKey(fields, "template_engine")
 	require.True(t, ok)
 	assert.Equal(t, FieldTypeEnum, engineField.Type)
-	assert.Equal(t, []string{"mustache", "jinja2_subset"}, enumValues(engineField.Enum))
+	assert.Equal(t, []string{"mustache"}, enumValues(engineField.Enum),
+		"jinja2_subset is refused by the plugin, so the catalog must not offer it")
 	assert.Equal(t, "mustache", engineField.Default)
 
 	contextVars, ok := fieldByKey(fields, "context_variables")

--- a/pkg/infra/plugins/prompttemplate/body.go
+++ b/pkg/infra/plugins/prompttemplate/body.go
@@ -39,6 +39,13 @@ type templateRef struct {
 	label string
 }
 
+func (r templateRef) String() string {
+	if r.label == "" {
+		return r.name
+	}
+	return r.name + "@" + r.label
+}
+
 type requestBody struct {
 	fields         map[string]json.RawMessage
 	system         string

--- a/pkg/infra/plugins/prompttemplate/data.go
+++ b/pkg/infra/plugins/prompttemplate/data.go
@@ -28,4 +28,7 @@ type PromptTemplateData struct {
 	SkippedIDs       []string `json:"skipped_ids,omitempty"`
 	UnresolvedIDs    []string `json:"unresolved_variables,omitempty"`
 	ResolvedTemplate string   `json:"resolved_template,omitempty"`
+	// DiscardedMessages counts the conversation turns a rendered template
+	// replaced, which is otherwise invisible to the caller and to the operator.
+	DiscardedMessages int `json:"discarded_messages,omitempty"`
 }

--- a/pkg/infra/plugins/prompttemplate/modea_test.go
+++ b/pkg/infra/plugins/prompttemplate/modea_test.go
@@ -198,8 +198,9 @@ func TestExecuteEnforceUnresolvedRejects(t *testing.T) {
 	require.Error(t, err)
 	pe, ok := appplugins.AsPluginError(err)
 	require.True(t, ok)
-	assert.Equal(t, http.StatusInternalServerError, pe.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, pe.StatusCode)
 	assert.Equal(t, typeVariableUnresolved, pe.Type)
+	assert.Contains(t, pe.Message, "tenant", "the caller is told which variable it failed to supply")
 }
 
 func TestExecuteObserveDoesNotMutateOrReject(t *testing.T) {

--- a/pkg/infra/plugins/prompttemplate/modeb.go
+++ b/pkg/infra/plugins/prompttemplate/modeb.go
@@ -26,6 +26,7 @@ type modeBResult struct {
 	hasReference     bool
 	changed          bool
 	resolvedTemplate string
+	discarded        int
 }
 
 func applyModeB(cfg *config, rb *requestBody, clientVars map[string]any, ctxVars map[string]string) (modeBResult, error) {
@@ -38,6 +39,16 @@ func applyModeB(cfg *config, rb *requestBody, clientVars map[string]any, ctxVars
 	}
 
 	ref := refs[0]
+	if other, ok := conflictingRef(refs); ok {
+		// A rendered template replaces the whole conversation, so two different
+		// ones cannot both be honoured. Rendering the first silently served a
+		// template the caller did not ask for.
+		return modeBResult{hasReference: true}, reject(
+			http.StatusBadRequest,
+			typeAmbiguous,
+			fmt.Sprintf("request references both %s and %s; only one template can be rendered", ref, other),
+		)
+	}
 	nt, ok := findNamedTemplate(cfg, ref.name)
 	if !ok {
 		return modeBResult{hasReference: true}, reject(http.StatusBadRequest, typeNotFound, fmt.Sprintf("template %q not found", ref.name))
@@ -58,12 +69,31 @@ func applyModeB(cfg *config, rb *requestBody, clientVars map[string]any, ctxVars
 	if err != nil {
 		return result, err
 	}
+	before := len(rb.messages)
 	if err := rb.replaceMessages(rendered); err != nil {
 		return result, reject(http.StatusInternalServerError, typeRenderFailed, "rendered template is not a valid messages array")
 	}
 
 	result.changed = true
+	// Rendering replaces the conversation rather than the referencing message,
+	// so a multi-turn caller loses the history it sent. Reported because the
+	// caller cannot see it: the answer just gets worse.
+	if dropped := before - len(rb.messages); dropped > 0 {
+		result.discarded = dropped
+	}
 	return result, nil
+}
+
+// conflictingRef reports the first reference that asks for something other than
+// refs[0]. Repeating the same reference is not a conflict: a multi-turn client
+// resends its earlier turns, so the same one arrives again on every request.
+func conflictingRef(refs []templateRef) (templateRef, bool) {
+	for _, ref := range refs[1:] {
+		if ref != refs[0] {
+			return ref, true
+		}
+	}
+	return templateRef{}, false
 }
 
 func findNamedTemplate(cfg *config, name string) (*namedTemplate, bool) {

--- a/pkg/infra/plugins/prompttemplate/modeb_test.go
+++ b/pkg/infra/plugins/prompttemplate/modeb_test.go
@@ -220,16 +220,31 @@ func TestApplyModeBBareStringWrap(t *testing.T) {
 	assert.JSONEq(t, `{"messages":[{"role":"user","content":"You are a friendly bot."}]}`, string(out))
 }
 
-func TestApplyModeBUsesFirstReference(t *testing.T) {
+func TestApplyModeBRejectsConflictingReferences(t *testing.T) {
 	enabled := true
 	first := namedTemplate{Name: "first", Versions: []templateVersion{{Labels: []string{"stable"}, Content: `[{"role":"system","content":"FIRST"}]`}}}
 	second := namedTemplate{Name: "second", Versions: []templateVersion{{Labels: []string{"stable"}, Content: `[{"role":"system","content":"SECOND"}]`}}}
 	cfg := &config{TemplateEngine: engineMustache, NamedTemplates: []namedTemplate{first, second}, DefaultLabel: "stable", OnMissingClientVariable: onMissingClientError, EscapeJSONControlChars: &enabled}
 	rb, err := decodeBody([]byte(`{"messages":[{"role":"user","content":"{template://first}"},{"role":"user","content":"{template://second}"}]}`))
 	require.NoError(t, err)
+	_, err = applyModeB(cfg, rb, nil, nil)
+	pe := requirePluginError(t, err)
+	assert.Equal(t, http.StatusBadRequest, pe.StatusCode)
+	assert.Equal(t, typeAmbiguous, pe.Type)
+}
+
+// A multi-turn caller resends its earlier turns, so the reference it used before
+// arrives again alongside the current one. Identical repeats are unambiguous.
+func TestApplyModeBAcceptsRepeatedReference(t *testing.T) {
+	enabled := true
+	first := namedTemplate{Name: "first", Versions: []templateVersion{{Labels: []string{"stable"}, Content: `[{"role":"system","content":"FIRST"}]`}}}
+	cfg := &config{TemplateEngine: engineMustache, NamedTemplates: []namedTemplate{first}, DefaultLabel: "stable", OnMissingClientVariable: onMissingClientError, EscapeJSONControlChars: &enabled}
+	rb, err := decodeBody([]byte(`{"messages":[{"role":"user","content":"{template://first}"},{"role":"assistant","content":"ok"},{"role":"user","content":"{template://first}"}]}`))
+	require.NoError(t, err)
 	outcome, err := applyModeB(cfg, rb, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "first", outcome.resolvedTemplate)
+	assert.Equal(t, 2, outcome.discarded, "the two turns the template replaced are reported")
 	out, err := rb.marshal()
 	require.NoError(t, err)
 	assert.JSONEq(t, `{"messages":[{"role":"system","content":"FIRST"}]}`, string(out))

--- a/pkg/infra/plugins/prompttemplate/plugin.go
+++ b/pkg/infra/plugins/prompttemplate/plugin.go
@@ -32,6 +32,7 @@ const (
 	typeVariableInvalid    = "template_variable_invalid"
 	typeNotFound           = "template_not_found"
 	typeRequired           = "template_required"
+	typeAmbiguous          = "template_ambiguous"
 	typeRenderFailed       = "template_render_failed"
 )
 
@@ -133,7 +134,14 @@ func runModes(cfg *config, rb *requestBody, properties map[string]any, ctxVars m
 	if modeA {
 		aOutcome = applyModeA(cfg, rb, ctxVars)
 		if cfg.OnMissingContextVariable == onMissingContextError && len(aOutcome.unresolved) > 0 {
-			return aOutcome, bOutcome, reject(http.StatusInternalServerError, typeVariableUnresolved, "unresolved context variable")
+			// The variable is missing because the caller omitted the header or the
+			// claim it comes from, so this is their error to fix, as it already is
+			// for a missing client variable in mode B.
+			return aOutcome, bOutcome, reject(
+				http.StatusBadRequest,
+				typeVariableUnresolved,
+				fmt.Sprintf("context variable %q could not be resolved", aOutcome.unresolved[0]),
+			)
 		}
 	}
 	return aOutcome, bOutcome, nil
@@ -141,11 +149,12 @@ func runModes(cfg *config, rb *requestBody, properties map[string]any, ctxVars m
 
 func buildData(decision string, a modeAOutcome, b modeBResult) PromptTemplateData {
 	return PromptTemplateData{
-		Decision:         decision,
-		InjectedIDs:      a.injected,
-		SkippedIDs:       a.skipped,
-		UnresolvedIDs:    a.unresolved,
-		ResolvedTemplate: b.resolvedTemplate,
+		Decision:          decision,
+		InjectedIDs:       a.injected,
+		SkippedIDs:        a.skipped,
+		UnresolvedIDs:     a.unresolved,
+		ResolvedTemplate:  b.resolvedTemplate,
+		DiscardedMessages: b.discarded,
 	}
 }
 

--- a/tests/functional/plugin_prompt_template_test.go
+++ b/tests/functional/plugin_prompt_template_test.go
@@ -198,7 +198,7 @@ func TestPluginE2E_PromptTemplate_ErrorCodes(t *testing.T) {
 		},
 	}
 
-	t.Run("unresolved context variable returns 500 template_variable_unresolved", func(t *testing.T) {
+	t.Run("unresolved context variable returns 400 template_variable_unresolved", func(t *testing.T) {
 		up := newJSONUpstream(t, "prompt-unresolved")
 		apiKey, path := setupPolicyRoute(t, up, promptTemplatePolicy(map[string]any{
 			"context_variables": map[string]any{
@@ -213,8 +213,9 @@ func TestPluginE2E_PromptTemplate_ErrorCodes(t *testing.T) {
 		body := mustJSON(t, chatBody([]map[string]any{{"role": "user", "content": "Hello"}}, nil))
 		status, _, raw := proxyRequest(t, http.MethodPost, apiKey, path, nil, body)
 
-		assert.Equal(t, http.StatusInternalServerError, status, "body: %s", raw)
+		assert.Equal(t, http.StatusBadRequest, status, "body: %s", raw)
 		assert.Contains(t, string(raw), "template_variable_unresolved")
+		assert.Contains(t, string(raw), "tenant", "the caller is told which variable it failed to supply")
 		assert.Equal(t, 0, up.Hits(), "a rejected request must not reach the upstream")
 	})
 
@@ -270,6 +271,43 @@ func TestPluginE2E_PromptTemplate_ErrorCodes(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, status, "body: %s", raw)
 		assert.Contains(t, string(raw), "template_not_found")
 		assert.Equal(t, 0, up.Hits())
+	})
+
+	t.Run("two different references return 400 template_ambiguous", func(t *testing.T) {
+		up := newJSONUpstream(t, "prompt-ambiguous")
+		apiKey, path := setupPolicyRoute(t, up, promptTemplatePolicy(map[string]any{
+			"named_templates":            namedTemplate,
+			"default_label":              "stable",
+			"allow_untemplated_requests": false,
+		}))
+
+		body := mustJSON(t, chatBody([]map[string]any{
+			{"role": "user", "content": "{template://support-bot@stable} and {template://other@stable}"},
+		}, map[string]any{"properties": map[string]any{"persona": "friendly"}}))
+		status, _, raw := proxyRequest(t, http.MethodPost, apiKey, path, nil, body)
+
+		assert.Equal(t, http.StatusBadRequest, status, "body: %s", raw)
+		assert.Contains(t, string(raw), "template_ambiguous")
+		assert.Equal(t, 0, up.Hits())
+	})
+
+	t.Run("the same reference repeated across turns still renders", func(t *testing.T) {
+		up := newJSONUpstream(t, "prompt-repeated")
+		apiKey, path := setupPolicyRoute(t, up, promptTemplatePolicy(map[string]any{
+			"named_templates":            namedTemplate,
+			"default_label":              "stable",
+			"allow_untemplated_requests": false,
+		}))
+
+		body := mustJSON(t, chatBody([]map[string]any{
+			{"role": "user", "content": "{template://support-bot@stable}"},
+			{"role": "assistant", "content": "sure"},
+			{"role": "user", "content": "{template://support-bot@stable}"},
+		}, map[string]any{"properties": map[string]any{"persona": "friendly"}}))
+		status, _, raw := proxyRequest(t, http.MethodPost, apiKey, path, nil, body)
+
+		assert.Equal(t, http.StatusOK, status, "body: %s", raw)
+		assert.Equal(t, 1, up.Hits(), "a repeated reference is not a conflict and must be served")
 	})
 
 	t.Run("no reference with allow_untemplated_requests false returns 400 template_required", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Four behaviours the plugin had and did not announce, all surfaced by an end-to-end sweep of its option surface (66 cases against production, every one of them green — none of these was a broken promise, which is why unit tests never caught them).

**A caller's mistake answered 5xx.** A missing context variable means the caller omitted the header or the JWT claim it comes from, but mode A answered `500 template_variable_unresolved` where mode B answers `400` for the same class of failure. A 5xx wakes an on-call engineer and invites automatic retries for a request that can never succeed unchanged. It now answers `400`, and names the variable instead of the bare `"unresolved context variable"` it used to send while holding the name in hand.

**The second template reference was dropped in silence.** Only `refs[0]` was rendered, so a client referencing two templates got a valid answer built from one of them and no way to notice. Two *different* references are now refused with `400 template_ambiguous`, naming both.

The refusal is deliberately narrow: a rendered template replaces the whole conversation, so a multi-turn client resends its earlier turns and the same reference arrives again on every request. Those repeats are unambiguous and still render — refusing them would break every conversation that uses one template twice.

**The discarded conversation is now visible.** Rendering replaces every message rather than the referencing one, so a multi-turn caller loses the history it just paid to build. That is mode B's design and this PR leaves it alone, but `discarded_messages` is now reported in the plugin's telemetry so an operator can see what the caller cannot.

**An engine nobody could select.** The catalog offered `jinja2_subset` in a dropdown whose own description says only mustache is supported, and the plugin refuses it at policy creation. It is no longer advertised.

## Risk

The ambiguous-reference refusal is the only change that can turn a working request into an error: a client deliberately relying on "first wins" with two *different* templates now gets a 400. Judged acceptable because that path was serving a template the caller had not asked for, but it is the line to review.

## Test plan

- [x] `go test -race ./pkg/infra/plugins/prompttemplate/... ./pkg/app/plugins/...`
- [x] `go vet`, `golangci-lint run` (0 issues), `gofmt`
- [x] Three unit tests that pinned the old behaviour updated; one added for the repeated reference and the discarded count
- [x] `go test -tags functional ./tests/functional/...` — the functional case pinning the 500 sat two subtests above the one demanding 400 for mode B's equivalent failure, and now asserts 400 plus the named variable; two cases added for the ambiguous refusal and the repeated reference
- [ ] Re-run the e2e suite after deploy — two cases in `multi-agent-tests` assert this contract and are red until then

Made with [Cursor](https://cursor.com)

