### PR TITLE
fix(prompt_compression): advertise every option and name the real skip reason

### DIFF
--- a/pkg/app/plugins/catalog_metadata.go
+++ b/pkg/app/plugins/catalog_metadata.go
@@ -760,6 +760,48 @@ var pluginCatalogMeta = map[string]catalogMeta{
 		schema: SettingsSchema{
 			Fields: []Field{
 				{
+					Key:         "compress_json",
+					Label:       "Compress JSON",
+					Type:        FieldTypeBoolean,
+					Description: "Minify standalone JSON message content, ```json fenced blocks and tool-call arguments. At least one transform must stay enabled.",
+					Default:     true,
+				},
+				{
+					Key:         "normalize_whitespace",
+					Label:       "Normalize Whitespace",
+					Type:        FieldTypeBoolean,
+					Description: "Trim trailing spaces per line, keeping Markdown hard line breaks, and collapse runs of blank lines.",
+					Default:     true,
+				},
+				{
+					Key:         "strip_ansi",
+					Label:       "Strip ANSI Escapes",
+					Type:        FieldTypeBoolean,
+					Description: "Remove ANSI colour and cursor sequences, common in captured terminal and CI logs.",
+					Default:     true,
+				},
+				{
+					Key:         "max_consecutive_blank_lines",
+					Label:       "Max Consecutive Blank Lines",
+					Type:        FieldTypeInteger,
+					Description: "Longest run of blank lines kept when whitespace is normalized. Between 1 and 1000.",
+					Default:     1,
+				},
+				{
+					Key:         "min_length",
+					Label:       "Minimum Content Length",
+					Type:        FieldTypeInteger,
+					Description: "Skip message content shorter than this many bytes; 0 compresses everything. Leaving small messages byte-identical protects provider prompt-cache prefixes.",
+					Default:     256,
+				},
+				{
+					Key:         "max_body_bytes",
+					Label:       "Max Body Bytes",
+					Type:        FieldTypeInteger,
+					Description: "Skip the whole pipeline for request bodies larger than this, bounding per-request CPU cost; 0 disables the cap.",
+					Default:     1048576,
+				},
+				{
 					Key:         "target_roles",
 					Label:       "Target Roles",
 					Type:        FieldTypeArray,

--- a/pkg/app/plugins/catalog_test.go
+++ b/pkg/app/plugins/catalog_test.go
@@ -749,3 +749,39 @@ func TestPromptTemplateSchema_Tree(t *testing.T) {
 		assert.Truef(t, ok, "missing top-level field %q", k)
 	}
 }
+
+// The keys are string literals rather than the plugin's config struct because
+// infra plugins depend on this package; the point of the test is that the two
+// lists cannot drift apart unnoticed. Settings are not validated against the
+// schema, so an option missing here still works over the API and is simply
+// unreachable from the admin UI — the failure mode this test exists to prevent.
+func TestPromptCompressionSchema_AdvertisesEveryHonouredOption(t *testing.T) {
+	meta, ok := pluginCatalogMeta["prompt_compression"]
+	require.True(t, ok)
+
+	fields := meta.schema.Fields
+	for _, expected := range []struct {
+		key       string
+		fieldType FieldType
+		def       any
+	}{
+		{"compress_json", FieldTypeBoolean, true},
+		{"normalize_whitespace", FieldTypeBoolean, true},
+		{"strip_ansi", FieldTypeBoolean, true},
+		{"max_consecutive_blank_lines", FieldTypeInteger, 1},
+		{"min_length", FieldTypeInteger, 256},
+		{"max_body_bytes", FieldTypeInteger, 1048576},
+	} {
+		field, found := fieldByKey(fields, expected.key)
+		require.Truef(t, found, "the plugin honours %q but the catalog does not offer it", expected.key)
+		assert.Equal(t, expected.fieldType, field.Type, expected.key)
+		assert.Equal(t, expected.def, field.Default,
+			"%s must advertise the default the plugin actually applies", expected.key)
+	}
+
+	roles, found := fieldByKey(fields, "target_roles")
+	require.True(t, found)
+	assert.Equal(t, FieldTypeArray, roles.Type)
+	require.NotNil(t, roles.Item)
+	assert.Equal(t, []string{"system", "user", "assistant", "tool"}, enumValues(roles.Item.Enum))
+}

--- a/pkg/infra/plugins/promptcompression/data.go
+++ b/pkg/infra/plugins/promptcompression/data.go
@@ -27,6 +27,11 @@ const (
 	decisionNoChange     = "no_change"
 	decisionSkipped      = "skipped_too_large"
 	decisionSkippedLossy = "skipped_lossy_roundtrip"
+	// decisionSkippedFormat separates "this plugin does not speak the wire
+	// format the client used" from "this payload cannot be rewritten safely".
+	// Both leave the request untouched, but only the second is something the
+	// caller can act on by changing what they send.
+	decisionSkippedFormat = "skipped_unsupported_format"
 )
 
 // Response headers surfacing the compression outcome to the caller, following

--- a/pkg/infra/plugins/promptcompression/plugin.go
+++ b/pkg/infra/plugins/promptcompression/plugin.go
@@ -104,11 +104,18 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 		p.debug(ctx, "resolve request format failed", slog.Any("error", err))
 		return passThrough(), nil
 	}
+	// Only the OpenAI-compatible and Anthropic request shapes are modeled here,
+	// so a client on any other route (the Responses API, Gemini's own) is left
+	// alone. Reported apart from the round-trip veto below: nothing the caller
+	// does to the payload will change this one.
+	if !supportedFormat(format) {
+		return p.skip(in, cfg, decisionSkippedFormat), nil
+	}
 	// The canonical round-trip is lossy for shapes it does not model
 	// (multimodal parts, cache_control annotations, unmodeled fields). A
 	// request that might lose data on re-encode is never touched.
-	if !supportedFormat(format) || !roundTripSafe(in.Request.Body) {
-		return p.skipLossy(in, cfg), nil
+	if !roundTripSafe(in.Request.Body) {
+		return p.skip(in, cfg, decisionSkippedLossy), nil
 	}
 	creq, err := p.registry.DecodeRequestFor(in.Request.Body, format)
 	if err != nil || creq == nil {
@@ -121,19 +128,19 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 		return passThrough(), nil
 	}
 	if changed && !keepsTopLevelFields(in.Request.Body, body) {
-		return p.skipLossy(in, cfg), nil
+		return p.skip(in, cfg, decisionSkippedLossy), nil
 	}
 	return p.decide(in, cfg, changed, body), nil
 }
 
-// skipLossy records that the request was left untouched because compressing
-// it would risk dropping content the canonical model does not represent.
-func (p *Plugin) skipLossy(in appplugins.ExecInput, cfg Settings) *appplugins.Result {
+// skip records that the request was forwarded untouched, naming which of the
+// guards declined it so the operator is not sent looking in the wrong place.
+func (p *Plugin) skip(in appplugins.ExecInput, cfg Settings, decision string) *appplugins.Result {
 	data := &Data{
 		Stage:      string(in.Stage),
 		Mode:       string(in.Mode),
 		Transforms: cfg.describe(),
-		Decision:   decisionSkippedLossy,
+		Decision:   decision,
 		BytesIn:    len(in.Request.Body),
 		BytesOut:   len(in.Request.Body),
 	}

--- a/pkg/infra/plugins/promptcompression/plugin_test.go
+++ b/pkg/infra/plugins/promptcompression/plugin_test.go
@@ -387,4 +387,23 @@ func TestExecuteSetsCompressionHeaders(t *testing.T) {
 		require.Nil(t, res.RequestBody)
 		require.Equal(t, []string{"skipped_lossy_roundtrip"}, res.Headers[headerDecision])
 	})
+
+	// A payload the plugin would happily compress on /chat/completions, sent on
+	// a route it does not model. Reporting the round-trip veto here would send
+	// the operator to inspect a prompt that was never the problem.
+	t.Run("an unsupported wire format is reported apart from a lossy payload", func(t *testing.T) {
+		t.Parallel()
+		body := []byte(`{"model":"gpt-4o","input":[{"role":"user","content":"` + verbose + `"}]}`)
+		in := execInput(
+			policy.StagePreRequest,
+			policy.ModeEnforce,
+			defaultSettings(),
+			reqCtx(openAIProvider, string(adapter.FormatOpenAIResponses), body),
+			newEvent(),
+		)
+		res, err := p.Execute(context.Background(), in)
+		require.NoError(t, err)
+		require.Nil(t, res.RequestBody)
+		require.Equal(t, []string{"skipped_unsupported_format"}, res.Headers[headerDecision])
+	})
 }


### PR DESCRIPTION
## Summary

Two contract gaps found by the end-to-end sweep of the plugin (36 cases against the production gateway). Neither is a broken promise: the compression itself does what it says, losslessly and deterministically, and the model really is billed for less. Both are about what the plugin tells the people using it.

**Six options nobody could find.** The plugin honours seven settings and `catalog_metadata.go` advertised one (`target_roles`). Since settings are not validated against the schema, the other six worked perfectly well over the API — the sweep proves each one changes behaviour — but the admin UI renders this schema, so they could only be found by reading the Go source. An operator who wanted JSON minified with whitespace preserved, or the 256-byte floor lowered for short messages, had a plugin that did exactly that and no way to reach it. All six are now advertised with the defaults the plugin actually applies.

**A reason that was not the reason.** An unsupported wire format reported `skipped_lossy_roundtrip`, the same verdict as a payload carrying a `cache_control` annotation or an unmodelled key. But a client on the Responses API has a perfectly good payload and a route the plugin does not model, so the verdict sent whoever read it to inspect prompts that were never the problem and could never be fixed. That path now reports `skipped_unsupported_format`.

## Test plan

- [x] `go test ./pkg/app/plugins/... ./pkg/infra/plugins/promptcompression/... -race`
- [x] `go vet` and `golangci-lint run` clean on both packages
- [x] New unit case: an unsupported wire format is reported apart from a lossy payload
- [x] New unit case: the catalog advertises every option the plugin honours, with its real default
- [ ] After deploy: re-run `pytest src/e2e/tests/test_prompt_compression.py` in multi-agent-tests — the catalog case is red until this ships, and the Responses-API case asserts the new verdict

## Notes

Settings are still not validated against the schema (`ErrorUnused: false` is global to every plugin), so this changes nothing for existing policies — it only makes the options visible. The header value for the unsupported-format path changes, which is why the e2e case moves with it.

Made with [Cursor](https://cursor.com)