### PR TITLE
fix(routing): request the firewall complexity API on its canonical path

### DIFF
--- a/pkg/infra/complexity/client.go
+++ b/pkg/infra/complexity/client.go
@@ -30,11 +30,14 @@ import (
 )
 
 const (
-	complexityPath   = "/v1/complexity"
+	// The API canonicalises this route with a trailing slash and answers the
+	// slashless form with a 307, so omitting it costs a redirect per score.
+	complexityPath   = "/v1/complexity/"
 	headerToken      = "token"
 	contentTypeJSON  = "application/json"
 	maxResponseBytes = 1 << 20
 	defaultTimeout   = 15 * time.Second
+	maxRedirects     = 10
 )
 
 // ErrUnauthorized is returned when the Firewall Complexity API rejects the token.
@@ -63,10 +66,23 @@ func NewClient(baseURL string, tokenProvider TokenProvider, timeout time.Duratio
 		timeout = defaultTimeout
 	}
 	return &Client{
-		http:          &http.Client{Timeout: timeout},
+		http:          &http.Client{Timeout: timeout, CheckRedirect: checkRedirect},
 		baseURL:       strings.TrimRight(baseURL, "/"),
 		tokenProvider: tokenProvider,
 	}
+}
+
+// checkRedirect keeps the Firewall token off the wire in clear text: the API
+// redirects to an http:// Location even when reached over https, and following
+// that would replay the request, token header included, unencrypted.
+func checkRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= maxRedirects {
+		return fmt.Errorf("complexity: stopped after %d redirects", maxRedirects)
+	}
+	if len(via) > 0 && via[0].URL.Scheme == "https" && req.URL.Scheme != "https" {
+		return fmt.Errorf("complexity: refusing redirect from https to %s", req.URL.Scheme)
+	}
+	return nil
 }
 
 // Configured reports whether the endpoint and token provider are configured.

--- a/pkg/infra/complexity/client_test.go
+++ b/pkg/infra/complexity/client_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -73,6 +74,44 @@ func TestClient_Score_Success(t *testing.T) {
 	score, err := c.Score(context.Background(), "hello", "chat_1", "tenant_1")
 	require.NoError(t, err)
 	assert.InDelta(t, 0.41, score, 1e-9)
+}
+
+func TestClient_Score_UsesCanonicalPathWithoutRedirect(t *testing.T) {
+	t.Parallel()
+	var mu sync.Mutex
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		paths = append(paths, r.URL.Path)
+		mu.Unlock()
+		if r.URL.Path != "/v1/complexity/" {
+			http.Redirect(w, r, "/v1/complexity/", http.StatusTemporaryRedirect)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(scoreResponse{Score: 0.5, RawScore: 0.5})
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, tokenProviderStub{configured: true, token: "tok"}, time.Second)
+	_, err := c.Score(context.Background(), "hello", "", "")
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []string{"/v1/complexity/"}, paths)
+}
+
+func TestCheckRedirect(t *testing.T) {
+	t.Parallel()
+	secure, err := http.NewRequest(http.MethodPost, "https://firewall.example.com/v1/complexity/", nil)
+	require.NoError(t, err)
+	plain, err := http.NewRequest(http.MethodPost, "http://firewall.example.com/v1/complexity/", nil)
+	require.NoError(t, err)
+
+	assert.Error(t, checkRedirect(plain, []*http.Request{secure}))
+	assert.NoError(t, checkRedirect(secure, []*http.Request{plain}))
+	assert.NoError(t, checkRedirect(plain, []*http.Request{plain}))
+	assert.Error(t, checkRedirect(plain, make([]*http.Request, maxRedirects)))
 }
 
 func TestClient_Score_NotConfigured(t *testing.T) {

--- a/tests/functional/firewall_complexity_stub_test.go
+++ b/tests/functional/firewall_complexity_stub_test.go
@@ -13,7 +13,8 @@ import (
 
 const (
 	firewallComplexityFunctionalSecret = "functional-firewall-secret"
-	firewallComplexityPath             = "/v1/complexity"
+	// Trailing slash mirrors the real API, which redirects the slashless form.
+	firewallComplexityPath = "/v1/complexity/"
 
 	// Message-content markers the stub maps to deterministic complexity
 	// scores, so each test drives routing purely through the prompt it sends


### PR DESCRIPTION
## Summary

Smart routing scored every `model: auto` request through `POST /v1/complexity`, but the Firewall API canonicalises that route **with** a trailing slash and answers the slashless form with a `307`. Each score therefore paid an extra round trip on the hot path.

Verified against production:

```
POST https://firewall.neuraltrust.ai/v1/complexity   -> 307
  location: http://firewall.neuraltrust.ai/v1/complexity/
POST https://firewall.neuraltrust.ai/v1/complexity/  -> 200  {"score":0.3411...}
```

The redirect also points at an **`http://`** Location even when the endpoint is reached over `https`. Go follows `307`s replaying method, body and headers, so the `token` header — the Firewall JWT — travelled unencrypted on that second hop. Production is unaffected today because the gateway dials the in-cluster `http://` service, but any deployment pointing at the public `https://` URL leaked the token in clear text.

Changes:

- Request `/v1/complexity/` directly, removing the redirect.
- Add a `CheckRedirect` that refuses redirects downgrading `https` to `http`, while still allowing `http -> https` for TLS-terminating ingresses. Overriding `CheckRedirect` drops Go's default 10-redirect cap, so it is reinstated explicitly.
- The functional stub registered the slashless path as an exact `ServeMux` route, which masked production behaviour and would have 404'd after this change, silently degrading smart routing to round-robin. It now mirrors the real API.

The pre-existing success test asserted the request path against the `complexityPath` constant itself, so it stayed green for any value. The new test counts every request reaching the server and requires exactly one to `/v1/complexity/`; reverting the constant makes it fail with `["/v1/complexity", "/v1/complexity/"]`.

## Test plan

- [x] `go build ./...`, `go vet`, `golangci-lint run ./pkg/infra/complexity/...` (0 issues)
- [x] `go test -race -count=1 ./pkg/infra/complexity/... ./pkg/infra/loadbalancer/...`
- [x] `go test -tags functional -run TestSmartRoutingE2E ./tests/functional/...`
- [x] Regression check: reverting the trailing slash fails the new test
- [x] Manual prod verification of the `307` and its `http://` Location (above)

Made with [Cursor](https://cursor.com)