### PR TITLE
fix: tear down a redundant MCP session off the session cache lock

### DIFF
--- a/pkg/infra/mcp/client/cached_dialer.go
+++ b/pkg/infra/mcp/client/cached_dialer.go
@@ -89,14 +89,23 @@ func (d *cachedDialer) connectAndStore(ctx context.Context, key string, target a
 		return nil, err
 	}
 	d.mu.Lock()
-	defer d.mu.Unlock()
 	if e, ok := d.entries[key]; ok {
-		sess.Close(ctx)
 		e.lastUsed = time.Now()
-		return e.session, nil
+		winner := e.session
+		d.mu.Unlock()
+		closeInBackground(sess)
+		return winner, nil
 	}
 	d.entries[key] = &sessionEntry{session: sess, lastUsed: time.Now()}
+	d.mu.Unlock()
 	return sess, nil
+}
+
+// closeInBackground tears a session down off the request path: the teardown is
+// a round trip to the upstream that nobody is waiting on, and it outlives the
+// context of the caller that lost the race to store its session.
+func closeInBackground(sess *Session) {
+	go sess.Close(context.Background())
 }
 
 func (d *cachedDialer) drop(ctx context.Context, key string, sess *Session) {
@@ -121,14 +130,9 @@ func (d *cachedDialer) evictIdleLocked() {
 			stale = append(stale, e.session)
 		}
 	}
-	if len(stale) == 0 {
-		return
+	for _, s := range stale {
+		closeInBackground(s)
 	}
-	go func() {
-		for _, s := range stale {
-			s.Close(context.Background())
-		}
-	}()
 }
 
 func credentialFingerprint(headers map[string]string) string {

--- a/pkg/infra/mcp/client/cached_dialer_test.go
+++ b/pkg/infra/mcp/client/cached_dialer_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	appmcp "github.com/NeuralTrust/TrustGate/pkg/app/mcp"
 	mcpclient "github.com/NeuralTrust/TrustGate/pkg/infra/mcp/client"
@@ -173,6 +174,68 @@ func TestCachedDialer_NoPinKeyConnectsFresh(t *testing.T) {
 	}
 	if got := upstream.inits.Load(); got != 2 {
 		t.Fatalf("expected a fresh session per connect without a pin key, got %d inits", got)
+	}
+}
+
+func TestCachedDialer_ClosingARedundantSessionDoesNotStallTheCache(t *testing.T) {
+	t.Parallel()
+
+	var dialling atomic.Int64
+	bothDialling := make(chan struct{})
+	tearingDown := make(chan struct{}, 4)
+	finishTeardown := make(chan struct{})
+
+	server := sdk.NewServer(&sdk.Implementation{Name: "stub", Version: "1"}, nil)
+	server.AddReceivingMiddleware(func(next sdk.MethodHandler) sdk.MethodHandler {
+		return func(ctx context.Context, method string, req sdk.Request) (sdk.Result, error) {
+			if method == "initialize" {
+				if n := dialling.Add(1); n <= 2 {
+					if n == 2 {
+						close(bothDialling)
+					}
+					<-bothDialling
+				}
+			}
+			return next(ctx, method, req)
+		}
+	})
+	inner := sdk.NewStreamableHTTPHandler(func(*http.Request) *sdk.Server { return server }, nil)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			tearingDown <- struct{}{}
+			<-finishTeardown
+		}
+		inner.ServeHTTP(w, r)
+	}))
+	defer srv.Close()
+	defer close(finishTeardown)
+
+	dialer := newCachedDialer()
+	for i := 0; i < 2; i++ {
+		go func() {
+			_, _ = dialer.Connect(context.Background(),
+				appmcp.Target{URL: srv.URL, PinKey: "gw:consumer:reg"})
+		}()
+	}
+	select {
+	case <-tearingDown:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the session that lost the race was never torn down")
+	}
+
+	dialled := make(chan error, 1)
+	go func() {
+		_, err := dialer.Connect(context.Background(),
+			appmcp.Target{URL: srv.URL, PinKey: "gw:consumer:other"})
+		dialled <- err
+	}()
+	select {
+	case err := <-dialled:
+		if err != nil {
+			t.Fatalf("connect to a second registry: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("a session lookup waited on the teardown round trip of an unrelated session")
 	}
 }
 


### PR DESCRIPTION
## Summary

Found while benchmarking MCP discovery for #391, but it is a separate defect in the session cache.

When two callers race to open a session for the same upstream, one of them wins and stores its session; the loser closes the one it just opened. That close was happening **inside** the session cache mutex, and closing an MCP session is an HTTP `DELETE` to the upstream. So a network round trip — to a server that had just demonstrated it can be slow — was blocking every session lookup in the process.

The failure mode this guards against is not only latency: an upstream that accepts the `DELETE` and never answers holds the global session cache lock for as long as it stays silent, stalling all MCP traffic in the pod.

The fix is what the two neighbouring functions already do. `drop()` unlocks before closing; the idle eviction hands the stale sessions to a goroutine. `connectAndStore` was the only one that had not been given the same care. Both teardown paths now go through one helper.

## Why the teardown is also off the request path

The loser's caller was paying a round trip for a session it is not going to use, and it does so while the caller's context is about to be cancelled by the request finishing. The close now runs in the background with its own context, the same way the idle eviction already tore down stale sessions.

## What the numbers looked like

Local benchmark, 6 concurrent callers on a cold cache against an upstream with an 80 ms hop. Before #391, each caller opened its own session and five of them lost the race, so five teardown round trips serialised on the lock: **753 ms** wall, against **320 ms** of unavoidable upstream hops. #391 removes the redundant sessions in that particular scenario by deduplicating discovery, but the lock is still held across a network call for any other race — concurrent calls after an idle eviction, or after a lost session is re-dialled.

## Test plan

- [x] `TestCachedDialer_ClosingARedundantSessionDoesNotStallTheCache` — two callers race for one upstream, the loser's `DELETE` is held open, and an unrelated session lookup must not wait on it. Fails on `develop` (times out on the lock), passes here.
- [x] `go test -race ./pkg/infra/mcp/client/...`
- [x] `golangci-lint run ./pkg/infra/mcp/client/...` — 0 issues
- [x] Functional MCP suite green (the local environment's gateway instance cap makes the tail of the suite fail on any branch, including `develop`; they pass when run in isolation)

Made with [Cursor](https://cursor.com)