### PR TITLE
Update Cloudflare backend policies to detach security policies while …

### DIFF
--- a/k8s/overlays/prod-us/cloudflare-backendpolicy.yaml
+++ b/k8s/overlays/prod-us/cloudflare-backendpolicy.yaml
@@ -1,30 +1,36 @@
-# Cloud Armor: allow only Cloudflare-proxied traffic to these Services' load
-# balancer backends. References neuraltrust-prod-us-cloudflare-only (preview
-# until public Gateway is attached and logs are clean).
+# GCPBackendPolicy for agentgateway backends on the external Gateway.
 #
-# timeoutSec also lives here because it is a GCPBackendPolicy field. Omitting it
+# Cloudflare-only Cloud Armor is commented out while public hostnames are
+# DNS-only (grey cloud). Uncomment securityPolicy (and remove securityPolicy: "")
+# when those records are proxied again. Empty string explicitly detaches Armor;
+# omitting the field can leave it attached.
+#
+# timeoutSec lives here because it is a GCPBackendPolicy field. Omitting it
 # yields the GCP default of 30s, which cuts LLM completions mid-generation; the
 # proxy and MCP backends serve long-running upstream calls and need the higher
 # bound. The admin backend keeps the default: its requests are short.
-apiVersion: networking.gke.io/v1
-kind: GCPBackendPolicy
-metadata:
-  name: cloudflare-only-agentgateway-admin
-spec:
-  default:
-    securityPolicy: neuraltrust-prod-us-cloudflare-only
-  targetRef:
-    group: ""
-    kind: Service
-    name: agentgateway-admin
----
+#
+# --- admin (Cloudflare Armor only; re-enable with the others when proxied) ---
+# apiVersion: networking.gke.io/v1
+# kind: GCPBackendPolicy
+# metadata:
+#   name: cloudflare-only-agentgateway-admin
+# spec:
+#   default:
+#     securityPolicy: neuraltrust-prod-us-cloudflare-only
+#   targetRef:
+#     group: ""
+#     kind: Service
+#     name: agentgateway-admin
+# ---
 apiVersion: networking.gke.io/v1
 kind: GCPBackendPolicy
 metadata:
   name: cloudflare-only-agentgateway-proxy
 spec:
   default:
-    securityPolicy: neuraltrust-prod-us-cloudflare-only
+    # securityPolicy: neuraltrust-prod-us-cloudflare-only
+    securityPolicy: ""
     timeoutSec: 300
   targetRef:
     group: ""
@@ -37,7 +43,8 @@ metadata:
   name: cloudflare-only-agentgateway-mcp
 spec:
   default:
-    securityPolicy: neuraltrust-prod-us-cloudflare-only
+    # securityPolicy: neuraltrust-prod-us-cloudflare-only
+    securityPolicy: ""
     timeoutSec: 300
   targetRef:
     group: ""

--- a/k8s/overlays/prod/cloudflare-backendpolicy.yaml
+++ b/k8s/overlays/prod/cloudflare-backendpolicy.yaml
@@ -1,31 +1,36 @@
-# Cloud Armor: allow only Cloudflare-proxied traffic to these Services' load
-# balancer backends. References the security policy created in
-# cloud-infrastructure (var.enable_cloudflare_only_armor). Prod only — dev uses
-# the internal gateway. Namespace is applied by the overlay's namespace setting.
+# GCPBackendPolicy for agentgateway backends on the external Gateway.
 #
-# timeoutSec also lives here because it is a GCPBackendPolicy field. Omitting it
+# Cloudflare-only Cloud Armor is commented out while public hostnames are
+# DNS-only (grey cloud). Uncomment securityPolicy (and remove securityPolicy: "")
+# when those records are proxied again. Empty string explicitly detaches Armor;
+# omitting the field can leave it attached.
+#
+# timeoutSec lives here because it is a GCPBackendPolicy field. Omitting it
 # yields the GCP default of 30s, which cuts LLM completions mid-generation; the
 # proxy and MCP backends serve long-running upstream calls and need the higher
 # bound. The admin backend keeps the default: its requests are short.
-apiVersion: networking.gke.io/v1
-kind: GCPBackendPolicy
-metadata:
-  name: cloudflare-only-agentgateway-admin
-spec:
-  default:
-    securityPolicy: neuraltrust-prod-cloudflare-only
-  targetRef:
-    group: ""
-    kind: Service
-    name: agentgateway-admin
----
+#
+# --- admin (Cloudflare Armor only; re-enable with the others when proxied) ---
+# apiVersion: networking.gke.io/v1
+# kind: GCPBackendPolicy
+# metadata:
+#   name: cloudflare-only-agentgateway-admin
+# spec:
+#   default:
+#     securityPolicy: neuraltrust-prod-cloudflare-only
+#   targetRef:
+#     group: ""
+#     kind: Service
+#     name: agentgateway-admin
+# ---
 apiVersion: networking.gke.io/v1
 kind: GCPBackendPolicy
 metadata:
   name: cloudflare-only-agentgateway-proxy
 spec:
   default:
-    securityPolicy: neuraltrust-prod-cloudflare-only
+    # securityPolicy: neuraltrust-prod-cloudflare-only
+    securityPolicy: ""
     timeoutSec: 300
   targetRef:
     group: ""
@@ -38,7 +43,8 @@ metadata:
   name: cloudflare-only-agentgateway-mcp
 spec:
   default:
-    securityPolicy: neuraltrust-prod-cloudflare-only
+    # securityPolicy: neuraltrust-prod-cloudflare-only
+    securityPolicy: ""
     timeoutSec: 300
   targetRef:
     group: ""


### PR DESCRIPTION
…public hostnames are DNS-only. Comments added for clarity on re-enabling security policies when proxied. Timeout settings adjusted to ensure long-running requests are handled appropriately.