### PR TITLE
fix: give a per-tool budget of N its own N calls

### DIFF
--- a/pkg/app/plugins/catalog_metadata.go
+++ b/pkg/app/plugins/catalog_metadata.go
@@ -334,13 +334,6 @@ var pluginCatalogMeta = map[string]catalogMeta{
 					Enum:        enumOptions("reject_response", "inject_error_result", "strip_tool_from_request"),
 					Default:     "reject_response",
 				},
-				{
-					Key:         "scope",
-					Label:       "Scope",
-					Type:        FieldTypeEnum,
-					Description: "Informational; effective scope derives from the policy global flag.",
-					Enum:        enumOptions("consumer", "global"),
-				},
 			},
 		},
 	},

--- a/pkg/infra/plugins/pertoolratelimit/config.go
+++ b/pkg/infra/plugins/pertoolratelimit/config.go
@@ -28,11 +28,6 @@ const (
 	behaviorStrip  = "strip_tool_from_request"
 )
 
-var validScopes = map[string]struct{}{
-	"consumer": {},
-	"global":   {},
-}
-
 var enforceableBehaviors = map[string]struct{}{
 	behaviorReject: {},
 	behaviorInject: {},
@@ -51,8 +46,11 @@ type ruleConfig struct {
 	Behavior string         `mapstructure:"behavior"`
 }
 
+// config has no scope of its own: the counters are keyed by the scope of the
+// policy that carries the plugin. It used to accept one, validated it, and never
+// read it, so a policy asking for a budget shared across consumers silently got
+// one per consumer.
 type config struct {
-	Scope           string       `mapstructure:"scope"`
 	Rules           []ruleConfig `mapstructure:"rules"`
 	BehaviorDefault string       `mapstructure:"behavior_default"`
 }
@@ -74,11 +72,6 @@ func parseConfig(settings map[string]any) (*config, error) {
 }
 
 func (c *config) validate() error {
-	if c.Scope != "" {
-		if _, ok := validScopes[c.Scope]; !ok {
-			return fmt.Errorf("per_tool_rate_limiter: scope must be one of consumer, global")
-		}
-	}
 	if err := validateBehavior(c.BehaviorDefault); err != nil {
 		return fmt.Errorf("per_tool_rate_limiter: behavior_default: %w", err)
 	}

--- a/pkg/infra/plugins/pertoolratelimit/plugin.go
+++ b/pkg/infra/plugins/pertoolratelimit/plugin.go
@@ -171,6 +171,10 @@ func (p *Plugin) preRequest(
 	if err != nil || canonical == nil {
 		return okResult(), nil
 	}
+	spent, err := p.spentBefore(ctx, cfg, in, dimension, subject, canonical.Tools)
+	if err != nil {
+		return nil, fmt.Errorf("per_tool_rate_limiter: %w", err)
+	}
 	if len(canonical.Messages) > 0 {
 		if err := p.countExecuted(ctx, cfg, in, dimension, subject, canonical.Messages); err != nil {
 			return nil, fmt.Errorf("per_tool_rate_limiter: %w", err)
@@ -194,10 +198,7 @@ func (p *Plugin) preRequest(
 		if !p.enforcedAtRequest(behavior, canonical.Stream) {
 			continue
 		}
-		ws, err := p.overLimit(ctx, in.Config.ID, dimension, subject, tool, rule)
-		if err != nil {
-			return nil, fmt.Errorf("per_tool_rate_limiter: %w", err)
-		}
+		ws := spent[tool]
 		if ws == nil {
 			continue
 		}
@@ -211,6 +212,35 @@ func (p *Plugin) preRequest(
 		return okResult(), nil
 	}
 	return p.stripTools(in.Request.Body, format, canonical, strip)
+}
+
+func (p *Plugin) spentBefore(
+	ctx context.Context,
+	cfg *config,
+	in appplugins.ExecInput,
+	dimension, subject string,
+	tools []adapter.CanonicalTool,
+) (map[string]*windowState, error) {
+	spent := make(map[string]*windowState, len(tools))
+	for i := range tools {
+		tool := tools[i].Name
+		if tool == "" {
+			continue
+		}
+		if _, done := spent[tool]; done {
+			continue
+		}
+		rule, ok := matchRule(cfg.Rules, tool)
+		if !ok {
+			continue
+		}
+		ws, err := p.overLimit(ctx, in.Config.ID, dimension, subject, tool, rule)
+		if err != nil {
+			return nil, err
+		}
+		spent[tool] = ws
+	}
+	return spent, nil
 }
 
 func (p *Plugin) enforcedAtRequest(behavior string, streaming bool) bool {

--- a/pkg/infra/plugins/pertoolratelimit/plugin_test.go
+++ b/pkg/infra/plugins/pertoolratelimit/plugin_test.go
@@ -191,11 +191,10 @@ func TestPlugin_ValidateConfig(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "bad scope",
+			name: "scope is no longer a setting and is ignored like any other unknown key",
 			settings: map[string]any{"scope": "tenant", "rules": []any{map[string]any{
 				"tool": "send_email", "windows": []any{map[string]any{"duration": "1m", "max": 5}},
 			}}},
-			wantErr: true,
 		},
 	}
 
@@ -773,6 +772,38 @@ func TestPlugin_PreRequest_NoRejectUnderBudget(t *testing.T) {
 	assert.Nil(t, res.RequestBody)
 }
 
+// Most cases here seed the counter and check the limit, or count with no limit
+// in play. These two do both in the one request, which is where the budget used
+// to lose a call: the request handing back the Nth result moved the counter to
+// max and was then refused by it, so max: 1 completed none.
+
+func TestPlugin_PreRequest_ReportingAResultDoesNotRefuseTheCallThatEarnedIt(t *testing.T) {
+	p, rdb := newPluginRedis(t)
+	settings := ruleSettings("send_email", "reject_response", "1m", 1)
+	body := openAIToolResultsRaw(t, []string{"send_email"}, []tcSpec{{"call_1", "send_email"}}, []string{"call_1"})
+
+	res, err := p.Execute(context.Background(), input(policy.StagePreRequest, settings, openAIReq(body), nil))
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+
+	val, err := rdb.Get(context.Background(), consumerKey("send_email", 0)).Result()
+	require.NoError(t, err)
+	assert.Equal(t, "1", val, "the result is still counted, it just does not refuse itself")
+}
+
+func TestPlugin_PreRequest_RejectsOnceTheBudgetWasAlreadySpent(t *testing.T) {
+	p, rdb := newPluginRedis(t)
+	settings := ruleSettings("send_email", "reject_response", "1m", 1)
+	seed(t, rdb, consumerKey("send_email", 0), 1)
+	body := openAIToolResultsRaw(t, []string{"send_email"}, []tcSpec{{"call_2", "send_email"}}, []string{"call_2"})
+
+	_, err := p.Execute(context.Background(), input(policy.StagePreRequest, settings, openAIReq(body), nil))
+
+	pe, ok := appplugins.AsPluginError(err)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusTooManyRequests, pe.StatusCode)
+}
+
 func TestPlugin_PreRequest_NoRejectWhenToolNotDeclared(t *testing.T) {
 	p, rdb := newPluginRedis(t)
 	settings := ruleSettings("send_email", "reject_response", "1m", 5)
@@ -1024,11 +1055,13 @@ func TestPlugin_FullCycle_CountThenReject(t *testing.T) {
 		return openAIReq(openAIToolResultsRaw(t, []string{"send_email"}, []tcSpec{{id, "send_email"}}, []string{id}))
 	}
 
-	res, err := p.Execute(context.Background(), input(policy.StagePreRequest, settings, turn("call_1"), nil))
-	require.NoError(t, err)
-	assert.Equal(t, http.StatusOK, res.StatusCode)
+	for _, id := range []string{"call_1", "call_2"} {
+		res, err := p.Execute(context.Background(), input(policy.StagePreRequest, settings, turn(id), nil))
+		require.NoError(t, err, "a budget of two covers %s", id)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+	}
 
-	_, err = p.Execute(context.Background(), input(policy.StagePreRequest, settings, turn("call_2"), nil))
+	_, err := p.Execute(context.Background(), input(policy.StagePreRequest, settings, turn("call_3"), nil))
 	pe, ok := appplugins.AsPluginError(err)
 	require.True(t, ok)
 	assert.Equal(t, http.StatusTooManyRequests, pe.StatusCode)

--- a/tests/functional/plugin_per_tool_rate_limiter_test.go
+++ b/tests/functional/plugin_per_tool_rate_limiter_test.go
@@ -138,7 +138,11 @@ func TestPluginE2E_PerToolRateLimiter_RejectResponse(t *testing.T) {
 	status, _, raw := proxyRequest(t, http.MethodPost, apiKey, path, nil, proposal)
 	require.Equal(t, http.StatusOK, status, "proposal turn is under the limit, body: %s", raw)
 
-	execution := mustJSON(t, chatRequestWithToolResult("call_1", "get_weather"))
+	// An agent framework re-declares its tools on every turn, so the request that
+	// reports a result is also the one enforcement reads. Declaring them here is
+	// what keeps the budget honest: the call this turn is reporting is the one
+	// the budget granted, and refusing it would leave max: 1 completing none.
+	execution := mustJSON(t, chatRequestWithToolResult("call_1", "get_weather", "get_weather"))
 	status, _, raw = proxyRequest(t, http.MethodPost, apiKey, path, nil, execution)
 	require.Equal(t, http.StatusOK, status, "executed-result turn charges the counter and passes through, body: %s", raw)
 


### PR DESCRIPTION
## Summary

Two fixes to `per_tool_rate_limiter`, both found by the e2e sweep of the plugin in [multi-agent-tests](https://github.com/NeuralTrust/multi-agent-tests) (32 cases against production).

**A budget of N allowed N-1 calls, and `max: 1` allowed none.** The counter is moved by the request reporting an execution, and the limit was checked straight after — so the call that took the counter to `max` was the one refused, after the client had already run the tool. Measured against production: `max: 1` → 0 completed round trips, 2 → 1, 3 → 2, 4 → 3. An operator writing `max: 1` gets an agent that can never finish a call, and at any N the work of the Nth execution is paid for and thrown away.

The verdict is now taken on what was spent *before* the request reported anything. Counting is unchanged, so a result is still recorded even on the turn that is refused, and the `tool_call_id` dedupe still keeps a resent history from paying twice.

Worth noting the plugin already disagreed with itself: the MCP path counts on the response leg, so the same rule set allowed N calls over MCP and N-1 over the LLM proxy.

**`scope` is removed.** It was validated as an enum an operator picks a value from, and never read — the dimension comes from the scope of the policy. A policy asking for `scope: global` silently kept one budget per consumer. The catalog schema already described the field as informational; removing it leaves one source of truth, the same call [#367](https://github.com/NeuralTrust/TrustGate/pull/367) made for `stream_usage_injection`. Existing policies carrying the key keep working — unknown settings are ignored.

## Why no test caught it

The unit tests each exercise one half: seed the counter and check the limit, or count with no limit in play. The one that did both, `TestPlugin_FullCycle_CountThenReject`, simply codified the off-by-one. And the functional reject case had its execution turn *omit* the `tools` array — no agent framework does that, they re-declare tools every turn, which is exactly when counting and enforcement meet.

So the functional case now declares its tools on the turn that reports a result, which makes it the regression test, and the full-cycle unit test asserts a budget of two covering two calls.

## Test plan

- [x] `go test ./pkg/...` green
- [x] `golangci-lint run` on the touched packages — 0 issues
- [x] `go test -tags functional -run PerToolRateLimiter ./tests/functional/` — 5/5, including the reworked reject case and the MCP deny case
- [ ] After deploy: re-run the e2e sweep, which is pinned to today's semantics and has the two affected cases flagged in its module docstring

## Not addressed here

Two further findings from the sweep, neither a correctness bug: `inject_error_result` silently degrades to stripping when the answer streams (the client gets no explanation), and the first matching rule wins, so `[get_*: 5, get_weather: 1]` gives `get_weather` five. Both are documented in the suite's README rather than changed, since either fix is a behaviour change worth deciding on separately.

Made with [Cursor](https://cursor.com)