### PR TITLE
fix: key the TrustGuard settings cache on the legacy direction alias

### DIFF
--- a/pkg/infra/plugins/trustguard/config_test.go
+++ b/pkg/infra/plugins/trustguard/config_test.go
@@ -16,11 +16,13 @@ package trustguard
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/NeuralTrust/TrustGate/pkg/domain/policy"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers/adapter"
 )
 
 const testCollectorID = "11111111-1111-4111-8111-111111111111"
@@ -89,6 +91,24 @@ func TestParseConfig(t *testing.T) {
 			assert.Equal(t, tt.wantInspect, cfg.Inspect)
 		})
 	}
+}
+
+func TestConfigCacheKeepsDirectionAndInspectApart(t *testing.T) {
+	p := New(adapter.NewRegistry(), "http://guard.local", time.Second, "id", "secret", nil)
+
+	legacy, err := p.config(map[string]any{"direction": inspectRequest, "collector_id": testCollectorID})
+	require.NoError(t, err)
+	assert.Equal(t, inspectRequest, legacy.Inspect)
+
+	unset, err := p.config(map[string]any{"collector_id": testCollectorID})
+	require.NoError(t, err)
+	assert.Equal(t, inspectRequestResponse, unset.Inspect,
+		"a policy that sets neither key must not inherit the cached config of one that sets direction")
+
+	again, err := p.config(map[string]any{"direction": inspectRequest, "collector_id": testCollectorID})
+	require.NoError(t, err)
+	assert.Equal(t, inspectRequest, again.Inspect,
+		"the cached entry for direction must survive a policy that leaves it unset")
 }
 
 func TestSelectsStage(t *testing.T) {

--- a/pkg/infra/plugins/trustguard/plugin.go
+++ b/pkg/infra/plugins/trustguard/plugin.go
@@ -451,8 +451,17 @@ func (p *Plugin) config(settings map[string]any) (Settings, error) {
 	return cfg, nil
 }
 
+// configCacheKey must name every setting parseConfig reads, direction included:
+// it is an alias for inspect, so omitting it gives a policy that sets only
+// direction the same key as one that sets neither, and the first of the two to
+// be parsed decides which legs both of them inspect.
 func configCacheKey(settings map[string]any) string {
-	return fmt.Sprintf("%v\x00%v", settings["inspect"], settings["collector_id"])
+	return fmt.Sprintf(
+		"%v\x00%v\x00%v",
+		settings["inspect"],
+		settings["direction"],
+		settings["collector_id"],
+	)
 }
 
 func gatewayTraceID(ctx context.Context) string {


### PR DESCRIPTION
## Summary

The `trustguard` plugin caches its parsed settings under a key built from `inspect` and `collector_id`. `direction` is the legacy alias for `inspect`, and it was not in the key — so a policy that sets only `direction` shared a cache entry with one that sets neither, and whichever of the two a gateway replica parsed first decided which legs **both** of them inspected.

A policy written as `direction: request` could therefore end up inspecting the response leg too, or a policy meant to cover both legs could end up covering only the request. Which replica serves the call decides the outcome, so it presents as an intermittent guardrail rather than a clean break.

Found by the new TrustGuard end-to-end sweep in `multi-agent-tests`, which reproduced it in 4 of 5 runs: a `direction: request` policy blocked on the response leg using a sibling policy's `request_response` config, and the 403 named the output-leg detector.

## Test plan

- [x] `TestConfigCacheKeepsDirectionAndInspectApart` — fails on `develop`, passes with the fix (verified both ways)
- [x] `go test ./pkg/infra/plugins/trustguard/...`
- [x] `go vet` + `golangci-lint run` clean
- [ ] Re-run the e2e case against production once deployed: `uv run pytest src/e2e/tests/test_trustguard.py -k legacy_direction`

Made with [Cursor](https://cursor.com)