### PR TITLE
fix: accept Cursor's custom tool spelling on chat/completions (ENG-1281)

### DIFF
--- a/pkg/infra/providers/adapter/normalize.go
+++ b/pkg/infra/providers/adapter/normalize.go
@@ -15,6 +15,7 @@
 package adapter
 
 import (
+	"bytes"
 	"encoding/json"
 	"strings"
 
@@ -32,6 +33,9 @@ import (
 //   - Ensures every tools[].function.parameters is a non-empty JSON Schema object.
 //     Gemini cross-format requests often omit parameters; strict OpenAI-wire
 //     upstreams (e.g. Cerebras gpt-oss) reject tools without it.
+//   - Ensures every custom tool is nested under "custom" with its grammar under
+//     format.grammar. Clients targeting GPT-5 models declare custom tools the
+//     Responses way, which chat/completions rejects.
 //
 // The function is a no-op (returns the original body) when no changes are
 // needed, so it is safe to call unconditionally on every OpenAI-bound request.
@@ -88,6 +92,11 @@ func NormalizeOpenAIRequest(body []byte) []byte {
 
 	if toolsRaw, ok := raw["tools"]; ok {
 		if b, toolsChanged := normalizeToolsFunctionParameters(toolsRaw); toolsChanged {
+			toolsRaw = b
+			raw["tools"] = b
+			changed = true
+		}
+		if b, toolsChanged := normalizeCustomTools(toolsRaw); toolsChanged {
 			raw["tools"] = b
 			changed = true
 		}
@@ -136,6 +145,73 @@ func normalizeToolsFunctionParameters(toolsRaw json.RawMessage) (json.RawMessage
 			continue
 		}
 		tools[i]["function"] = fnBytes
+		changed = true
+	}
+	if !changed {
+		return toolsRaw, false
+	}
+	b, err := json.Marshal(tools)
+	if err != nil {
+		return toolsRaw, false
+	}
+	return b, true
+}
+
+// normalizeCustomTools rewrites custom tools spelled the Responses way into the
+// shape chat/completions requires. Clients that target GPT-5 models (Cursor)
+// declare them flat, with name/description/format alongside "type" and the
+// grammar fields alongside format.type; chat/completions demands the payload
+// nested under "custom" and the grammar under format.grammar, and rejects the
+// whole request otherwise (ENG-1281). Tools already in the nested shape are
+// left untouched, so this is idempotent.
+func normalizeCustomTools(toolsRaw json.RawMessage) (json.RawMessage, bool) {
+	if len(toolsRaw) == 0 || string(toolsRaw) == "null" {
+		return toolsRaw, false
+	}
+	var tools []map[string]json.RawMessage
+	if err := json.Unmarshal(toolsRaw, &tools); err != nil {
+		return toolsRaw, false
+	}
+	changed := false
+	for i := range tools {
+		var kind string
+		if json.Unmarshal(tools[i]["type"], &kind) != nil || kind != "custom" {
+			continue
+		}
+
+		custom := map[string]json.RawMessage{}
+		rewritten := false
+		if nested, ok := tools[i]["custom"]; ok && !isEmptyOrNull(nested) {
+			if json.Unmarshal(nested, &custom) != nil {
+				continue
+			}
+		} else {
+			for _, field := range []string{"name", "description", "format"} {
+				if v, ok := tools[i][field]; ok {
+					custom[field] = v
+					delete(tools[i], field)
+				}
+			}
+			if len(custom) == 0 {
+				continue
+			}
+			rewritten = true
+		}
+
+		if format, ok := custom["format"]; ok {
+			if wrapped := wrapCustomToolFormat(format); !bytes.Equal(wrapped, format) {
+				custom["format"] = wrapped
+				rewritten = true
+			}
+		}
+		if !rewritten {
+			continue
+		}
+		b, err := json.Marshal(custom)
+		if err != nil {
+			return toolsRaw, false
+		}
+		tools[i]["custom"] = b
 		changed = true
 	}
 	if !changed {

--- a/pkg/infra/providers/adapter/normalize_test.go
+++ b/pkg/infra/providers/adapter/normalize_test.go
@@ -333,6 +333,86 @@ func TestNormalizeOpenAIRequest_PreservesExistingToolFunctionParameters(t *testi
 	assert.Contains(t, props, "q")
 }
 
+// Cursor sends a chat/completions body whose custom tool is spelled the
+// Responses way. Forwarded verbatim, OpenAI answers "Missing required
+// parameter: tools[N].custom" and the whole turn fails (ENG-1281).
+func TestNormalizeOpenAIRequest_NestsFlatCustomTool(t *testing.T) {
+	input := `{
+		"model": "gpt-5.1",
+		"messages": [{"role": "user", "content": "hello"}],
+		"tools": [
+			{"type": "function", "function": {"name": "read_file", "parameters": {"type": "object", "properties": {"p": {"type": "string"}}}}},
+			{
+				"type": "custom",
+				"name": "ApplyPatch",
+				"description": "Patch files",
+				"format": {"type": "grammar", "syntax": "lark", "definition": "start: /.+/"}
+			}
+		]
+	}`
+
+	out := NormalizeOpenAIRequest([]byte(input))
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(out, &result))
+	tools := result["tools"].([]any)
+	require.Len(t, tools, 2)
+
+	assert.Equal(t, "function", tools[0].(map[string]any)["type"], "function tools must be left alone")
+
+	tool := tools[1].(map[string]any)
+	assert.Equal(t, "custom", tool["type"])
+	assert.NotContains(t, tool, "name", "the flat spelling must be removed")
+	assert.NotContains(t, tool, "format", "the flat spelling must be removed")
+
+	custom := tool["custom"].(map[string]any)
+	assert.Equal(t, "ApplyPatch", custom["name"])
+	assert.Equal(t, "Patch files", custom["description"])
+	format := custom["format"].(map[string]any)
+	assert.Equal(t, "grammar", format["type"])
+	grammar := format["grammar"].(map[string]any)
+	assert.Equal(t, "lark", grammar["syntax"])
+	assert.Equal(t, "start: /.+/", grammar["definition"])
+
+	assert.JSONEq(t, string(out), string(NormalizeOpenAIRequest(out)), "normalization must be idempotent")
+}
+
+func TestNormalizeOpenAIRequest_LeavesWellFormedCustomToolUntouched(t *testing.T) {
+	input := `{
+		"model": "gpt-5.1",
+		"messages": [{"role": "user", "content": "hello"}],
+		"tools": [
+			{
+				"type": "custom",
+				"custom": {
+					"name": "bash",
+					"format": {"type": "grammar", "grammar": {"syntax": "lark", "definition": "start: /.+/"}}
+				}
+			}
+		]
+	}`
+
+	assert.JSONEq(t, input, string(NormalizeOpenAIRequest([]byte(input))))
+}
+
+// A custom tool with no grammar (freeform text) still needs the "custom" nesting.
+func TestNormalizeOpenAIRequest_NestsFlatCustomToolWithoutGrammar(t *testing.T) {
+	input := `{
+		"model": "gpt-5.1",
+		"messages": [{"role": "user", "content": "hello"}],
+		"tools": [{"type": "custom", "name": "freeform", "description": "Anything"}]
+	}`
+
+	out := NormalizeOpenAIRequest([]byte(input))
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(out, &result))
+	custom := result["tools"].([]any)[0].(map[string]any)["custom"].(map[string]any)
+	assert.Equal(t, "freeform", custom["name"])
+	assert.Equal(t, "Anything", custom["description"])
+	assert.NotContains(t, custom, "format")
+}
+
 func TestNormalizeRequestForProvider_Cerebras_InjectsToolParameters(t *testing.T) {
 	input := `{
 		"model": "gpt-oss-120b",

--- a/pkg/infra/providers/adapter/openai_completions_adapter.go
+++ b/pkg/infra/providers/adapter/openai_completions_adapter.go
@@ -50,6 +50,13 @@ type openaiTool struct {
 	Type     string            `json:"type"`
 	Function *openaiFunction   `json:"function,omitempty"`
 	Custom   *openaiCustomTool `json:"custom,omitempty"`
+	// Clients built against the Responses API (Cursor with GPT-5 models) send
+	// custom tools flat, with the payload alongside "type" instead of nested
+	// under "custom". Decoding both shapes keeps such a tool from being
+	// dropped; encoding always emits the nested Chat Completions shape.
+	Name        string          `json:"name,omitempty"`
+	Description string          `json:"description,omitempty"`
+	Format      json.RawMessage `json:"format,omitempty"`
 }
 
 // openaiCustomTool is the freeform tool shape GPT-5 models accept. Format is
@@ -65,6 +72,76 @@ type openaiFunction struct {
 	Name        string                 `json:"name"`
 	Description string                 `json:"description,omitempty"`
 	Parameters  map[string]interface{} `json:"parameters,omitempty"`
+}
+
+// A grammar format is spelled differently on each wire: Chat Completions nests
+// the grammar fields under a "grammar" object, the Responses API keeps them
+// alongside "type". The canonical model stores the flat form, so these two
+// helpers translate on the way in and out. Non-grammar formats (e.g. plain
+// text) are identical on both wires and pass through untouched.
+
+func flattenCustomToolFormat(raw json.RawMessage) json.RawMessage {
+	var format map[string]json.RawMessage
+	if len(raw) == 0 || json.Unmarshal(raw, &format) != nil {
+		return raw
+	}
+	inner, ok := format["grammar"]
+	if !ok {
+		return raw
+	}
+	kind, ok := format["type"]
+	if !ok {
+		return raw
+	}
+	var grammar map[string]json.RawMessage
+	if json.Unmarshal(inner, &grammar) != nil {
+		return raw
+	}
+	flat := map[string]json.RawMessage{"type": kind}
+	for k, v := range grammar {
+		flat[k] = v
+	}
+	out, err := json.Marshal(flat)
+	if err != nil {
+		return raw
+	}
+	return out
+}
+
+func wrapCustomToolFormat(raw json.RawMessage) json.RawMessage {
+	var format map[string]json.RawMessage
+	if len(raw) == 0 || json.Unmarshal(raw, &format) != nil {
+		return raw
+	}
+	if _, already := format["grammar"]; already {
+		return raw
+	}
+	var kind string
+	if err := json.Unmarshal(format["type"], &kind); err != nil || kind != "grammar" {
+		return raw
+	}
+	grammar := make(map[string]json.RawMessage, len(format))
+	for k, v := range format {
+		if k == "type" {
+			continue
+		}
+		grammar[k] = v
+	}
+	if len(grammar) == 0 {
+		return raw
+	}
+	inner, err := json.Marshal(grammar)
+	if err != nil {
+		return raw
+	}
+	out, err := json.Marshal(map[string]json.RawMessage{
+		"type":    format["type"],
+		"grammar": inner,
+	})
+	if err != nil {
+		return raw
+	}
+	return out
 }
 
 type openaiToolCall struct {
@@ -286,12 +363,16 @@ func decodeCompletionsRequest(body []byte) (*CanonicalRequest, error) {
 
 	for _, t := range req.Tools {
 		switch {
-		case t.Type == "custom" && t.Custom != nil:
+		case t.Type == "custom":
+			custom := t.Custom
+			if custom == nil {
+				custom = &openaiCustomTool{Name: t.Name, Description: t.Description, Format: t.Format}
+			}
 			cr.Tools = append(cr.Tools, CanonicalTool{
 				Kind:        ToolKindCustom,
-				Name:        t.Custom.Name,
-				Description: t.Custom.Description,
-				Format:      t.Custom.Format,
+				Name:        custom.Name,
+				Description: custom.Description,
+				Format:      flattenCustomToolFormat(custom.Format),
 			})
 		case t.Function != nil:
 			cr.Tools = append(cr.Tools, CanonicalTool{
@@ -359,7 +440,7 @@ func encodeCompletionsRequest(req *CanonicalRequest) ([]byte, error) {
 				Custom: &openaiCustomTool{
 					Name:        t.Name,
 					Description: t.Description,
-					Format:      t.Format,
+					Format:      wrapCustomToolFormat(t.Format),
 				},
 			})
 			continue

--- a/pkg/infra/providers/adapter/openai_completions_adapter_test.go
+++ b/pkg/infra/providers/adapter/openai_completions_adapter_test.go
@@ -166,6 +166,18 @@ func TestCanonical_OpenAI_Completions_DeveloperAndRefusal(t *testing.T) {
 	assert.Equal(t, "I cannot help with that.", cresp.Content)
 }
 
+// customToolGrammar returns the grammar payload of an encoded custom tool,
+// asserting the nesting chat/completions requires: format.grammar.{syntax,definition}.
+func customToolGrammar(t *testing.T, custom map[string]any) map[string]any {
+	t.Helper()
+	format, ok := custom["format"].(map[string]any)
+	require.True(t, ok, "format must survive: %v", custom)
+	assert.Equal(t, "grammar", format["type"])
+	grammar, ok := format["grammar"].(map[string]any)
+	require.True(t, ok, "chat/completions requires format.grammar: %v", format)
+	return grammar
+}
+
 // GPT-5 models accept freeform "custom" tools alongside classic "function"
 // tools. A canonical round-trip must not turn one into the other (ENG-1281).
 func TestCanonical_OpenAI_Completions_CustomToolRoundtrip(t *testing.T) {
@@ -176,7 +188,7 @@ func TestCanonical_OpenAI_Completions_CustomToolRoundtrip(t *testing.T) {
 	}{
 		{
 			name: "custom tool keeps its type, name and format",
-			tool: `{"type":"custom","custom":{"name":"bash","description":"Run a shell command","format":{"type":"grammar","syntax":"lark","definition":"start: /.+/"}}}`,
+			tool: `{"type":"custom","custom":{"name":"bash","description":"Run a shell command","format":{"type":"grammar","grammar":{"syntax":"lark","definition":"start: /.+/"}}}}`,
 			check: func(t *testing.T, canonical CanonicalTool, encoded map[string]any) {
 				assert.Equal(t, ToolKindCustom, canonical.Kind)
 				assert.Equal(t, "bash", canonical.Name)
@@ -188,10 +200,34 @@ func TestCanonical_OpenAI_Completions_CustomToolRoundtrip(t *testing.T) {
 				custom, ok := encoded["custom"].(map[string]any)
 				require.True(t, ok, "custom payload must survive: %v", encoded)
 				assert.Equal(t, "bash", custom["name"])
-				format, ok := custom["format"].(map[string]any)
-				require.True(t, ok, "format must survive verbatim: %v", custom)
-				assert.Equal(t, "lark", format["syntax"])
-				assert.Equal(t, "start: /.+/", format["definition"])
+				grammar := customToolGrammar(t, custom)
+				assert.Equal(t, "lark", grammar["syntax"])
+				assert.Equal(t, "start: /.+/", grammar["definition"])
+			},
+		},
+		{
+			// Cursor declares custom tools the way the Responses API spells
+			// them, even on a Chat Completions request. Dropping the tool loses
+			// the model's editing capability, and forwarding it verbatim makes
+			// OpenAI reject the call with "Missing required parameter:
+			// tools[N].custom" (ENG-1281).
+			name: "custom tool declared flat is normalised to the nested shape",
+			tool: `{"type":"custom","name":"ApplyPatch","description":"Patch files","format":{"type":"grammar","syntax":"lark","definition":"start: /.+/"}}`,
+			check: func(t *testing.T, canonical CanonicalTool, encoded map[string]any) {
+				assert.Equal(t, ToolKindCustom, canonical.Kind)
+				assert.Equal(t, "ApplyPatch", canonical.Name)
+				assert.Equal(t, "Patch files", canonical.Description)
+
+				assert.Equal(t, "custom", encoded["type"])
+				assert.Nil(t, encoded["name"], "the flat spelling must not survive encoding")
+				assert.Nil(t, encoded["format"], "the flat spelling must not survive encoding")
+
+				custom, ok := encoded["custom"].(map[string]any)
+				require.True(t, ok, "custom payload must be nested: %v", encoded)
+				assert.Equal(t, "ApplyPatch", custom["name"])
+				grammar := customToolGrammar(t, custom)
+				assert.Equal(t, "lark", grammar["syntax"])
+				assert.Equal(t, "start: /.+/", grammar["definition"])
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

Follow-up to #403. That PR stopped custom tools from being flattened into function tools inside the canonical model, but Cursor still failed with:

```
Missing required parameter: 'tools[7].custom'
```

Capturing Cursor's real request showed why. It sends a **chat/completions** body (`messages`, `stream_options`) whose tools are all well-formed `{type, function}` — except one, which is declared the way the **Responses API** spells custom tools:

```jsonc
// what Cursor sends                      // what chat/completions requires
{ "type": "custom",                       { "type": "custom",
  "name": "ApplyPatch",                     "custom": {
  "description": "...",                       "name": "ApplyPatch",
  "format": {                                 "description": "...",
    "type": "grammar",                        "format": {
    "syntax": "lark",                           "type": "grammar",
    "definition": "..."                         "grammar": { "syntax": "lark", "definition": "..." }
  } }                                         } } }
```

Both differences matter, and I confirmed each one against the real OpenAI API:

| Payload sent to `chat/completions` | OpenAI |
|---|---|
| tool declared flat (Cursor's shape) | `Missing required parameter: 'tools[0].custom'` |
| nested tool, but `format` flat | `Missing required parameter: 'tools[0].custom.format.grammar'` |
| nested tool, `format.grammar` nested | 200 |

The gateway was not transforming anything here: in passthrough it forwarded Cursor's body verbatim and OpenAI rejected it. On the canonical path the flat tool was silently dropped instead, costing the model its editing capability.

## Changes

- `normalize.go` — `NormalizeOpenAIRequest` now rewrites custom tools into the nested shape and wraps a flat grammar under `format.grammar`. This runs on **both** paths, so passthrough is covered too. Idempotent: already-correct tools are untouched.
- `openai_completions_adapter.go` — the completions decoder reads the flat spelling as well, so the tool survives a canonical round-trip; `flattenCustomToolFormat` / `wrapCustomToolFormat` translate the grammar between the two wires (the canonical model stores the flat form, which is what the Responses adapter already used).

## Test plan

- [x] Unit tests: flat tool is nested, well-formed tool untouched, normalization is idempotent, flat tool without grammar, cross-wire grammar round-trip
- [x] `go test ./pkg/...` and `golangci-lint run` clean
- [x] **Cursor's captured payload against the real OpenAI API**: before → `Missing required parameter: 'tools[7].custom'`, after → 200
- [x] Same payload end-to-end through a local gateway, both non-streaming and streaming, on a chat/completions target and a `api: responses` target
- [x] Verified on the capture upstream that `ApplyPatch` arrives nested with `format.grammar` intact and no leftover flat keys

## Note

Separately from this PR, `gpt-5.6-sol` refuses function tools on `chat/completions` when `reasoning_effort` is set and demands `/v1/responses`. Gateways serving Cursor with that model still need `provider_options: {"api": "responses"}` in the registry.

ENG-1281 — https://linear.app/neuraltrust/issue/ENG-1281/trustgate-cursor-connection-with-gpt-5x-fails

Made with [Cursor](https://cursor.com)