### PR TITLE
fix: publish traffic limits a client can act on

### DIFF
--- a/pkg/app/plugins/catalog_metadata.go
+++ b/pkg/app/plugins/catalog_metadata.go
@@ -76,15 +76,14 @@ var pluginCatalogMeta = map[string]catalogMeta{
 					Key:         "window",
 					Label:       "Window",
 					Type:        FieldTypeDuration,
-					Description: "Sliding window duration (e.g. 1s, 1m, 1h).",
+					Description: "Sliding window duration, one second or longer (e.g. 1s, 1m, 1h).",
 					Required:    true,
 				},
 				{
 					Key:         "retry_after",
 					Label:       "Retry After",
 					Type:        FieldTypeString,
-					Description: "Value sent in the Retry-After header, in seconds, when the limit is exceeded.",
-					Default:     "60",
+					Description: "Value sent in the Retry-After header, in seconds, when the limit is exceeded. Defaults to the window, which is when the budget actually returns.",
 				},
 				{
 					Key:         "group_by_header",
@@ -121,7 +120,7 @@ var pluginCatalogMeta = map[string]catalogMeta{
 					Key:         "max_chars_per_request",
 					Label:       "Max Characters Per Request",
 					Type:        FieldTypeInteger,
-					Description: "Maximum number of UTF-8 characters allowed in the request body.",
+					Description: "Maximum number of UTF-8 characters allowed in the request body. Leave it out to use the default; zero is not a valid ceiling.",
 					Default:     100000,
 				},
 				{

--- a/pkg/infra/plugins/ratelimit/config.go
+++ b/pkg/infra/plugins/ratelimit/config.go
@@ -16,12 +16,14 @@ package ratelimit
 
 import (
 	"fmt"
+	"math"
+	"strconv"
 	"time"
 
 	"github.com/NeuralTrust/TrustGate/pkg/infra/plugins/pluginutil"
 )
 
-const defaultRetryAfter = "60"
+const minWindow = time.Second
 
 // config is the rate_limiter settings. The limit is a single sliding window;
 // whether it is enforced gateway-wide or per consumer is decided by the policy
@@ -47,9 +49,21 @@ func parseConfig(settings map[string]any) (*config, error) {
 		return nil, err
 	}
 	if cfg.RetryAfter == "" {
-		cfg.RetryAfter = defaultRetryAfter
+		cfg.RetryAfter = defaultRetryAfter(cfg.Window)
 	}
 	return &cfg, nil
+}
+
+// defaultRetryAfter is the window itself: telling a client to come back in a
+// fixed minute when the budget returns in ten seconds wastes the difference.
+// The window has already been validated as a duration of at least one second.
+func defaultRetryAfter(window string) string {
+	parsed, err := time.ParseDuration(window)
+	if err != nil {
+		return "60"
+	}
+	seconds := int64(math.Ceil(parsed.Seconds()))
+	return strconv.FormatInt(seconds, 10)
 }
 
 func (c *config) validate() error {
@@ -59,8 +73,15 @@ func (c *config) validate() error {
 	if c.Window == "" {
 		return fmt.Errorf("rate_limiter: window is required")
 	}
-	if _, err := time.ParseDuration(c.Window); err != nil {
+	window, err := time.ParseDuration(c.Window)
+	if err != nil {
 		return fmt.Errorf("rate_limiter: invalid window: %w", err)
+	}
+	// Requests are counted at one-second resolution, so a shorter window would
+	// be silently rounded up and a non-positive one would let everything
+	// through while still looking like a limit.
+	if window < minWindow {
+		return fmt.Errorf("rate_limiter: window must be at least %s, got %s", minWindow, c.Window)
 	}
 	return nil
 }

--- a/pkg/infra/plugins/ratelimit/plugin.go
+++ b/pkg/infra/plugins/ratelimit/plugin.go
@@ -115,8 +115,8 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 		return nil, err
 	}
 
+	reset := now.Add(window)
 	headers := make(map[string][]string)
-	setLimitHeaders(headers, dimension, cfg.Limit, count, now.Add(window))
 
 	data := RateLimiterData{
 		ExceededType: dimension,
@@ -130,6 +130,7 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 		data.RetryAfter = cfg.RetryAfter
 
 		if appplugins.Blocks(in.Mode) && !appplugins.Throttles(in.Mode) {
+			setLimitHeaders(headers, dimension, cfg.Limit, count, reset)
 			headers["Retry-After"] = []string{cfg.RetryAfter}
 			appplugins.SetDecision(in.Event, in.Mode)
 			if in.Event != nil {
@@ -154,6 +155,9 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 	if err := p.record(ctx, redisKey, now, window); err != nil {
 		return nil, err
 	}
+	// The client is told what is left once this request is counted: a client
+	// reading "1 remaining" must be able to spend it without being rejected.
+	setLimitHeaders(headers, dimension, cfg.Limit, count+1, reset)
 
 	if in.Event != nil {
 		in.Event.SetStatusCode(http.StatusOK)

--- a/pkg/infra/plugins/ratelimit/plugin_test.go
+++ b/pkg/infra/plugins/ratelimit/plugin_test.go
@@ -117,6 +117,20 @@ func TestPlugin_ValidateConfig(t *testing.T) {
 			wantErr:  true,
 		},
 		{
+			name:     "zero window would let everything through",
+			settings: limitSettings(5, "0s"),
+			wantErr:  true,
+		},
+		{
+			name:     "window below the counting resolution",
+			settings: limitSettings(5, "500ms"),
+			wantErr:  true,
+		},
+		{
+			name:     "window at the counting resolution",
+			settings: limitSettings(5, "1s"),
+		},
+		{
 			name:     "rejects legacy nested limits map",
 			settings: map[string]any{"limits": map[string]any{"global": map[string]any{"limit": 5, "window": "1m"}}},
 			wantErr:  true,
@@ -147,7 +161,8 @@ func TestPlugin_Execute_AllowsUnderLimit(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	assert.Equal(t, []string{"3"}, res.Headers["X-RateLimit-consumer-Limit"])
-	assert.Equal(t, []string{"3"}, res.Headers["X-RateLimit-consumer-Remaining"])
+	assert.Equal(t, []string{"2"}, res.Headers["X-RateLimit-consumer-Remaining"],
+		"remaining counts the budget left once this request is counted")
 }
 
 func TestPlugin_Execute_RejectsOverLimit(t *testing.T) {
@@ -174,6 +189,25 @@ func TestPlugin_Execute_RejectsOverLimit(t *testing.T) {
 	assert.Equal(t, float64(2), payload["limit"])
 	assert.Equal(t, float64(30), payload["retry_after_seconds"])
 	assert.Contains(t, payload["message"], "consumer rate limit exceeded")
+}
+
+// A client that reads "1 remaining" must be able to spend it, so the countdown
+// reaches zero on the last request the window still allows.
+func TestPlugin_Execute_RemainingHitsZeroOnTheLastAllowedRequest(t *testing.T) {
+	p, _ := newTestPlugin(t)
+	settings := limitSettings(3, "1m")
+
+	var remaining []string
+	for i := 0; i < 3; i++ {
+		res, err := p.Execute(context.Background(), execInput(settings, consumerScope("c-1")))
+		require.NoError(t, err, "request %d should pass", i)
+		remaining = append(remaining, res.Headers["X-RateLimit-consumer-Remaining"][0])
+	}
+
+	assert.Equal(t, []string{"2", "1", "0"}, remaining)
+
+	_, err := p.Execute(context.Background(), execInput(settings, consumerScope("c-1")))
+	require.Error(t, err, "the request after a zero remaining must be rejected")
 }
 
 // A non-global policy must give each consumer an independent budget even when
@@ -266,7 +300,7 @@ func TestPlugin_Execute_ObserveReportsExceeded(t *testing.T) {
 
 func TestPlugin_Execute_ThrottleDelaysButAllows(t *testing.T) {
 	p, _ := newTestPlugin(t)
-	settings := limitSettings(1, "200ms")
+	settings := limitSettings(1, "1s")
 
 	for i := 0; i < 3; i++ {
 		in := execInput(settings, consumerScope("c-1"))
@@ -351,14 +385,27 @@ func TestThrottleDelay(t *testing.T) {
 	assert.Equal(t, 100*time.Millisecond, throttleDelay(time.Second, 10))
 }
 
-func TestPlugin_Execute_DefaultRetryAfter(t *testing.T) {
-	p, _ := newTestPlugin(t)
-	settings := limitSettings(1, "1m")
+// Without an explicit retry_after the client is told to come back when the
+// window releases the budget, not after an unrelated fixed minute.
+func TestPlugin_Execute_DefaultRetryAfterIsTheWindow(t *testing.T) {
+	for _, tt := range []struct {
+		window string
+		want   string
+	}{
+		{window: "1m", want: "60"},
+		{window: "10s", want: "10"},
+		{window: "1500ms", want: "2"},
+	} {
+		t.Run(tt.window, func(t *testing.T) {
+			p, _ := newTestPlugin(t)
+			settings := limitSettings(1, tt.window)
 
-	_, err := p.Execute(context.Background(), execInput(settings, globalScope()))
-	require.NoError(t, err)
-	_, err = p.Execute(context.Background(), execInput(settings, globalScope()))
-	require.Error(t, err)
-	pe, _ := appplugins.AsPluginError(err)
-	assert.Equal(t, []string{"60"}, pe.Headers["Retry-After"])
+			_, err := p.Execute(context.Background(), execInput(settings, globalScope()))
+			require.NoError(t, err)
+			_, err = p.Execute(context.Background(), execInput(settings, globalScope()))
+			require.Error(t, err)
+			pe, _ := appplugins.AsPluginError(err)
+			assert.Equal(t, []string{tt.want}, pe.Headers["Retry-After"])
+		})
+	}
 }

--- a/pkg/infra/plugins/requestsize/config.go
+++ b/pkg/infra/plugins/requestsize/config.go
@@ -33,10 +33,13 @@ const (
 	defaultMaxCharsPerRequest = 100_000
 )
 
+// config is the request_size_limiter settings. MaxCharsPerRequest is a pointer
+// so an operator writing 0 can be told it means nothing, instead of silently
+// getting the default ceiling an omitted field asks for.
 type config struct {
 	AllowedPayloadSize   int      `mapstructure:"allowed_payload_size"`
 	SizeUnit             sizeUnit `mapstructure:"size_unit"`
-	MaxCharsPerRequest   int64    `mapstructure:"max_chars_per_request"`
+	MaxCharsPerRequest   *int64   `mapstructure:"max_chars_per_request"`
 	RequireContentLength bool     `mapstructure:"require_content_length"`
 }
 
@@ -61,8 +64,8 @@ func (c *config) validate() error {
 	default:
 		return fmt.Errorf("request_size_limiter: size_unit must be one of bytes, kilobytes, megabytes")
 	}
-	if c.MaxCharsPerRequest < 0 {
-		return fmt.Errorf("request_size_limiter: max_chars_per_request cannot be negative")
+	if c.MaxCharsPerRequest != nil && *c.MaxCharsPerRequest <= 0 {
+		return fmt.Errorf("request_size_limiter: max_chars_per_request must be > 0 when set")
 	}
 	return nil
 }
@@ -74,9 +77,17 @@ func (c *config) applyDefaults() {
 	if c.AllowedPayloadSize <= 0 {
 		c.AllowedPayloadSize = defaultAllowedPayloadSize
 	}
-	if c.MaxCharsPerRequest <= 0 {
-		c.MaxCharsPerRequest = defaultMaxCharsPerRequest
+	if c.MaxCharsPerRequest == nil {
+		maxChars := int64(defaultMaxCharsPerRequest)
+		c.MaxCharsPerRequest = &maxChars
 	}
+}
+
+func (c *config) maxChars() int64 {
+	if c.MaxCharsPerRequest == nil {
+		return defaultMaxCharsPerRequest
+	}
+	return *c.MaxCharsPerRequest
 }
 
 func (c *config) maxSizeBytes() int {

--- a/pkg/infra/plugins/requestsize/plugin.go
+++ b/pkg/infra/plugins/requestsize/plugin.go
@@ -99,7 +99,7 @@ func (p *Plugin) Execute(_ context.Context, in appplugins.ExecInput) (*appplugin
 			RequestSizeBytes:   byteSize,
 			RequestSizeChars:   charCount,
 			MaxSizeBytes:       maxBytes,
-			MaxCharsPerRequest: int(cfg.MaxCharsPerRequest),
+			MaxCharsPerRequest: int(cfg.maxChars()),
 			LimitExceeded:      true,
 			ExceededType:       "bytes",
 		})
@@ -113,12 +113,12 @@ func (p *Plugin) Execute(_ context.Context, in appplugins.ExecInput) (*appplugin
 		return allowResult(byteSize, charCount, maxBytes, cfg), nil
 	}
 
-	if int64(charCount) > cfg.MaxCharsPerRequest {
+	if int64(charCount) > cfg.maxChars() {
 		setSizeExtras(in.Event, RequestSizeLimiterData{
 			RequestSizeBytes:   byteSize,
 			RequestSizeChars:   charCount,
 			MaxSizeBytes:       maxBytes,
-			MaxCharsPerRequest: int(cfg.MaxCharsPerRequest),
+			MaxCharsPerRequest: int(cfg.maxChars()),
 			LimitExceeded:      true,
 			ExceededType:       "chars",
 		})
@@ -136,7 +136,7 @@ func (p *Plugin) Execute(_ context.Context, in appplugins.ExecInput) (*appplugin
 		RequestSizeBytes:   byteSize,
 		RequestSizeChars:   charCount,
 		MaxSizeBytes:       maxBytes,
-		MaxCharsPerRequest: int(cfg.MaxCharsPerRequest),
+		MaxCharsPerRequest: int(cfg.maxChars()),
 		LimitExceeded:      false,
 	})
 	return allowResult(byteSize, charCount, maxBytes, cfg), nil
@@ -149,7 +149,7 @@ func allowResult(byteSize, charCount, maxBytes int, cfg *config) *appplugins.Res
 			"X-Request-Size-Bytes": {strconv.Itoa(byteSize)},
 			"X-Request-Size-Chars": {strconv.Itoa(charCount)},
 			"X-Size-Limit-Bytes":   {strconv.Itoa(maxBytes)},
-			"X-Size-Limit-Chars":   {strconv.FormatInt(cfg.MaxCharsPerRequest, 10)},
+			"X-Size-Limit-Chars":   {strconv.FormatInt(cfg.maxChars(), 10)},
 		},
 	}
 }

--- a/pkg/infra/plugins/requestsize/plugin_test.go
+++ b/pkg/infra/plugins/requestsize/plugin_test.go
@@ -52,6 +52,8 @@ func TestPlugin_ValidateConfig(t *testing.T) {
 		{name: "zero payload", settings: map[string]any{"allowed_payload_size": 0}, wantErr: true},
 		{name: "bad unit", settings: map[string]any{"allowed_payload_size": 5, "size_unit": "gigabytes"}, wantErr: true},
 		{name: "negative chars", settings: map[string]any{"allowed_payload_size": 5, "max_chars_per_request": -1}, wantErr: true},
+		{name: "zero chars means nothing", settings: map[string]any{"allowed_payload_size": 5, "max_chars_per_request": 0}, wantErr: true},
+		{name: "omitted chars takes the default", settings: map[string]any{"allowed_payload_size": 5}},
 	}
 	p := New()
 	for _, tt := range tests {
@@ -75,6 +77,8 @@ func TestPlugin_Execute_AllowsSmallBody(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{"5"}, res.Headers["X-Request-Size-Bytes"])
 	assert.Equal(t, []string{"5"}, res.Headers["X-Request-Size-Chars"])
+	assert.Equal(t, []string{"100000"}, res.Headers["X-Size-Limit-Chars"],
+		"an omitted character ceiling falls back to the default")
 }
 
 func TestPlugin_Execute_RejectsLargeBytes(t *testing.T) {


### PR DESCRIPTION
## Summary

End-to-end sweeps of `rate_limiter` (23 cases) and `request_size_limiter` (24 cases) against production found that both plugins block exactly where their configuration says — but the numbers they publish for the client to act on were not always true.

- **`Remaining` was one ahead.** `X-RateLimit-*-Remaining` reported the budget *before* the current request was counted, so a client reading `1 remaining` got a 429 on its very next call. It now counts what is left once the request in hand has been counted, reaching `0` on the last call that is served.
- **`Retry-After` was unrelated to the window.** It defaulted to a fixed `60` whatever the window, so a ten-second window told every rejected client to sleep for a minute while `X-RateLimit-*-Reset` said otherwise. It now defaults to the window itself.
- **Windows that could not be enforced were accepted.** `window: 0s` let every request through while the policy screen still showed a limit, and sub-second windows were silently rounded up by the one-second counting resolution in Redis. Both are refused at policy creation.
- **`max_chars_per_request: 0` meant 100 000.** An explicit zero was indistinguishable from an omitted field and was replaced by the default ceiling. The field is now a pointer, so an omitted one still takes the default and an explicit zero is refused.

Catalog descriptions for `window`, `retry_after` and `max_chars_per_request` are updated to match.

## Test plan

- [x] `go test -race ./pkg/infra/plugins/ratelimit/... ./pkg/infra/plugins/requestsize/... ./pkg/app/plugins/...`
- [x] `go test ./pkg/...` — no regressions
- [x] `golangci-lint run` on the touched packages — 0 issues
- [x] New unit cases: the remaining countdown reaching zero on the last allowed request, `Retry-After` derived from the window (`1m`, `10s`, `1500ms`), non-positive and sub-second windows refused, explicit vs omitted character ceiling
- [ ] After deploy, the six red e2e cases in `multi-agent-tests` (`test_rate_limiter.py`, `test_request_size_limiter.py`) go green — five of them here, the sixth (`throttle` on an enforce-only plugin) from #379

## Notes

`require_content_length` is left as it is, but worth knowing: a chunked request with no `Content-Length` of its own reaches the plugin with one, because the edge proxy buffers the body and restores the header. The option cannot fire for traffic arriving through the edge.

Made with [Cursor](https://cursor.com)