### PR TITLE
feat: support per-tier model on smart routing

### DIFF
--- a/pkg/api/handler/http/consumer/request/create_consumer_request.go
+++ b/pkg/api/handler/http/consumer/request/create_consumer_request.go
@@ -115,6 +115,10 @@ type SmartRoutingConfigRequest struct {
 type SmartRoutingTierRequest struct {
 	MinScore   float64 `json:"min_score"`
 	RegistryID string  `json:"registry_id"`
+	// Model is an optional per-tier default override. When set, smart routing
+	// injects this model after selecting the tier's registry by score. Multiple
+	// tiers may share a registry_id with different models.
+	Model string `json:"model,omitempty"`
 }
 
 type LBPoolMemberRequest struct {
@@ -175,6 +179,7 @@ func (s *SmartRoutingConfigRequest) ToDomain() (*registrydomain.SmartRoutingConf
 		tiers = append(tiers, registrydomain.SmartRoutingTier{
 			MinScore:   tier.MinScore,
 			RegistryID: registryID,
+			Model:      strings.TrimSpace(tier.Model),
 		})
 	}
 	return &registrydomain.SmartRoutingConfig{Tiers: tiers}, nil

--- a/pkg/api/handler/http/consumer/response/consumer_response.go
+++ b/pkg/api/handler/http/consumer/response/consumer_response.go
@@ -81,6 +81,7 @@ type SmartRoutingConfigResponse struct {
 type SmartRoutingTierResponse struct {
 	MinScore   float64        `json:"min_score"`
 	RegistryID ids.RegistryID `json:"registry_id"`
+	Model      string         `json:"model,omitempty"`
 }
 
 type LBPoolMemberResponse struct {
@@ -206,6 +207,7 @@ func fromSmartRouting(config *registrydomain.SmartRoutingConfig) *SmartRoutingCo
 		tiers = append(tiers, SmartRoutingTierResponse{
 			MinScore:   tier.MinScore,
 			RegistryID: tier.RegistryID,
+			Model:      tier.Model,
 		})
 	}
 	return &SmartRoutingConfigResponse{Tiers: tiers}

--- a/pkg/app/proxy/routing.go
+++ b/pkg/app/proxy/routing.go
@@ -256,19 +256,49 @@ func firstAvailableFallback(
 
 func (f *forwarder) stampRoutingPolicy(dto *forwardRequestDTO, rc *appconsumer.RoutableConsumer, bk *domain.Registry) {
 	dto.routeSource = routeSourceFor(dto.candidates, bk)
+	var (
+		allowed      []string
+		defaultModel string
+	)
 	if candidate, ok := dto.candidates.ForRegistry(bk.ID); ok {
-		dto.request.AllowedModels = candidate.Allowed
-		dto.request.DefaultModel = candidate.Default
-		return
-	}
-	policy, ok := rc.Consumer.ModelPolicies.For(bk.ID)
-	if !ok {
+		allowed = candidate.Allowed
+		defaultModel = candidate.Default
+	} else if policy, ok := rc.Consumer.ModelPolicies.For(bk.ID); ok {
+		allowed = policy.Allowed
+		defaultModel = policy.Default
+	} else {
 		dto.request.AllowedModels = nil
 		dto.request.DefaultModel = ""
 		return
 	}
-	dto.request.AllowedModels = policy.Allowed
-	dto.request.DefaultModel = policy.Default
+	// Prefer a per-tier smart-routing model when the scored tier targets this
+	// registry. Falls back to the registry policy default otherwise.
+	if model := smartRoutingTierModel(rc, bk.ID, dto.request.ComplexityScore); model != "" {
+		defaultModel = model
+	}
+	dto.request.AllowedModels = allowed
+	dto.request.DefaultModel = defaultModel
+}
+
+// smartRoutingTierModel returns the optional model override from the winning
+// smart-routing tier when it targets registryID.
+func smartRoutingTierModel(
+	rc *appconsumer.RoutableConsumer,
+	registryID ids.RegistryID,
+	score *float64,
+) string {
+	if score == nil || rc == nil || rc.Consumer == nil {
+		return ""
+	}
+	cfg := rc.Consumer.LBConfig
+	if cfg == nil || !cfg.Enabled || cfg.SmartRouting == nil {
+		return ""
+	}
+	tier, ok := cfg.SmartRouting.TierForScore(*score)
+	if !ok || tier.RegistryID != registryID {
+		return ""
+	}
+	return strings.TrimSpace(tier.Model)
 }
 
 func routeSourceFor(candidates *routingdomain.CandidateSet, bk *domain.Registry) string {

--- a/pkg/domain/consumer/lb_config.go
+++ b/pkg/domain/consumer/lb_config.go
@@ -18,6 +18,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/registry"
@@ -93,7 +94,10 @@ func (l *LBConfig) Validate(inline ModelPolicies) error {
 		if err := l.SmartRouting.Validate(); err != nil {
 			return fmt.Errorf("%w: %s", ErrInvalidLBConfig, err.Error())
 		}
-		return l.validateSmartRoutingMembers()
+		if err := l.validateSmartRoutingMembers(); err != nil {
+			return err
+		}
+		return l.validateSmartRoutingTierModels(inline)
 	default:
 		if l.EmbeddingConfig != nil {
 			return fmt.Errorf("%w: embedding_config is only valid for the semantic algorithm", ErrInvalidLBConfig)
@@ -113,6 +117,38 @@ func (l *LBConfig) validateSmartRoutingMembers() error {
 	for i, tier := range l.SmartRouting.Tiers {
 		if _, ok := members[tier.RegistryID]; !ok {
 			return fmt.Errorf("%w: smart_routing.tiers[%d].registry_id %s is not a pool member", ErrInvalidLBConfig, i, tier.RegistryID)
+		}
+	}
+	return nil
+}
+
+// validateSmartRoutingTierModels ensures each tier model is allowed by the
+// registry's model policy when that policy restricts models.
+func (l *LBConfig) validateSmartRoutingTierModels(inline ModelPolicies) error {
+	if l == nil || l.SmartRouting == nil {
+		return nil
+	}
+	for i, tier := range l.SmartRouting.Tiers {
+		model := strings.TrimSpace(tier.Model)
+		if model == "" {
+			continue
+		}
+		policy, ok := inline.For(tier.RegistryID)
+		if !ok {
+			return fmt.Errorf("%w: smart_routing.tiers[%d].registry_id %s is not in model_policies", ErrInvalidLBConfig, i, tier.RegistryID)
+		}
+		if len(policy.Allowed) == 0 {
+			continue
+		}
+		allowed := false
+		for _, candidate := range policy.Allowed {
+			if candidate == model {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return fmt.Errorf("%w: smart_routing.tiers[%d].model %q is not allowed by model_policies", ErrInvalidLBConfig, i, model)
 		}
 	}
 	return nil

--- a/pkg/domain/registry/smart_routing_config.go
+++ b/pkg/domain/registry/smart_routing_config.go
@@ -16,15 +16,19 @@ package registry
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
 )
 
 // SmartRoutingTier binds a complexity-score threshold to a target registry. A
-// tier is selected when the score is at least MinScore.
+// tier is selected when the score is at least MinScore. Model is an optional
+// override applied when the tier wins; when empty, the registry's model policy
+// default is used. Multiple tiers may share a RegistryID with different models.
 type SmartRoutingTier struct {
 	MinScore   float64        `json:"min_score"`
 	RegistryID ids.RegistryID `json:"registry_id"`
+	Model      string         `json:"model,omitempty"`
 }
 
 // SmartRoutingConfig maps complexity scores in [0,1] to registries. The tier
@@ -53,12 +57,12 @@ func (c *SmartRoutingConfig) Validate() error {
 	return nil
 }
 
-// RegistryForScore returns the registry mapped to the given complexity score:
-// the tier with the greatest MinScore that is not above the score. It reports
-// false when no tier applies (e.g. the score is below every threshold).
-func (c *SmartRoutingConfig) RegistryForScore(score float64) (ids.RegistryID, bool) {
+// TierForScore returns the tier mapped to the given complexity score: the one
+// with the greatest MinScore that is not above the score. It reports false when
+// no tier applies (e.g. the score is below every threshold).
+func (c *SmartRoutingConfig) TierForScore(score float64) (SmartRoutingTier, bool) {
 	var (
-		best     ids.RegistryID
+		best     SmartRoutingTier
 		bestMin  float64
 		selected bool
 	)
@@ -67,10 +71,34 @@ func (c *SmartRoutingConfig) RegistryForScore(score float64) (ids.RegistryID, bo
 			continue
 		}
 		if !selected || tier.MinScore > bestMin {
-			best = tier.RegistryID
+			best = tier
 			bestMin = tier.MinScore
 			selected = true
 		}
 	}
 	return best, selected
+}
+
+// RegistryForScore returns the registry mapped to the given complexity score:
+// the tier with the greatest MinScore that is not above the score. It reports
+// false when no tier applies (e.g. the score is below every threshold).
+func (c *SmartRoutingConfig) RegistryForScore(score float64) (ids.RegistryID, bool) {
+	tier, ok := c.TierForScore(score)
+	if !ok {
+		return ids.RegistryID{}, false
+	}
+	return tier.RegistryID, true
+}
+
+// ModelForScore returns the optional model override for the winning tier.
+func (c *SmartRoutingConfig) ModelForScore(score float64) (string, bool) {
+	tier, ok := c.TierForScore(score)
+	if !ok {
+		return "", false
+	}
+	model := strings.TrimSpace(tier.Model)
+	if model == "" {
+		return "", false
+	}
+	return model, true
 }

--- a/pkg/domain/registry/smart_routing_config_test.go
+++ b/pkg/domain/registry/smart_routing_config_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"testing"
+
+	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
+)
+
+func TestSmartRoutingConfig_TierForScore_SameRegistryDifferentModels(t *testing.T) {
+	t.Parallel()
+	reg := ids.New[ids.RegistryKind]()
+	cfg := &SmartRoutingConfig{
+		Tiers: []SmartRoutingTier{
+			{MinScore: 0, RegistryID: reg, Model: "gpt-4o-mini"},
+			{MinScore: 0.3, RegistryID: reg, Model: "gpt-4.1-mini"},
+			{MinScore: 0.8, RegistryID: reg, Model: "gpt-5.6-luna"},
+		},
+	}
+
+	cases := []struct {
+		score float64
+		model string
+	}{
+		{0.1, "gpt-4o-mini"},
+		{0.5, "gpt-4.1-mini"},
+		{0.9, "gpt-5.6-luna"},
+	}
+	for _, tc := range cases {
+		tier, ok := cfg.TierForScore(tc.score)
+		if !ok {
+			t.Fatalf("score %g: expected a tier", tc.score)
+		}
+		if tier.RegistryID != reg {
+			t.Fatalf("score %g: registry = %s, want %s", tc.score, tier.RegistryID, reg)
+		}
+		model, ok := cfg.ModelForScore(tc.score)
+		if !ok || model != tc.model {
+			t.Fatalf("score %g: model = %q ok=%v, want %q", tc.score, model, ok, tc.model)
+		}
+	}
+}
+
+func TestSmartRoutingConfig_ModelForScore_EmptyWhenUnset(t *testing.T) {
+	t.Parallel()
+	reg := ids.New[ids.RegistryKind]()
+	cfg := &SmartRoutingConfig{
+		Tiers: []SmartRoutingTier{
+			{MinScore: 0, RegistryID: reg},
+		},
+	}
+	if model, ok := cfg.ModelForScore(0.2); ok || model != "" {
+		t.Fatalf("expected no model override, got %q ok=%v", model, ok)
+	}
+}

--- a/pkg/infra/context/request_context.go
+++ b/pkg/infra/context/request_context.go
@@ -50,6 +50,10 @@ type RequestContext struct {
 	AllowedModels      []string
 	DefaultModel       string
 	RequestedModel     string
+	// ComplexityScore is set by the smart-routing strategy when a score is
+	// obtained. The forwarder uses it to apply a per-tier model override from
+	// lb_config.smart_routing.tiers[].model.
+	ComplexityScore *float64
 	// MCP marks a native MCP tools/call payload so protocol-aware plugins
 	// inspect it via the MCP text path instead of the LLM canonical decoders.
 	MCP bool

--- a/pkg/infra/loadbalancer/strategies/smart_routing.go
+++ b/pkg/infra/loadbalancer/strategies/smart_routing.go
@@ -17,6 +17,7 @@ package strategies
 import (
 	"context"
 	"log/slog"
+	"strings"
 	"sync"
 
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
@@ -70,7 +71,9 @@ func (s *SmartRouting) Next(
 	if len(candidates) == 0 {
 		return nil
 	}
-	if len(candidates) == 1 {
+	// Skip scoring when a single candidate is enough for routing AND no tier
+	// carries a per-tier model override (same registry, different models).
+	if len(candidates) == 1 && !s.hasTierModelOverrides() {
 		return candidates[0]
 	}
 	if s.config == nil || s.scorer == nil || !s.scorer.Configured() || req == nil {
@@ -84,8 +87,15 @@ func (s *SmartRouting) Next(
 	if err != nil {
 		return s.fallbackNext(ctx, req, exclude, "complexity score unavailable")
 	}
+	// Persist the score so the forwarder can apply a per-tier model override
+	// (tiers may share a registry with different models).
+	scoreCopy := score
+	req.ComplexityScore = &scoreCopy
 	target := s.registryForScore(score, candidates)
 	if target == nil {
+		if len(candidates) == 1 {
+			return candidates[0]
+		}
 		return s.fallbackNext(ctx, req, exclude, "no candidate matched complexity score")
 	}
 	if s.logger != nil {
@@ -95,6 +105,18 @@ func (s *SmartRouting) Next(
 		)
 	}
 	return target
+}
+
+func (s *SmartRouting) hasTierModelOverrides() bool {
+	if s.config == nil {
+		return false
+	}
+	for _, tier := range s.config.Tiers {
+		if strings.TrimSpace(tier.Model) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *SmartRouting) registryForScore(score float64, candidates []*registry.Registry) *registry.Registry {

--- a/pkg/infra/loadbalancer/strategies/smart_routing_test.go
+++ b/pkg/infra/loadbalancer/strategies/smart_routing_test.go
@@ -77,14 +77,49 @@ func TestSmartRouting_MapsScoreToTier(t *testing.T) {
 			cfg := tiersFor(backends, 0.0, 0.4, 0.8)
 			scorer := &fakeScorer{score: tc.score, configured: true}
 			s := NewSmartRouting(backends, cfg, scorer, nil)
-			got := s.Next(context.Background(), promptReq(), nil)
+			req := promptReq()
+			got := s.Next(context.Background(), req, nil)
 			if got == nil || got.Name != tc.want {
 				t.Fatalf("score %g: got %+v, want %q", tc.score, got, tc.want)
 			}
 			if scorer.calls != 1 {
 				t.Fatalf("expected exactly one score call, got %d", scorer.calls)
 			}
+			if req.ComplexityScore == nil || *req.ComplexityScore != tc.score {
+				t.Fatalf("score %g: ComplexityScore = %v, want %g", tc.score, req.ComplexityScore, tc.score)
+			}
 		})
+	}
+}
+
+func TestSmartRouting_SameRegistryDifferentTierModels(t *testing.T) {
+	t.Parallel()
+	// One pool member is enough when tiers carry per-tier models: scoring still
+	// runs so the forwarder can pick the winning tier's model.
+	backends := makeBackends("shared")
+	reg := backends[0].ID
+	cfg := &registry.SmartRoutingConfig{
+		Tiers: []registry.SmartRoutingTier{
+			{MinScore: 0.0, RegistryID: reg, Model: "model-simple"},
+			{MinScore: 0.5, RegistryID: reg, Model: "model-hard"},
+		},
+	}
+	scorer := &fakeScorer{score: 0.9, configured: true}
+	s := NewSmartRouting(backends, cfg, scorer, nil)
+	req := promptReq()
+	got := s.Next(context.Background(), req, nil)
+	if got == nil || got.ID != reg {
+		t.Fatalf("expected shared registry, got %+v", got)
+	}
+	if scorer.calls != 1 {
+		t.Fatalf("expected scoring for per-tier models, calls=%d", scorer.calls)
+	}
+	if req.ComplexityScore == nil {
+		t.Fatal("expected ComplexityScore to be set")
+	}
+	model, ok := cfg.ModelForScore(*req.ComplexityScore)
+	if !ok || model != "model-hard" {
+		t.Fatalf("tier model = %q ok=%v, want model-hard", model, ok)
 	}
 }
 

--- a/tests/functional/smart_routing_e2e_test.go
+++ b/tests/functional/smart_routing_e2e_test.go
@@ -95,6 +95,75 @@ func TestSmartRoutingE2E_RoutesByScoreAndInjectsRegistryDefaultModel(t *testing.
 	})
 }
 
+// setupSmartRouteSameRegistry wires one upstream/registry with three complexity
+// tiers that share that registry but declare distinct per-tier models.
+func setupSmartRouteSameRegistry(t *testing.T, upstream *fakeUpstream, simpleModel, mediumModel, hardModel string) (string, string) {
+	t.Helper()
+	gatewayID := CreateGateway(t, map[string]any{"slug": uniqueName("smart-same-reg-gw")})
+	registryID := CreateRegistry(t, gatewayID, openaiBackendPayload(uniqueName("be-shared"), upstream.URL()))
+
+	coID := CreateConsumer(t, gatewayID, map[string]any{
+		"name": uniqueName("smart-same-reg-cons"),
+		"registries": []map[string]any{
+			{
+				"id": registryID,
+				"model_policies": map[string]any{
+					"allowed": []string{simpleModel, mediumModel, hardModel},
+					"default": simpleModel,
+				},
+			},
+		},
+		"lb_config": map[string]any{
+			"enabled":   true,
+			"algorithm": "smart-routing",
+			"members":   []map[string]any{{"registry_id": registryID}},
+			"smart_routing": map[string]any{
+				"tiers": []map[string]any{
+					{"min_score": 0.0, "registry_id": registryID, "model": simpleModel},
+					{"min_score": 0.3, "registry_id": registryID, "model": mediumModel},
+					{"min_score": 0.8, "registry_id": registryID, "model": hardModel},
+				},
+			},
+		},
+	})
+	apiKey := createAndAttachAPIKey(t, gatewayID, coID)
+	return apiKey, chatCompletionsPath(t, coID)
+}
+
+func TestSmartRoutingE2E_SameRegistryInjectsPerTierModel(t *testing.T) {
+	defer Track(t, "SmartRoutingE2E")()
+
+	const (
+		simpleModel = "model-simple-tier"
+		mediumModel = "model-medium-tier"
+		hardModel   = "model-hard-tier"
+	)
+
+	t.Run("low score injects the simple tier model on the shared registry", func(t *testing.T) {
+		up := newJSONUpstream(t, "served-by-shared")
+		apiKey, path := setupSmartRouteSameRegistry(t, up, simpleModel, mediumModel, hardModel)
+
+		status, _, body := proxyPost(t, apiKey, path, smartChatRequest(smartRouteLowContent))
+
+		require.Equal(t, http.StatusOK, status, "body: %s", body)
+		assert.Equal(t, 1, up.Hits())
+		assert.Contains(t, string(up.LastBody()), simpleModel,
+			"low score must inject the simple tier model even when registry is shared")
+	})
+
+	t.Run("high score injects the hard tier model on the shared registry", func(t *testing.T) {
+		up := newJSONUpstream(t, "served-by-shared")
+		apiKey, path := setupSmartRouteSameRegistry(t, up, simpleModel, mediumModel, hardModel)
+
+		status, _, body := proxyPost(t, apiKey, path, smartChatRequest(smartRouteHighContent))
+
+		require.Equal(t, http.StatusOK, status, "body: %s", body)
+		assert.Equal(t, 1, up.Hits())
+		assert.Contains(t, string(up.LastBody()), hardModel,
+			"high score must inject the hard tier model even when registry is shared")
+	})
+}
+
 func TestSmartRoutingE2E_FallsBackToRoundRobinOnScoreError(t *testing.T) {
 	defer Track(t, "SmartRoutingE2E")()
 


### PR DESCRIPTION
Allow complexity tiers that share a registry to declare distinct models, persist them on lb_config.smart_routing.tiers, and inject the winning tier model at request time.