### PR TITLE
fix(adapter): forward Anthropic thinking deltas through the stream

### DIFF
--- a/pkg/infra/providers/adapter/anthropic_adapter.go
+++ b/pkg/infra/providers/adapter/anthropic_adapter.go
@@ -20,6 +20,17 @@ import (
 	"strings"
 )
 
+// defaultAnthropicMaxTokens is the fallback when the caller sends no max_tokens.
+// Anthropic requires the field, so some value must be sent, and the previous
+// 4096 truncated answers on extended-thinking models, where reasoning and the
+// visible answer share the budget.
+//
+// It is deliberately far below the 64000 ceiling of current Claude models: a
+// larger value is rejected outright by models with a lower ceiling, and on a
+// non-streamed request it generates for longer than upstream proxies keep the
+// connection open, turning a truncated answer into no answer at all.
+const defaultAnthropicMaxTokens = 8192
+
 // AnthropicAdapter converts between Anthropic Messages API format and the
 // canonical internal model.
 type AnthropicAdapter struct{}
@@ -154,6 +165,7 @@ type anthropicMessageStart struct {
 type anthropicDelta struct {
 	Type        string `json:"type,omitempty"`
 	Text        string `json:"text,omitempty"`
+	Thinking    string `json:"thinking,omitempty"`     // for thinking_delta (extended thinking streaming)
 	PartialJSON string `json:"partial_json,omitempty"` // for input_json_delta (tool_use streaming)
 	StopReason  string `json:"stop_reason,omitempty"`
 }
@@ -370,7 +382,7 @@ func (a *AnthropicAdapter) EncodeRequest(req *CanonicalRequest) ([]byte, error) 
 	if req.MaxTokens > 0 {
 		out.MaxTokens = req.MaxTokens
 	} else {
-		out.MaxTokens = 4096
+		out.MaxTokens = defaultAnthropicMaxTokens
 	}
 
 	// Messages: collapse canonical Role="tool" messages into one Anthropic "user" message with tool_result blocks
@@ -587,6 +599,11 @@ func (a *AnthropicAdapter) DecodeStreamChunk(chunk []byte) (*CanonicalStreamChun
 		}
 		if delta.Type == "text_delta" && delta.Text != "" {
 			return &CanonicalStreamChunk{Delta: delta.Text}, nil
+		}
+		// Extended thinking: without forwarding these the stream stays silent for
+		// the whole reasoning phase and intermediaries close the idle connection.
+		if delta.Type == "thinking_delta" && delta.Thinking != "" {
+			return &CanonicalStreamChunk{ReasoningDelta: delta.Thinking}, nil
 		}
 		if delta.Type == "input_json_delta" {
 			return &CanonicalStreamChunk{

--- a/pkg/infra/providers/adapter/anthropic_adapter.go
+++ b/pkg/infra/providers/adapter/anthropic_adapter.go
@@ -20,15 +20,7 @@ import (
 	"strings"
 )
 
-// defaultAnthropicMaxTokens is the fallback when the caller sends no max_tokens.
-// Anthropic requires the field, so some value must be sent, and the previous
-// 4096 truncated answers on extended-thinking models, where reasoning and the
-// visible answer share the budget.
-//
-// It is deliberately far below the 64000 ceiling of current Claude models: a
-// larger value is rejected outright by models with a lower ceiling, and on a
-// non-streamed request it generates for longer than upstream proxies keep the
-// connection open, turning a truncated answer into no answer at all.
+// Not the 64000 model ceiling: lower-ceiling models reject larger values, and a longer generation outlives the proxy read timeout.
 const defaultAnthropicMaxTokens = 8192
 
 // AnthropicAdapter converts between Anthropic Messages API format and the
@@ -165,7 +157,7 @@ type anthropicMessageStart struct {
 type anthropicDelta struct {
 	Type        string `json:"type,omitempty"`
 	Text        string `json:"text,omitempty"`
-	Thinking    string `json:"thinking,omitempty"`     // for thinking_delta (extended thinking streaming)
+	Thinking    string `json:"thinking,omitempty"`
 	PartialJSON string `json:"partial_json,omitempty"` // for input_json_delta (tool_use streaming)
 	StopReason  string `json:"stop_reason,omitempty"`
 }
@@ -600,8 +592,7 @@ func (a *AnthropicAdapter) DecodeStreamChunk(chunk []byte) (*CanonicalStreamChun
 		if delta.Type == "text_delta" && delta.Text != "" {
 			return &CanonicalStreamChunk{Delta: delta.Text}, nil
 		}
-		// Extended thinking: without forwarding these the stream stays silent for
-		// the whole reasoning phase and intermediaries close the idle connection.
+		// Forwarded so the stream is not silent during the reasoning phase, which proxies close as idle.
 		if delta.Type == "thinking_delta" && delta.Thinking != "" {
 			return &CanonicalStreamChunk{ReasoningDelta: delta.Thinking}, nil
 		}

--- a/pkg/infra/providers/adapter/anthropic_adapter_test.go
+++ b/pkg/infra/providers/adapter/anthropic_adapter_test.go
@@ -363,10 +363,6 @@ func TestCanonical_Anthropic_SystemArrayAndToolResultBlocks(t *testing.T) {
 	assert.Equal(t, "t1", tool.ToolCallID)
 }
 
-// ---------------------------------------------------------------------------
-// Extended thinking: thinking_delta must survive the stream
-// ---------------------------------------------------------------------------
-
 func TestAnthropicDecodeStreamChunk_ThinkingDelta(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -412,9 +408,6 @@ func TestAnthropicDecodeStreamChunk_ThinkingDelta(t *testing.T) {
 	}
 }
 
-// A thinking delta arriving from Anthropic must reach an OpenAI-wire client as
-// reasoning_content. Dropping it left the SSE stream silent for the whole
-// reasoning phase, which intermediaries treat as an idle connection.
 func TestAnthropicThinkingDeltaReachesOpenAIStream(t *testing.T) {
 	input := `{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"step one"}}`
 

--- a/pkg/infra/providers/adapter/anthropic_adapter_test.go
+++ b/pkg/infra/providers/adapter/anthropic_adapter_test.go
@@ -362,3 +362,113 @@ func TestCanonical_Anthropic_SystemArrayAndToolResultBlocks(t *testing.T) {
 	assert.Equal(t, "error: timeout", tool.Content)
 	assert.Equal(t, "t1", tool.ToolCallID)
 }
+
+// ---------------------------------------------------------------------------
+// Extended thinking: thinking_delta must survive the stream
+// ---------------------------------------------------------------------------
+
+func TestAnthropicDecodeStreamChunk_ThinkingDelta(t *testing.T) {
+	tests := []struct {
+		name          string
+		body          string
+		wantReasoning string
+		wantText      string
+		wantNil       bool
+	}{
+		{
+			name:          "thinking_delta becomes a reasoning delta",
+			body:          `{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Let me think"}}`,
+			wantReasoning: "Let me think",
+		},
+		{
+			name:     "text_delta stays plain content",
+			body:     `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}`,
+			wantText: "Hi",
+		},
+		{
+			name:    "empty thinking_delta yields nothing",
+			body:    `{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":""}}`,
+			wantNil: true,
+		},
+		{
+			name:    "signature_delta is still ignored",
+			body:    `{"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"abc"}}`,
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := (&AnthropicAdapter{}).DecodeStreamChunk([]byte(tt.body))
+			require.NoError(t, err)
+			if tt.wantNil {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			assert.Equal(t, tt.wantReasoning, got.ReasoningDelta)
+			assert.Equal(t, tt.wantText, got.Delta)
+		})
+	}
+}
+
+// A thinking delta arriving from Anthropic must reach an OpenAI-wire client as
+// reasoning_content. Dropping it left the SSE stream silent for the whole
+// reasoning phase, which intermediaries treat as an idle connection.
+func TestAnthropicThinkingDeltaReachesOpenAIStream(t *testing.T) {
+	input := `{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"step one"}}`
+
+	lines, err := NewRegistry().AdaptStreamChunk([]byte(input), FormatOpenAI, FormatAnthropic)
+	require.NoError(t, err)
+	require.NotEmpty(t, lines, "thinking delta must produce SSE output")
+
+	var payload []byte
+	for _, l := range lines {
+		if p, ok := bytes.CutPrefix(l, []byte("data: ")); ok {
+			payload = p
+			break
+		}
+	}
+	require.NotNil(t, payload)
+
+	var chunk struct {
+		Choices []struct {
+			Delta struct {
+				Content          string `json:"content"`
+				ReasoningContent string `json:"reasoning_content"`
+			} `json:"delta"`
+		} `json:"choices"`
+	}
+	require.NoError(t, json.Unmarshal(payload, &chunk))
+	require.Len(t, chunk.Choices, 1)
+	assert.Equal(t, "step one", chunk.Choices[0].Delta.ReasoningContent)
+	assert.Empty(t, chunk.Choices[0].Delta.Content, "reasoning must not leak into content")
+}
+
+func TestAnthropicEncodeRequest_MaxTokensDefault(t *testing.T) {
+	tests := []struct {
+		name      string
+		maxTokens int
+		want      int
+	}{
+		{name: "caller value is respected", maxTokens: 512, want: 512},
+		{name: "absent value falls back to the default", maxTokens: 0, want: defaultAnthropicMaxTokens},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body, err := (&AnthropicAdapter{}).EncodeRequest(&CanonicalRequest{
+				Model:     "claude-opus-4-5",
+				MaxTokens: tt.maxTokens,
+				Messages:  []CanonicalMessage{{Role: "user", Content: "hi"}},
+			})
+			require.NoError(t, err)
+
+			var out struct {
+				MaxTokens int `json:"max_tokens"`
+			}
+			require.NoError(t, json.Unmarshal(body, &out))
+			assert.Equal(t, tt.want, out.MaxTokens)
+		})
+	}
+}

--- a/pkg/infra/providers/adapter/canonical.go
+++ b/pkg/infra/providers/adapter/canonical.go
@@ -153,9 +153,9 @@ type StreamToolCallDelta struct {
 type CanonicalStreamChunk struct {
 	ID                 string                     `json:"id,omitempty"`
 	Model              string                     `json:"model,omitempty"`
-	Role               string                     `json:"role,omitempty"`            // only on first chunk
-	Delta              string                     `json:"delta,omitempty"`           // text content delta
-	ReasoningDelta     string                     `json:"reasoning_delta,omitempty"` // thinking/reasoning content delta
+	Role               string                     `json:"role,omitempty"`  // only on first chunk
+	Delta              string                     `json:"delta,omitempty"` // text content delta
+	ReasoningDelta     string                     `json:"reasoning_delta,omitempty"`
 	FinishReason       string                     `json:"finish_reason,omitempty"`
 	ToolCallDeltas     []StreamToolCallDelta      `json:"tool_call_deltas,omitempty"`
 	Usage              *CanonicalUsage            `json:"usage,omitempty"` // present in the final chunk of some providers

--- a/pkg/infra/providers/adapter/canonical.go
+++ b/pkg/infra/providers/adapter/canonical.go
@@ -153,8 +153,9 @@ type StreamToolCallDelta struct {
 type CanonicalStreamChunk struct {
 	ID                 string                     `json:"id,omitempty"`
 	Model              string                     `json:"model,omitempty"`
-	Role               string                     `json:"role,omitempty"`  // only on first chunk
-	Delta              string                     `json:"delta,omitempty"` // text content delta
+	Role               string                     `json:"role,omitempty"`            // only on first chunk
+	Delta              string                     `json:"delta,omitempty"`           // text content delta
+	ReasoningDelta     string                     `json:"reasoning_delta,omitempty"` // thinking/reasoning content delta
 	FinishReason       string                     `json:"finish_reason,omitempty"`
 	ToolCallDeltas     []StreamToolCallDelta      `json:"tool_call_deltas,omitempty"`
 	Usage              *CanonicalUsage            `json:"usage,omitempty"` // present in the final chunk of some providers

--- a/pkg/infra/providers/adapter/openai_completions_adapter.go
+++ b/pkg/infra/providers/adapter/openai_completions_adapter.go
@@ -139,9 +139,10 @@ type openaiStreamChoice struct {
 }
 
 type openaiStreamDelta struct {
-	Role      string                 `json:"role,omitempty"`
-	Content   string                 `json:"content,omitempty"`
-	ToolCalls []openaiStreamToolCall `json:"tool_calls,omitempty"`
+	Role             string                 `json:"role,omitempty"`
+	Content          string                 `json:"content,omitempty"`
+	ReasoningContent string                 `json:"reasoning_content,omitempty"`
+	ToolCalls        []openaiStreamToolCall `json:"tool_calls,omitempty"`
 }
 
 type openaiStreamToolCall struct {
@@ -475,8 +476,9 @@ func decodeCompletionsStreamChunk(chunk []byte) (*CanonicalStreamChunk, error) {
 
 func encodeCompletionsStreamChunk(chunk *CanonicalStreamChunk) ([][]byte, error) {
 	delta := openaiStreamDelta{
-		Role:    chunk.Role,
-		Content: chunk.Delta,
+		Role:             chunk.Role,
+		Content:          chunk.Delta,
+		ReasoningContent: chunk.ReasoningDelta,
 	}
 	for _, tc := range chunk.ToolCallDeltas {
 		delta.ToolCalls = append(delta.ToolCalls, openaiStreamToolCall{


### PR DESCRIPTION
## Summary

Extended-thinking Claude models (opus-5 and friends) spend the first minute or more of a request emitting only `thinking_delta` events. The Anthropic stream decoder dropped them on the floor, so **the SSE stream carried no bytes at all during that whole phase** and upstream proxies closed it as an idle connection before any answer arrived.

Measured against production before the fix:

| Request | Duration | Result |
|---|---|---|
| `max_tokens=4096`, no stream | 65s | 200, truncated answer |
| `max_tokens=12000`, no stream | 125s | **524** (Cloudflare Proxy Read Timeout), no content |
| `max_tokens=12000`, `stream:true` | 129s | **INTERNAL_ERROR**, 1 chunk (role only), zero content |

That third row is the bug: 129 seconds of streaming that produced a single `role` chunk. This is also why the Playground showed a generic "Request failed" — it received a non-JSON `error code: 524` body that `parseGatewayError` cannot parse.

## Changes

- `thinking_delta` now decodes into a new `ReasoningDelta` field on `CanonicalStreamChunk` instead of being discarded.
- OpenAI-wire clients receive it as `delta.reasoning_content`, so bytes flow continuously and the connection is never idle.
- The no-`max_tokens` fallback goes from 4096 to 8192. On these models reasoning and the visible answer share the budget, so 4096 left nothing for the answer.

Anthropic-wire output is **unchanged**: the encoder already yields nothing for a reasoning-only chunk and the proxy skips empty encodes, so there is no regression for clients that do not speak OpenAI.

## Notes for the reviewer

- `max_tokens` cannot simply be omitted: it is a required field in the Anthropic Messages API and the request 400s without it.
- 8192 is deliberately not the model ceiling (64000 on current Claude models). A larger default is rejected outright by models with a lower ceiling, and on a non-streamed request it generates for longer than the 125s Cloudflare allows — turning a truncated answer into no answer. A per-model bound from the catalog (`catalog.Model.MaxOutput` via `FindModel`) would remove that caveat and is the natural follow-up.
- The 125s non-streaming ceiling is Cloudflare's Proxy Read Timeout, adjustable only on Enterprise zones. Streaming is not subject to it once bytes flow, which is what this PR restores.

## Test plan

- [x] `go build ./...`, `go vet`, `golangci-lint run` (0 issues)
- [x] Full `go test ./...` green
- [x] New tests: the four delta variants (thinking, text, empty thinking, signature), the end-to-end Anthropic to OpenAI hop asserting reasoning does not leak into `content`, and the `max_tokens` default
- [ ] Post-deploy: re-run `max_tokens=12000` with `stream:true` against opus-5 and confirm continuous chunks instead of a single one

Made with [Cursor](https://cursor.com)