### PR TITLE
Update Cloudflare backend policies to clarify handling of security po…

### DIFF
--- a/k8s/overlays/prod-us/cloudflare-backendpolicy.yaml
+++ b/k8s/overlays/prod-us/cloudflare-backendpolicy.yaml
@@ -1,9 +1,10 @@
 # GCPBackendPolicy for agentgateway backends on the external Gateway.
 #
 # Cloudflare-only Cloud Armor is commented out while public hostnames are
-# DNS-only (grey cloud). Uncomment securityPolicy (and remove securityPolicy: "")
-# when those records are proxied again. Empty string explicitly detaches Armor;
-# omitting the field can leave it attached.
+# DNS-only (grey cloud). Do NOT set securityPolicy: "" — GKE treats that as a
+# malformed policy URL and fails HTTPRoute reconciliation. Detach Armor with:
+#   gcloud compute backend-services update <bs> --global --security-policy=''
+# Uncomment securityPolicy when those records are proxied again.
 #
 # timeoutSec lives here because it is a GCPBackendPolicy field. Omitting it
 # yields the GCP default of 30s, which cuts LLM completions mid-generation; the
@@ -30,7 +31,6 @@ metadata:
 spec:
   default:
     # securityPolicy: neuraltrust-prod-us-cloudflare-only
-    securityPolicy: ""
     timeoutSec: 300
   targetRef:
     group: ""
@@ -44,7 +44,6 @@ metadata:
 spec:
   default:
     # securityPolicy: neuraltrust-prod-us-cloudflare-only
-    securityPolicy: ""
     timeoutSec: 300
   targetRef:
     group: ""

--- a/k8s/overlays/prod/cloudflare-backendpolicy.yaml
+++ b/k8s/overlays/prod/cloudflare-backendpolicy.yaml
@@ -1,9 +1,10 @@
 # GCPBackendPolicy for agentgateway backends on the external Gateway.
 #
 # Cloudflare-only Cloud Armor is commented out while public hostnames are
-# DNS-only (grey cloud). Uncomment securityPolicy (and remove securityPolicy: "")
-# when those records are proxied again. Empty string explicitly detaches Armor;
-# omitting the field can leave it attached.
+# DNS-only (grey cloud). Do NOT set securityPolicy: "" — GKE treats that as a
+# malformed policy URL and fails HTTPRoute reconciliation. Detach Armor with:
+#   gcloud compute backend-services update <bs> --global --security-policy=''
+# Uncomment securityPolicy when those records are proxied again.
 #
 # timeoutSec lives here because it is a GCPBackendPolicy field. Omitting it
 # yields the GCP default of 30s, which cuts LLM completions mid-generation; the
@@ -30,7 +31,6 @@ metadata:
 spec:
   default:
     # securityPolicy: neuraltrust-prod-cloudflare-only
-    securityPolicy: ""
     timeoutSec: 300
   targetRef:
     group: ""
@@ -44,7 +44,6 @@ metadata:
 spec:
   default:
     # securityPolicy: neuraltrust-prod-cloudflare-only
-    securityPolicy: ""
     timeoutSec: 300
   targetRef:
     group: ""


### PR DESCRIPTION
…licies during DNS-only configurations. Removed empty securityPolicy fields to prevent GKE reconciliation errors and added comments for guidance on re-enabling security policies when proxied.