### PR TITLE
fix: refuse a policy mode the plugin does not support

### DIFF
--- a/pkg/app/plugins/mocks/registry_mock.go
+++ b/pkg/app/plugins/mocks/registry_mock.go
@@ -219,6 +219,53 @@ func (_c *Registry_Validate_Call) RunAndReturn(run func(string, map[string]inter
 	return _c
 }
 
+// ValidateMode provides a mock function with given fields: name, selected
+func (_m *Registry) ValidateMode(name string, selected policy.Mode) error {
+	ret := _m.Called(name, selected)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ValidateMode")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, policy.Mode) error); ok {
+		r0 = rf(name, selected)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Registry_ValidateMode_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ValidateMode'
+type Registry_ValidateMode_Call struct {
+	*mock.Call
+}
+
+// ValidateMode is a helper method to define mock.On call
+//   - name string
+//   - selected policy.Mode
+func (_e *Registry_Expecter) ValidateMode(name interface{}, selected interface{}) *Registry_ValidateMode_Call {
+	return &Registry_ValidateMode_Call{Call: _e.mock.On("ValidateMode", name, selected)}
+}
+
+func (_c *Registry_ValidateMode_Call) Run(run func(name string, selected policy.Mode)) *Registry_ValidateMode_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string), args[1].(policy.Mode))
+	})
+	return _c
+}
+
+func (_c *Registry_ValidateMode_Call) Return(_a0 error) *Registry_ValidateMode_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Registry_ValidateMode_Call) RunAndReturn(run func(string, policy.Mode) error) *Registry_ValidateMode_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ValidateStages provides a mock function with given fields: name, selected
 func (_m *Registry) ValidateStages(name string, selected []policy.Stage) error {
 	ret := _m.Called(name, selected)

--- a/pkg/app/plugins/modes.go
+++ b/pkg/app/plugins/modes.go
@@ -23,6 +23,19 @@ import (
 )
 
 var ErrInvalidModes = errors.New("plugin: invalid declared modes")
+var ErrModeNotSupported = errors.New("plugin: mode not supported")
+
+// ValidateMode reports whether a policy may run the plugin in the given mode.
+// An empty mode is the default one, which every plugin supports.
+func ValidateMode(p PluginDescriptor, selected policy.Mode) error {
+	mode := selected.Normalize()
+	for _, m := range p.SupportedModes() {
+		if m == mode {
+			return nil
+		}
+	}
+	return fmt.Errorf("%w: %q", ErrModeNotSupported, mode)
+}
 
 func validateDeclaredModes(name string, modes []policy.Mode) error {
 	if len(modes) == 0 {

--- a/pkg/app/plugins/registry.go
+++ b/pkg/app/plugins/registry.go
@@ -32,6 +32,7 @@ type Registry interface {
 	Get(name string) (Plugin, bool)
 	Validate(name string, settings map[string]any) error
 	ValidateStages(name string, selected []policy.Stage) error
+	ValidateMode(name string, selected policy.Mode) error
 	Names() []string
 }
 
@@ -102,6 +103,14 @@ func (r *registry) ValidateStages(name string, selected []policy.Stage) error {
 		return fmt.Errorf("%w: %s", ErrUnknownPlugin, name)
 	}
 	return ValidateStages(p, selected)
+}
+
+func (r *registry) ValidateMode(name string, selected policy.Mode) error {
+	p, ok := r.plugins[name]
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrUnknownPlugin, name)
+	}
+	return ValidateMode(p, selected)
 }
 
 func (r *registry) Names() []string {

--- a/pkg/app/plugins/registry_test.go
+++ b/pkg/app/plugins/registry_test.go
@@ -29,17 +29,24 @@ type stagePlugin struct {
 	mandatory []policy.Stage
 	supported []policy.Stage
 	protocols []Protocol
+	modes     []policy.Mode
 }
 
 func (s *stagePlugin) Name() string                                        { return s.name }
 func (s *stagePlugin) MandatoryStages() []policy.Stage                     { return s.mandatory }
 func (s *stagePlugin) SupportedStages() []policy.Stage                     { return s.supported }
-func (s *stagePlugin) SupportedModes() []policy.Mode                       { return []policy.Mode{policy.ModeEnforce} }
 func (s *stagePlugin) ValidateConfig(map[string]any) error                 { return nil }
 func (s *stagePlugin) Execute(context.Context, ExecInput) (*Result, error) { return nil, nil }
 func (s *stagePlugin) MutatesRequestBody() bool                            { return false }
 func (s *stagePlugin) MutatesResponseBody() bool                           { return false }
 func (s *stagePlugin) MutatesMetadata() bool                               { return false }
+
+func (s *stagePlugin) SupportedModes() []policy.Mode {
+	if s.modes != nil {
+		return s.modes
+	}
+	return []policy.Mode{policy.ModeEnforce}
+}
 
 func (s *stagePlugin) SupportedProtocols() []Protocol {
 	if s.protocols != nil {
@@ -171,4 +178,28 @@ func TestRegistry_ValidateStages(t *testing.T) {
 	require.NoError(t, reg.ValidateStages("mandatoryonly", nil))
 	// Unknown plugin.
 	require.ErrorIs(t, reg.ValidateStages("missing", nil), ErrUnknownPlugin)
+}
+
+func TestRegistry_ValidateMode(t *testing.T) {
+	reg := NewRegistry()
+	require.NoError(t, reg.Register(&stagePlugin{
+		name:      "enforceonly",
+		mandatory: []policy.Stage{policy.StagePreRequest},
+		supported: []policy.Stage{policy.StagePreRequest},
+	}))
+	require.NoError(t, reg.Register(&stagePlugin{
+		name:      "observable",
+		mandatory: []policy.Stage{policy.StagePreRequest},
+		supported: []policy.Stage{policy.StagePreRequest},
+		modes:     []policy.Mode{policy.ModeEnforce, policy.ModeObserve},
+	}))
+
+	require.NoError(t, reg.ValidateMode("enforceonly", policy.ModeEnforce))
+	// An empty mode is the default one, which every plugin supports.
+	require.NoError(t, reg.ValidateMode("enforceonly", ""))
+	// A plugin that cannot dry-run must not be configured to.
+	require.ErrorIs(t, reg.ValidateMode("enforceonly", policy.ModeObserve), ErrModeNotSupported)
+	require.NoError(t, reg.ValidateMode("observable", policy.ModeObserve))
+	require.ErrorIs(t, reg.ValidateMode("observable", policy.ModeThrottle), ErrModeNotSupported)
+	require.ErrorIs(t, reg.ValidateMode("missing", policy.ModeEnforce), ErrUnknownPlugin)
 }

--- a/pkg/app/policy/creator.go
+++ b/pkg/app/policy/creator.go
@@ -74,7 +74,7 @@ func (c *creator) Create(ctx context.Context, in CreateInput) (*domain.Policy, e
 	if err != nil {
 		return nil, err
 	}
-	if err := validatePlugin(c.registry, in.Slug, in.Stages, in.Settings); err != nil {
+	if err := validatePlugin(c.registry, in.Slug, in.Stages, p.Mode, in.Settings); err != nil {
 		return nil, err
 	}
 	if err := c.repo.Save(ctx, p); err != nil {

--- a/pkg/app/policy/creator_test.go
+++ b/pkg/app/policy/creator_test.go
@@ -46,6 +46,7 @@ func newRegistryMock(t *testing.T, stagesErr error) *pluginmocks.Registry {
 	t.Helper()
 	reg := pluginmocks.NewRegistry(t)
 	reg.EXPECT().ValidateStages(mock.Anything, mock.Anything).Return(stagesErr).Maybe()
+	reg.EXPECT().ValidateMode(mock.Anything, mock.Anything).Return(nil).Maybe()
 	reg.EXPECT().Validate(mock.Anything, mock.Anything).Return(nil).Maybe()
 	return reg
 }
@@ -109,6 +110,21 @@ func TestCreator_Create_RejectsUnsupportedStage(t *testing.T) {
 	_, err := creator.Create(context.Background(), validCreateInput(ids.New[ids.GatewayKind]()))
 	if !errors.Is(err, sentinel) {
 		t.Fatalf("err = %v, want registry stage error", err)
+	}
+}
+
+func TestCreator_Create_RejectsUnsupportedMode(t *testing.T) {
+	t.Parallel()
+	repo := repomocks.NewRepository(t)
+	sentinel := errors.New("mode not supported")
+	reg := pluginmocks.NewRegistry(t)
+	reg.EXPECT().ValidateStages(mock.Anything, mock.Anything).Return(nil).Maybe()
+	reg.EXPECT().ValidateMode(mock.Anything, mock.Anything).Return(sentinel).Once()
+	creator := apppolicy.NewCreator(repo, reg, newCacheManager(), newTestLogger(), nil)
+
+	_, err := creator.Create(context.Background(), validCreateInput(ids.New[ids.GatewayKind]()))
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want registry mode error", err)
 	}
 }
 

--- a/pkg/app/policy/updater.go
+++ b/pkg/app/policy/updater.go
@@ -114,7 +114,13 @@ func (u *updater) Update(ctx context.Context, in UpdateInput) (*domain.Policy, e
 	if err := existing.Validate(); err != nil {
 		return nil, err
 	}
-	if err := validatePlugin(u.registry, existing.Slug, existing.Stages, existing.Settings); err != nil {
+	if err := validatePlugin(
+		u.registry,
+		existing.Slug,
+		existing.Stages,
+		existing.Mode,
+		existing.Settings,
+	); err != nil {
 		return nil, err
 	}
 	if err := u.repo.Update(ctx, existing); err != nil {

--- a/pkg/app/policy/validate.go
+++ b/pkg/app/policy/validate.go
@@ -22,8 +22,17 @@ import (
 	domain "github.com/NeuralTrust/TrustGate/pkg/domain/policy"
 )
 
-func validatePlugin(reg appplugins.Registry, slug string, stages []domain.Stage, settings map[string]any) error {
+func validatePlugin(
+	reg appplugins.Registry,
+	slug string,
+	stages []domain.Stage,
+	mode domain.Mode,
+	settings map[string]any,
+) error {
 	if err := reg.ValidateStages(slug, stages); err != nil {
+		return errors.Join(commonerrors.ErrValidation, err)
+	}
+	if err := reg.ValidateMode(slug, mode); err != nil {
 		return errors.Join(commonerrors.ErrValidation, err)
 	}
 	if err := reg.Validate(slug, settings); err != nil {

--- a/pkg/infra/plugins/toolinjection/config.go
+++ b/pkg/infra/plugins/toolinjection/config.go
@@ -24,6 +24,8 @@ const (
 	conflictGatewayWins = "gateway_wins"
 	conflictClientWins  = "client_wins"
 	conflictReject      = "reject"
+
+	toolTypeFunction = "function"
 )
 
 var validScopes = map[string]struct{}{
@@ -79,6 +81,11 @@ func (c *config) validate() error {
 	for i := range c.InjectTools {
 		if c.InjectTools[i].Function.Name == "" {
 			return fmt.Errorf("tool_injection: inject_tools[%d]: function.name must not be empty", i)
+		}
+		// Every entry becomes a function tool whatever the type says, so a type
+		// the plugin cannot honour is refused rather than silently reinterpreted.
+		if t := c.InjectTools[i].Type; t != "" && t != toolTypeFunction {
+			return fmt.Errorf("tool_injection: inject_tools[%d]: type must be %q", i, toolTypeFunction)
 		}
 	}
 	if len(c.InjectTools) == 0 {

--- a/pkg/infra/plugins/toolinjection/plugin_test.go
+++ b/pkg/infra/plugins/toolinjection/plugin_test.go
@@ -75,6 +75,23 @@ func TestConfigValidate(t *testing.T) {
 			settings: map[string]any{},
 			wantErr:  true,
 		},
+		{
+			name: "omitted type defaults to function",
+			settings: map[string]any{
+				"inject_tools": []any{
+					map[string]any{"function": map[string]any{"name": "safety_check"}},
+				},
+			},
+		},
+		{
+			name: "type outside the catalog enum",
+			settings: map[string]any{
+				"inject_tools": []any{
+					map[string]any{"type": "retrieval", "function": map[string]any{"name": "safety_check"}},
+				},
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Found while building the end-to-end suite for `tool_injection`.

**A dry run that was not one.** A policy could be created with `mode: observe` for a plugin that declares only `enforce`, and the plugin then ran as usual. `tool_injection` mutated the request and injected its tools: 566 prompt tokens and a real tool call, against a policy an operator believed was only watching. The plugins that *can* dry-run check the mode inside their own `Execute`; the ones that cannot say so through `SupportedModes()`, which the catalog already publishes to the UI. Nothing validated a policy against that declaration — stages were checked, modes were not — so this was open to every plugin, not just this one.

`ValidateMode` mirrors `ValidateStages`: same place in the registry, same call site in `validatePlugin`, and it runs on create and update.

**An enum nobody enforced.** `tool_injection` advertises `type` as an enum whose only value is `function` and never reads the field, so `retrieval` silently became a function tool. It is now refused at policy creation.

## Blast radius

Only `tool_injection` and `per_tool_rate_limiter` declare `enforce` alone, so those are the two that start refusing `observe`. Every other plugin supports it, and `throttle` remains valid only for `rate_limiter` — which is what the catalog has always said. Runtime is untouched: this validates at create and update, so an existing policy carrying an unsupported mode keeps serving traffic, but editing it will now require correcting the mode.

## Test plan

- [x] `go test -race ./pkg/app/policy/... ./pkg/app/plugins/... ./pkg/infra/plugins/toolinjection/...`
- [x] `go test ./...` — no new failures
- [x] `golangci-lint run` on the touched packages — 0 issues
- [x] Functional suite: no failure delta against the base commit locally
- [ ] e2e against prod after deploy: the two `tool_injection` cases asserting these refusals are red today and should go green

Made with [Cursor](https://cursor.com)