### PR TITLE
fix(proxy): raise timeout chain above the 30s LLM completion wall

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,9 @@ APP_ENV=dev
 SERVER_ADMIN_PORT=8080
 SERVER_PROXY_PORT=8081
 SERVER_READ_TIMEOUT=60s
-SERVER_WRITE_TIMEOUT=60s
+# Applies to the whole response write. Keep it above the 5m stream bound, or
+# long SSE streams are truncated mid-flight.
+SERVER_WRITE_TIMEOUT=300s
 SERVER_IDLE_TIMEOUT=120s
 
 # Server Secret (REQUIRED, at least 32 bytes of random data)
@@ -130,11 +132,17 @@ PLAYGROUND_TRACE_STORE_ENABLED=true
 PLAYGROUND_TRACE_STORE_TTL=10m
 
 # Upstream Forwarding Configuration
-UPSTREAM_TIMEOUT=60s
+UPSTREAM_TIMEOUT=300s
 UPSTREAM_ERROR_PASSTHROUGH=true
 
 # Provider Defaults
-PROVIDER_REQUEST_TIMEOUT=60s
+PROVIDER_REQUEST_TIMEOUT=300s
+# Bounds the wait for upstream response headers. Non-streaming providers hold
+# headers back until the completion is fully generated, so this caps total
+# generation time rather than time-to-first-byte. Defaults to
+# PROVIDER_REQUEST_TIMEOUT; setting it lower silently truncates long
+# completions. Only set it explicitly to fail faster on unresponsive providers.
+# PROVIDER_RESPONSE_HEADER_TIMEOUT=300s
 PROVIDER_MAX_RETRIES=2
 
 # Model/Provider Catalog (admin-only, best-effort sync from models.dev on boot)

--- a/k8s/overlays/dev/config.env
+++ b/k8s/overlays/dev/config.env
@@ -10,6 +10,9 @@ RATE_LIMIT_ENABLED=true
 SERVER_ADMIN_PORT=8080
 SERVER_PROXY_PORT=8081
 SERVER_MCP_PORT=8082
+# Must stay above the 5m StreamTimeout: fasthttp applies WriteTimeout to the
+# whole response write, so a lower value truncates long SSE streams.
+SERVER_WRITE_TIMEOUT=300s
 LOG_LEVEL=debug
 LOG_FORMAT=json
 TELEMETRY_ENABLED=true
@@ -18,8 +21,11 @@ METRICS_QUEUE_SIZE=1000
 METRICS_WORKER_COUNT=1
 METRICS_FLUSH_INTERVAL=5s
 UPSTREAM_ERROR_PASSTHROUGH=true
-UPSTREAM_TIMEOUT=60s
-PROVIDER_REQUEST_TIMEOUT=60s
+UPSTREAM_TIMEOUT=300s
+# Bounds a full non-streaming completion, not just time-to-first-byte, because
+# providers withhold response headers until generation finishes.
+# PROVIDER_RESPONSE_HEADER_TIMEOUT defaults to this value.
+PROVIDER_REQUEST_TIMEOUT=300s
 PROVIDER_MAX_RETRIES=2
 APPLICATION_VERSION=c66388ae8295e31256dd0d6156743a7299f88250
 GATEWAY_BASE_DOMAIN=llm.dev.neuraltrust.ai

--- a/k8s/overlays/prod-us/cloudflare-backendpolicy.yaml
+++ b/k8s/overlays/prod-us/cloudflare-backendpolicy.yaml
@@ -1,6 +1,11 @@
 # Cloud Armor: allow only Cloudflare-proxied traffic to these Services' load
 # balancer backends. References neuraltrust-prod-us-cloudflare-only (preview
 # until public Gateway is attached and logs are clean).
+#
+# timeoutSec also lives here because it is a GCPBackendPolicy field. Omitting it
+# yields the GCP default of 30s, which cuts LLM completions mid-generation; the
+# proxy and MCP backends serve long-running upstream calls and need the higher
+# bound. The admin backend keeps the default: its requests are short.
 apiVersion: networking.gke.io/v1
 kind: GCPBackendPolicy
 metadata:
@@ -20,6 +25,7 @@ metadata:
 spec:
   default:
     securityPolicy: neuraltrust-prod-us-cloudflare-only
+    timeoutSec: 300
   targetRef:
     group: ""
     kind: Service
@@ -32,6 +38,7 @@ metadata:
 spec:
   default:
     securityPolicy: neuraltrust-prod-us-cloudflare-only
+    timeoutSec: 300
   targetRef:
     group: ""
     kind: Service

--- a/k8s/overlays/prod-us/config.env
+++ b/k8s/overlays/prod-us/config.env
@@ -10,6 +10,9 @@ RATE_LIMIT_ENABLED=true
 SERVER_ADMIN_PORT=8080
 SERVER_PROXY_PORT=8081
 SERVER_MCP_PORT=8082
+# Must stay above the 5m StreamTimeout: fasthttp applies WriteTimeout to the
+# whole response write, so a lower value truncates long SSE streams.
+SERVER_WRITE_TIMEOUT=300s
 LOG_LEVEL=info
 LOG_FORMAT=json
 TELEMETRY_ENABLED=true
@@ -18,8 +21,11 @@ METRICS_QUEUE_SIZE=1000
 METRICS_WORKER_COUNT=1
 METRICS_FLUSH_INTERVAL=5s
 UPSTREAM_ERROR_PASSTHROUGH=true
-UPSTREAM_TIMEOUT=60s
-PROVIDER_REQUEST_TIMEOUT=60s
+UPSTREAM_TIMEOUT=300s
+# Bounds a full non-streaming completion, not just time-to-first-byte, because
+# providers withhold response headers until generation finishes.
+# PROVIDER_RESPONSE_HEADER_TIMEOUT defaults to this value.
+PROVIDER_REQUEST_TIMEOUT=300s
 PROVIDER_MAX_RETRIES=2
 APPLICATION_VERSION=v0.33.2
 # Subdomain discovery for {slug}.llm.us / {slug}.mcp.us (public edge + PSC).

--- a/k8s/overlays/prod/cloudflare-backendpolicy.yaml
+++ b/k8s/overlays/prod/cloudflare-backendpolicy.yaml
@@ -2,6 +2,11 @@
 # balancer backends. References the security policy created in
 # cloud-infrastructure (var.enable_cloudflare_only_armor). Prod only — dev uses
 # the internal gateway. Namespace is applied by the overlay's namespace setting.
+#
+# timeoutSec also lives here because it is a GCPBackendPolicy field. Omitting it
+# yields the GCP default of 30s, which cuts LLM completions mid-generation; the
+# proxy and MCP backends serve long-running upstream calls and need the higher
+# bound. The admin backend keeps the default: its requests are short.
 apiVersion: networking.gke.io/v1
 kind: GCPBackendPolicy
 metadata:
@@ -21,6 +26,7 @@ metadata:
 spec:
   default:
     securityPolicy: neuraltrust-prod-cloudflare-only
+    timeoutSec: 300
   targetRef:
     group: ""
     kind: Service
@@ -33,6 +39,7 @@ metadata:
 spec:
   default:
     securityPolicy: neuraltrust-prod-cloudflare-only
+    timeoutSec: 300
   targetRef:
     group: ""
     kind: Service

--- a/k8s/overlays/prod/config.env
+++ b/k8s/overlays/prod/config.env
@@ -10,6 +10,9 @@ RATE_LIMIT_ENABLED=true
 SERVER_ADMIN_PORT=8080
 SERVER_PROXY_PORT=8081
 SERVER_MCP_PORT=8082
+# Must stay above the 5m StreamTimeout: fasthttp applies WriteTimeout to the
+# whole response write, so a lower value truncates long SSE streams.
+SERVER_WRITE_TIMEOUT=300s
 LOG_LEVEL=info
 LOG_FORMAT=json
 TELEMETRY_ENABLED=true
@@ -18,8 +21,11 @@ METRICS_QUEUE_SIZE=1000
 METRICS_WORKER_COUNT=1
 METRICS_FLUSH_INTERVAL=5s
 UPSTREAM_ERROR_PASSTHROUGH=true
-UPSTREAM_TIMEOUT=60s
-PROVIDER_REQUEST_TIMEOUT=60s
+UPSTREAM_TIMEOUT=300s
+# Bounds a full non-streaming completion, not just time-to-first-byte, because
+# providers withhold response headers until generation finishes.
+# PROVIDER_RESPONSE_HEADER_TIMEOUT defaults to this value.
+PROVIDER_REQUEST_TIMEOUT=300s
 PROVIDER_MAX_RETRIES=2
 APPLICATION_VERSION=v0.33.2
 TRUSTGUARD_BASE_URL=http://trustguard-data.trustguard.svc.cluster.local:8081

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -355,8 +355,9 @@ type UpstreamConfig struct {
 }
 
 type ProviderConfig struct {
-	RequestTimeout time.Duration
-	MaxRetries     int
+	RequestTimeout        time.Duration
+	ResponseHeaderTimeout time.Duration
+	MaxRetries            int
 }
 
 type CatalogConfig struct {
@@ -652,9 +653,15 @@ func getUpstreamConfig() UpstreamConfig {
 }
 
 func getProviderConfig() ProviderConfig {
+	requestTimeout := getEnvDuration("PROVIDER_REQUEST_TIMEOUT", defaultProviderRequestTimeout)
+	// Non-streaming providers withhold response headers until the whole
+	// completion is generated, so a header timeout below the request timeout
+	// would cap generation time without the request timeout ever applying.
+	// Defaulting to the request timeout keeps the two from drifting apart.
 	return ProviderConfig{
-		RequestTimeout: getEnvDuration("PROVIDER_REQUEST_TIMEOUT", defaultProviderRequestTimeout),
-		MaxRetries:     getEnvInt("PROVIDER_MAX_RETRIES", defaultProviderMaxRetries),
+		RequestTimeout:        requestTimeout,
+		ResponseHeaderTimeout: getEnvDuration("PROVIDER_RESPONSE_HEADER_TIMEOUT", requestTimeout),
+		MaxRetries:            getEnvInt("PROVIDER_MAX_RETRIES", defaultProviderMaxRetries),
 	}
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -75,6 +75,51 @@ func TestGetFirewallComplexityConfig(t *testing.T) {
 	}
 }
 
+func TestGetProviderConfig_ResponseHeaderTimeout(t *testing.T) {
+	tests := []struct {
+		name           string
+		requestTimeout string
+		headerTimeout  string
+		wantRequest    time.Duration
+		wantHeader     time.Duration
+	}{
+		{
+			name:        "both unset fall back to defaults",
+			wantRequest: defaultProviderRequestTimeout,
+			wantHeader:  defaultProviderRequestTimeout,
+		},
+		{
+			name:           "header timeout tracks request timeout when unset",
+			requestTimeout: "300s",
+			wantRequest:    300 * time.Second,
+			wantHeader:     300 * time.Second,
+		},
+		{
+			name:           "explicit header timeout wins",
+			requestTimeout: "300s",
+			headerTimeout:  "45s",
+			wantRequest:    300 * time.Second,
+			wantHeader:     45 * time.Second,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("PROVIDER_REQUEST_TIMEOUT", tc.requestTimeout)
+			t.Setenv("PROVIDER_RESPONSE_HEADER_TIMEOUT", tc.headerTimeout)
+
+			cfg := getProviderConfig()
+
+			if cfg.RequestTimeout != tc.wantRequest {
+				t.Errorf("RequestTimeout = %s, want %s", cfg.RequestTimeout, tc.wantRequest)
+			}
+			if cfg.ResponseHeaderTimeout != tc.wantHeader {
+				t.Errorf("ResponseHeaderTimeout = %s, want %s", cfg.ResponseHeaderTimeout, tc.wantHeader)
+			}
+		})
+	}
+}
+
 func TestLoadConfig_PostgresLoginModes(t *testing.T) {
 	tests := []struct {
 		name, login, password, sslMode, wantLogin, wantPassword string

--- a/pkg/container/modules/providers.go
+++ b/pkg/container/modules/providers.go
@@ -31,5 +31,6 @@ func Providers(c *container.Container) error {
 	}
 	return c.Invoke(func(cfg *config.Config) {
 		providers.SetDefaultHTTPTimeout(cfg.Provider.RequestTimeout)
+		providers.SetDefaultResponseHeaderTimeout(cfg.Provider.ResponseHeaderTimeout)
 	})
 }

--- a/pkg/infra/providers/http_client.go
+++ b/pkg/infra/providers/http_client.go
@@ -28,9 +28,25 @@ import (
 // Override with SetDefaultHTTPTimeout during initialization.
 var DefaultHTTPTimeout = 120 * time.Second
 
+// DefaultResponseHeaderTimeout bounds the wait for an upstream provider's
+// response headers. Override with SetDefaultResponseHeaderTimeout during
+// initialization.
+//
+// Non-streaming providers withhold response headers until the whole completion
+// has been generated, so this value caps total generation time for
+// non-streaming requests. Keeping it below DefaultHTTPTimeout silently
+// truncates long completions regardless of the configured request timeout.
+var DefaultResponseHeaderTimeout = 120 * time.Second
+
 func SetDefaultHTTPTimeout(d time.Duration) {
 	if d > 0 {
 		DefaultHTTPTimeout = d
+	}
+}
+
+func SetDefaultResponseHeaderTimeout(d time.Duration) {
+	if d > 0 {
+		DefaultResponseHeaderTimeout = d
 	}
 }
 
@@ -120,7 +136,7 @@ func newTransport() *http.Transport {
 
 		IdleConnTimeout: 60 * time.Second,
 
-		ResponseHeaderTimeout: 30 * time.Second,
+		ResponseHeaderTimeout: DefaultResponseHeaderTimeout,
 
 		ExpectContinueTimeout: 1 * time.Second,
 

--- a/pkg/infra/providers/http_client_test.go
+++ b/pkg/infra/providers/http_client_test.go
@@ -17,6 +17,7 @@ package providers
 import (
 	"bytes"
 	"io"
+	"net/http"
 	"testing"
 	"time"
 
@@ -69,6 +70,33 @@ func TestSetDefaultHTTPTimeout(t *testing.T) {
 
 	SetDefaultHTTPTimeout(0)
 	assert.Equal(t, 42*time.Second, DefaultHTTPTimeout, "non-positive duration must be ignored")
+}
+
+func TestSetDefaultResponseHeaderTimeout(t *testing.T) {
+	original := DefaultResponseHeaderTimeout
+	t.Cleanup(func() { DefaultResponseHeaderTimeout = original })
+
+	SetDefaultResponseHeaderTimeout(90 * time.Second)
+	assert.Equal(t, 90*time.Second, DefaultResponseHeaderTimeout)
+
+	SetDefaultResponseHeaderTimeout(0)
+	assert.Equal(t, 90*time.Second, DefaultResponseHeaderTimeout, "non-positive duration must be ignored")
+}
+
+func TestHTTPClientPool_TransportUsesConfiguredResponseHeaderTimeout(t *testing.T) {
+	original := DefaultResponseHeaderTimeout
+	t.Cleanup(func() { DefaultResponseHeaderTimeout = original })
+	SetDefaultResponseHeaderTimeout(300 * time.Second)
+
+	pool := NewHTTPClientPool()
+
+	transport, ok := pool.Get("anthropic", DefaultHTTPTimeout).Transport.(*http.Transport)
+	require.True(t, ok, "non-streaming client must use *http.Transport")
+	assert.Equal(t, 300*time.Second, transport.ResponseHeaderTimeout)
+
+	streamTransport, ok := pool.GetStream("anthropic").Transport.(*http.Transport)
+	require.True(t, ok, "streaming client must use *http.Transport")
+	assert.Equal(t, 300*time.Second, streamTransport.ResponseHeaderTimeout)
 }
 
 func TestDrainBody(t *testing.T) {


### PR DESCRIPTION
## Summary

LLM completions longer than roughly 1500 output tokens were being cut off in production. Reproduced against `*.llm.neuraltrust.ai`:

| Request | Result |
|---|---|
| Short answer (`max_tokens: 300`) | 200 in 1.8s |
| Real prompt, non-streaming | **504 at exactly 30.1s** |
| Real prompt, `"stream": true` | **reset at exactly 30.1s**, mid-sentence, after 45 chunks |

Streaming dying at the same 30s while chunks were still flowing ruled out an idle timeout: it is an absolute cap on request duration.

## Root cause — two 30s limits firing at once

Lifting either one alone would have changed nothing, which is why both are in this PR:

1. **GCP load balancer.** The `GCPBackendPolicy` for `agentgateway-proxy` and `agentgateway-mcp` set only `securityPolicy`. With `timeoutSec` omitted, [GKE applies a default of 30s](https://cloud.google.com/kubernetes-engine/docs/how-to/configure-gateway-resources).
2. **`Transport.ResponseHeaderTimeout`, hardcoded to 30s.** Non-streaming providers withhold response headers until the whole completion is generated, so this bounded *total generation time*, not time-to-first-byte — silently undercutting `PROVIDER_REQUEST_TIMEOUT=60s`.

## Changes

- `timeoutSec: 300` on the proxy and MCP backend policies (`prod`, `prod-us`). The admin backend keeps the 30s default; its requests are short.
- `ResponseHeaderTimeout` is now configurable and **defaults to `PROVIDER_REQUEST_TIMEOUT`** rather than carrying its own constant, so the two cannot drift apart and reintroduce a hidden sub-cap. `PROVIDER_RESPONSE_HEADER_TIMEOUT` can still lower it to fail fast against an unresponsive provider.
- `UPSTREAM_TIMEOUT` and `PROVIDER_REQUEST_TIMEOUT` to `300s` across `dev`/`prod`/`prod-us`.
- **`SERVER_WRITE_TIMEOUT=300s` (new).** Not part of the original diagnosis: fasthttp applies `WriteTimeout` to the whole response write, so the previous 60s truncated any SSE stream at one minute despite the 5m `StreamTimeout`. This would have been the next wall.

`SERVER_READ_TIMEOUT` is deliberately left at 60s — it only governs reading the inbound request (a small JSON), and raising it would widen the slowloris window for no benefit.

## Test plan

- [x] `go build ./...`, `go vet`, `golangci-lint run` (0 issues), full `go test ./...` green
- [x] New table-driven test in `config_test.go` covering all three resolution paths (both unset, inherited, explicit override)
- [x] New test asserting the transport actually adopts the configured value, for both the pooled and streaming clients
- [x] `kubectl kustomize` builds clean for all three overlays; verified `timeoutSec: 300` and the three env vars in the rendered output
- [ ] After deploy: confirm a >30s completion returns 200 instead of 504

## Known limits, not addressed here

- **Cloudflare still caps requests at ~100s** in front of all of this, so the effective ceiling goes from 30s to ~100s, not 300s. Raising it is a Cloudflare-side change and needs Enterprise.
- **`claude-opus-5` will still return empty content.** Thinking blocks are mapped to `reasoning.summary` and never to `message.content`, and `thinking_delta` events are dropped from the stream entirely. That is a separate bug in the Anthropic adapter. After this PR it stops being a 504 and becomes a 200 with an empty body, which is harder to diagnose — worth fixing or de-listing the model in the same window.

Made with [Cursor](https://cursor.com)