### PR TITLE
fix: preserve OpenAI custom tools through the canonical model (ENG-1281)

### DIFF
--- a/pkg/app/proxy/provider_stream.go
+++ b/pkg/app/proxy/provider_stream.go
@@ -76,6 +76,7 @@ func injectStreamIncludeUsage(body []byte) []byte {
 // toolCallEntry holds accumulated tool call data for a single index.
 type toolCallEntry struct {
 	ID   string
+	Kind adapter.CanonicalToolKind
 	Name string
 	Args string
 }
@@ -96,7 +97,7 @@ func (a *toolCallAccumulator) Merge(deltas []adapter.StreamToolCallDelta) {
 		tc := &deltas[i]
 		cur := (*a)[tc.Index]
 		if cur == nil {
-			cur = &toolCallEntry{ID: tc.ID, Name: tc.Name}
+			cur = &toolCallEntry{ID: tc.ID, Kind: tc.Kind, Name: tc.Name}
 			(*a)[tc.Index] = cur
 		}
 		if tc.Name != "" {
@@ -104,6 +105,9 @@ func (a *toolCallAccumulator) Merge(deltas []adapter.StreamToolCallDelta) {
 		}
 		if tc.ID != "" {
 			cur.ID = tc.ID
+		}
+		if tc.Kind != adapter.ToolKindFunction {
+			cur.Kind = tc.Kind
 		}
 		cur.Args += tc.ArgumentsDelta
 	}
@@ -125,6 +129,7 @@ func (a *toolCallAccumulator) Flush() []adapter.StreamToolCallDelta {
 		deltas = append(deltas, adapter.StreamToolCallDelta{
 			Index:          idx,
 			ID:             cur.ID,
+			Kind:           cur.Kind,
 			Name:           cur.Name,
 			ArgumentsDelta: cur.Args,
 		})

--- a/pkg/app/proxy/stream_toolcall_coalesce.go
+++ b/pkg/app/proxy/stream_toolcall_coalesce.go
@@ -142,7 +142,20 @@ func (c *toolCallCoalescer) merge(rawCalls []any) {
 		if id, ok := m["id"].(string); ok {
 			d.ID = id
 		}
-		if fn, ok := m["function"].(map[string]any); ok {
+		if kind, ok := m["type"].(string); ok && kind == "custom" {
+			d.Kind = adapter.ToolKindCustom
+		}
+		// A custom tool call streams its freeform payload under custom.input;
+		// later fragments may omit the type, so the payload key decides.
+		if custom, ok := m["custom"].(map[string]any); ok {
+			d.Kind = adapter.ToolKindCustom
+			if name, ok := custom["name"].(string); ok {
+				d.Name = name
+			}
+			if input, ok := custom["input"].(string); ok {
+				d.ArgumentsDelta = input
+			}
+		} else if fn, ok := m["function"].(map[string]any); ok {
 			if name, ok := fn["name"].(string); ok {
 				d.Name = name
 			}
@@ -176,15 +189,21 @@ func (c *toolCallCoalescer) flushLines() [][]byte {
 	deltas := c.acc.Flush()
 	toolCalls := make([]any, 0, len(deltas))
 	for _, d := range deltas {
-		toolCalls = append(toolCalls, map[string]any{
-			"index": d.Index,
-			"id":    d.ID,
-			"type":  "function",
-			"function": map[string]any{
+		call := map[string]any{"index": d.Index, "id": d.ID}
+		if d.Kind == adapter.ToolKindCustom {
+			call["type"] = "custom"
+			call["custom"] = map[string]any{
+				"name":  d.Name,
+				"input": d.ArgumentsDelta,
+			}
+		} else {
+			call["type"] = "function"
+			call["function"] = map[string]any{
 				"name":      d.Name,
 				"arguments": d.ArgumentsDelta,
-			},
-		})
+			}
+		}
+		toolCalls = append(toolCalls, call)
 	}
 	chunk := make(map[string]any, len(c.envelope)+1)
 	for k, v := range c.envelope {

--- a/pkg/app/proxy/stream_toolcall_coalesce_test.go
+++ b/pkg/app/proxy/stream_toolcall_coalesce_test.go
@@ -106,6 +106,39 @@ func TestCoalesceOpenAIToolCallStream_MergesFragmentedArguments(t *testing.T) {
 	assert.Contains(t, out, "data: [DONE]")
 }
 
+// GPT-5 custom tool calls stream their freeform payload under custom.input.
+// Coalescing them into a function call loses both the name and the input, so
+// the client sees an unusable tool call (ENG-1281).
+func TestCoalesceOpenAIToolCallStream_MergesCustomToolCall(t *testing.T) {
+	out := collectLines(t, coalesceOpenAIToolCallStream(linesSeq(
+		`data: {"id":"c1","object":"chat.completion.chunk","model":"gpt-5.1","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_1","type":"custom","custom":{"name":"bash","input":""}}]},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"c1","object":"chat.completion.chunk","model":"gpt-5.1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"custom":{"input":"ls -la "}}]},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"c1","object":"chat.completion.chunk","model":"gpt-5.1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"custom":{"input":"/tmp"}}]},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"c1","object":"chat.completion.chunk","model":"gpt-5.1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		``,
+		`data: [DONE]`,
+		``,
+	)))
+
+	chunks := dataChunks(t, out)
+	require.Len(t, chunks, 3)
+
+	calls := chunkToolCalls(chunks[1])
+	require.Len(t, calls, 1)
+	call := calls[0].(map[string]any)
+	assert.Equal(t, "call_1", call["id"])
+	assert.Equal(t, "custom", call["type"])
+	assert.Nil(t, call["function"], "a custom call must not be coalesced into a function")
+
+	custom, ok := call["custom"].(map[string]any)
+	require.True(t, ok, "custom payload must survive: %v", call)
+	assert.Equal(t, "bash", custom["name"])
+	assert.Equal(t, "ls -la /tmp", custom["input"], "fragmented input must be reassembled")
+}
+
 func TestCoalesceOpenAIToolCallStream_ContentOnlyPassthroughVerbatim(t *testing.T) {
 	in := []string{
 		`data: {"id":"c1","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,

--- a/pkg/infra/providers/adapter/canonical.go
+++ b/pkg/infra/providers/adapter/canonical.go
@@ -23,20 +23,20 @@ const MetadataUsageKey = "usage"
 
 // CanonicalRequest is the internal neutral representation of any AI provider
 type CanonicalRequest struct {
-	Model          string                 `json:"model,omitempty"`
-	System         string                 `json:"system,omitempty"`
-	Messages       []CanonicalMessage     `json:"messages,omitempty"`
-	Tools          []CanonicalTool        `json:"tools,omitempty"`
-	ToolChoice     *CanonicalToolChoice   `json:"tool_choice,omitempty"`
-	MaxTokens      int                    `json:"max_tokens,omitempty"`
-	Temperature    *float64               `json:"temperature,omitempty"`
-	TopP           *float64               `json:"top_p,omitempty"`
-	TopK           *int                   `json:"top_k,omitempty"`
-	Stop           []string               `json:"stop,omitempty"`
-	Stream         bool                   `json:"stream,omitempty"`
-	ResponseFormat *CanonicalRespFormat          `json:"response_format,omitempty"`
-	Metadata       map[string]interface{}        `json:"metadata,omitempty"`
-	RequestExtensions map[string]json.RawMessage   `json:"request_extensions,omitempty"`
+	Model             string                     `json:"model,omitempty"`
+	System            string                     `json:"system,omitempty"`
+	Messages          []CanonicalMessage         `json:"messages,omitempty"`
+	Tools             []CanonicalTool            `json:"tools,omitempty"`
+	ToolChoice        *CanonicalToolChoice       `json:"tool_choice,omitempty"`
+	MaxTokens         int                        `json:"max_tokens,omitempty"`
+	Temperature       *float64                   `json:"temperature,omitempty"`
+	TopP              *float64                   `json:"top_p,omitempty"`
+	TopK              *int                       `json:"top_k,omitempty"`
+	Stop              []string                   `json:"stop,omitempty"`
+	Stream            bool                       `json:"stream,omitempty"`
+	ResponseFormat    *CanonicalRespFormat       `json:"response_format,omitempty"`
+	Metadata          map[string]interface{}     `json:"metadata,omitempty"`
+	RequestExtensions map[string]json.RawMessage `json:"request_extensions,omitempty"`
 }
 
 // CanonicalMessage represents a single turn in the conversation.
@@ -47,11 +47,28 @@ type CanonicalMessage struct {
 	ToolCallID string              `json:"tool_call_id,omitempty"`
 }
 
+// CanonicalToolKind distinguishes the tool shapes the gateway can represent.
+// The zero value is ToolKindFunction so tools built before custom tools existed
+// keep their meaning.
+type CanonicalToolKind string
+
+const (
+	// ToolKindFunction is a JSON-schema tool (OpenAI "function", Anthropic tool).
+	ToolKindFunction CanonicalToolKind = ""
+	// ToolKindCustom is a freeform tool that takes raw text instead of a JSON
+	// schema (OpenAI "custom" tools, introduced with GPT-5).
+	ToolKindCustom CanonicalToolKind = "custom"
+)
+
 // CanonicalTool represents a tool/function the model can call.
 type CanonicalTool struct {
+	Kind        CanonicalToolKind      `json:"kind,omitempty"`
 	Name        string                 `json:"name"`
 	Description string                 `json:"description,omitempty"`
 	Schema      map[string]interface{} `json:"schema,omitempty"`
+	// Format carries the grammar/format payload of a ToolKindCustom tool
+	// verbatim. It is nil for function tools.
+	Format json.RawMessage `json:"format,omitempty"`
 }
 
 // CanonicalToolChoice controls how the model selects tools.
@@ -64,9 +81,12 @@ type CanonicalToolChoice struct {
 
 // CanonicalToolCall represents a tool invocation by the model.
 type CanonicalToolCall struct {
-	ID        string `json:"id"`
-	Name      string `json:"name"`
-	Arguments string `json:"arguments"` // raw JSON string
+	ID   string            `json:"id"`
+	Kind CanonicalToolKind `json:"kind,omitempty"`
+	Name string            `json:"name"`
+	// Arguments holds a raw JSON string for function calls and the freeform
+	// text input for ToolKindCustom calls.
+	Arguments string `json:"arguments"`
 }
 
 // CanonicalRespFormat controls the response format.
@@ -143,10 +163,13 @@ func newCanonicalUsage(in, out, total int) *CanonicalUsage {
 // StreamToolCallDelta is one tool-call delta in a streamed response (OpenAI
 // streams tool_calls with incremental arguments; Anthropic uses input_json_delta).
 type StreamToolCallDelta struct {
-	Index          int    `json:"index"`
-	ID             string `json:"id,omitempty"`
-	Name           string `json:"name,omitempty"`
-	ArgumentsDelta string `json:"arguments_delta,omitempty"` // incremental piece
+	Index int               `json:"index"`
+	ID    string            `json:"id,omitempty"`
+	Kind  CanonicalToolKind `json:"kind,omitempty"`
+	Name  string            `json:"name,omitempty"`
+	// ArgumentsDelta is an incremental piece of the JSON arguments, or of the
+	// freeform text input when Kind is ToolKindCustom.
+	ArgumentsDelta string `json:"arguments_delta,omitempty"`
 }
 
 // CanonicalStreamChunk is one piece of a streamed response.

--- a/pkg/infra/providers/adapter/openai_completions_adapter.go
+++ b/pkg/infra/providers/adapter/openai_completions_adapter.go
@@ -47,8 +47,18 @@ type openaiMessage struct {
 }
 
 type openaiTool struct {
-	Type     string         `json:"type"`
-	Function openaiFunction `json:"function"`
+	Type     string            `json:"type"`
+	Function *openaiFunction   `json:"function,omitempty"`
+	Custom   *openaiCustomTool `json:"custom,omitempty"`
+}
+
+// openaiCustomTool is the freeform tool shape GPT-5 models accept. Format is
+// kept as raw JSON because its grammar payload is not part of the canonical
+// model and must survive a round-trip untouched.
+type openaiCustomTool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Format      json.RawMessage `json:"format,omitempty"`
 }
 
 type openaiFunction struct {
@@ -58,14 +68,54 @@ type openaiFunction struct {
 }
 
 type openaiToolCall struct {
-	ID       string         `json:"id"`
-	Type     string         `json:"type"`
-	Function openaiCallFunc `json:"function"`
+	ID       string            `json:"id"`
+	Type     string            `json:"type"`
+	Function *openaiCallFunc   `json:"function,omitempty"`
+	Custom   *openaiCustomCall `json:"custom,omitempty"`
 }
 
 type openaiCallFunc struct {
 	Name      string `json:"name"`
 	Arguments string `json:"arguments"`
+}
+
+// openaiCustomCall is how GPT-5 models invoke a freeform "custom" tool: the
+// payload is raw text rather than JSON arguments.
+type openaiCustomCall struct {
+	Name  string `json:"name"`
+	Input string `json:"input"`
+}
+
+func decodeOpenAIToolCall(tc openaiToolCall) CanonicalToolCall {
+	if tc.Type == "custom" && tc.Custom != nil {
+		return CanonicalToolCall{
+			ID:        tc.ID,
+			Kind:      ToolKindCustom,
+			Name:      tc.Custom.Name,
+			Arguments: tc.Custom.Input,
+		}
+	}
+	call := CanonicalToolCall{ID: tc.ID}
+	if tc.Function != nil {
+		call.Name = tc.Function.Name
+		call.Arguments = tc.Function.Arguments
+	}
+	return call
+}
+
+func encodeOpenAIToolCall(tc CanonicalToolCall) openaiToolCall {
+	if tc.Kind == ToolKindCustom {
+		return openaiToolCall{
+			ID:     tc.ID,
+			Type:   "custom",
+			Custom: &openaiCustomCall{Name: tc.Name, Input: tc.Arguments},
+		}
+	}
+	return openaiToolCall{
+		ID:       tc.ID,
+		Type:     "function",
+		Function: &openaiCallFunc{Name: tc.Name, Arguments: tc.Arguments},
+	}
 }
 
 type openaiRespFormat struct {
@@ -146,15 +196,37 @@ type openaiStreamDelta struct {
 }
 
 type openaiStreamToolCall struct {
-	Index    int                    `json:"index"`
-	ID       string                 `json:"id,omitempty"`
-	Type     string                 `json:"type,omitempty"`
-	Function openaiStreamToolCallFn `json:"function,omitempty"`
+	Index    int                     `json:"index"`
+	ID       string                  `json:"id,omitempty"`
+	Type     string                  `json:"type,omitempty"`
+	Function *openaiStreamToolCallFn `json:"function,omitempty"`
+	Custom   *openaiStreamToolCallFn `json:"custom,omitempty"`
 }
 
+// openaiStreamToolCallFn carries the incremental name/payload of a streamed
+// tool call. Custom tool calls stream their freeform text under "input"
+// instead of "arguments", so both keys are decoded into Arguments.
 type openaiStreamToolCallFn struct {
 	Name      string `json:"name,omitempty"`
 	Arguments string `json:"arguments,omitempty"`
+	Input     string `json:"input,omitempty"`
+}
+
+func (f *openaiStreamToolCallFn) payload() string {
+	if f == nil {
+		return ""
+	}
+	if f.Input != "" {
+		return f.Input
+	}
+	return f.Arguments
+}
+
+func (f *openaiStreamToolCallFn) name() string {
+	if f == nil {
+		return ""
+	}
+	return f.Name
 }
 
 // ---------------------------------------------------------------------------
@@ -199,11 +271,7 @@ func decodeCompletionsRequest(body []byte) (*CanonicalRequest, error) {
 			ToolCallID: m.ToolCallID,
 		}
 		for _, tc := range m.ToolCalls {
-			cm.ToolCalls = append(cm.ToolCalls, CanonicalToolCall{
-				ID:        tc.ID,
-				Name:      tc.Function.Name,
-				Arguments: tc.Function.Arguments,
-			})
+			cm.ToolCalls = append(cm.ToolCalls, decodeOpenAIToolCall(tc))
 		}
 
 		if m.Role == "system" || m.Role == "developer" {
@@ -217,11 +285,21 @@ func decodeCompletionsRequest(body []byte) (*CanonicalRequest, error) {
 	}
 
 	for _, t := range req.Tools {
-		cr.Tools = append(cr.Tools, CanonicalTool{
-			Name:        t.Function.Name,
-			Description: t.Function.Description,
-			Schema:      t.Function.Parameters,
-		})
+		switch {
+		case t.Type == "custom" && t.Custom != nil:
+			cr.Tools = append(cr.Tools, CanonicalTool{
+				Kind:        ToolKindCustom,
+				Name:        t.Custom.Name,
+				Description: t.Custom.Description,
+				Format:      t.Custom.Format,
+			})
+		case t.Function != nil:
+			cr.Tools = append(cr.Tools, CanonicalTool{
+				Name:        t.Function.Name,
+				Description: t.Function.Description,
+				Schema:      t.Function.Parameters,
+			})
+		}
 	}
 
 	cr.ToolChoice = decodeOpenAIToolChoice(req.ToolChoice)
@@ -269,22 +347,26 @@ func encodeCompletionsRequest(req *CanonicalRequest) ([]byte, error) {
 			ToolCallID: m.ToolCallID,
 		}
 		for _, tc := range m.ToolCalls {
-			msg.ToolCalls = append(msg.ToolCalls, openaiToolCall{
-				ID:   tc.ID,
-				Type: "function",
-				Function: openaiCallFunc{
-					Name:      tc.Name,
-					Arguments: tc.Arguments,
-				},
-			})
+			msg.ToolCalls = append(msg.ToolCalls, encodeOpenAIToolCall(tc))
 		}
 		out.Messages = append(out.Messages, msg)
 	}
 
 	for _, t := range req.Tools {
+		if t.Kind == ToolKindCustom {
+			out.Tools = append(out.Tools, openaiTool{
+				Type: "custom",
+				Custom: &openaiCustomTool{
+					Name:        t.Name,
+					Description: t.Description,
+					Format:      t.Format,
+				},
+			})
+			continue
+		}
 		out.Tools = append(out.Tools, openaiTool{
 			Type: "function",
-			Function: openaiFunction{
+			Function: &openaiFunction{
 				Name:        t.Name,
 				Description: t.Description,
 				Parameters:  t.Schema,
@@ -323,11 +405,7 @@ func decodeCompletionsResponse(body []byte) (*CanonicalResponse, error) {
 				cr.Content = strings.TrimSpace(*choice.Message.Refusal)
 			}
 			for _, tc := range choice.Message.ToolCalls {
-				cr.ToolCalls = append(cr.ToolCalls, CanonicalToolCall{
-					ID:        tc.ID,
-					Name:      tc.Function.Name,
-					Arguments: tc.Function.Arguments,
-				})
+				cr.ToolCalls = append(cr.ToolCalls, decodeOpenAIToolCall(tc))
 			}
 		}
 		cr.FinishReason = choice.FinishReason
@@ -367,14 +445,7 @@ func encodeCompletionsResponse(resp *CanonicalResponse) ([]byte, error) {
 		Content: stringToContent(resp.Content),
 	}
 	for _, tc := range resp.ToolCalls {
-		msg.ToolCalls = append(msg.ToolCalls, openaiToolCall{
-			ID:   tc.ID,
-			Type: "function",
-			Function: openaiCallFunc{
-				Name:      tc.Name,
-				Arguments: tc.Arguments,
-			},
-		})
+		msg.ToolCalls = append(msg.ToolCalls, encodeOpenAIToolCall(tc))
 	}
 
 	out := openaiResponse{
@@ -439,12 +510,16 @@ func decodeCompletionsStreamChunk(chunk []byte) (*CanonicalStreamChunk, error) {
 			sc.FinishReason = *choice.FinishReason
 		}
 		for _, tc := range delta.ToolCalls {
-			sc.ToolCallDeltas = append(sc.ToolCallDeltas, StreamToolCallDelta{
-				Index:          tc.Index,
-				ID:             tc.ID,
-				Name:           tc.Function.Name,
-				ArgumentsDelta: tc.Function.Arguments,
-			})
+			scd := StreamToolCallDelta{Index: tc.Index, ID: tc.ID}
+			if tc.Type == "custom" || tc.Custom != nil {
+				scd.Kind = ToolKindCustom
+				scd.Name = tc.Custom.name()
+				scd.ArgumentsDelta = tc.Custom.payload()
+			} else {
+				scd.Name = tc.Function.name()
+				scd.ArgumentsDelta = tc.Function.payload()
+			}
+			sc.ToolCallDeltas = append(sc.ToolCallDeltas, scd)
 		}
 	}
 
@@ -481,11 +556,20 @@ func encodeCompletionsStreamChunk(chunk *CanonicalStreamChunk) ([][]byte, error)
 		ReasoningContent: chunk.ReasoningDelta,
 	}
 	for _, tc := range chunk.ToolCallDeltas {
+		if tc.Kind == ToolKindCustom {
+			delta.ToolCalls = append(delta.ToolCalls, openaiStreamToolCall{
+				Index:  tc.Index,
+				ID:     tc.ID,
+				Type:   "custom",
+				Custom: &openaiStreamToolCallFn{Name: tc.Name, Input: tc.ArgumentsDelta},
+			})
+			continue
+		}
 		delta.ToolCalls = append(delta.ToolCalls, openaiStreamToolCall{
 			Index: tc.Index,
 			ID:    tc.ID,
 			Type:  "function",
-			Function: openaiStreamToolCallFn{
+			Function: &openaiStreamToolCallFn{
 				Name:      tc.Name,
 				Arguments: tc.ArgumentsDelta,
 			},

--- a/pkg/infra/providers/adapter/openai_completions_adapter_test.go
+++ b/pkg/infra/providers/adapter/openai_completions_adapter_test.go
@@ -165,3 +165,203 @@ func TestCanonical_OpenAI_Completions_DeveloperAndRefusal(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "I cannot help with that.", cresp.Content)
 }
+
+// GPT-5 models accept freeform "custom" tools alongside classic "function"
+// tools. A canonical round-trip must not turn one into the other (ENG-1281).
+func TestCanonical_OpenAI_Completions_CustomToolRoundtrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		tool  string
+		check func(t *testing.T, canonical CanonicalTool, encoded map[string]any)
+	}{
+		{
+			name: "custom tool keeps its type, name and format",
+			tool: `{"type":"custom","custom":{"name":"bash","description":"Run a shell command","format":{"type":"grammar","syntax":"lark","definition":"start: /.+/"}}}`,
+			check: func(t *testing.T, canonical CanonicalTool, encoded map[string]any) {
+				assert.Equal(t, ToolKindCustom, canonical.Kind)
+				assert.Equal(t, "bash", canonical.Name)
+				assert.Equal(t, "Run a shell command", canonical.Description)
+
+				assert.Equal(t, "custom", encoded["type"])
+				assert.Nil(t, encoded["function"], "a custom tool must not be emitted as a function")
+
+				custom, ok := encoded["custom"].(map[string]any)
+				require.True(t, ok, "custom payload must survive: %v", encoded)
+				assert.Equal(t, "bash", custom["name"])
+				format, ok := custom["format"].(map[string]any)
+				require.True(t, ok, "format must survive verbatim: %v", custom)
+				assert.Equal(t, "lark", format["syntax"])
+				assert.Equal(t, "start: /.+/", format["definition"])
+			},
+		},
+		{
+			name: "custom tool without a format stays a custom tool",
+			tool: `{"type":"custom","custom":{"name":"freeform"}}`,
+			check: func(t *testing.T, canonical CanonicalTool, encoded map[string]any) {
+				assert.Equal(t, ToolKindCustom, canonical.Kind)
+				assert.Equal(t, "freeform", canonical.Name)
+				assert.Equal(t, "custom", encoded["type"])
+				custom, ok := encoded["custom"].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, "freeform", custom["name"])
+			},
+		},
+		{
+			name: "function tool is unaffected",
+			tool: `{"type":"function","function":{"name":"read_file","description":"Read","parameters":{"type":"object","properties":{"p":{"type":"string"}}}}}`,
+			check: func(t *testing.T, canonical CanonicalTool, encoded map[string]any) {
+				assert.Equal(t, ToolKindFunction, canonical.Kind)
+				assert.Equal(t, "read_file", canonical.Name)
+				assert.Equal(t, "function", encoded["type"])
+				assert.Nil(t, encoded["custom"])
+				fn, ok := encoded["function"].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, "read_file", fn["name"])
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			a := &OpenAIAdapter{}
+			body := `{"model":"gpt-5.1","messages":[{"role":"user","content":"hi"}],"tools":[` + tc.tool + `]}`
+
+			canonical, err := a.DecodeRequest([]byte(body))
+			require.NoError(t, err)
+			require.Len(t, canonical.Tools, 1)
+
+			encoded, err := a.EncodeRequest(canonical)
+			require.NoError(t, err)
+
+			var out struct {
+				Tools []map[string]any `json:"tools"`
+			}
+			require.NoError(t, json.Unmarshal(encoded, &out))
+			require.Len(t, out.Tools, 1)
+
+			tc.check(t, canonical.Tools[0], out.Tools[0])
+		})
+	}
+}
+
+// An agent loop replays previous custom tool calls in the message history, so
+// the call shape must round-trip as faithfully as the tool declaration.
+func TestCanonical_OpenAI_Completions_CustomToolCallRoundtrip(t *testing.T) {
+	a := &OpenAIAdapter{}
+	body := `{
+		"model":"gpt-5.1",
+		"messages":[
+			{"role":"user","content":"run ls"},
+			{"role":"assistant","tool_calls":[
+				{"id":"call_1","type":"custom","custom":{"name":"bash","input":"ls -la /tmp"}},
+				{"id":"call_2","type":"function","function":{"name":"read_file","arguments":"{\"p\":\"a.txt\"}"}}
+			]},
+			{"role":"tool","tool_call_id":"call_1","content":"total 0"}
+		]
+	}`
+
+	cr, err := a.DecodeRequest([]byte(body))
+	require.NoError(t, err)
+	require.Len(t, cr.Messages, 3)
+
+	calls := cr.Messages[1].ToolCalls
+	require.Len(t, calls, 2)
+	assert.Equal(t, ToolKindCustom, calls[0].Kind)
+	assert.Equal(t, "bash", calls[0].Name)
+	assert.Equal(t, "ls -la /tmp", calls[0].Arguments, "freeform input is carried in Arguments")
+	assert.Equal(t, ToolKindFunction, calls[1].Kind)
+	assert.Equal(t, "read_file", calls[1].Name)
+
+	encoded, err := a.EncodeRequest(cr)
+	require.NoError(t, err)
+
+	var out struct {
+		Messages []struct {
+			Role      string           `json:"role"`
+			ToolCalls []map[string]any `json:"tool_calls"`
+		} `json:"messages"`
+	}
+	require.NoError(t, json.Unmarshal(encoded, &out))
+
+	var assistant []map[string]any
+	for _, m := range out.Messages {
+		if m.Role == "assistant" {
+			assistant = m.ToolCalls
+		}
+	}
+	require.Len(t, assistant, 2)
+
+	assert.Equal(t, "custom", assistant[0]["type"])
+	assert.Nil(t, assistant[0]["function"])
+	custom, ok := assistant[0]["custom"].(map[string]any)
+	require.True(t, ok, "custom call payload must survive: %v", assistant[0])
+	assert.Equal(t, "bash", custom["name"])
+	assert.Equal(t, "ls -la /tmp", custom["input"])
+
+	assert.Equal(t, "function", assistant[1]["type"])
+	assert.Nil(t, assistant[1]["custom"])
+}
+
+// Streamed custom tool calls put their freeform payload under "input" rather
+// than "arguments"; re-encoding a chunk must not flatten them into an empty
+// function call (ENG-1281).
+func TestCanonical_OpenAI_Completions_CustomToolCallStreamRoundtrip(t *testing.T) {
+	a := &OpenAIAdapter{}
+	chunks := []string{
+		`{"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"custom","custom":{"name":"bash"}}]}}]}`,
+		`{"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"custom":{"input":"ls -la"}}]}}]}`,
+	}
+
+	var name, input string
+	for _, raw := range chunks {
+		sc, err := a.DecodeStreamChunk([]byte(raw))
+		require.NoError(t, err)
+		require.Len(t, sc.ToolCallDeltas, 1)
+		delta := sc.ToolCallDeltas[0]
+		assert.Equal(t, ToolKindCustom, delta.Kind)
+		if delta.Name != "" {
+			name = delta.Name
+		}
+		input += delta.ArgumentsDelta
+
+		lines, err := a.EncodeStreamChunk(sc)
+		require.NoError(t, err)
+		require.NotEmpty(t, lines)
+
+		payload := string(lines[0])
+		assert.Contains(t, payload, `"type":"custom"`)
+		assert.NotContains(t, payload, `"function"`, "a custom call must not be re-encoded as a function")
+	}
+
+	assert.Equal(t, "bash", name)
+	assert.Equal(t, "ls -la", input)
+}
+
+// Tool-rewriting plugins re-encode the canonical request; a custom tool that
+// survives the cycle must still be filterable by name.
+func TestCanonical_OpenAI_Completions_CustomToolIsNamedForPlugins(t *testing.T) {
+	a := &OpenAIAdapter{}
+	body := `{"model":"gpt-5.1","messages":[{"role":"user","content":"hi"}],"tools":[
+		{"type":"function","function":{"name":"read_file","parameters":{"type":"object"}}},
+		{"type":"custom","custom":{"name":"bash","format":{"type":"text"}}}
+	]}`
+
+	canonical, err := a.DecodeRequest([]byte(body))
+	require.NoError(t, err)
+	require.Len(t, canonical.Tools, 2)
+
+	names := []string{canonical.Tools[0].Name, canonical.Tools[1].Name}
+	assert.Equal(t, []string{"read_file", "bash"}, names)
+
+	canonical.Tools = canonical.Tools[1:]
+	encoded, err := a.EncodeRequest(canonical)
+	require.NoError(t, err)
+
+	var out struct {
+		Tools []map[string]any `json:"tools"`
+	}
+	require.NoError(t, json.Unmarshal(encoded, &out))
+	require.Len(t, out.Tools, 1)
+	assert.Equal(t, "custom", out.Tools[0]["type"])
+}

--- a/pkg/infra/providers/adapter/openai_responses_adapter.go
+++ b/pkg/infra/providers/adapter/openai_responses_adapter.go
@@ -58,6 +58,7 @@ type openaiResponsesTool struct {
 	Name        string                 `json:"name"`
 	Description string                 `json:"description,omitempty"`
 	Parameters  map[string]interface{} `json:"parameters,omitempty"`
+	Format      json.RawMessage        `json:"format,omitempty"`
 	Strict      *bool                  `json:"strict,omitempty"`
 }
 
@@ -220,14 +221,21 @@ func decodeResponsesRequest(body []byte) (*CanonicalRequest, error) {
 		if json.Unmarshal(raw, &tool) != nil || tool.Name == "" {
 			continue
 		}
-		if tool.Type != "" && tool.Type != "function" {
-			continue
+		switch tool.Type {
+		case "custom":
+			cr.Tools = append(cr.Tools, CanonicalTool{
+				Kind:        ToolKindCustom,
+				Name:        tool.Name,
+				Description: tool.Description,
+				Format:      tool.Format,
+			})
+		case "", "function":
+			cr.Tools = append(cr.Tools, CanonicalTool{
+				Name:        tool.Name,
+				Description: tool.Description,
+				Schema:      tool.Parameters,
+			})
 		}
-		cr.Tools = append(cr.Tools, CanonicalTool{
-			Name:        tool.Name,
-			Description: tool.Description,
-			Schema:      tool.Parameters,
-		})
 	}
 
 	return cr, nil
@@ -495,6 +503,11 @@ func encodeResponsesRequest(req *CanonicalRequest) ([]byte, error) {
 			Name:        t.Name,
 			Description: t.Description,
 			Parameters:  t.Schema,
+		}
+		if t.Kind == ToolKindCustom {
+			tool.Type = "custom"
+			tool.Parameters = nil
+			tool.Format = t.Format
 		}
 		raw, _ := json.Marshal(tool)
 		out.Tools = append(out.Tools, raw)

--- a/pkg/infra/providers/adapter/openai_responses_adapter_test.go
+++ b/pkg/infra/providers/adapter/openai_responses_adapter_test.go
@@ -784,3 +784,39 @@ func TestUsageSubCounts_OpenAIResponses_CachedInput(t *testing.T) {
 	assert.Equal(t, 4, cr.Usage.CachedInputTokens)
 	assert.Equal(t, 5, cr.Usage.InputTokens, "CachedInputTokens is a sub-count; InputTokens must not be reduced")
 }
+
+// Responses API custom tools are flat (no nested "custom" object). They used to
+// be dropped on decode, silently removing the tool from the request (ENG-1281).
+func TestCanonical_OpenAIResponses_CustomToolRoundtrip(t *testing.T) {
+	a := &OpenAIResponsesAdapter{}
+	body := []byte(`{
+		"model":"gpt-5.1",
+		"input":"hi",
+		"tools":[
+			{"type":"function","name":"read_file","parameters":{"type":"object"}},
+			{"type":"custom","name":"bash","description":"Run a shell command","format":{"type":"text"}}
+		]
+	}`)
+
+	cr, err := a.DecodeRequest(body)
+	require.NoError(t, err)
+	require.Len(t, cr.Tools, 2, "custom tools must not be dropped")
+	assert.Equal(t, ToolKindFunction, cr.Tools[0].Kind)
+	assert.Equal(t, ToolKindCustom, cr.Tools[1].Kind)
+	assert.Equal(t, "bash", cr.Tools[1].Name)
+
+	encoded, err := a.EncodeRequest(cr)
+	require.NoError(t, err)
+
+	var out struct {
+		Tools []map[string]any `json:"tools"`
+	}
+	require.NoError(t, json.Unmarshal(encoded, &out))
+	require.Len(t, out.Tools, 2)
+	assert.Equal(t, "function", out.Tools[0]["type"])
+	assert.Equal(t, "custom", out.Tools[1]["type"])
+	assert.Equal(t, "bash", out.Tools[1]["name"])
+	format, ok := out.Tools[1]["format"].(map[string]any)
+	require.True(t, ok, "format must survive: %v", out.Tools[1])
+	assert.Equal(t, "text", format["type"])
+}


### PR DESCRIPTION
## Summary

GPT-5 clients such as Cursor send `custom` tools (freeform text tools) alongside classic `function` tools. TrustGate's canonical model could only express function tools, so custom tools were destroyed whenever a request or response left the byte-exact passthrough path.

Two user-visible failures:

- **Any tool-rewriting plugin corrupts the request.** `tool_allowlist`, `per_tool_rate_limiter` and `tool_injection` re-encode the request through the canonical model, turning every custom tool into `{"type":"function","function":{"name":"","arguments":""}}`. OpenAI rejects it with `Invalid 'tools[N].function.name': empty string`.
- **Streamed custom tool calls arrive unusable.** `coalesceOpenAIToolCallStream` runs on *every* OpenAI-compatible streamed response, plugins or not, and only understood function calls. The client received a tool call with no name and no input — the tool silently never ran.

Naming custom tool calls also restores per-tool budgets for them: `per_tool_rate_limiter` skips tool calls with an empty name, so a budget on a tool declared as `custom` was silently unenforceable.

## Changes

- `CanonicalTool` / `CanonicalToolCall` / `StreamToolCallDelta` gain an explicit `Kind`. The zero value stays `function`, so every existing tool keeps its meaning.
- `CanonicalTool.Format` carries the custom tool's grammar payload verbatim — the gateway does not need to understand it, only to not lose it.
- Completions adapter, Responses adapter and the stream coalescer encode and decode both shapes.

## Test plan

- [x] Unit tests for custom tool declarations, custom tool calls, and the streamed/fragmented custom call, in both adapters and the coalescer
- [x] `go test ./...`, `go vet ./...`, `golangci-lint run` on the touched packages — clean
- [x] End-to-end against the real OpenAI API with TrustGate running locally:
  - [x] custom tool survives `tool_allowlist`, `per_tool_rate_limiter` and `tool_injection` (HTTP 200, tool intact)
  - [x] streamed custom tool call returns `type=custom`, `name=bash`, reassembled input
  - [x] full agent loop: the custom call replayed in the message history is accepted
  - [x] denying the custom tool by name removes it cleanly instead of corrupting it
  - [x] `per_tool_rate_limiter` now counts executed custom tools and strips the tool once over budget
- [x] Regression: function-only tool calls, streaming and non-streaming, unchanged

## Notes

`pkg/infra/providers/adapter/canonical.go` was not `gofmt`-clean on `main`; the struct realignment hunk in that file is the formatter, not a functional change.

## Linear

ENG-1281 — https://linear.app/neuraltrust/issue/ENG-1281/trustgate-cursor-connection-with-gpt-5x-fails

Made with [Cursor](https://cursor.com)