### PR TITLE
feat(gateway): filter policy list by category and type via slug

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1620,6 +1620,18 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "description": "Catalog category (group type); comma-separated multi",
+                        "name": "category",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Plugin slug (FE type filter); comma-separated multi",
+                        "name": "type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Sort field (name, created_at, updated_at, priority)",
                         "name": "sort",
                         "in": "query"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1999,6 +1999,22 @@
                         }
                     },
                     {
+                        "description": "Catalog category (group type); comma-separated multi",
+                        "name": "category",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Plugin slug (FE type filter); comma-separated multi",
+                        "name": "type",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "description": "Sort field (name, created_at, updated_at, priority)",
                         "name": "sort",
                         "in": "query",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1613,6 +1613,18 @@
                     },
                     {
                         "type": "string",
+                        "description": "Catalog category (group type); comma-separated multi",
+                        "name": "category",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Plugin slug (FE type filter); comma-separated multi",
+                        "name": "type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Sort field (name, created_at, updated_at, priority)",
                         "name": "sort",
                         "in": "query"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3377,6 +3377,14 @@ paths:
         in: query
         name: mode
         type: string
+      - description: Catalog category (group type); comma-separated multi
+        in: query
+        name: category
+        type: string
+      - description: Plugin slug (FE type filter); comma-separated multi
+        in: query
+        name: type
+        type: string
       - description: Sort field (name, created_at, updated_at, priority)
         in: query
         name: sort

--- a/pkg/api/handler/http/httpio/params.go
+++ b/pkg/api/handler/http/httpio/params.go
@@ -169,8 +169,6 @@ func ParseOptionalBool(c *fiber.Ctx, name string) (*bool, error) {
 	return &v, nil
 }
 
-// ParseCSVQuery splits a query param on commas (and repeated keys) into trimmed
-// non-empty values. Missing returns nil.
 func ParseCSVQuery(c *fiber.Ctx, name string) []string {
 	args := c.Context().QueryArgs()
 	rawValues := args.PeekMulti(name)

--- a/pkg/api/handler/http/httpio/params.go
+++ b/pkg/api/handler/http/httpio/params.go
@@ -169,6 +169,29 @@ func ParseOptionalBool(c *fiber.Ctx, name string) (*bool, error) {
 	return &v, nil
 }
 
+// ParseCSVQuery splits a query param on commas (and repeated keys) into trimmed
+// non-empty values. Missing returns nil.
+func ParseCSVQuery(c *fiber.Ctx, name string) []string {
+	args := c.Context().QueryArgs()
+	rawValues := args.PeekMulti(name)
+	if len(rawValues) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(rawValues))
+	for _, raw := range rawValues {
+		for _, part := range strings.Split(string(raw), ",") {
+			part = strings.TrimSpace(part)
+			if part != "" {
+				out = append(out, part)
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 func containsString(items []string, want string) bool {
 	for _, item := range items {
 		if item == want {

--- a/pkg/api/handler/http/httpio/params_test.go
+++ b/pkg/api/handler/http/httpio/params_test.go
@@ -17,6 +17,7 @@ package httpio
 import (
 	"errors"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
@@ -282,6 +283,47 @@ func TestParseOptionalBool(t *testing.T) {
 			}
 			if got == nil || *got != tc.want {
 				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseCSVQuery(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		target string
+		want   []string
+	}{
+		{name: "missing", target: "/test", want: nil},
+		{name: "single", target: "/test?category=Guardrails", want: []string{"Guardrails"}},
+		{name: "comma separated", target: "/test?category=Guardrails,Quota", want: []string{"Guardrails", "Quota"}},
+		{name: "trims spaces", target: "/test?category=Guardrails,%20Quota", want: []string{"Guardrails", "Quota"}},
+		{name: "repeated keys", target: "/test?type=a&type=b", want: []string{"a", "b"}},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := runInCtx(t, tc.target, "/test", func(c *fiber.Ctx) ([]string, error) {
+				name := "category"
+				if strings.Contains(tc.target, "type=") {
+					name = "type"
+				}
+				return ParseCSVQuery(c, name), nil
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Fatalf("got %v, want %v", got, tc.want)
+				}
 			}
 		})
 	}

--- a/pkg/api/handler/http/policy/list_policy_handler.go
+++ b/pkg/api/handler/http/policy/list_policy_handler.go
@@ -43,6 +43,8 @@ func NewListPolicyHandler(finder apppolicy.Finder) *ListPolicyHandler {
 // @Param        enabled     query     bool    false  "Filter by enabled flag"
 // @Param        global      query     bool    false  "Filter by global flag"
 // @Param        mode        query     string  false  "Filter by mode (enforce, throttle, observe)"
+// @Param        category    query     string  false  "Catalog category (group type); comma-separated multi"
+// @Param        type        query     string  false  "Plugin slug (FE type filter); comma-separated multi"
 // @Param        sort        query     string  false  "Sort field (name, created_at, updated_at, priority)"
 // @Param        order       query     string  false  "Sort order (asc, desc)"
 // @Param        page        query     int     false  "Page number (1-based)"
@@ -81,22 +83,26 @@ func (h *ListPolicyHandler) Handle(c *fiber.Ctx) error {
 		}
 	}
 	req := request.ListPolicyRequest{
-		Search:  httpio.ParseSearch(c),
-		Enabled: enabled,
-		Global:  global,
-		Mode:    mode,
-		Page:    page,
-		Sort:    sort,
+		Search:     httpio.ParseSearch(c),
+		Enabled:    enabled,
+		Global:     global,
+		Mode:       mode,
+		Categories: httpio.ParseCSVQuery(c, "category"),
+		Types:      httpio.ParseCSVQuery(c, "type"),
+		Page:       page,
+		Sort:       sort,
 	}
 
 	items, total, err := h.finder.List(c.UserContext(), domain.ListFilter{
-		GatewayID: gatewayID,
-		Search:    req.Search,
-		Enabled:   req.Enabled,
-		Global:    req.Global,
-		Mode:      req.Mode,
-		Page:      req.Page,
-		Sort:      req.Sort,
+		GatewayID:  gatewayID,
+		Search:     req.Search,
+		Enabled:    req.Enabled,
+		Global:     req.Global,
+		Mode:       req.Mode,
+		Categories: req.Categories,
+		Types:      req.Types,
+		Page:       req.Page,
+		Sort:       req.Sort,
 	})
 	if err != nil {
 		return httpio.WriteError(c, err)

--- a/pkg/api/handler/http/policy/request/list_policy_request.go
+++ b/pkg/api/handler/http/policy/request/list_policy_request.go
@@ -20,10 +20,12 @@ import (
 )
 
 type ListPolicyRequest struct {
-	Search  string
-	Enabled *bool
-	Global  *bool
-	Mode    domain.Mode
-	Page    listing.Page
-	Sort    listing.Sort
+	Search     string
+	Enabled    *bool
+	Global     *bool
+	Mode       domain.Mode
+	Categories []string
+	Types      []string
+	Page       listing.Page
+	Sort       listing.Sort
 }

--- a/pkg/app/policy/finder.go
+++ b/pkg/app/policy/finder.go
@@ -70,9 +70,6 @@ func (f *finder) FindByID(ctx context.Context, gatewayID ids.GatewayID, id ids.P
 	return scopeToGateway(p, gatewayID)
 }
 
-// scopeToGateway enforces that a policy belongs to the requesting gateway,
-// returning ErrNotFound for cross-gateway ids so the API never confirms the
-// existence of another gateway's resource.
 func scopeToGateway(p *domain.Policy, gatewayID ids.GatewayID) (*domain.Policy, error) {
 	if p.GatewayID != gatewayID {
 		return nil, domain.ErrNotFound

--- a/pkg/app/policy/finder.go
+++ b/pkg/app/policy/finder.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"log/slog"
 
+	appplugins "github.com/NeuralTrust/TrustGate/pkg/app/plugins"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
 	domain "github.com/NeuralTrust/TrustGate/pkg/domain/policy"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/cache"
@@ -33,13 +34,20 @@ var _ Finder = (*finder)(nil)
 
 type finder struct {
 	repo        domain.Repository
+	catalog     appplugins.CatalogService
 	memoryCache *cache.TTLMap
 	logger      *slog.Logger
 }
 
-func NewFinder(repo domain.Repository, manager *cache.TTLMapManager, logger *slog.Logger) Finder {
+func NewFinder(
+	repo domain.Repository,
+	catalog appplugins.CatalogService,
+	manager *cache.TTLMapManager,
+	logger *slog.Logger,
+) Finder {
 	return &finder{
 		repo:        repo,
+		catalog:     catalog,
 		memoryCache: manager.GetTTLMap(cache.PolicyTTLName),
 		logger:      logger,
 	}
@@ -73,5 +81,13 @@ func scopeToGateway(p *domain.Policy, gatewayID ids.GatewayID) (*domain.Policy, 
 }
 
 func (f *finder) List(ctx context.Context, filter domain.ListFilter) ([]*domain.Policy, int, error) {
+	slugs, restricted := ResolveListSlugs(f.catalog.Catalog(), filter.Categories, filter.Types)
+	filter.Categories = nil
+	filter.Types = nil
+	filter.RestrictToSlugs = restricted
+	filter.Slugs = slugs
+	if restricted && len(slugs) == 0 {
+		return []*domain.Policy{}, 0, nil
+	}
 	return f.repo.List(ctx, filter)
 }

--- a/pkg/app/policy/finder_test.go
+++ b/pkg/app/policy/finder_test.go
@@ -20,12 +20,25 @@ import (
 	"testing"
 
 	apppolicy "github.com/NeuralTrust/TrustGate/pkg/app/policy"
+	appplugins "github.com/NeuralTrust/TrustGate/pkg/app/plugins"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
 	domain "github.com/NeuralTrust/TrustGate/pkg/domain/policy"
 	repomocks "github.com/NeuralTrust/TrustGate/pkg/domain/policy/mocks"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/cache"
 	"github.com/stretchr/testify/mock"
 )
+
+type stubCatalog struct {
+	catalog appplugins.Catalog
+}
+
+func (s stubCatalog) Catalog() appplugins.Catalog {
+	return s.catalog
+}
+
+func emptyCatalog() appplugins.CatalogService {
+	return stubCatalog{}
+}
 
 func TestFinder_FindByID_CacheHit(t *testing.T) {
 	t.Parallel()
@@ -37,7 +50,7 @@ func TestFinder_FindByID_CacheHit(t *testing.T) {
 	mgr := newCacheManager()
 	mgr.GetTTLMap(cache.PolicyTTLName).Set(id.String(), cached)
 
-	finder := apppolicy.NewFinder(repo, mgr, newTestLogger())
+	finder := apppolicy.NewFinder(repo, emptyCatalog(), mgr, newTestLogger())
 	got, err := finder.FindByID(context.Background(), gwID, id)
 	if err != nil {
 		t.Fatalf("FindByID: %v", err)
@@ -56,7 +69,7 @@ func TestFinder_FindByID_CacheMiss_PopulatesCache(t *testing.T) {
 	repo.EXPECT().FindByID(mock.Anything, id).Return(want, nil).Once()
 
 	mgr := newCacheManager()
-	finder := apppolicy.NewFinder(repo, mgr, newTestLogger())
+	finder := apppolicy.NewFinder(repo, emptyCatalog(), mgr, newTestLogger())
 
 	got, err := finder.FindByID(context.Background(), gwID, id)
 	if err != nil {
@@ -76,7 +89,7 @@ func TestFinder_FindByID_NotFound(t *testing.T) {
 	id := ids.New[ids.PolicyKind]()
 	repo.EXPECT().FindByID(mock.Anything, id).Return(nil, domain.ErrNotFound).Once()
 
-	finder := apppolicy.NewFinder(repo, newCacheManager(), newTestLogger())
+	finder := apppolicy.NewFinder(repo, emptyCatalog(), newCacheManager(), newTestLogger())
 	_, err := finder.FindByID(context.Background(), ids.New[ids.GatewayKind](), id)
 	if !errors.Is(err, domain.ErrNotFound) {
 		t.Fatalf("err = %v, want ErrNotFound", err)
@@ -90,7 +103,7 @@ func TestFinder_FindByID_WrongGateway(t *testing.T) {
 	want := &domain.Policy{ID: id, GatewayID: ids.New[ids.GatewayKind](), Name: "other"}
 	repo.EXPECT().FindByID(mock.Anything, id).Return(want, nil).Once()
 
-	finder := apppolicy.NewFinder(repo, newCacheManager(), newTestLogger())
+	finder := apppolicy.NewFinder(repo, emptyCatalog(), newCacheManager(), newTestLogger())
 	_, err := finder.FindByID(context.Background(), ids.New[ids.GatewayKind](), id)
 	if !errors.Is(err, domain.ErrNotFound) {
 		t.Fatalf("err = %v, want ErrNotFound for cross-gateway id", err)
@@ -103,17 +116,57 @@ func TestFinder_List(t *testing.T) {
 	want := []*domain.Policy{{ID: ids.New[ids.PolicyKind](), Name: "a"}}
 	repo.EXPECT().
 		List(mock.Anything, mock.MatchedBy(func(f domain.ListFilter) bool {
-			return f.Search == "a"
+			return f.Search == "a" && !f.RestrictToSlugs
 		})).
 		Return(want, 1, nil).
 		Once()
 
-	finder := apppolicy.NewFinder(repo, newCacheManager(), newTestLogger())
+	finder := apppolicy.NewFinder(repo, emptyCatalog(), newCacheManager(), newTestLogger())
 	got, total, err := finder.List(context.Background(), domain.ListFilter{Search: "a"})
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
 	if total != 1 || len(got) != 1 {
 		t.Fatalf("List returned total=%d len=%d", total, len(got))
+	}
+}
+
+func TestFinder_List_CategoryExpandsToSlugs(t *testing.T) {
+	t.Parallel()
+	repo := repomocks.NewRepository(t)
+	catalog := stubCatalog{catalog: appplugins.Catalog{
+		Groups: []appplugins.CatalogGroup{{
+			Type:  "Traffic Control",
+			Items: []appplugins.CatalogEntry{{Slug: "rate_limiter"}},
+		}},
+	}}
+	repo.EXPECT().
+		List(mock.Anything, mock.MatchedBy(func(f domain.ListFilter) bool {
+			return f.RestrictToSlugs && len(f.Slugs) == 1 && f.Slugs[0] == "rate_limiter"
+		})).
+		Return([]*domain.Policy{}, 0, nil).
+		Once()
+
+	finder := apppolicy.NewFinder(repo, catalog, newCacheManager(), newTestLogger())
+	_, _, err := finder.List(context.Background(), domain.ListFilter{
+		Categories: []string{"Traffic Control"},
+	})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+}
+
+func TestFinder_List_UnknownCategoryShortCircuits(t *testing.T) {
+	t.Parallel()
+	repo := repomocks.NewRepository(t)
+	finder := apppolicy.NewFinder(repo, emptyCatalog(), newCacheManager(), newTestLogger())
+	items, total, err := finder.List(context.Background(), domain.ListFilter{
+		Categories: []string{"Missing"},
+	})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if total != 0 || len(items) != 0 {
+		t.Fatalf("got total=%d len=%d", total, len(items))
 	}
 }

--- a/pkg/app/policy/list_slugs.go
+++ b/pkg/app/policy/list_slugs.go
@@ -20,10 +20,6 @@ import (
 	appplugins "github.com/NeuralTrust/TrustGate/pkg/app/plugins"
 )
 
-// ResolveListSlugs expands catalog category filters and optional type (plugin slug)
-// filters into the slug set used by repository list. restricted is true when any
-// category or type filter was requested. An empty slug slice with restricted true
-// means the filter matches nothing (unknown category, empty intersection, etc.).
 func ResolveListSlugs(catalog appplugins.Catalog, categories, types []string) (slugs []string, restricted bool) {
 	if len(categories) == 0 && len(types) == 0 {
 		return nil, false

--- a/pkg/app/policy/list_slugs.go
+++ b/pkg/app/policy/list_slugs.go
@@ -1,0 +1,84 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	"sort"
+
+	appplugins "github.com/NeuralTrust/TrustGate/pkg/app/plugins"
+)
+
+// ResolveListSlugs expands catalog category filters and optional type (plugin slug)
+// filters into the slug set used by repository list. restricted is true when any
+// category or type filter was requested. An empty slug slice with restricted true
+// means the filter matches nothing (unknown category, empty intersection, etc.).
+func ResolveListSlugs(catalog appplugins.Catalog, categories, types []string) (slugs []string, restricted bool) {
+	if len(categories) == 0 && len(types) == 0 {
+		return nil, false
+	}
+
+	typeSet := make(map[string]struct{}, len(types))
+	for _, slug := range types {
+		if slug == "" {
+			continue
+		}
+		typeSet[slug] = struct{}{}
+	}
+
+	if len(categories) == 0 {
+		return sortedKeys(typeSet), true
+	}
+
+	categorySlugs := make(map[string]struct{})
+	wanted := make(map[string]struct{}, len(categories))
+	for _, category := range categories {
+		if category == "" {
+			continue
+		}
+		wanted[category] = struct{}{}
+	}
+	for _, group := range catalog.Groups {
+		if _, ok := wanted[group.Type]; !ok {
+			continue
+		}
+		for _, item := range group.Items {
+			categorySlugs[item.Slug] = struct{}{}
+		}
+	}
+
+	if len(typeSet) == 0 {
+		return sortedKeys(categorySlugs), true
+	}
+
+	intersection := make(map[string]struct{})
+	for slug := range categorySlugs {
+		if _, ok := typeSet[slug]; ok {
+			intersection[slug] = struct{}{}
+		}
+	}
+	return sortedKeys(intersection), true
+}
+
+func sortedKeys(set map[string]struct{}) []string {
+	if len(set) == 0 {
+		return []string{}
+	}
+	out := make([]string, 0, len(set))
+	for key := range set {
+		out = append(out, key)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/pkg/app/policy/list_slugs_test.go
+++ b/pkg/app/policy/list_slugs_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy_test
+
+import (
+	"testing"
+
+	appplugins "github.com/NeuralTrust/TrustGate/pkg/app/plugins"
+	apppolicy "github.com/NeuralTrust/TrustGate/pkg/app/policy"
+)
+
+func TestResolveListSlugs(t *testing.T) {
+	t.Parallel()
+	catalog := appplugins.Catalog{
+		Groups: []appplugins.CatalogGroup{
+			{
+				Type: "Guardrails",
+				Items: []appplugins.CatalogEntry{
+					{Slug: "trustguard"},
+					{Slug: "openai_moderation"},
+				},
+			},
+			{
+				Type: "Traffic Control",
+				Items: []appplugins.CatalogEntry{
+					{Slug: "rate_limiter"},
+				},
+			},
+		},
+	}
+
+	t.Run("no filters", func(t *testing.T) {
+		t.Parallel()
+		slugs, restricted := apppolicy.ResolveListSlugs(catalog, nil, nil)
+		if restricted || slugs != nil {
+			t.Fatalf("got slugs=%v restricted=%v", slugs, restricted)
+		}
+	})
+
+	t.Run("category only", func(t *testing.T) {
+		t.Parallel()
+		slugs, restricted := apppolicy.ResolveListSlugs(catalog, []string{"Guardrails"}, nil)
+		if !restricted {
+			t.Fatal("expected restricted")
+		}
+		assertStrings(t, slugs, []string{"openai_moderation", "trustguard"})
+	})
+
+	t.Run("type only", func(t *testing.T) {
+		t.Parallel()
+		slugs, restricted := apppolicy.ResolveListSlugs(catalog, nil, []string{"rate_limiter"})
+		if !restricted {
+			t.Fatal("expected restricted")
+		}
+		assertStrings(t, slugs, []string{"rate_limiter"})
+	})
+
+	t.Run("category and type intersection", func(t *testing.T) {
+		t.Parallel()
+		slugs, restricted := apppolicy.ResolveListSlugs(
+			catalog,
+			[]string{"Guardrails"},
+			[]string{"trustguard", "rate_limiter"},
+		)
+		if !restricted {
+			t.Fatal("expected restricted")
+		}
+		assertStrings(t, slugs, []string{"trustguard"})
+	})
+
+	t.Run("unknown category yields empty restricted set", func(t *testing.T) {
+		t.Parallel()
+		slugs, restricted := apppolicy.ResolveListSlugs(catalog, []string{"Missing"}, nil)
+		if !restricted {
+			t.Fatal("expected restricted")
+		}
+		if len(slugs) != 0 {
+			t.Fatalf("expected empty slugs, got %v", slugs)
+		}
+	})
+}
+
+func assertStrings(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("len got=%d want=%d (%v vs %v)", len(got), len(want), got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("index %d: got %q want %q (full %v)", i, got[i], want[i], got)
+		}
+	}
+}

--- a/pkg/domain/policy/repository.go
+++ b/pkg/domain/policy/repository.go
@@ -30,8 +30,17 @@ type ListFilter struct {
 	Enabled   *bool
 	Global    *bool
 	Mode      Mode
-	Page      listing.Page
-	Sort      listing.Sort
+	// Categories are catalog group type strings (e.g. "Guardrails"). Expanded to
+	// slugs in the app layer before the repository query.
+	Categories []string
+	// Types are plugin slugs (FE filter id "type"). Combined with Categories via
+	// intersection when both are set.
+	Types []string
+	// RestrictToSlugs, when true, limits results to Slugs (empty Slugs → no rows).
+	RestrictToSlugs bool
+	Slugs           []string
+	Page            listing.Page
+	Sort            listing.Sort
 }
 
 //go:generate mockery --name=Repository --dir=. --output=./mocks --filename=policy_repository_mock.go --case=underscore --with-expecter

--- a/pkg/domain/policy/repository.go
+++ b/pkg/domain/policy/repository.go
@@ -21,22 +21,17 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/domain/listing"
 )
 
-// SortableFields are the whitelist of query fields accepted by list sort.
 var SortableFields = []string{"name", "created_at", "updated_at", "priority"}
 
 type ListFilter struct {
-	GatewayID ids.GatewayID
-	Search    string
-	Enabled   *bool
-	Global    *bool
-	Mode      Mode
-	// Categories are catalog group type strings (e.g. "Guardrails"). Expanded to
-	// slugs in the app layer before the repository query.
+	GatewayID  ids.GatewayID
+	Search     string
+	Enabled    *bool
+	Global     *bool
+	Mode       Mode
 	Categories []string
-	// Types are plugin slugs (FE filter id "type"). Combined with Categories via
-	// intersection when both are set.
-	Types []string
-	// RestrictToSlugs, when true, limits results to Slugs (empty Slugs → no rows).
+	Types      []string
+	// RestrictToSlugs with empty Slugs means match nothing (ENG-1242).
 	RestrictToSlugs bool
 	Slugs           []string
 	Page            listing.Page

--- a/pkg/infra/database/migrations/20260805140000_add_policies_gateway_slug_idx.go
+++ b/pkg/infra/database/migrations/20260805140000_add_policies_gateway_slug_idx.go
@@ -1,0 +1,45 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrations
+
+import (
+	"context"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/database"
+	"github.com/jackc/pgx/v5"
+)
+
+func init() {
+	database.RegisterMigration(database.Migration{
+		ID:   "20260805140000_add_policies_gateway_slug_idx",
+		Name: "add gateway_id+slug index for policy list type/category filters",
+		Up:   upAddPoliciesGatewaySlugIdx,
+		Down: downAddPoliciesGatewaySlugIdx,
+	})
+}
+
+func upAddPoliciesGatewaySlugIdx(ctx context.Context, tx pgx.Tx) error {
+	const ddl = `
+		CREATE INDEX IF NOT EXISTS policies_gateway_slug_idx
+			ON policies (gateway_id, slug);`
+	_, err := tx.Exec(ctx, ddl)
+	return err
+}
+
+func downAddPoliciesGatewaySlugIdx(ctx context.Context, tx pgx.Tx) error {
+	const ddl = `DROP INDEX IF EXISTS policies_gateway_slug_idx;`
+	_, err := tx.Exec(ctx, ddl)
+	return err
+}

--- a/pkg/infra/repository/policy/repository.go
+++ b/pkg/infra/repository/policy/repository.go
@@ -240,13 +240,28 @@ func (r *Repository) List(ctx context.Context, filter domain.ListFilter) ([]*dom
 		   AND ($2 = '' OR lower(name) LIKE '%' || lower($2) || '%' OR lower(slug) LIKE '%' || lower($2) || '%')
 		   AND ($3::boolean IS NULL OR enabled = $3)
 		   AND ($4::boolean IS NULL OR global = $4)
-		   AND ($5 = '' OR mode = $5)`
+		   AND ($5 = '' OR mode = $5)
+		   AND (NOT $6::boolean OR slug = ANY($7::text[]))`
 
 	gatewayParam := nullableUUID(filter.GatewayID.UUID())
 	modeParam := string(filter.Mode)
+	slugs := filter.Slugs
+	if slugs == nil {
+		slugs = []string{}
+	}
 
 	var total int
-	if err := r.conn.Pool.QueryRow(ctx, countQuery, gatewayParam, filter.Search, filter.Enabled, filter.Global, modeParam).Scan(&total); err != nil {
+	if err := r.conn.Pool.QueryRow(
+		ctx,
+		countQuery,
+		gatewayParam,
+		filter.Search,
+		filter.Enabled,
+		filter.Global,
+		modeParam,
+		filter.RestrictToSlugs,
+		slugs,
+	).Scan(&total); err != nil {
 		return nil, 0, fmt.Errorf("policy repository: count: %w", err)
 	}
 
@@ -257,9 +272,22 @@ func (r *Repository) List(ctx context.Context, filter domain.ListFilter) ([]*dom
 		   AND ($3::boolean IS NULL OR p.enabled = $3)
 		   AND ($4::boolean IS NULL OR p.global = $4)
 		   AND ($5 = '' OR p.mode = $5)
+		   AND (NOT $6::boolean OR p.slug = ANY($7::text[]))
 		 ORDER BY ` + policyOrderBy(filter.Sort) + `
-		 LIMIT $6 OFFSET $7`
-	rows, err := r.conn.Pool.Query(ctx, listQuery, gatewayParam, filter.Search, filter.Enabled, filter.Global, modeParam, page.Size, offset)
+		 LIMIT $8 OFFSET $9`
+	rows, err := r.conn.Pool.Query(
+		ctx,
+		listQuery,
+		gatewayParam,
+		filter.Search,
+		filter.Enabled,
+		filter.Global,
+		modeParam,
+		filter.RestrictToSlugs,
+		slugs,
+		page.Size,
+		offset,
+	)
 	if err != nil {
 		return nil, 0, fmt.Errorf("policy repository: list: %w", err)
 	}

--- a/tests/functional/list_policy_test.go
+++ b/tests/functional/list_policy_test.go
@@ -154,3 +154,61 @@ func TestListPolicies_SortByPriority(t *testing.T) {
 	}
 	assert.Equal(t, []float64{10, 20, 30}, prios)
 }
+
+func TestListPolicies_FilterByTypeSlug(t *testing.T) {
+	defer Track(t, "ListPolicy")()
+	gwID := CreateGateway(t, map[string]any{"slug": uniqueName("pol-type-gw")})
+	prefix := uniqueName("pol-type")
+	rateID := CreatePolicy(t, gwID, validPolicyPayload(prefix+"-rate"))
+	sizePayload := validPolicyPayload(prefix + "-size")
+	sizePayload["slug"] = "request_size_limiter"
+	sizePayload["settings"] = map[string]any{
+		"allowed_payload_size": 10,
+		"size_unit":            "megabytes",
+	}
+	_ = CreatePolicy(t, gwID, sizePayload)
+
+	status, body := sendRequest(t, http.MethodGet,
+		fmt.Sprintf("%s/v1/gateways/%s/policies?search=%s&type=rate_limiter",
+			AdminURL, gwID, url.QueryEscape(prefix)),
+		nil, nil,
+	)
+	require.Equal(t, http.StatusOK, status, "body=%v", body)
+	assert.Equal(t, float64(1), body["total"])
+	items, _ := body["items"].([]any)
+	require.Len(t, items, 1)
+	obj, _ := items[0].(map[string]any)
+	assert.Equal(t, rateID, obj["id"])
+	assert.Equal(t, "rate_limiter", obj["slug"])
+}
+
+func TestListPolicies_FilterByCategory(t *testing.T) {
+	defer Track(t, "ListPolicy")()
+	gwID := CreateGateway(t, map[string]any{"slug": uniqueName("pol-cat-gw")})
+	prefix := uniqueName("pol-cat")
+	_ = CreatePolicy(t, gwID, validPolicyPayload(prefix))
+
+	status, body := sendRequest(t, http.MethodGet,
+		fmt.Sprintf("%s/v1/gateways/%s/policies?search=%s&category=%s",
+			AdminURL, gwID, url.QueryEscape(prefix), url.QueryEscape("Traffic Control")),
+		nil, nil,
+	)
+	require.Equal(t, http.StatusOK, status, "body=%v", body)
+	assert.Equal(t, float64(1), body["total"])
+
+	status, body = sendRequest(t, http.MethodGet,
+		fmt.Sprintf("%s/v1/gateways/%s/policies?search=%s&category=%s",
+			AdminURL, gwID, url.QueryEscape(prefix), url.QueryEscape("Guardrails")),
+		nil, nil,
+	)
+	require.Equal(t, http.StatusOK, status, "body=%v", body)
+	assert.Equal(t, float64(0), body["total"])
+
+	status, body = sendRequest(t, http.MethodGet,
+		fmt.Sprintf("%s/v1/gateways/%s/policies?search=%s&category=%s",
+			AdminURL, gwID, url.QueryEscape(prefix), url.QueryEscape("Missing Category")),
+		nil, nil,
+	)
+	require.Equal(t, http.StatusOK, status, "body=%v", body)
+	assert.Equal(t, float64(0), body["total"])
+}

--- a/tests/functional/repositories/policy/repository_test.go
+++ b/tests/functional/repositories/policy/repository_test.go
@@ -329,6 +329,51 @@ func TestRepository_List_FilterByGatewayAndName(t *testing.T) {
 	}
 }
 
+func TestRepository_List_RestrictToSlugs(t *testing.T) {
+	r, gw, _ := setupRepo(t)
+	ctx := context.Background()
+	gwID := seedGateway(t, gw, "pgw-slug")
+
+	mustSave := func(p *domain.Policy) {
+		if err := r.Save(ctx, p); err != nil {
+			t.Fatalf("Save: %v", err)
+		}
+	}
+	mustSave(validPolicy(t, gwID, "rate-one"))
+	p2, err := domain.NewPolicy(gwID, "size-one", "request_size_limiter", true, 0, false,
+		map[string]any{"allowed_payload_size": 10, "size_unit": "megabytes"}, []domain.Stage{domain.StagePreRequest}, "", domain.ModeEnforce)
+	if err != nil {
+		t.Fatalf("NewPolicy: %v", err)
+	}
+	mustSave(p2)
+
+	items, total, err := r.List(ctx, domain.ListFilter{
+		GatewayID:       gwID,
+		RestrictToSlugs: true,
+		Slugs:           []string{"rate_limiter"},
+		Page:            listing.Page{Number: 1, Size: 10},
+	})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if total != 1 || len(items) != 1 || items[0].Slug != "rate_limiter" {
+		t.Fatalf("List(slug) total=%d items=%+v", total, items)
+	}
+
+	items, total, err = r.List(ctx, domain.ListFilter{
+		GatewayID:       gwID,
+		RestrictToSlugs: true,
+		Slugs:           []string{},
+		Page:            listing.Page{Number: 1, Size: 10},
+	})
+	if err != nil {
+		t.Fatalf("List empty slugs: %v", err)
+	}
+	if total != 0 || len(items) != 0 {
+		t.Fatalf("List(empty restrict) total=%d len=%d", total, len(items))
+	}
+}
+
 func TestRepository_GlobalFlag_RoundTripAndListByGateway(t *testing.T) {
 	r, gw, _ := setupRepo(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
- Expand `category` (catalog group) and `type` (plugin slug) query params on `GET .../policies` via the plugin catalog in the Finder.
- Repository filters with `slug = ANY(...)` (not JSONB `stages` — identity is `policies.slug` after the 1:1 collapse).
- Add `(gateway_id, slug)` index; unknown category/type → empty `200` list.
- Functional + unit coverage; swagger/openapi regenerated.

## Linear
ENG-1242 — https://linear.app/neuraltrust/issue/ENG-1242/featgateway-server-side-policy-list-filters-by-categorytype-slug

## Test plan
- [x] `go test ./pkg/app/policy/ ./pkg/api/handler/http/httpio/`
- [x] `go test -tags=functional ./tests/functional/repositories/policy/ -run List_Restrict`
- [ ] Functional HTTP: `?category=Traffic Control`, `?type=rate_limiter`, unknown category empty
- [ ] Combined with `search` / `enabled` / pagination


Made with [Cursor](https://cursor.com)