### PR TITLE
fix(routing): authenticate firewall complexity requests

### DIFF
--- a/k8s/base/secrets.env.example
+++ b/k8s/base/secrets.env.example
@@ -33,6 +33,7 @@
 #                         Secret Manager .env blob and loaded from the CSI-mounted
 #                         /etc/secrets/.env file. It must match Firewall's JWT_SECRET.
 #   FIREWALL_BASE_URL   - non-secret endpoint in overlays/*/config.env.
+#                         The client timeout is fixed at 30 seconds.
 #
 # DB-less config sync secrets (shared by admin + proxy + mcp via the CSI .env blob):
 #   CONFIG_SYNC_TOKEN   - the admin control plane requires it to serve the snapshot

--- a/k8s/base/secrets.env.example
+++ b/k8s/base/secrets.env.example
@@ -24,9 +24,15 @@
 #
 # These map to the following environment variables inside the containers:
 #   DB_HOST, REDIS_HOST, DB_PASSWORD, REDIS_PASSWORD, SERVER_SECRET_KEY, STS_SIGNING_KEY,
-#   TRUSTGUARD_CLIENT_SECRET, CONFIG_SYNC_TOKEN, CONFIG_SYNC_LKG_KEY
+#   TRUSTGUARD_CLIENT_SECRET, FIREWALL_SECRET_KEY, CONFIG_SYNC_TOKEN, CONFIG_SYNC_LKG_KEY
 # DB_NAME and DB_USER default to agentgateway (see overlays/*/config.env).
 # TRUSTGUARD_BASE_URL and TRUSTGUARD_CLIENT_ID are non-secret (set in config.env).
+#
+# Firewall smart routing:
+#   FIREWALL_SECRET_KEY - HS256 key stored in the environment's agentgateway
+#                         Secret Manager .env blob and loaded from the CSI-mounted
+#                         /etc/secrets/.env file. It must match Firewall's JWT_SECRET.
+#   FIREWALL_BASE_URL   - non-secret endpoint in overlays/*/config.env.
 #
 # DB-less config sync secrets (shared by admin + proxy + mcp via the CSI .env blob):
 #   CONFIG_SYNC_TOKEN   - the admin control plane requires it to serve the snapshot

--- a/k8s/overlays/dev/config.env
+++ b/k8s/overlays/dev/config.env
@@ -27,6 +27,7 @@ MCP_BASE_DOMAIN=mcp.dev.neuraltrust.ai
 TRUSTGUARD_BASE_URL=http://trustguard-data.trustguard.svc.cluster.local:8081
 TRUSTGUARD_TIMEOUT=15s
 TRUSTGUARD_CLIENT_ID=tgc_platform_dev
+FIREWALL_BASE_URL=http://firewall.firewall.svc.cluster.local:80
 # DB-less config sync (shared by admin control plane and proxy/mcp data planes).
 # CONFIG_SYNC_TOKEN and CONFIG_SYNC_LKG_KEY are secrets (see secrets.env.example).
 # CONFIG_SYNC_DATA_PLANE_ENABLED is set per-deployment (true on proxy/mcp only).

--- a/k8s/overlays/prod-us/config.env
+++ b/k8s/overlays/prod-us/config.env
@@ -29,6 +29,7 @@ MCP_BASE_DOMAIN=mcp.us.neuraltrust.ai
 TRUSTGUARD_BASE_URL=http://trustguard-data.trustguard.svc.cluster.local:8081
 TRUSTGUARD_TIMEOUT=15s
 TRUSTGUARD_CLIENT_ID=tgc_platform_prod_us
+FIREWALL_BASE_URL=http://firewall.firewall.svc.cluster.local:80
 # DB-less config sync (shared by admin control plane and proxy/mcp data planes).
 # CONFIG_SYNC_TOKEN and CONFIG_SYNC_LKG_KEY are secrets (see secret.env.example).
 # CONFIG_SYNC_DATA_PLANE_ENABLED is set per-deployment (true on proxy/mcp only).

--- a/k8s/overlays/prod/config.env
+++ b/k8s/overlays/prod/config.env
@@ -25,6 +25,7 @@ APPLICATION_VERSION=v0.33.2
 TRUSTGUARD_BASE_URL=http://trustguard-data.trustguard.svc.cluster.local:8081
 TRUSTGUARD_TIMEOUT=15s
 TRUSTGUARD_CLIENT_ID=tgc_platform_prod
+FIREWALL_BASE_URL=http://firewall.firewall.svc.cluster.local:80
 # DB-less config sync (shared by admin control plane and proxy/mcp data planes).
 # CONFIG_SYNC_TOKEN and CONFIG_SYNC_LKG_KEY are secrets (see secrets.env.example).
 # CONFIG_SYNC_DATA_PLANE_ENABLED is set per-deployment (true on proxy/mcp only).

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -108,7 +108,7 @@ const (
 
 	defaultTrustGuardTimeout = 15 * time.Second
 
-	defaultFirewallComplexityTimeout = 15 * time.Second
+	defaultFirewallComplexityTimeout = 30 * time.Second
 
 	defaultOpenAIModerationTimeout = 15 * time.Second
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -112,9 +112,9 @@ const (
 
 	defaultOpenAIModerationTimeout = 15 * time.Second
 
-	defaultConfigSyncDataPlaneEnabled  = false
-	defaultConfigSyncLKGPath           = "/var/lib/trustgate/snapshot.lkg"
-	defaultConfigSyncPollInterval      = 5 * time.Minute
+	defaultConfigSyncDataPlaneEnabled = false
+	defaultConfigSyncLKGPath          = "/var/lib/trustgate/snapshot.lkg"
+	defaultConfigSyncPollInterval     = 5 * time.Minute
 	// The dispatcher fires immediately on the first write signal (leading edge);
 	// the debounce is only the horizon for folding a burst of follow-up writes
 	// into one trailing recompile, so it stays short to keep propagation of
@@ -388,12 +388,12 @@ type TrustGuardConfig struct {
 }
 
 // FirewallComplexityConfig configures the Firewall Complexity API used by the
-// smart-routing load balancer. Token is a static bearer sent in the "token"
-// header; an empty BaseURL or Token disables smart routing at runtime.
+// smart-routing load balancer. An empty BaseURL or SecretKey disables smart
+// routing at runtime.
 type FirewallComplexityConfig struct {
-	BaseURL string
-	Token   string // #nosec G117 -- config struct field, not a hardcoded credential
-	Timeout time.Duration
+	BaseURL   string
+	SecretKey string // #nosec G117 -- config struct field, not a hardcoded credential
+	Timeout   time.Duration
 }
 
 type OpenAIModerationConfig struct {
@@ -706,9 +706,9 @@ func getTrustGuardConfig() TrustGuardConfig {
 
 func getFirewallComplexityConfig() FirewallComplexityConfig {
 	return FirewallComplexityConfig{
-		BaseURL: getEnv("FIREWALL_COMPLEXITY_BASE_URL", ""),
-		Token:   getEnv("FIREWALL_COMPLEXITY_TOKEN", ""),
-		Timeout: getEnvDuration("FIREWALL_COMPLEXITY_TIMEOUT", defaultFirewallComplexityTimeout),
+		BaseURL:   getEnv("FIREWALL_BASE_URL", ""),
+		SecretKey: getEnv("FIREWALL_SECRET_KEY", ""),
+		Timeout:   defaultFirewallComplexityTimeout,
 	}
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -60,6 +60,21 @@ func TestLoadConfig_AppliesDefaults(t *testing.T) {
 	}
 }
 
+func TestGetFirewallComplexityConfig(t *testing.T) {
+	t.Setenv("FIREWALL_BASE_URL", "https://firewall.example")
+	t.Setenv("FIREWALL_SECRET_KEY", "signing-secret")
+	cfg := getFirewallComplexityConfig()
+	if cfg.BaseURL != "https://firewall.example" {
+		t.Errorf("BaseURL = %q, want %q", cfg.BaseURL, "https://firewall.example")
+	}
+	if cfg.SecretKey != "signing-secret" {
+		t.Errorf("SecretKey = %q, want configured value", cfg.SecretKey)
+	}
+	if cfg.Timeout != defaultFirewallComplexityTimeout {
+		t.Errorf("Timeout = %s, want %s", cfg.Timeout, defaultFirewallComplexityTimeout)
+	}
+}
+
 func TestLoadConfig_PostgresLoginModes(t *testing.T) {
 	tests := []struct {
 		name, login, password, sslMode, wantLogin, wantPassword string

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -70,8 +70,8 @@ func TestGetFirewallComplexityConfig(t *testing.T) {
 	if cfg.SecretKey != "signing-secret" {
 		t.Errorf("SecretKey = %q, want configured value", cfg.SecretKey)
 	}
-	if cfg.Timeout != defaultFirewallComplexityTimeout {
-		t.Errorf("Timeout = %s, want %s", cfg.Timeout, defaultFirewallComplexityTimeout)
+	if cfg.Timeout != 30*time.Second {
+		t.Errorf("Timeout = %s, want 30s", cfg.Timeout)
 	}
 }
 

--- a/pkg/container/modules/loadbalancer.go
+++ b/pkg/container/modules/loadbalancer.go
@@ -23,6 +23,7 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/infra/complexity"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/embedding/factory"
 	embeddingopenai "github.com/NeuralTrust/TrustGate/pkg/infra/embedding/openai"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/firewall"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/loadbalancer"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/loadbalancer/strategies"
 	"go.uber.org/dig"
@@ -47,7 +48,7 @@ func LoadBalancer(c *container.Container) error {
 	if err := c.Provide(func(cfg *config.Config) strategies.ComplexityScorer {
 		return complexity.NewClient(
 			cfg.FirewallComplexity.BaseURL,
-			cfg.FirewallComplexity.Token,
+			firewall.NewTokenProvider(cfg.FirewallComplexity.SecretKey),
 			cfg.FirewallComplexity.Timeout,
 		)
 	}); err != nil {

--- a/pkg/infra/complexity/client.go
+++ b/pkg/infra/complexity/client.go
@@ -40,32 +40,38 @@ const (
 // ErrUnauthorized is returned when the Firewall Complexity API rejects the token.
 var ErrUnauthorized = errors.New("complexity: unauthorized")
 
-// ErrNotConfigured is returned when Score is called without a base URL and token.
+// ErrNotConfigured is returned when Score is called without a base URL and token provider.
 var ErrNotConfigured = errors.New("complexity: client not configured")
 
-// Client calls the Firewall Complexity API with a static bearer token.
-type Client struct {
-	http    *http.Client
-	baseURL string
-	token   string
+// TokenProvider supplies authentication tokens for Firewall requests.
+type TokenProvider interface {
+	Configured() bool
+	Invalidate()
+	Token() (string, error)
 }
 
-// NewClient builds a Client. An empty baseURL or token leaves it unconfigured
-// (see Configured), so callers can fall back to another strategy.
-func NewClient(baseURL, token string, timeout time.Duration) *Client {
+// Client calls the Firewall Complexity API.
+type Client struct {
+	http          *http.Client
+	baseURL       string
+	tokenProvider TokenProvider
+}
+
+// NewClient builds a Client. Missing endpoint credentials leave it unconfigured.
+func NewClient(baseURL string, tokenProvider TokenProvider, timeout time.Duration) *Client {
 	if timeout <= 0 {
 		timeout = defaultTimeout
 	}
 	return &Client{
-		http:    &http.Client{Timeout: timeout},
-		baseURL: strings.TrimRight(baseURL, "/"),
-		token:   token,
+		http:          &http.Client{Timeout: timeout},
+		baseURL:       strings.TrimRight(baseURL, "/"),
+		tokenProvider: tokenProvider,
 	}
 }
 
-// Configured reports whether both a base URL and token are set.
+// Configured reports whether the endpoint and token provider are configured.
 func (c *Client) Configured() bool {
-	return c.baseURL != "" && c.token != ""
+	return c.baseURL != "" && c.tokenProvider != nil && c.tokenProvider.Configured()
 }
 
 // Score returns the session-smoothed complexity score in [0,1] for input.
@@ -73,6 +79,10 @@ func (c *Client) Configured() bool {
 func (c *Client) Score(ctx context.Context, input, conversationID, tenantID string) (float64, error) {
 	if !c.Configured() {
 		return 0, ErrNotConfigured
+	}
+	token, err := c.tokenProvider.Token()
+	if err != nil {
+		return 0, fmt.Errorf("complexity: get token: %w", err)
 	}
 	payload, err := json.Marshal(scoreRequest{
 		Input:          input,
@@ -87,7 +97,7 @@ func (c *Client) Score(ctx context.Context, input, conversationID, tenantID stri
 	if err != nil {
 		return 0, fmt.Errorf("complexity: build request: %w", err)
 	}
-	req.Header.Set(headerToken, c.token)
+	req.Header.Set(headerToken, token)
 	req.Header.Set("Content-Type", contentTypeJSON)
 
 	res, err := c.http.Do(req)
@@ -103,6 +113,7 @@ func (c *Client) Score(ctx context.Context, input, conversationID, tenantID stri
 		return 0, fmt.Errorf("complexity: read response: %w", err)
 	}
 	if res.StatusCode == http.StatusUnauthorized {
+		c.tokenProvider.Invalidate()
 		return 0, ErrUnauthorized
 	}
 	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusMultipleChoices {

--- a/pkg/infra/complexity/client_test.go
+++ b/pkg/infra/complexity/client_test.go
@@ -28,12 +28,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type tokenProviderStub struct {
+	configured bool
+	token      string
+	err        error
+	invalidate func()
+}
+
+func (s tokenProviderStub) Configured() bool       { return s.configured }
+func (s tokenProviderStub) Token() (string, error) { return s.token, s.err }
+func (s tokenProviderStub) Invalidate() {
+	if s.invalidate != nil {
+		s.invalidate()
+	}
+}
+
 func TestClient_Configured(t *testing.T) {
 	t.Parallel()
-	assert.False(t, NewClient("", "", 0).Configured())
-	assert.False(t, NewClient("http://x", "", 0).Configured())
-	assert.False(t, NewClient("", "tok", 0).Configured())
-	assert.True(t, NewClient("http://x", "tok", 0).Configured())
+	configured := tokenProviderStub{configured: true, token: "tok"}
+	assert.False(t, NewClient("", configured, 0).Configured())
+	assert.False(t, NewClient("http://x", nil, 0).Configured())
+	assert.False(t, NewClient("http://x", tokenProviderStub{}, 0).Configured())
+	assert.True(t, NewClient("http://x", configured, 0).Configured())
 }
 
 func TestClient_Score_Success(t *testing.T) {
@@ -53,7 +69,7 @@ func TestClient_Score_Success(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewClient(srv.URL, "secret-token", time.Second)
+	c := NewClient(srv.URL, tokenProviderStub{configured: true, token: "secret-token"}, time.Second)
 	score, err := c.Score(context.Background(), "hello", "chat_1", "tenant_1")
 	require.NoError(t, err)
 	assert.InDelta(t, 0.41, score, 1e-9)
@@ -61,21 +77,35 @@ func TestClient_Score_Success(t *testing.T) {
 
 func TestClient_Score_NotConfigured(t *testing.T) {
 	t.Parallel()
-	c := NewClient("", "", time.Second)
+	c := NewClient("", nil, time.Second)
 	_, err := c.Score(context.Background(), "hello", "", "")
 	assert.ErrorIs(t, err, ErrNotConfigured)
 }
 
+func TestClient_Score_TokenError(t *testing.T) {
+	t.Parallel()
+	tokenErr := errors.New("mint token")
+	c := NewClient("http://x", tokenProviderStub{configured: true, err: tokenErr}, time.Second)
+	_, err := c.Score(context.Background(), "hello", "", "")
+	assert.ErrorIs(t, err, tokenErr)
+}
+
 func TestClient_Score_Unauthorized(t *testing.T) {
 	t.Parallel()
+	invalidated := false
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 	}))
 	defer srv.Close()
 
-	c := NewClient(srv.URL, "bad", time.Second)
+	c := NewClient(srv.URL, tokenProviderStub{
+		configured: true,
+		token:      "bad",
+		invalidate: func() { invalidated = true },
+	}, time.Second)
 	_, err := c.Score(context.Background(), "hello", "", "")
 	assert.ErrorIs(t, err, ErrUnauthorized)
+	assert.True(t, invalidated)
 }
 
 func TestClient_Score_ServerError(t *testing.T) {
@@ -85,7 +115,7 @@ func TestClient_Score_ServerError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewClient(srv.URL, "tok", time.Second)
+	c := NewClient(srv.URL, tokenProviderStub{configured: true, token: "tok"}, time.Second)
 	_, err := c.Score(context.Background(), "hello", "", "")
 	require.Error(t, err)
 	assert.False(t, errors.Is(err, ErrUnauthorized))

--- a/pkg/infra/firewall/token.go
+++ b/pkg/infra/firewall/token.go
@@ -1,0 +1,89 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package firewall provides authentication for NeuralTrust Firewall clients.
+package firewall
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+const (
+	tokenTTL         = time.Hour
+	tokenRefreshSkew = 5 * time.Minute
+)
+
+// ErrNotConfigured is returned when a token is requested without a secret key.
+var ErrNotConfigured = errors.New("firewall: token provider not configured")
+
+// TokenProvider mints and caches short-lived Firewall JWTs.
+type TokenProvider struct {
+	secretKey string
+	now       func() time.Time
+	mu        sync.Mutex
+	token     string
+	expiresAt time.Time
+}
+
+// NewTokenProvider builds a Firewall token provider.
+func NewTokenProvider(secretKey string) *TokenProvider {
+	return &TokenProvider{secretKey: strings.TrimSpace(secretKey), now: time.Now}
+}
+
+// Configured reports whether the provider has a signing key.
+func (p *TokenProvider) Configured() bool {
+	return p != nil && p.secretKey != ""
+}
+
+// Invalidate clears the cached token.
+func (p *TokenProvider) Invalidate() {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	p.token = ""
+	p.expiresAt = time.Time{}
+	p.mu.Unlock()
+}
+
+// Token returns a cached token or mints a new one before the cached token expires.
+func (p *TokenProvider) Token() (string, error) {
+	if !p.Configured() {
+		return "", ErrNotConfigured
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	now := p.now()
+	if p.token != "" && now.Before(p.expiresAt.Add(-tokenRefreshSkew)) {
+		return p.token, nil
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"purpose": "firewall",
+		"iat":     now.Unix(),
+		"exp":     now.Add(tokenTTL).Unix(),
+	})
+	signed, err := token.SignedString([]byte(p.secretKey))
+	if err != nil {
+		return "", fmt.Errorf("firewall: sign token: %w", err)
+	}
+	p.token = signed
+	p.expiresAt = now.Add(tokenTTL)
+	return signed, nil
+}

--- a/pkg/infra/firewall/token_test.go
+++ b/pkg/infra/firewall/token_test.go
@@ -1,0 +1,124 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package firewall
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenProvider_NotConfigured(t *testing.T) {
+	t.Parallel()
+	provider := NewTokenProvider(" ")
+	assert.False(t, provider.Configured())
+	_, err := provider.Token()
+	assert.ErrorIs(t, err, ErrNotConfigured)
+}
+
+func TestTokenProvider_CachesAndRefreshesToken(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, time.August, 5, 8, 0, 0, 0, time.UTC)
+	provider := NewTokenProvider("test-secret")
+	provider.now = func() time.Time { return now }
+	first, err := provider.Token()
+	require.NoError(t, err)
+	now = now.Add(tokenTTL - tokenRefreshSkew - time.Second)
+	cached, err := provider.Token()
+	require.NoError(t, err)
+	assert.Equal(t, first, cached)
+	now = now.Add(2 * time.Second)
+	refreshed, err := provider.Token()
+	require.NoError(t, err)
+	assert.NotEqual(t, first, refreshed)
+}
+
+func TestTokenProvider_MintsExpectedClaims(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, time.August, 5, 8, 0, 0, 0, time.UTC)
+	provider := NewTokenProvider("test-secret")
+	provider.now = func() time.Time { return now }
+	signed, err := provider.Token()
+	require.NoError(t, err)
+	parsed, err := jwt.Parse(signed, func(token *jwt.Token) (any, error) {
+		assert.Equal(t, jwt.SigningMethodHS256, token.Method)
+		return []byte("test-secret"), nil
+	}, jwt.WithTimeFunc(func() time.Time { return now }),
+		jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Alg()}))
+	require.NoError(t, err)
+	require.True(t, parsed.Valid)
+	claims, ok := parsed.Claims.(jwt.MapClaims)
+	require.True(t, ok)
+	assert.Equal(t, "firewall", claims["purpose"])
+	assert.Equal(t, float64(now.Unix()), claims["iat"])
+	assert.Equal(t, float64(now.Add(tokenTTL).Unix()), claims["exp"])
+}
+
+func TestTokenProvider_Invalidate(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, time.August, 5, 8, 0, 0, 0, time.UTC)
+	provider := NewTokenProvider("test-secret")
+	provider.now = func() time.Time { return now }
+	first, err := provider.Token()
+	require.NoError(t, err)
+	now = now.Add(time.Second)
+	provider.Invalidate()
+	refreshed, err := provider.Token()
+	require.NoError(t, err)
+	assert.NotEqual(t, first, refreshed)
+}
+
+func TestTokenProvider_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+	provider := NewTokenProvider("test-secret")
+	const workers = 64
+	tokens := make(chan string, workers)
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			token, err := provider.Token()
+			tokens <- token
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(tokens)
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	var first string
+	for token := range tokens {
+		require.NotEmpty(t, token)
+		if first == "" {
+			first = token
+		}
+		assert.Equal(t, first, token)
+	}
+}
+
+func TestTokenProvider_NilReceiver(t *testing.T) {
+	t.Parallel()
+	var provider *TokenProvider
+	assert.False(t, provider.Configured())
+	_, err := provider.Token()
+	assert.ErrorIs(t, err, ErrNotConfigured)
+}

--- a/tests/functional/firewall_complexity_stub_test.go
+++ b/tests/functional/firewall_complexity_stub_test.go
@@ -7,11 +7,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+
+	"github.com/golang-jwt/jwt/v5"
 )
 
 const (
-	firewallComplexityFunctionalToken = "functional-firewall-token"
-	firewallComplexityPath            = "/v1/complexity"
+	firewallComplexityFunctionalSecret = "functional-firewall-secret"
+	firewallComplexityPath             = "/v1/complexity"
 
 	// Message-content markers the stub maps to deterministic complexity
 	// scores, so each test drives routing purely through the prompt it sends
@@ -70,7 +72,7 @@ func newFirewallComplexityStubServer() *firewallComplexityStub {
 	stub := &firewallComplexityStub{}
 	mux := http.NewServeMux()
 	mux.HandleFunc(firewallComplexityPath, func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("token") != firewallComplexityFunctionalToken {
+		if !isValidFirewallToken(r.Header.Get("token")) {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
@@ -90,6 +92,17 @@ func newFirewallComplexityStubServer() *firewallComplexityStub {
 	})
 	stub.server = httptest.NewServer(mux)
 	return stub
+}
+
+func isValidFirewallToken(signed string) bool {
+	token, err := jwt.Parse(signed, func(token *jwt.Token) (any, error) {
+		return []byte(firewallComplexityFunctionalSecret), nil
+	}, jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Alg()}))
+	if err != nil || !token.Valid {
+		return false
+	}
+	claims, ok := token.Claims.(jwt.MapClaims)
+	return ok && claims["purpose"] == "firewall"
 }
 
 func writeFirewallScore(w http.ResponseWriter, score float64) {

--- a/tests/functional/setup_test.go
+++ b/tests/functional/setup_test.go
@@ -24,9 +24,9 @@ import (
 
 	"github.com/NeuralTrust/TrustGate/pkg/config"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/auth/jwt"
-	"github.com/redis/go-redis/v9"
 	"github.com/jackc/pgx/v5"
 	"github.com/joho/godotenv"
+	"github.com/redis/go-redis/v9"
 )
 
 var (
@@ -97,8 +97,8 @@ func buildCmdEnv(trustGuardBaseURL, firewallComplexityBaseURL string) []string {
 		env = append(env, "TRUSTGUARD_BASE_URL="+trustGuardBaseURL)
 	}
 	if firewallComplexityBaseURL != "" {
-		env = append(env, "FIREWALL_COMPLEXITY_BASE_URL="+firewallComplexityBaseURL)
-		env = append(env, "FIREWALL_COMPLEXITY_TOKEN="+firewallComplexityFunctionalToken)
+		env = append(env, "FIREWALL_BASE_URL="+firewallComplexityBaseURL)
+		env = append(env, "FIREWALL_SECRET_KEY="+firewallComplexityFunctionalSecret)
 	}
 	return env
 }


### PR DESCRIPTION
## What
Smart routing now authenticates with the Firewall Complexity API by minting short-lived HS256 JWTs from the signing key supplied through the existing Secret Manager CSI mount. This enables complexity scoring in deployed environments without a static token.

## How
- Add a concurrency-safe JWT provider with one-hour caching and early refresh.
- Invalidate cached credentials when Firewall returns `401`.
- Reduce configuration to `FIREWALL_BASE_URL` and `FIREWALL_SECRET_KEY` with a fixed 30-second timeout.
- Configure the in-cluster Firewall endpoint in dev, prod, and prod-us overlays.
- Validate signed JWTs in functional smart-routing tests.

## Testing
- `go test ./...`
- `go test -race ./pkg/infra/firewall ./pkg/infra/complexity ./pkg/config ./pkg/container/modules`
- `go vet` and `golangci-lint` on changed packages
- Functional test package compile with the `functional` tag
- `kubectl kustomize` for dev, prod, and prod-us
- Pre-commit hook, including the full repository test suite

## Risk
Medium — each environment must add `FIREWALL_SECRET_KEY` to the existing `agentgateway` Secret Manager `.env` blob before rollout. Rollback is reverting these commits and removing `FIREWALL_BASE_URL` from the overlays.

## Pre-flight checks

| Check | Result |
|---|---|
| Review (reviewer) | ✅ Intentional timeout contract retirement confirmed; no remaining blockers |
| Security (security-scanner) | ✅ No blockers; rollout and transport hardening suggestions noted |
| Performance (perf-analyzer) | ✅ No blockers; optional token-cache fast-path suggestions noted |

<details>
<summary>Non-blocking follow-ups</summary>

- Confirm `FIREWALL_SECRET_KEY` is present in every environment's `agentgateway` secret before deployment.
- Consider audience-scoped JWT claims and mesh mTLS when Firewall supports them.
- Profile token-cache lock contention before adding a lock-free fast path.

</details>

@ops

Made with [Cursor](https://cursor.com)