### PR TITLE
feat: serve the OpenAI chat surface the client asked for (ENG-1281)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2507,9 +2507,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/pkg/app/proxy/provider.go
+++ b/pkg/app/proxy/provider.go
@@ -237,7 +237,7 @@ func (p *providerInvoker) prepare(
 
 	sourceFormat := sourceFormatFromRequest(req)
 	capability := capabilityFromRequest(req)
-	targetFormat := adapter.ResolveTargetFormatForCapability(bk.Provider(), capability, bk.ProviderOptions())
+	targetFormat := adapter.ResolveTargetFormatForCapability(bk.Provider(), capability, sourceFormat, bk.ProviderOptions())
 
 	req.Provider = bk.Provider()
 	req.SourceFormat = string(sourceFormat)
@@ -279,7 +279,7 @@ func (p *providerInvoker) prepare(
 	return &preparedInvocation{
 		client: client,
 		cfg: &providers.Config{
-			Options:       bk.ProviderOptions(),
+			Options:       adapter.OpenAIProviderOptionsForTarget(bk.Provider(), targetFormat, bk.ProviderOptions()),
 			Credentials:   providers.CredentialsFromTargetAuth(bk.Auth()),
 			Model:         sentModel,
 			DefaultModel:  req.DefaultModel,

--- a/pkg/infra/providers/adapter/adapter_test.go
+++ b/pkg/infra/providers/adapter/adapter_test.go
@@ -231,6 +231,115 @@ func TestResolveTargetFormat_OpenAICompatible(t *testing.T) {
 		"openai_compatible must stay Chat Completions regardless of the api option")
 }
 
+// A client picks an OpenAI chat surface by calling either /v1/chat/completions
+// or /v1/responses, and the gateway must serve the one it asked for instead of
+// downgrading a Responses request to Chat Completions.
+func TestResolveTargetFormatForCapability_MirrorsInboundRoute(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		source   Format
+		options  map[string]any
+		want     Format
+	}{
+		{
+			name:     "responses route reaches the responses surface",
+			provider: "openai",
+			source:   FormatOpenAIResponses,
+			want:     FormatOpenAIResponses,
+		},
+		{
+			name:     "completions route reaches the completions surface",
+			provider: "openai",
+			source:   FormatOpenAI,
+			want:     FormatOpenAI,
+		},
+		{
+			// The Azure client only builds chat/completions URLs, so mirroring
+			// there would produce a body its endpoint cannot accept.
+			name:     "azure does not mirror the route",
+			provider: "azure",
+			source:   FormatOpenAIResponses,
+			want:     FormatAzure,
+		},
+		{
+			name:     "azure still honours an explicit api option",
+			provider: "azure",
+			source:   FormatOpenAI,
+			options:  map[string]any{"api": "responses"},
+			want:     FormatOpenAIResponses,
+		},
+		{
+			name:     "an explicit api option overrides the route",
+			provider: "openai",
+			source:   FormatOpenAI,
+			options:  map[string]any{"api": "responses"},
+			want:     FormatOpenAIResponses,
+		},
+		{
+			name:     "an explicit completions option overrides the route",
+			provider: "openai",
+			source:   FormatOpenAIResponses,
+			options:  map[string]any{"api": "completions"},
+			want:     FormatOpenAI,
+		},
+		{
+			name:     "providers with a single chat surface ignore the route",
+			provider: "anthropic",
+			source:   FormatOpenAIResponses,
+			want:     FormatAnthropic,
+		},
+		{
+			name:     "openai_compatible stays chat completions",
+			provider: "openai_compatible",
+			source:   FormatOpenAIResponses,
+			want:     FormatOpenAI,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := ResolveTargetFormatForCapability(tc.provider, "chat", tc.source, tc.options)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// The provider client picks its endpoint from provider_options.api, so the
+// resolved surface has to be restated there or the two decisions can disagree.
+func TestOpenAIProviderOptionsForTarget(t *testing.T) {
+	t.Run("responses target sets the api option", func(t *testing.T) {
+		in := map[string]any{"base_url": "https://host/v1"}
+		got := OpenAIProviderOptionsForTarget("openai", FormatOpenAIResponses, in)
+
+		assert.Equal(t, "responses", got["api"])
+		assert.Equal(t, "https://host/v1", got["base_url"])
+		assert.NotContains(t, in, "api", "the registry options must not be mutated")
+	})
+
+	t.Run("completions target pins the api option", func(t *testing.T) {
+		got := OpenAIProviderOptionsForTarget("openai", FormatOpenAI, nil)
+		assert.Equal(t, "completions", got["api"])
+	})
+
+	t.Run("other providers are left alone", func(t *testing.T) {
+		in := map[string]any{"project": "p"}
+		assert.Equal(t, in, OpenAIProviderOptionsForTarget("vertex", FormatOpenAIResponses, in))
+	})
+}
+
+// Embeddings and rerank have a single surface, so the chat route must not leak
+// into them.
+func TestResolveTargetFormatForCapability_NonChatCapabilitiesIgnoreRoute(t *testing.T) {
+	assert.Equal(t, FormatOpenAIEmbeddings,
+		ResolveTargetFormatForCapability("openai", "embeddings", FormatOpenAIResponses, nil))
+	assert.Equal(t, FormatCohereEmbed,
+		ResolveTargetFormatForCapability("cohere", "embeddings", FormatOpenAIResponses, nil))
+	assert.Equal(t, FormatCohereRerank,
+		ResolveTargetFormatForCapability("cohere", "rerank", FormatOpenAIResponses, nil))
+}
+
 // ---------------------------------------------------------------------------
 // Cross-provider: OpenAI → Anthropic
 // ---------------------------------------------------------------------------

--- a/pkg/infra/providers/adapter/format.go
+++ b/pkg/infra/providers/adapter/format.go
@@ -197,7 +197,13 @@ func ResolveAgentFormat(providerName, sourceFormat string, providerOptions map[s
 }
 
 // ResolveTargetFormatForCapability picks the provider wire format for a proxy capability.
-func ResolveTargetFormatForCapability(providerName string, capability string, providerOptions map[string]any) Format {
+// sourceFormat is the dialect the client spoke, derived from the inbound route.
+func ResolveTargetFormatForCapability(
+	providerName string,
+	capability string,
+	sourceFormat Format,
+	providerOptions map[string]any,
+) Format {
 	switch capability {
 	case "embeddings":
 		if providerName == provider.Cohere {
@@ -207,8 +213,64 @@ func ResolveTargetFormatForCapability(providerName string, capability string, pr
 	case "rerank":
 		return FormatCohereRerank
 	default:
-		return ResolveTargetFormat(providerName, providerOptions)
+		return resolveChatTargetFormat(providerName, sourceFormat, providerOptions)
 	}
+}
+
+// Values accepted by provider_options.api for the OpenAI provider. Duplicated
+// from pkg/infra/providers to keep this package free of that dependency.
+const (
+	OpenAIAPICompletions = "completions"
+	OpenAIAPIResponses   = "responses"
+)
+
+// OpenAI exposes two chat surfaces, and a client picks one by calling either
+// /v1/chat/completions or /v1/responses. Honour that choice: downgrading a
+// Responses request to Chat Completions drops everything the newer surface
+// adds. An explicit provider_options.api still wins, which is the only way to
+// reach a surface the client did not ask for. Azure is excluded from the
+// mirroring because its client only builds chat/completions URLs.
+func resolveChatTargetFormat(providerName string, sourceFormat Format, providerOptions map[string]any) Format {
+	wireFormat := resolveProviderWireFormat(providerName)
+	providerFormat := Format(providerName)
+	if providerFormat != FormatOpenAI && providerFormat != FormatAzure {
+		return wireFormat
+	}
+	if api, ok := providerOptions["api"].(string); ok {
+		switch api {
+		case OpenAIAPIResponses:
+			return FormatOpenAIResponses
+		case OpenAIAPICompletions:
+			return wireFormat
+		}
+	}
+	if providerFormat == FormatOpenAI && sourceFormat == FormatOpenAIResponses {
+		return FormatOpenAIResponses
+	}
+	return wireFormat
+}
+
+// OpenAIProviderOptionsForTarget restates the resolved chat surface in the
+// options handed to the provider client, which picks its endpoint from
+// provider_options.api. Without this the route-derived decision and the URL the
+// client builds could disagree. The input map is never mutated.
+func OpenAIProviderOptionsForTarget(providerName string, targetFormat Format, options map[string]any) map[string]any {
+	if Format(providerName) != FormatOpenAI {
+		return options
+	}
+	api := OpenAIAPICompletions
+	if targetFormat == FormatOpenAIResponses {
+		api = OpenAIAPIResponses
+	}
+	if current, ok := options["api"].(string); ok && current == api {
+		return options
+	}
+	out := make(map[string]any, len(options)+1)
+	for k, v := range options {
+		out[k] = v
+	}
+	out["api"] = api
+	return out
 }
 
 func IsSameWireFormat(a, b Format) bool {

--- a/tests/functional/common_test.go
+++ b/tests/functional/common_test.go
@@ -49,11 +49,16 @@ func CreateGateway(t *testing.T, payload map[string]any) string {
 		payload["tenant_id"] = "functional-tenant"
 	}
 	if _, ok := payload["entitlements"]; !ok {
+		// The API rejects stamped limits unless all three are set, and
+		// max_instances caps gateways per tenant. Every test here shares one
+		// tenant, so a small value would give the whole suite a budget that
+		// the next test to be added would exhaust. Tests that exercise the cap
+		// itself stamp their own entitlements.
 		payload["entitlements"] = map[string]any{
 			"tier":            "free",
 			"burst_per_min":   60,
 			"quota_per_month": 10000,
-			"max_instances":   5,
+			"max_instances":   1000,
 		}
 	}
 	status, body := sendRequest(t, http.MethodPost, AdminURL+"/v1/gateways", nil, payload)

--- a/tests/functional/create_gateway_test.go
+++ b/tests/functional/create_gateway_test.go
@@ -10,12 +10,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// stampedFreeEntitlements is the minimal entitlements block the admin API
+// accepts. max_instances is deliberately far above what the suite creates: it
+// caps gateways per tenant and every test shares one tenant, so a small value
+// would fail whichever test happens to run last.
 func stampedFreeEntitlements() map[string]any {
 	return map[string]any{
 		"tier":            "free",
 		"burst_per_min":   60,
 		"quota_per_month": 10000,
-		"max_instances":   5,
+		"max_instances":   1000,
 	}
 }
 

--- a/tests/functional/payload_normalization_test.go
+++ b/tests/functional/payload_normalization_test.go
@@ -76,7 +76,9 @@ func TestPayloadNormalization_CrossFormat(t *testing.T) {
 		assert.Equal(t, 1, up.Hits())
 	})
 
-	t.Run("responses request to an openai upstream is adapted both ways", func(t *testing.T) {
+	// A client picks an OpenAI chat surface by the route it calls, and the
+	// gateway serves that one instead of downgrading it (ENG-1281).
+	t.Run("responses request to an openai upstream reaches the responses surface", func(t *testing.T) {
 		up := newJSONUpstream(t, "responses-served")
 		apiKey, slug := setupSlugRoute(t, up, []string{"gpt-4o-mini"}, "")
 
@@ -84,13 +86,47 @@ func TestPayloadNormalization_CrossFormat(t *testing.T) {
 		status, _, body := proxyPost(t, apiKey, "/"+slug+"/v1/responses", payload)
 
 		assert.Equal(t, http.StatusOK, status, "body: %s", body)
-		assert.Contains(t, string(body), `"object":"response"`,
-			"the client must receive a responses-format payload")
-		assert.Contains(t, string(body), "responses-served")
 		assert.Equal(t, 1, up.Hits())
+		assert.Equal(t, "/responses", up.LastPath(),
+			"the upstream must be called on the surface the client asked for")
+		assert.Contains(t, string(up.LastBody()), `"input"`,
+			"the responses body must reach the upstream intact")
+		assert.NotContains(t, string(up.LastBody()), `"messages"`,
+			"the request must not be downgraded to chat completions")
+		assert.Contains(t, string(up.LastBody()), `"model":"gpt-4o-mini"`)
+		assert.NotContains(t, string(up.LastBody()), "@openai/",
+			"the routing prefix must never leak upstream")
+	})
+
+	// Setting provider_options.api is the only way to reach a surface the
+	// client did not ask for, and the answer still comes back in the client's
+	// own dialect.
+	t.Run("an explicit completions option overrides the responses route", func(t *testing.T) {
+		up := newJSONUpstream(t, "responses-served")
+		gatewayID := CreateGateway(t, map[string]any{"slug": uniqueName("norm-gw")})
+		backend := openaiBackendPayload(uniqueName("be"), up.URL())
+		backend["provider_options"] = map[string]any{"base_url": up.URL(), "api": "completions"}
+		backendID := CreateRegistry(t, gatewayID, backend)
+		coID := CreateConsumer(t, gatewayID, map[string]any{
+			"name": uniqueName("cons"),
+			"registries": []map[string]any{
+				{"id": backendID, "model_policies": map[string]any{"allowed": []string{"gpt-4o-mini"}}},
+			},
+		})
+		apiKey := createAndAttachAPIKey(t, gatewayID, coID)
+
+		payload := map[string]any{"model": "@openai/gpt-4o-mini", "input": "Hello"}
+		status, _, body := proxyPost(t, apiKey, "/"+ConsumerSlug(t, coID)+"/v1/responses", payload)
+
+		assert.Equal(t, http.StatusOK, status, "body: %s", body)
+		assert.Equal(t, 1, up.Hits())
+		assert.Equal(t, "/chat/completions", up.LastPath(),
+			"the explicit option must win over the inbound route")
 		assert.Contains(t, string(up.LastBody()), `"messages"`,
 			"the upstream must receive a chat-completions body")
-		assert.Contains(t, string(up.LastBody()), `"model":"gpt-4o-mini"`)
+		assert.Contains(t, string(body), `"object":"response"`,
+			"the client must still receive a responses-format payload")
+		assert.Contains(t, string(body), "responses-served")
 	})
 
 	t.Run("gemini request with the model in the path is adapted both ways", func(t *testing.T) {

--- a/tests/functional/proxy_e2e_test.go
+++ b/tests/functional/proxy_e2e_test.go
@@ -27,6 +27,7 @@ type fakeUpstream struct {
 	mu       sync.Mutex
 	lastBody []byte
 	lastAuth string
+	lastPath string
 }
 
 func (u *fakeUpstream) URL() string { return u.server.URL }
@@ -45,12 +46,21 @@ func (u *fakeUpstream) LastAuth() string {
 	return u.lastAuth
 }
 
+// LastPath reports the endpoint the gateway called, which is how a test tells
+// the OpenAI chat surfaces apart.
+func (u *fakeUpstream) LastPath() string {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return u.lastPath
+}
+
 func (u *fakeUpstream) record(r *http.Request) {
 	atomic.AddInt64(&u.hits, 1)
 	body, _ := io.ReadAll(r.Body)
 	u.mu.Lock()
 	u.lastBody = body
 	u.lastAuth = r.Header.Get("Authorization")
+	u.lastPath = r.URL.Path
 	u.mu.Unlock()
 }
 


### PR DESCRIPTION
## Summary

A client picks between OpenAI's two chat surfaces by calling either `/v1/chat/completions` or `/v1/responses`. The gateway ignored that: the inbound route only set the *source* dialect, while the outbound target came solely from `provider_options.api`, defaulting to Chat Completions. A request arriving at `/v1/responses` was therefore converted down to Chat Completions, losing what the newer surface adds.

Now the route is honoured:

| Inbound route | `provider_options.api` | Upstream |
|---|---|---|
| `/v1/responses` | unset | `/v1/responses` |
| `/v1/chat/completions` | unset | `/v1/chat/completions` |
| either | `responses` / `completions` | as configured (override) |

The explicit option is kept because it is the only way to reach a surface the client did not ask for — which some models require (see note).

Two details worth reviewing:

- **Azure is excluded from the mirroring.** Its client only builds `chat/completions` URLs, so mirroring would hand its endpoint a body it cannot accept. Its existing `api: responses` override behaviour is untouched.
- **The resolved surface is restated in the options given to the provider client.** The client picks its endpoint from `provider_options.api`, so without this the routing decision and the URL it builds disagree — I hit exactly that mid-implementation: a Responses body was posted to `/v1/chat/completions` and OpenAI answered `Missing required parameter: 'messages'`.

## Test plan

- [x] Unit tests for both routes, both override values, Azure, non-OpenAI providers, and the non-chat capabilities (embeddings/rerank must ignore the route)
- [x] `go test ./pkg/...` and `golangci-lint run` clean
- [x] End-to-end against a local gateway and the real OpenAI API. Upstream surface verified with a discriminating probe rather than by inspecting logs: `gpt-5.6-sol` with a function tool only succeeds when the request truly lands on `/v1/responses`

```
/v1/responses,        api unset      -> OK, object=response
/v1/chat/completions, api unset      -> refused by OpenAI (proves completions upstream)
/v1/chat/completions, api=responses  -> OK (proves responses upstream), client still gets chat.completion
```

## Context

Found while investigating ENG-1281. The Cursor failure itself turned out to be a **Cursor bug**, not ours: with a base URL override it emits a Chat Completions body whose custom tool is spelled the Responses way, and it fails identically when pointed straight at `https://api.openai.com/v1` with no gateway involved. #404 proposed compensating for that and was closed deliberately — we should not silently repair a payload a client sends incorrectly. This PR only fixes what is genuinely ours.

Unrelated to tool spelling: `gpt-5.6-sol` refuses function tools on `/v1/chat/completions` unless `reasoning_effort` is `none`, so gateways serving that model need the `api: responses` override.

ENG-1281 — https://linear.app/neuraltrust/issue/ENG-1281/trustgate-cursor-connection-with-gpt-5x-fails

Made with [Cursor](https://cursor.com)

---

The last commit bumps `nanoid` in `frontend/package-lock.json`. It is unrelated to the change and belongs to the transitive dependency CVE-2026-67213, which Trivy flags on every branch. It was cherry-picked from #406 so this PR can go green on its own; #406 can be closed.
