### PR TITLE
perf: discover MCP upstreams concurrently, once, and remember failures

### DIFF
--- a/pkg/app/mcp/composer.go
+++ b/pkg/app/mcp/composer.go
@@ -27,6 +27,7 @@ import (
 	consumerdomain "github.com/NeuralTrust/TrustGate/pkg/domain/consumer"
 	registrydomain "github.com/NeuralTrust/TrustGate/pkg/domain/registry"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/trace"
+	"golang.org/x/sync/singleflight"
 )
 
 //go:generate mockery --name=Composer --dir=. --output=./mocks --filename=mcp_composer_mock.go --case=underscore --with-expecter
@@ -46,6 +47,7 @@ type composer struct {
 	dialer    Dialer
 	creds     CredentialResolver
 	discovery DiscoveryCache
+	flight    singleflight.Group
 	logger    *slog.Logger
 }
 
@@ -177,9 +179,9 @@ func (c *composer) compose(ctx context.Context, rc *appconsumer.RoutableConsumer
 	var pendingConsent *ConsentRequiredError
 	denied := make(map[string]struct{})
 	reachable := 0
-	for _, reg := range registries {
-		tools, err := c.discover(ctx, rc, reg)
-		if err != nil {
+	for _, found := range c.discoverTools(ctx, rc, registries) {
+		reg, tools := found.registry, found.items
+		if err := found.err; err != nil {
 			if ctx.Err() != nil {
 				return nil, ctx.Err()
 			}

--- a/pkg/app/mcp/discovery.go
+++ b/pkg/app/mcp/discovery.go
@@ -20,16 +20,78 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"time"
 
 	appconsumer "github.com/NeuralTrust/TrustGate/pkg/app/consumer"
 	consumerdomain "github.com/NeuralTrust/TrustGate/pkg/domain/consumer"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/identity"
 	registrydomain "github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	"golang.org/x/sync/errgroup"
 )
+
+// discoveryFanOut bounds how many upstreams are discovered at once. A consumer
+// federating many registries should not open a connection to all of them in one
+// burst, and past a handful the wall time is dominated by the slowest anyway.
+const discoveryFanOut = 8
+
+// negativeTTL is how long a failed discovery is remembered. It is deliberately
+// far shorter than the success TTL: an upstream that comes back should be
+// served again quickly, and all this needs to buy is that a dead one is dialled
+// once per window instead of once per request.
+const negativeTTL = 10 * time.Second
 
 type DiscoveryCache interface {
 	Get(key string) (any, bool)
 	Set(key string, value any)
+}
+
+// discoveryFailure is a remembered failure, sharing the cache with the results
+// it stands in for. The entry carries its own deadline because the cache has a
+// single TTL sized for successful discoveries.
+type discoveryFailure struct {
+	err   error
+	until time.Time
+}
+
+// discovered is one registry's outcome, kept alongside the registry so a
+// concurrent fan-out can be read back in the order the consumer declared.
+type discovered[T any] struct {
+	registry *registrydomain.Registry
+	items    []T
+	err      error
+}
+
+// discoverAll discovers every registry at once and returns the outcomes in
+// registry order. Order is what decides which upstream wins a name clash and
+// which pending consent is reported, so it must not depend on who answers
+// first.
+func discoverAll[T any](
+	c *composer,
+	ctx context.Context,
+	rc *appconsumer.RoutableConsumer,
+	registries []*registrydomain.Registry,
+	kind string,
+	list func(context.Context, Upstream) ([]T, error),
+) []discovered[T] {
+	out := make([]discovered[T], len(registries))
+	if len(registries) == 1 {
+		items, err := discoverCached(c, ctx, rc, registries[0], kind, list)
+		out[0] = discovered[T]{registry: registries[0], items: items, err: err}
+		return out
+	}
+	var group errgroup.Group
+	group.SetLimit(discoveryFanOut)
+	for i, reg := range registries {
+		out[i] = discovered[T]{registry: reg}
+		group.Go(func() error {
+			items, err := discoverCached(c, ctx, rc, reg, kind, list)
+			out[i].items, out[i].err = items, err
+			return nil
+		})
+	}
+	// Every goroutine reports its own outcome, so the group never carries one.
+	_ = group.Wait()
+	return out
 }
 
 func federate[T any](
@@ -49,14 +111,14 @@ func federate[T any](
 	var out []T
 	reachable := 0
 	var firstConsent *ConsentRequiredError
-	for _, reg := range registries {
-		items, err := discoverCached(c, ctx, rc, reg, kind, list)
-		if err != nil {
+	for _, found := range discoverAll(c, ctx, rc, registries, kind, list) {
+		reg := found.registry
+		if found.err != nil {
 			if ctx.Err() != nil {
 				return nil, ctx.Err()
 			}
 			var consentErr *ConsentRequiredError
-			if errors.As(err, &consentErr) {
+			if errors.As(found.err, &consentErr) {
 				if firstConsent == nil {
 					firstConsent = consentErr
 				}
@@ -65,14 +127,14 @@ func federate[T any](
 				continue
 			}
 			if !failOpen {
-				return nil, fmt.Errorf("%w: registry %q: %w", ErrUpstreamUnavailable, reg.Name, err)
+				return nil, fmt.Errorf("%w: registry %q: %w", ErrUpstreamUnavailable, reg.Name, found.err)
 			}
 			c.logger.Warn("mcp composer: skipping unreachable upstream",
-				"registry", reg.Name, "error", err)
+				"registry", reg.Name, "error", found.err)
 			continue
 		}
 		reachable++
-		out = append(out, filter(reg, items)...)
+		out = append(out, filter(reg, found.items)...)
 	}
 	if reachable == 0 {
 		if firstConsent != nil {
@@ -93,8 +155,12 @@ func mcpRegistries(rc *appconsumer.RoutableConsumer) []*registrydomain.Registry 
 	return out
 }
 
-func (c *composer) discover(ctx context.Context, rc *appconsumer.RoutableConsumer, reg *registrydomain.Registry) ([]Tool, error) {
-	return discoverCached(c, ctx, rc, reg, "tools", func(ctx context.Context, up Upstream) ([]Tool, error) {
+func (c *composer) discoverTools(
+	ctx context.Context,
+	rc *appconsumer.RoutableConsumer,
+	registries []*registrydomain.Registry,
+) []discovered[Tool] {
+	return discoverAll(c, ctx, rc, registries, "tools", func(ctx context.Context, up Upstream) ([]Tool, error) {
 		return up.ListTools(ctx)
 	})
 }
@@ -108,13 +174,44 @@ func discoverCached[T any](
 	list func(context.Context, Upstream) ([]T, error),
 ) ([]T, error) {
 	key, cacheable := discoveryKey(ctx, reg, kind)
-	if cacheable {
-		if cached, ok := c.discovery.Get(key); ok {
-			if items, ok := cached.([]T); ok {
-				return items, nil
-			}
-		}
+	if !cacheable {
+		return askUpstream(c, ctx, rc, reg, list)
 	}
+	if items, err, ok := cachedDiscovery[T](c, key); ok {
+		return items, err
+	}
+	// One discovery per key at a time. Without this, a burst arriving after the
+	// entry expires all dials the same upstream, which is exactly when it is
+	// least able to take it.
+	shared, err, _ := c.flight.Do(key, func() (any, error) {
+		if items, err, ok := cachedDiscovery[T](c, key); ok {
+			return items, err
+		}
+		items, err := askUpstream(c, ctx, rc, reg, list)
+		if err != nil {
+			c.rememberFailure(key, err)
+			return nil, err
+		}
+		c.discovery.Set(key, items)
+		return items, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	items, ok := shared.([]T)
+	if !ok {
+		return nil, fmt.Errorf("mcp discovery: unexpected cached type for %q", kind)
+	}
+	return items, nil
+}
+
+func askUpstream[T any](
+	c *composer,
+	ctx context.Context,
+	rc *appconsumer.RoutableConsumer,
+	reg *registrydomain.Registry,
+	list func(context.Context, Upstream) ([]T, error),
+) ([]T, error) {
 	target, err := c.target(ctx, rc, reg)
 	if err != nil {
 		return nil, err
@@ -124,14 +221,34 @@ func discoverCached[T any](
 		return nil, err
 	}
 	defer up.Close(ctx)
-	items, err := list(ctx, up)
-	if err != nil {
-		return nil, err
+	return list(ctx, up)
+}
+
+// cachedDiscovery reports a hit, which is either the tools an upstream served
+// or the failure it answered with while that failure is still recent.
+func cachedDiscovery[T any](c *composer, key string) ([]T, error, bool) {
+	cached, ok := c.discovery.Get(key)
+	if !ok {
+		return nil, nil, false
 	}
-	if cacheable {
-		c.discovery.Set(key, items)
+	if items, ok := cached.([]T); ok {
+		return items, nil, true
 	}
-	return items, nil
+	if failure, ok := cached.(discoveryFailure); ok && time.Now().Before(failure.until) {
+		return nil, failure.err, true
+	}
+	return nil, nil, false
+}
+
+// rememberFailure holds on to an unreachable upstream for a few seconds so it
+// is dialled once per window rather than once per request. Consent is left out:
+// it is the user's to resolve, and resolving it should take effect at once.
+func (c *composer) rememberFailure(key string, err error) {
+	var consentErr *ConsentRequiredError
+	if errors.As(err, &consentErr) {
+		return
+	}
+	c.discovery.Set(key, discoveryFailure{err: err, until: time.Now().Add(negativeTTL)})
 }
 
 func discoveryKey(ctx context.Context, reg *registrydomain.Registry, kind string) (string, bool) {

--- a/pkg/app/mcp/discovery_test.go
+++ b/pkg/app/mcp/discovery_test.go
@@ -1,0 +1,260 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcp
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	consumerdomain "github.com/NeuralTrust/TrustGate/pkg/domain/consumer"
+	registrydomain "github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+)
+
+// countingDialer records every dial so a test can say how often an upstream was
+// reached, which is what caching and deduplication are about.
+type countingDialer struct {
+	mu    sync.Mutex
+	dials map[string]int
+	open  func(url string) (Upstream, error)
+}
+
+func newCountingDialer(open func(url string) (Upstream, error)) *countingDialer {
+	return &countingDialer{dials: map[string]int{}, open: open}
+}
+
+func (d *countingDialer) Connect(_ context.Context, target Target) (Upstream, error) {
+	d.mu.Lock()
+	d.dials[target.URL]++
+	d.mu.Unlock()
+	return d.open(target.URL)
+}
+
+func (d *countingDialer) count(url string) int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.dials[url]
+}
+
+// gatedUpstream runs a hook before listing, so a test can hold a discovery open
+// while it inspects what the rest of the request is doing.
+type gatedUpstream struct {
+	*fakeUpstream
+	before func()
+}
+
+func (g *gatedUpstream) ListTools(ctx context.Context) ([]Tool, error) {
+	if g.before != nil {
+		g.before()
+	}
+	return g.fakeUpstream.ListTools(ctx)
+}
+
+func mcpClient() *consumerdomain.Consumer {
+	return &consumerdomain.Consumer{Type: consumerdomain.TypeMCP}
+}
+
+func TestDiscovery_UpstreamsAreDiscoveredConcurrently(t *testing.T) {
+	t.Parallel()
+	const upstreams = 3
+	// Every discovery waits for all of them to have started. Run one at a time
+	// and none can ever finish, so a serial composer fails on the deadline
+	// rather than on a stopwatch.
+	var once sync.Once
+	arrived := make(chan struct{}, upstreams)
+	all := make(chan struct{})
+	gate := func() {
+		arrived <- struct{}{}
+		if len(arrived) == upstreams {
+			once.Do(func() { close(all) })
+		}
+		select {
+		case <-all:
+		case <-time.After(5 * time.Second):
+		}
+	}
+
+	regs := make([]*registrydomain.Registry, 0, upstreams)
+	ups := map[string]Upstream{}
+	for _, name := range []string{"a", "b", "c"} {
+		url := "https://" + name + ".example.com/mcp"
+		regs = append(regs, mcpRegistry(t, name, url))
+		ups[url] = &gatedUpstream{
+			fakeUpstream: &fakeUpstream{tools: tools(name + "_tool")},
+			before:       gate,
+		}
+	}
+	dialer := newCountingDialer(func(url string) (Upstream, error) { return ups[url], nil })
+	c := NewComposer(dialer, nil, newMapCache(), slog.New(slog.DiscardHandler))
+
+	done := make(chan []Tool, 1)
+	go func() {
+		got, err := c.ListTools(context.Background(), routable(mcpClient(), regs...))
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		done <- got
+	}()
+
+	select {
+	case got := <-done:
+		if len(got) != upstreams {
+			t.Fatalf("tools = %v, want one per upstream", toolNames(got))
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("discovery did not overlap: upstreams are still being dialled one after another")
+	}
+}
+
+func TestDiscovery_OrderSurvivesTheFanOut(t *testing.T) {
+	t.Parallel()
+	// The first registry answers last. Order decides which upstream wins a name
+	// clash, so it has to come from the consumer's list and not from the race.
+	slow := &gatedUpstream{
+		fakeUpstream: &fakeUpstream{tools: tools("first")},
+		before:       func() { time.Sleep(30 * time.Millisecond) },
+	}
+	fast := &fakeUpstream{tools: tools("second")}
+	regA := mcpRegistry(t, "a", "https://a.example.com/mcp")
+	regB := mcpRegistry(t, "b", "https://b.example.com/mcp")
+	dialer := newCountingDialer(func(url string) (Upstream, error) {
+		if url == "https://a.example.com/mcp" {
+			return slow, nil
+		}
+		return fast, nil
+	})
+	c := NewComposer(dialer, nil, newMapCache(), slog.New(slog.DiscardHandler))
+
+	got, err := c.ListTools(context.Background(), routable(mcpClient(), regA, regB))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if names := toolNames(got); len(names) != 2 || names[0] != "first" || names[1] != "second" {
+		t.Fatalf("tools = %v, want the slow first registry to stay first", names)
+	}
+}
+
+func TestDiscovery_ConcurrentRequestsDialAnUpstreamOnce(t *testing.T) {
+	t.Parallel()
+	const callers = 8
+	release := make(chan struct{})
+	up := &gatedUpstream{
+		fakeUpstream: &fakeUpstream{tools: tools("weather")},
+		before:       func() { <-release },
+	}
+	reg := mcpRegistry(t, "a", "https://a.example.com/mcp")
+	dialer := newCountingDialer(func(string) (Upstream, error) { return up, nil })
+	c := NewComposer(dialer, nil, newMapCache(), slog.New(slog.DiscardHandler))
+
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := c.ListTools(context.Background(), routable(mcpClient(), reg)); err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		}()
+	}
+	// Let them pile up on the one discovery that got through, then let it finish.
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	if got := dialer.count("https://a.example.com/mcp"); got != 1 {
+		t.Fatalf("dialled %d times, want 1: a burst on a cold cache should not stampede the upstream", got)
+	}
+}
+
+func TestDiscovery_AnUnreachableUpstreamIsNotDialledOnEveryRequest(t *testing.T) {
+	t.Parallel()
+	down := mcpRegistry(t, "down", "https://down.example.com/mcp")
+	up := mcpRegistry(t, "up", "https://up.example.com/mcp")
+	healthy := &fakeUpstream{tools: tools("weather")}
+	dialer := newCountingDialer(func(url string) (Upstream, error) {
+		if url == "https://down.example.com/mcp" {
+			return nil, errors.New("connection refused")
+		}
+		return healthy, nil
+	})
+	c := NewComposer(dialer, nil, newMapCache(), slog.New(slog.DiscardHandler))
+	rc := routable(mcpClient(), down, up)
+
+	for range 3 {
+		got, err := c.ListTools(context.Background(), rc)
+		if err != nil {
+			t.Fatalf("fail-open should still serve the reachable upstream: %v", err)
+		}
+		if names := toolNames(got); len(names) != 1 || names[0] != "weather" {
+			t.Fatalf("tools = %v, want the healthy upstream's", names)
+		}
+	}
+
+	if got := dialer.count("https://down.example.com/mcp"); got != 1 {
+		t.Fatalf("dialled the dead upstream %d times, want 1 for the window", got)
+	}
+}
+
+func TestDiscovery_ARememberedFailureIsForgottenWhenItExpires(t *testing.T) {
+	t.Parallel()
+	reg := mcpRegistry(t, "a", "https://a.example.com/mcp")
+	healthy := &fakeUpstream{tools: tools("weather")}
+	dialer := newCountingDialer(func(string) (Upstream, error) { return healthy, nil })
+	cache := newMapCache()
+	c := NewComposer(dialer, nil, cache, slog.New(slog.DiscardHandler))
+
+	key, ok := discoveryKey(context.Background(), reg, "tools")
+	if !ok {
+		t.Fatal("this registry should have a cacheable discovery key")
+	}
+	cache.Set(key, discoveryFailure{
+		err:   errors.New("connection refused"),
+		until: time.Now().Add(-time.Second),
+	})
+
+	got, err := c.ListTools(context.Background(), routable(mcpClient(), reg))
+	if err != nil {
+		t.Fatalf("a stale failure must not outlive its window: %v", err)
+	}
+	if names := toolNames(got); len(names) != 1 || names[0] != "weather" {
+		t.Fatalf("tools = %v, want the recovered upstream's", names)
+	}
+}
+
+func TestDiscovery_PendingConsentIsNotRemembered(t *testing.T) {
+	t.Parallel()
+	// Consent is the user's to give, and giving it should be served at once
+	// rather than after a window nobody told them about.
+	reg := mcpRegistry(t, "a", "https://a.example.com/mcp")
+	dialer := newCountingDialer(func(string) (Upstream, error) {
+		return nil, &ConsentRequiredError{Provider: "github"}
+	})
+	c := NewComposer(dialer, nil, newMapCache(), slog.New(slog.DiscardHandler))
+	rc := routable(mcpClient(), reg)
+
+	for range 2 {
+		var consentErr *ConsentRequiredError
+		if _, err := c.ListTools(context.Background(), rc); !errors.As(err, &consentErr) {
+			t.Fatalf("error = %v, want a consent requirement", err)
+		}
+	}
+
+	if got := dialer.count("https://a.example.com/mcp"); got != 2 {
+		t.Fatalf("dialled %d times, want 2: a consent requirement must not be cached", got)
+	}
+}


### PR DESCRIPTION
## Summary

Every `tools/call` composes the consumer's MCP surface before it can route, and that composition dialled each registry **in turn**, on **every** request that found a cold cache, with **no memory** of the ones that did not answer. This makes those three things right.

## What the traces said

Numbering the `tools/call` of each consumer by order of arrival, in production (`trustgate_events`, 3h window):

| call | n | routing p50 | upstream avg |
|---|---|---|---|
| 1st | 108 | **196 ms** | 82 ms |
| 2nd | 28 | 3 ms | 59 ms |
| 3rd | 12 | 3 ms | 64 ms |
| 4th+ | 7 | 2 ms | 55 ms |

Warm, the gateway's own share is 3 ms — the same as the LLM proxy's 4 ms. Everything is in the cold start: before dispatching, `compose()` has to know which registry owns the tool, so it connects (TCP + TLS + `initialize`) and asks `tools/list`. That result is cached 5 minutes.

## Measured locally, before and after

Functional harness, real gateway binary built from each branch, upstreams on loopback with 80 ms injected per HTTP request (a loopback upstream answers in microseconds, which hides exactly the round trips this is about). Two runs each, reproducible within a few ms.

| Scenario | develop | this branch |
|---|---|---|
| Cold `tools/call`, 4 registries | **1086 ms** | **350 ms** |
| Warm `tools/call`, same consumer | 85 ms | 85 ms |
| 1 sick upstream (2 s to fail) + 1 healthy, three calls | 4.34 s / 4.09 s / 4.09 s | 4.09 s / **84 ms** / **85 ms** |
| 6 concurrent callers on a cold cache, slowest | 758 ms | 343 ms |

The warm path is untouched, which is the number that matters most for a change to a hot path.

## What changed

**Concurrent fan-out.** `compose()` and the generic `federate()` behind prompts and resources both looped over registries sequentially, so a consumer federating N upstreams paid N cold discoveries end to end — and one slow upstream delayed every healthy one behind it. They now run together, bounded at 8.

Order is load-bearing: it decides which upstream wins a name clash and which pending consent is reported. Results are written into a slice indexed by registry position and read back in the consumer's order, so nothing observable depends on who answers first.

**One discovery per key in flight.** There was no `singleflight` here, though the codebase uses it in the path resolver, the data finder and credential refresh. A burst arriving just after a 5-minute entry expired all dialled the same upstream — precisely when it is least able to take it. Six concurrent cold callers now cost one discovery, not six.

**A failure is remembered for 10 seconds.** Nothing was cached on the error path, so an unreachable registry was re-dialled on every single `tools/call`, blocking up to the 30 s `responseHeaderTimeout` before the healthy upstreams were consulted. Ten seconds is deliberately far below the success TTL: an upstream that recovers should be served again quickly, and all this needs to buy is one dial per window instead of one per request.

Consent requirements are **not** remembered — that failure is the user's to resolve, and resolving it should take effect at once.

## Where the time actually goes

The table above is wall time measured at the client, so it includes the upstream hops. Counting the JSON-RPC methods the upstream receives splits it:

| Call | Upstream hops | Upstream time | Gateway |
|---|---|---|---|
| Cold `tools/call`, 1 registry | 4 (`initialize`, `notifications/initialized`, `tools/list`, `tools/call`) | 320 ms | **13 ms** |
| Warm `tools/call` | 1 (`tools/call`) | 80 ms | **3.5 ms** |

The gateway's own share on a warm call is the 3 ms of `routing_ms` seen in production. The cold-start cost is not the gateway thinking, it is the handshake: three round trips before the call itself, paid per registry.

That is what makes the fan-out the lever. With 6 concurrent cold callers over one registry, `develop` sends 29 requests upstream (6 handshakes, 6 `tools/list`, 6 calls, and 5 `DELETE`s from the sessions that lost the race); this branch sends 9 (one handshake, one `tools/list`, six calls), and the remaining 347 ms is 320 ms of unavoidable hops.

Those 5 `DELETE`s turned out to be a second, unrelated defect — the session cache held its mutex across the teardown round trip. Fixed separately in #392.

## What this does not fix

The sick-upstream row above shows it: the **first** call of each 10-second window still waits for the dead registry, because compose waits for the whole fan-out. Capping discovery below the 30 s response-header timeout would fix that, but it turns a slow-but-alive upstream into a skipped one (or, fail-closed, into an error), so it wants deciding on its own rather than riding along here.

## Test plan

- [x] `TestDiscovery_UpstreamsAreDiscoveredConcurrently` — every discovery waits for all of them to have started, so a serial composer deadlocks rather than merely being slow. Verified red with `discoveryFanOut = 1`.
- [x] `TestDiscovery_ConcurrentRequestsDialAnUpstreamOnce` — 8 callers on a cold cache, 1 dial. Verified red without the `singleflight` (8 dials).
- [x] `TestDiscovery_AnUnreachableUpstreamIsNotDialledOnEveryRequest` — 3 requests, 1 dial of the dead upstream, healthy sibling still served. Verified red without the negative entry (3 dials).
- [x] `TestDiscovery_ARememberedFailureIsForgottenWhenItExpires` — a stale entry does not outlive its window.
- [x] `TestDiscovery_PendingConsentIsNotRemembered` — 2 requests, 2 dials.
- [x] `TestDiscovery_OrderSurvivesTheFanOut` — the slow first registry still comes first.
- [x] `go test -race ./pkg/app/mcp/... ./pkg/api/handler/http/mcp/... ./pkg/infra/mcp/...`
- [x] `go test ./pkg/...` clean
- [x] `golangci-lint run ./pkg/app/mcp/...` — 0 issues
- [x] Local before/after measurement above, against a real gateway on both branches.
- [x] Functional, individually: `TestPluginE2E_PerToolRateLimiter_MCPToolCallDeny`, `TestMCPPluginChain_ObserveModeNeverBlocks`, `TestMCPPluginChain_GuardErrorFailsOpen`. In a batch they hit the environment's pre-existing gateway-instance cap, unrelated to this change.

The benchmark that produced the table is not committed: it costs two gateways and ~17 s of the functional suite, and wall-clock assertions do not belong in CI. It is three tests using the existing `startMCPUpstream` helpers, easy to reconstruct from the scenario column.
