### PR TITLE
chore: bump nanoid to 3.3.18 (CVE-2026-67213)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2507,9 +2507,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

Trivy started failing on every new run. `nanoid` before 3.3.17 loops forever in `customAlphabet` when given a non-integer size (CVE-2026-67213, HIGH). It is a transitive dependency of the frontend, so only the lockfile changes: 3 lines.

This is not caused by any recent PR. The CVE was published after the last green run, which is why older PRs still show a passing Trivy check while anything re-run today goes red.

## Verification

Scanned `origin/main` and a feature branch with the same Trivy database:

| Tree | Finding |
|---|---|
| `origin/main` | CVE-2026-67213 · nanoid 3.3.16 · HIGH |
| feature branch (#405) | CVE-2026-67213 · nanoid 3.3.16 · HIGH |

Identical, which rules out the feature branch as the cause. After the bump the same scan reports 0 HIGH/CRITICAL findings.

## Test plan

- [x] `trivy fs --scanners vuln --severity HIGH,CRITICAL` clean after the bump
- [x] Lockfile-only change, patch version within the existing semver range
- [ ] CI green

Unblocks #405.

Made with [Cursor](https://cursor.com)