### PR TITLE
feat(mcp): normalize modern MCP responses (RUN-1103)

### DIFF
--- a/openspec/changes/run-1103-dual-era-northbound-protocol-boundary/tasks.md
+++ b/openspec/changes/run-1103-dual-era-northbound-protocol-boundary/tasks.md
@@ -37,12 +37,12 @@ Each child PR must show only its slice; merge to `main` in order and retarget th
 
 ## Phase 2: Modern response adapter (PR 2)
 
-- [ ] 2.1 Create `modern_response.go` and tests for copied object normalization, universal server info, private TTLs, and non-object HTTP 500/`-32603`. Depends: Phase 1.
-- [ ] 2.2 Add recursive `x-mcp-header` sanitization and concurrent immutability tests in `modern_response_test.go`. Done: modern copy changes only; legacy/cached payload remains intact under `-race`.
-- [ ] 2.3 Wire modern success/error adaptation in `mcp_handler.go`; test list/read/tool-call fields and legacy byte-shape compatibility in `mcp_handler_test.go`. Depends: 2.1–2.2.
-- [ ] 2.4 Run `clean-comments` on phase files; retain tooling directives only.
-- [ ] 2.5 Run `/reviewer` against PR 2 scope; resolve cache, mutation, and status findings.
-- [ ] 2.6 Run `/verifier` with the Phase 1 command set. Done: all green.
+- [x] 2.1 Create `modern_response.go` and tests for copied object normalization, universal server info, private TTLs, and non-object HTTP 500/`-32603`. Depends: Phase 1.
+- [x] 2.2 Add recursive `x-mcp-header` sanitization and concurrent immutability tests in `modern_response_test.go`. Done: modern copy changes only; legacy/cached payload remains intact under `-race`.
+- [x] 2.3 Wire modern success/error adaptation in `mcp_handler.go`; test list/read/tool-call fields and legacy byte-shape compatibility in `mcp_handler_test.go`. Depends: 2.1–2.2.
+- [x] 2.4 Run `clean-comments` on phase files; retain tooling directives only.
+- [x] 2.5 Run `/reviewer` against PR 2 scope; resolve cache, mutation, and status findings.
+- [x] 2.6 Run `/verifier` with the Phase 1 command set. Done: all green.
 
 ## Phase 3: Scoped discovery and transport closure (PR 3)
 

--- a/pkg/api/handler/http/mcp/mcp_handler.go
+++ b/pkg/api/handler/http/mcp/mcp_handler.go
@@ -179,7 +179,14 @@ func (h *Handler) Handle(c *fiber.Ctx) error {
 
 	result, err := h.gateway.Dispatch(c.UserContext(), rc, req.Method, req.Params)
 	if err != nil {
-		return writeAppError(c, req.ID, err)
+		return writeAppError(c, req.ID, err, era, req.Method)
+	}
+	if era == protocolEraModern {
+		normalized, err := normalizeModernResult(req.Method, result, rc)
+		if err != nil {
+			return writeRPCErrorStatus(c, req.ID, fiber.StatusInternalServerError, codeInternalError, "internal error", nil)
+		}
+		return writeRPCResult(c, req.ID, normalized)
 	}
 	if raw, ok := result.(json.RawMessage); ok {
 		return writeRawRPCResult(c, req.ID, raw)
@@ -270,13 +277,22 @@ func surfaceFingerprint(rc *appconsumer.RoutableConsumer) string {
 	return hex.EncodeToString(sum[:6])
 }
 
-func writeAppError(c *fiber.Ctx, id json.RawMessage, err error) error {
+func writeAppError(c *fiber.Ctx, id json.RawMessage, err error, era protocolEra, method string) error {
 	var (
 		rpcErr        *appmcp.RPCError
 		consentErr    *appmcp.ConsentRequiredError
 		notPermitted  *appmcp.ToolNotPermittedError
 		invalidParams *InvalidParamsError
 	)
+	if era == protocolEraModern && method == "resources/read" {
+		if errors.As(err, &rpcErr) && int(rpcErr.Code) == codeResourceNotFound {
+			applyRPCErrorHeaders(c, rpcErr)
+			return writeRPCErrorStatus(c, id, fiber.StatusBadRequest, codeInvalidParams, rpcErr.Message, rpcErr.Data)
+		}
+		if errors.Is(err, appmcp.ErrResourceNotFound) {
+			return writeRPCErrorStatus(c, id, fiber.StatusBadRequest, codeInvalidParams, err.Error(), nil)
+		}
+	}
 	switch {
 	case errors.As(err, &rpcErr):
 		switch {

--- a/pkg/api/handler/http/mcp/mcp_handler.go
+++ b/pkg/api/handler/http/mcp/mcp_handler.go
@@ -286,7 +286,7 @@ func writeAppError(c *fiber.Ctx, id json.RawMessage, err error, era protocolEra,
 	)
 	if era == protocolEraModern && method == "resources/read" {
 		if errors.As(err, &rpcErr) && int(rpcErr.Code) == codeResourceNotFound {
-			applyRPCErrorHeaders(c, rpcErr)
+			applyRPCErrorHeaders(c, rpcErr, era)
 			return writeRPCErrorStatus(c, id, fiber.StatusBadRequest, codeInvalidParams, rpcErr.Message, rpcErr.Data)
 		}
 		if errors.Is(err, appmcp.ErrResourceNotFound) {
@@ -303,7 +303,7 @@ func writeAppError(c *fiber.Ctx, id json.RawMessage, err error, era protocolEra,
 		default:
 			middleware.SetOpsOutcome(c, o11y.OutcomeServerError)
 		}
-		applyRPCErrorHeaders(c, rpcErr)
+		applyRPCErrorHeaders(c, rpcErr, era)
 		return writeJSONStatus(c, httpStatusForRPCError(rpcErr), rpcResponse{
 			JSONRPC: "2.0",
 			ID:      normalizeID(id),
@@ -452,11 +452,14 @@ func httpStatusForRPCError(_ *appmcp.RPCError) int {
 	return fiber.StatusOK
 }
 
-func applyRPCErrorHeaders(c *fiber.Ctx, err *appmcp.RPCError) {
+func applyRPCErrorHeaders(c *fiber.Ctx, err *appmcp.RPCError, era protocolEra) {
 	if err == nil {
 		return
 	}
 	for name, values := range err.HTTPHeaders {
+		if era == protocolEraModern && strings.EqualFold(name, "Mcp-Session-Id") {
+			continue
+		}
 		for _, value := range values {
 			c.Response().Header.Add(name, value)
 		}

--- a/pkg/api/handler/http/mcp/mcp_handler_test.go
+++ b/pkg/api/handler/http/mcp/mcp_handler_test.go
@@ -301,6 +301,71 @@ func TestHandler_ToolsCall_PassesUpstreamRPCErrorThrough(t *testing.T) {
 	}
 }
 
+func TestHandler_RPCErrorSessionHeaderIsolationByEra(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name           string
+		body           string
+		requestHeaders http.Header
+		sessionHeader  string
+		wantSession    bool
+	}{
+		{
+			name:          "legacy preserves session header",
+			body:          `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"boom"}}`,
+			sessionHeader: "mCp-SeSsIoN-iD",
+			wantSession:   true,
+		},
+		{
+			name:           "modern filters canonical casing",
+			body:           `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"boom","_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}`,
+			requestHeaders: modernHeadersWithName("tools/call", "boom"),
+			sessionHeader:  "Mcp-Session-Id",
+		},
+		{
+			name:           "modern filters lowercase",
+			body:           `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"boom","_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}`,
+			requestHeaders: modernHeadersWithName("tools/call", "boom"),
+			sessionHeader:  "mcp-session-id",
+		},
+		{
+			name:           "modern filters mixed casing",
+			body:           `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"boom","_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}`,
+			requestHeaders: modernHeadersWithName("tools/call", "boom"),
+			sessionHeader:  "mCp-SeSsIoN-iD",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			composer := mocks.NewComposer(t)
+			composer.EXPECT().CallTool(mock.Anything, mock.Anything, "boom", mock.Anything).
+				Return(nil, &appmcp.RPCError{
+					Code:    -32099,
+					Message: "upstream exploded",
+					HTTPHeaders: http.Header{
+						tc.sessionHeader: {"session-value"},
+						"X-Upstream":     {"preserved"},
+					},
+				}).Once()
+			app := newApp(t, composer, consumerdomain.TypeMCP, true)
+			req := httptest.NewRequest(fiber.MethodPost, mcpPath, strings.NewReader(tc.body))
+			req.Header.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSON)
+			for name, values := range tc.requestHeaders {
+				for _, value := range values {
+					req.Header.Add(name, value)
+				}
+			}
+			res, err := app.Test(req, -1)
+			require.NoError(t, err)
+			defer func() { _ = res.Body.Close() }()
+			require.Equal(t, "preserved", res.Header.Get("X-Upstream"))
+			require.Equal(t, tc.wantSession, res.Header.Get("Mcp-Session-Id") == "session-value")
+		})
+	}
+}
+
 func TestHandler_ToolsCall_ConsentRequiredRidesOn200(t *testing.T) {
 	t.Parallel()
 	composer := mocks.NewComposer(t)

--- a/pkg/api/handler/http/mcp/mcp_handler_test.go
+++ b/pkg/api/handler/http/mcp/mcp_handler_test.go
@@ -184,6 +184,33 @@ func modernHeadersFor(method string) http.Header {
 	}
 }
 
+func modernHeadersWithName(method, name string) http.Header {
+	headers := modernHeadersFor(method)
+	headers.Set("Mcp-Name", name)
+	return headers
+}
+
+func containsHeaderAnnotation(value any) bool {
+	switch current := value.(type) {
+	case map[string]any:
+		if _, ok := current["x-mcp-header"]; ok {
+			return true
+		}
+		for _, nested := range current {
+			if containsHeaderAnnotation(nested) {
+				return true
+			}
+		}
+	case []any:
+		for _, nested := range current {
+			if containsHeaderAnnotation(nested) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func TestHandler_DefaultIdP_AllowedWithoutAttachedAuth(t *testing.T) {
 	t.Parallel()
 	gwID := ids.New[ids.GatewayKind]()
@@ -238,19 +265,23 @@ func TestHandler_Initialize_UnknownVersionFallsBackToLatest(t *testing.T) {
 
 func TestHandler_ToolsList_ComposedSurface(t *testing.T) {
 	t.Parallel()
+	var tool appmcp.Tool
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"name":"gh_search",
+		"inputSchema":{"type":"object","properties":{"query":{"type":"string","x-mcp-header":"X-Query"}}}
+	}`), &tool))
 	composer := mocks.NewComposer(t)
 	composer.EXPECT().ListTools(mock.Anything, mock.Anything).
-		Return([]appmcp.Tool{{Name: "gh_search"}}, nil).Once()
+		Return([]appmcp.Tool{tool}, nil).Once()
 	app := newApp(t, composer, consumerdomain.TypeMCP, true)
 
-	status, body := rpcCall(t, app, `{"jsonrpc":"2.0","id":7,"method":"tools/list"}`)
-	if status != fiber.StatusOK {
-		t.Fatalf("status = %d", status)
-	}
-	tools := body["result"].(map[string]any)["tools"].([]any)
-	if len(tools) != 1 || tools[0].(map[string]any)["name"] != "gh_search" {
-		t.Fatalf("tools = %v", tools)
-	}
+	status, raw := rpcRawCallWithHeaders(t, app, `{"jsonrpc":"2.0","id":7,"method":"tools/list"}`, nil)
+	require.Equal(t, fiber.StatusOK, status)
+	require.Equal(
+		t,
+		`{"jsonrpc":"2.0","id":7,"result":{"tools":[{"inputSchema":{"type":"object","properties":{"query":{"type":"string","x-mcp-header":"X-Query"}}},"name":"gh_search"}]}}`,
+		string(raw),
+	)
 }
 
 func TestHandler_ToolsCall_PassesUpstreamRPCErrorThrough(t *testing.T) {
@@ -663,9 +694,14 @@ func TestHandler_ModernMethodFilteringPrecedesConsumerLookup(t *testing.T) {
 
 func TestHandler_ModernHappyPathUsesExistingDispatcher(t *testing.T) {
 	t.Parallel()
+	var tool appmcp.Tool
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"name":"search",
+		"inputSchema":{"type":"object","properties":{"query":{"type":"string","x-mcp-header":"X-Query"}}}
+	}`), &tool))
 	composer := mocks.NewComposer(t)
 	composer.EXPECT().ListTools(mock.Anything, mock.Anything).
-		Return([]appmcp.Tool{{Name: "search"}}, nil).Once()
+		Return([]appmcp.Tool{tool}, nil).Once()
 	app := newApp(t, composer, consumerdomain.TypeMCP, true)
 	body := `{"jsonrpc":"2.0","id":"modern-1","method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}`
 	status, response := rpcCallWithHeaders(t, app, body, modernHeadersFor("tools/list"))
@@ -673,7 +709,176 @@ func TestHandler_ModernHappyPathUsesExistingDispatcher(t *testing.T) {
 	require.Equal(t, "modern-1", response["id"])
 	result := response["result"].(map[string]any)
 	require.Len(t, result["tools"], 1)
-	require.NotContains(t, result, "resultType")
+	require.Equal(t, "complete", result["resultType"])
+	require.Equal(t, float64(300000), result["ttlMs"])
+	require.Equal(t, "private", result["cacheScope"])
+	serverInfo := result["_meta"].(map[string]any)["io.modelcontextprotocol/serverInfo"].(map[string]any)
+	require.True(t, strings.HasPrefix(serverInfo["version"].(string), "1.0+"))
+	require.False(t, containsHeaderAnnotation(result))
+}
+
+func TestHandler_ModernMethodsDispatchAndAdaptFields(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		body      string
+		headers   http.Header
+		setup     func(*mocks.Composer)
+		resultKey string
+		wantTTL   any
+	}{
+		{
+			name:    "resource read",
+			body:    `{"jsonrpc":"2.0","id":11,"method":"resources/read","params":{"uri":"file:///doc","_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}`,
+			headers: modernHeadersWithName("resources/read", "file:///doc"),
+			setup: func(composer *mocks.Composer) {
+				composer.EXPECT().ReadResource(mock.Anything, mock.Anything, "file:///doc").
+					Return(json.RawMessage(`{"contents":[{"uri":"file:///doc","text":"kept"}],"extra":"preserved"}`), nil).Once()
+			},
+			resultKey: "contents",
+			wantTTL:   float64(0),
+		},
+		{
+			name:    "tool call",
+			body:    `{"jsonrpc":"2.0","id":12,"method":"tools/call","params":{"name":"search","arguments":{"q":"value"},"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}`,
+			headers: modernHeadersWithName("tools/call", "search"),
+			setup: func(composer *mocks.Composer) {
+				composer.EXPECT().CallTool(mock.Anything, mock.Anything, "search", mock.Anything).
+					Return(json.RawMessage(`{"content":[{"type":"text","text":"kept"}],"extra":"preserved"}`), nil).Once()
+			},
+			resultKey: "content",
+		},
+		{
+			name:    "prompts list",
+			body:    `{"jsonrpc":"2.0","id":17,"method":"prompts/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}`,
+			headers: modernHeadersFor("prompts/list"),
+			setup: func(composer *mocks.Composer) {
+				composer.EXPECT().ListPrompts(mock.Anything, mock.Anything).
+					Return([]appmcp.Prompt{{Name: "writer"}}, nil).Once()
+			},
+			resultKey: "prompts",
+			wantTTL:   float64(300000),
+		},
+		{
+			name:    "prompt get",
+			body:    `{"jsonrpc":"2.0","id":18,"method":"prompts/get","params":{"name":"writer","_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}`,
+			headers: modernHeadersWithName("prompts/get", "writer"),
+			setup: func(composer *mocks.Composer) {
+				composer.EXPECT().GetPrompt(mock.Anything, mock.Anything, "writer", mock.Anything).
+					Return(json.RawMessage(`{"messages":[]}`), nil).Once()
+			},
+			resultKey: "messages",
+		},
+		{
+			name:    "resources list",
+			body:    `{"jsonrpc":"2.0","id":19,"method":"resources/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}`,
+			headers: modernHeadersFor("resources/list"),
+			setup: func(composer *mocks.Composer) {
+				composer.EXPECT().ListResources(mock.Anything, mock.Anything).
+					Return([]appmcp.Resource{{Name: "document", URI: "file:///doc"}}, nil).Once()
+			},
+			resultKey: "resources",
+			wantTTL:   float64(300000),
+		},
+		{
+			name:    "resource templates list",
+			body:    `{"jsonrpc":"2.0","id":20,"method":"resources/templates/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}`,
+			headers: modernHeadersFor("resources/templates/list"),
+			setup: func(composer *mocks.Composer) {
+				composer.EXPECT().ListResourceTemplates(mock.Anything, mock.Anything).
+					Return([]appmcp.ResourceTemplate{{Name: "document", URITemplate: "file:///{id}"}}, nil).Once()
+			},
+			resultKey: "resourceTemplates",
+			wantTTL:   float64(300000),
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			composer := mocks.NewComposer(t)
+			tc.setup(composer)
+			app := newApp(t, composer, consumerdomain.TypeMCP, true)
+			status, response := rpcCallWithHeaders(t, app, tc.body, tc.headers)
+			require.Equal(t, fiber.StatusOK, status)
+			result := response["result"].(map[string]any)
+			require.Contains(t, result, tc.resultKey)
+			require.Equal(t, "complete", result["resultType"])
+			require.Contains(t, result["_meta"].(map[string]any), "io.modelcontextprotocol/serverInfo")
+			if tc.wantTTL != nil {
+				require.Equal(t, tc.wantTTL, result["ttlMs"])
+				require.Equal(t, "private", result["cacheScope"])
+			} else {
+				require.NotContains(t, result, "ttlMs")
+				require.NotContains(t, result, "cacheScope")
+			}
+		})
+	}
+}
+
+func TestHandler_ModernInvalidSuccessPayloadReturnsInternalError(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		result json.RawMessage
+	}{
+		{name: "nil", result: nil},
+		{name: "empty raw", result: json.RawMessage{}},
+		{name: "null", result: json.RawMessage(`null`)},
+		{name: "array", result: json.RawMessage(`[]`)},
+		{name: "non-object metadata", result: json.RawMessage(`{"_meta":[]}`)},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			composer := mocks.NewComposer(t)
+			composer.EXPECT().CallTool(mock.Anything, mock.Anything, "search", mock.Anything).
+				Return(tc.result, nil).Once()
+			app := newApp(t, composer, consumerdomain.TypeMCP, true)
+			body := `{"jsonrpc":"2.0","id":13,"method":"tools/call","params":{"name":"search","_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}`
+			status, response := rpcCallWithHeaders(t, app, body, modernHeadersWithName("tools/call", "search"))
+			require.Equal(t, fiber.StatusInternalServerError, status)
+			require.Equal(t, float64(-32603), response["error"].(map[string]any)["code"])
+			require.Equal(t, float64(13), response["id"])
+		})
+	}
+}
+
+func TestHandler_ModernResourceMissUsesInvalidParams(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{name: "domain error", err: appmcp.ErrResourceNotFound},
+		{name: "legacy upstream code", err: &appmcp.RPCError{Code: -32002, Message: "resource missing"}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			composer := mocks.NewComposer(t)
+			composer.EXPECT().ReadResource(mock.Anything, mock.Anything, "file:///missing").
+				Return(nil, tc.err).Once()
+			app := newApp(t, composer, consumerdomain.TypeMCP, true)
+			body := `{"jsonrpc":"2.0","id":14,"method":"resources/read","params":{"uri":"file:///missing","_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}`
+			status, response := rpcCallWithHeaders(t, app, body, modernHeadersWithName("resources/read", "file:///missing"))
+			require.Equal(t, fiber.StatusBadRequest, status)
+			require.Equal(t, float64(-32602), response["error"].(map[string]any)["code"])
+		})
+	}
+}
+
+func TestHandler_LegacyResourceMissKeepsLegacyError(t *testing.T) {
+	t.Parallel()
+	composer := mocks.NewComposer(t)
+	composer.EXPECT().ReadResource(mock.Anything, mock.Anything, "file:///missing").
+		Return(nil, appmcp.ErrResourceNotFound).Once()
+	app := newApp(t, composer, consumerdomain.TypeMCP, true)
+	status, response := rpcCall(t, app, `{"jsonrpc":"2.0","id":16,"method":"resources/read","params":{"uri":"file:///missing"}}`)
+	require.Equal(t, fiber.StatusOK, status)
+	require.Equal(t, float64(-32002), response["error"].(map[string]any)["code"])
 }
 
 func TestHandler_ModernValidationPrecedesDownstream(t *testing.T) {

--- a/pkg/api/handler/http/mcp/modern_response.go
+++ b/pkg/api/handler/http/mcp/modern_response.go
@@ -1,3 +1,17 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mcp
 
 import (

--- a/pkg/api/handler/http/mcp/modern_response.go
+++ b/pkg/api/handler/http/mcp/modern_response.go
@@ -1,0 +1,77 @@
+package mcp
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+
+	appconsumer "github.com/NeuralTrust/TrustGate/pkg/app/consumer"
+)
+
+const (
+	modernCacheTTLDefault = 300000
+	modernCacheTTLRead    = 0
+	modernServerInfoKey   = "io.modelcontextprotocol/serverInfo"
+)
+
+var errModernResultNotObject = errors.New("modern MCP result must be an object")
+
+func normalizeModernResult(method string, result any, rc *appconsumer.RoutableConsumer) (map[string]any, error) {
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		return nil, err
+	}
+
+	var normalized map[string]any
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.UseNumber()
+	if err := decoder.Decode(&normalized); err != nil || normalized == nil {
+		return nil, errModernResultNotObject
+	}
+
+	if method == "tools/list" {
+		removeMCPHeaderAnnotations(normalized)
+	}
+
+	metadata := make(map[string]any)
+	if existing, ok := normalized["_meta"]; ok {
+		existingMetadata, ok := existing.(map[string]any)
+		if !ok {
+			return nil, errModernResultNotObject
+		}
+		metadata = existingMetadata
+	}
+	metadata[modernServerInfoKey] = map[string]any{
+		"name":    serverName,
+		"version": serverVersion + "+" + surfaceFingerprint(rc),
+	}
+	normalized["_meta"] = metadata
+	normalized["resultType"] = "complete"
+	delete(normalized, "ttlMs")
+	delete(normalized, "cacheScope")
+
+	switch method {
+	case "server/discover", "tools/list", "resources/list", "resources/templates/list", "prompts/list":
+		normalized["ttlMs"] = modernCacheTTLDefault
+		normalized["cacheScope"] = "private"
+	case "resources/read":
+		normalized["ttlMs"] = modernCacheTTLRead
+		normalized["cacheScope"] = "private"
+	}
+
+	return normalized, nil
+}
+
+func removeMCPHeaderAnnotations(value any) {
+	switch current := value.(type) {
+	case map[string]any:
+		delete(current, "x-mcp-header")
+		for _, nested := range current {
+			removeMCPHeaderAnnotations(nested)
+		}
+	case []any:
+		for _, nested := range current {
+			removeMCPHeaderAnnotations(nested)
+		}
+	}
+}

--- a/pkg/api/handler/http/mcp/modern_response_test.go
+++ b/pkg/api/handler/http/mcp/modern_response_test.go
@@ -1,3 +1,17 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mcp
 
 import (

--- a/pkg/api/handler/http/mcp/modern_response_test.go
+++ b/pkg/api/handler/http/mcp/modern_response_test.go
@@ -1,0 +1,158 @@
+package mcp
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+
+	appconsumer "github.com/NeuralTrust/TrustGate/pkg/app/consumer"
+	appmcp "github.com/NeuralTrust/TrustGate/pkg/app/mcp"
+	consumerdomain "github.com/NeuralTrust/TrustGate/pkg/domain/consumer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeModernResult(t *testing.T) {
+	t.Parallel()
+	defaultTTL := modernCacheTTLDefault
+	readTTL := modernCacheTTLRead
+	cases := map[string]*int{
+		"server/discover":          &defaultTTL,
+		"tools/list":               &defaultTTL,
+		"resources/list":           &defaultTTL,
+		"resources/templates/list": &defaultTTL,
+		"prompts/list":             &defaultTTL,
+		"resources/read":           &readTTL,
+		"tools/call":               nil,
+		"prompts/get":              nil,
+	}
+	rc := &appconsumer.RoutableConsumer{Consumer: &consumerdomain.Consumer{}}
+	for method, wantTTL := range cases {
+		t.Run(method, func(t *testing.T) {
+			t.Parallel()
+			source := map[string]any{
+				"value":      "preserved",
+				"resultType": "input_required",
+				"ttlMs":      1,
+				"cacheScope": "public",
+				"_meta": map[string]any{
+					"upstream":          "preserved",
+					modernServerInfoKey: map[string]any{"name": "upstream", "version": "0"},
+				},
+			}
+			normalized, err := normalizeModernResult(method, source, rc)
+			require.NoError(t, err)
+			require.Equal(t, "preserved", normalized["value"])
+			require.Equal(t, "complete", normalized["resultType"])
+			metadata := normalized["_meta"].(map[string]any)
+			require.Equal(t, "preserved", metadata["upstream"])
+			serverInfo := metadata[modernServerInfoKey].(map[string]any)
+			require.Equal(t, serverName, serverInfo["name"])
+			require.Equal(t, serverVersion+"+"+surfaceFingerprint(rc), serverInfo["version"])
+			if wantTTL == nil {
+				require.NotContains(t, normalized, "ttlMs")
+				require.NotContains(t, normalized, "cacheScope")
+			} else {
+				require.Equal(t, *wantTTL, normalized["ttlMs"])
+				require.Equal(t, "private", normalized["cacheScope"])
+			}
+			require.Equal(t, "input_required", source["resultType"])
+			require.Equal(t, "public", source["cacheScope"])
+			require.Equal(t, "upstream", source["_meta"].(map[string]any)[modernServerInfoKey].(map[string]any)["name"])
+		})
+	}
+}
+
+func TestNormalizeModernResultPreservesJSONNumbers(t *testing.T) {
+	t.Parallel()
+	normalized, err := normalizeModernResult("tools/call", json.RawMessage(`{"value":9007199254740993}`), nil)
+	require.NoError(t, err)
+	raw, err := json.Marshal(normalized)
+	require.NoError(t, err)
+	require.Contains(t, string(raw), `"value":9007199254740993`)
+}
+
+func TestNormalizeModernToolsListConcurrentImmutability(t *testing.T) {
+	t.Parallel()
+	var tool appmcp.Tool
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"name":"search",
+		"x-mcp-header":"top",
+		"inputSchema":{
+			"type":"object",
+			"x-mcp-header":"schema",
+			"properties":{
+				"query":{"type":"string","x-mcp-header":"X-Query"},
+				"nested":{"type":"array","items":[{"x-mcp-header":"array"},{"type":"string"}]}
+			}
+		}
+	}`), &tool))
+	source := map[string]any{"tools": []appmcp.Tool{tool}, "x-mcp-header": "result"}
+	before, err := json.Marshal(source)
+	require.NoError(t, err)
+
+	const workers = 32
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			normalized, err := normalizeModernResult("tools/list", source, nil)
+			if err != nil {
+				errs <- err
+				return
+			}
+			if containsMCPHeaderAnnotation(normalized) {
+				errs <- fmt.Errorf("modern result retained x-mcp-header")
+				return
+			}
+			legacy, err := json.Marshal(source)
+			if err != nil {
+				errs <- err
+				return
+			}
+			if !bytes.Equal(before, legacy) {
+				errs <- fmt.Errorf("shared result mutated")
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	after, err := json.Marshal(source)
+	require.NoError(t, err)
+	require.Equal(t, before, after)
+	require.True(t, containsMCPHeaderAnnotation(decodeJSONValue(t, after)))
+}
+
+func decodeJSONValue(t *testing.T, raw []byte) any {
+	t.Helper()
+	var value any
+	require.NoError(t, json.Unmarshal(raw, &value))
+	return value
+}
+
+func containsMCPHeaderAnnotation(value any) bool {
+	switch current := value.(type) {
+	case map[string]any:
+		if _, ok := current["x-mcp-header"]; ok {
+			return true
+		}
+		for _, nested := range current {
+			if containsMCPHeaderAnnotation(nested) {
+				return true
+			}
+		}
+	case []any:
+		for _, nested := range current {
+			if containsMCPHeaderAnnotation(nested) {
+				return true
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- normalize modern successful results with `resultType`, `serverInfo`, and private cache hints
- strip `x-mcp-header` annotations from copied northbound tool schemas without mutating cached or legacy payloads
- preserve exact JSON numbers and map modern resource misses to the current protocol contract
- suppress legacy `Mcp-Session-Id` headers on modern errors while preserving legacy forwarding

## Stack
1. [#400](https://github.com/NeuralTrust/TrustGate/pull/400) — protocol classification and validation
2. This PR — modern response adapter
3. `feat/run-1103-dual-era-northbound-discovery` — scoped server discovery

Merge the stack in order.

## Linear
[RUN-1103](https://linear.app/neuraltrust/issue/RUN-1103/featmcp-add-dual-era-northbound-protocol-boundary)

## Size exception rationale
This slice exceeds the 400-line review budget because the response adapter requires behavioral coverage across tools, prompts, resources, raw JSON precision, reserved-field ownership, error mapping, and concurrent schema immutability. Production changes remain isolated to the MCP transport package. The repository has no `size:exception` label to request.

## Test plan
- [x] `go test -race ./pkg/api/handler/http/mcp ./pkg/app/mcp`
- [x] `go vet ./...`
- [x] `golangci-lint run`
- [x] `make license-check`
- [x] feature-wide reviewer and security scan

Made with [Cursor](https://cursor.com)