### PR TITLE
refactor: balance load across (registry, model) routes

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -4176,6 +4176,10 @@ const docTemplate = `{
         "github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_request.LBPoolMemberRequest": {
             "type": "object",
             "properties": {
+                "model": {
+                    "description": "Model pins this pool entry to a single model, which is what allows the same\nregistry to appear several times as independently balanced routes.",
+                    "type": "string"
+                },
                 "models": {
                     "type": "array",
                     "items": {
@@ -4184,6 +4188,13 @@ const docTemplate = `{
                 },
                 "registry_id": {
                     "type": "string"
+                },
+                "weight": {
+                    "description": "Weight is the relative weighted-round-robin share of this route on a 1..100\nscale, defaulting to the consumer's registry weight.",
+                    "type": "integer",
+                    "maximum": 100,
+                    "minimum": 1,
+                    "example": 1
                 }
             }
         },
@@ -4252,6 +4263,10 @@ const docTemplate = `{
             "properties": {
                 "min_score": {
                     "type": "number"
+                },
+                "model": {
+                    "description": "Model selects which route of the registry this tier targets. It is required\nwhen the pool declares the registry more than once.",
+                    "type": "string"
                 },
                 "registry_id": {
                     "type": "string"
@@ -4513,6 +4528,9 @@ const docTemplate = `{
         "github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_response.LBPoolMemberResponse": {
             "type": "object",
             "properties": {
+                "model": {
+                    "type": "string"
+                },
                 "models": {
                     "type": "array",
                     "items": {
@@ -4521,6 +4539,9 @@ const docTemplate = `{
                 },
                 "registry_id": {
                     "type": "string"
+                },
+                "weight": {
+                    "type": "integer"
                 }
             }
         },
@@ -4588,6 +4609,9 @@ const docTemplate = `{
             "properties": {
                 "min_score": {
                     "type": "number"
+                },
+                "model": {
+                    "type": "string"
                 },
                 "registry_id": {
                     "type": "string"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -5083,6 +5083,10 @@
             "github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_request.LBPoolMemberRequest": {
                 "type": "object",
                 "properties": {
+                    "model": {
+                        "description": "Model pins this pool entry to a single model, which is what allows the same\nregistry to appear several times as independently balanced routes.",
+                        "type": "string"
+                    },
                     "models": {
                         "type": "array",
                         "items": {
@@ -5091,6 +5095,13 @@
                     },
                     "registry_id": {
                         "type": "string"
+                    },
+                    "weight": {
+                        "description": "Weight is the relative weighted-round-robin share of this route on a 1..100\nscale, defaulting to the consumer's registry weight.",
+                        "type": "integer",
+                        "maximum": 100,
+                        "minimum": 1,
+                        "example": 1
                     }
                 }
             },
@@ -5159,6 +5170,10 @@
                 "properties": {
                     "min_score": {
                         "type": "number"
+                    },
+                    "model": {
+                        "description": "Model selects which route of the registry this tier targets. It is required\nwhen the pool declares the registry more than once.",
+                        "type": "string"
                     },
                     "registry_id": {
                         "type": "string"
@@ -5420,6 +5435,9 @@
             "github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_response.LBPoolMemberResponse": {
                 "type": "object",
                 "properties": {
+                    "model": {
+                        "type": "string"
+                    },
                     "models": {
                         "type": "array",
                         "items": {
@@ -5428,6 +5446,9 @@
                     },
                     "registry_id": {
                         "type": "string"
+                    },
+                    "weight": {
+                        "type": "integer"
                     }
                 }
             },
@@ -5495,6 +5516,9 @@
                 "properties": {
                     "min_score": {
                         "type": "number"
+                    },
+                    "model": {
+                        "type": "string"
                     },
                     "registry_id": {
                         "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -4169,6 +4169,10 @@
         "github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_request.LBPoolMemberRequest": {
             "type": "object",
             "properties": {
+                "model": {
+                    "description": "Model pins this pool entry to a single model, which is what allows the same\nregistry to appear several times as independently balanced routes.",
+                    "type": "string"
+                },
                 "models": {
                     "type": "array",
                     "items": {
@@ -4177,6 +4181,13 @@
                 },
                 "registry_id": {
                     "type": "string"
+                },
+                "weight": {
+                    "description": "Weight is the relative weighted-round-robin share of this route on a 1..100\nscale, defaulting to the consumer's registry weight.",
+                    "type": "integer",
+                    "maximum": 100,
+                    "minimum": 1,
+                    "example": 1
                 }
             }
         },
@@ -4245,6 +4256,10 @@
             "properties": {
                 "min_score": {
                     "type": "number"
+                },
+                "model": {
+                    "description": "Model selects which route of the registry this tier targets. It is required\nwhen the pool declares the registry more than once.",
+                    "type": "string"
                 },
                 "registry_id": {
                     "type": "string"
@@ -4506,6 +4521,9 @@
         "github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_response.LBPoolMemberResponse": {
             "type": "object",
             "properties": {
+                "model": {
+                    "type": "string"
+                },
                 "models": {
                     "type": "array",
                     "items": {
@@ -4514,6 +4532,9 @@
                 },
                 "registry_id": {
                     "type": "string"
+                },
+                "weight": {
+                    "type": "integer"
                 }
             }
         },
@@ -4581,6 +4602,9 @@
             "properties": {
                 "min_score": {
                     "type": "number"
+                },
+                "model": {
+                    "type": "string"
                 },
                 "registry_id": {
                     "type": "string"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -438,12 +438,25 @@ definitions:
     type: object
   github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_request.LBPoolMemberRequest:
     properties:
+      model:
+        description: |-
+          Model pins this pool entry to a single model, which is what allows the same
+          registry to appear several times as independently balanced routes.
+        type: string
       models:
         items:
           type: string
         type: array
       registry_id:
         type: string
+      weight:
+        description: |-
+          Weight is the relative weighted-round-robin share of this route on a 1..100
+          scale, defaulting to the consumer's registry weight.
+        example: 1
+        maximum: 100
+        minimum: 1
+        type: integer
     type: object
   github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_request.ModelPolicyRequest:
     properties:
@@ -490,6 +503,11 @@ definitions:
     properties:
       min_score:
         type: number
+      model:
+        description: |-
+          Model selects which route of the registry this tier targets. It is required
+          when the pool declares the registry more than once.
+        type: string
       registry_id:
         type: string
     type: object
@@ -664,12 +682,16 @@ definitions:
     type: object
   github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_response.LBPoolMemberResponse:
     properties:
+      model:
+        type: string
       models:
         items:
           type: string
         type: array
       registry_id:
         type: string
+      weight:
+        type: integer
     type: object
   github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_response.ListConsumerResponse:
     properties:
@@ -713,6 +735,8 @@ definitions:
     properties:
       min_score:
         type: number
+      model:
+        type: string
       registry_id:
         type: string
     type: object

--- a/frontend/src/components/entities/consumer-detail.tsx
+++ b/frontend/src/components/entities/consumer-detail.tsx
@@ -308,16 +308,65 @@ function BindingSection<T extends NamedEntity>({
   );
 }
 
-// Model policies (registry_id → allowed/default) are required for every member
-// of an enabled lb_config pool. This merges the consumer's existing policies
-// with a bare entry for any attached registry that lacks one, so enabling load
-// balancing never fails validation.
-function poolModelPolicies(consumer: Consumer, attached: Registry[]): ModelPolicy[] {
+type PoolRoute = { registry_id: string; model: string; weight: string };
+
+type TierDraft = { min_score: string; registry_id: string; model: string };
+
+function poolRoutesFrom(consumer: Consumer): PoolRoute[] {
+  const registryWeight = new Map((consumer.registry_weights ?? []).map((w) => [w.registry_id, w.weight]));
+  return (consumer.lb_config?.members ?? []).map((m) => ({
+    registry_id: m.registry_id,
+    model: m.model ?? "",
+    weight: String(m.weight ?? registryWeight.get(m.registry_id) ?? 1),
+  }));
+}
+
+function mergePoolRoutes(routes: PoolRoute[], attached: Registry[]): PoolRoute[] {
+  const attachedIds = new Set(attached.map((r) => r.id));
+  const merged = routes.filter((r) => attachedIds.has(r.registry_id));
+  const covered = new Set(merged.map((r) => r.registry_id));
+  for (const r of attached) {
+    if (!covered.has(r.id)) merged.push({ registry_id: r.id, model: "", weight: "1" });
+  }
+  return merged;
+}
+
+function routeWeightOf(route: PoolRoute): number {
+  return Math.min(100, Math.max(1, Math.round(Number(route.weight) || 1)));
+}
+
+function routesOf(routes: PoolRoute[], registryId: string): PoolRoute[] {
+  return routes.filter((r) => r.registry_id === registryId);
+}
+
+// Mirrors the backend route-identity rules so the user sees the problem before saving.
+function poolRouteError(routes: PoolRoute[]): string | null {
+  const seen = new Set<string>();
+  for (const route of routes) {
+    const model = route.model.trim();
+    if (!model && routesOf(routes, route.registry_id).length > 1) {
+      return "Every route of a registry that appears more than once needs a model.";
+    }
+    const key = `${route.registry_id}|${model}`;
+    if (seen.has(key)) return "Two routes share the same registry and model.";
+    seen.add(key);
+  }
+  return null;
+}
+
+// An enabled pool requires a policy per member and a pinned model inside any non-empty allowlist.
+function poolModelPolicies(consumer: Consumer, attached: Registry[], routes: PoolRoute[]): ModelPolicy[] {
   const existing = new Map((consumer.model_policies ?? []).map((p) => [p.registry_id, p]));
   return attached.map((r) => {
     const current = existing.get(r.id);
+    const allowed = current?.allowed ?? [];
     const policy: ModelPolicy = { registry_id: r.id };
-    if (current?.allowed && current.allowed.length > 0) policy.allowed = current.allowed;
+    if (allowed.length > 0) {
+      const pinned = routesOf(routes, r.id)
+        .map((route) => route.model.trim())
+        .filter((model) => model !== "" && !allowed.includes(model));
+      policy.allowed = [...allowed, ...new Set(pinned)];
+    }
     if (current?.default) policy.default = current.default;
     return policy;
   });
@@ -337,19 +386,14 @@ function RoutingTab({ consumer, onClose }: { consumer: Consumer; onClose: () => 
   const [embProvider, setEmbProvider] = useState(emb?.provider ?? "");
   const [embModel, setEmbModel] = useState(emb?.model ?? "");
   const [embKey, setEmbKey] = useState("");
-  const [tiers, setTiers] = useState<{ min_score: string; registry_id: string }[]>(() =>
+  const [tiers, setTiers] = useState<TierDraft[]>(() =>
     (consumer.lb_config?.smart_routing?.tiers ?? []).map((t) => ({
       min_score: String(t.min_score),
       registry_id: t.registry_id,
+      model: t.model ?? "",
     })),
   );
-  // Only user edits live in state; the displayed value falls back to the
-  // consumer's configured weight, then a default of 1.
-  const [weights, setWeights] = useState<Record<string, string>>(() => {
-    const init: Record<string, string> = {};
-    for (const w of consumer.registry_weights ?? []) init[w.registry_id] = String(w.weight);
-    return init;
-  });
+  const [routes, setRoutes] = useState<PoolRoute[]>(() => poolRoutesFrom(consumer));
   const fb = consumer.fallback;
   const [triggers, setTriggers] = useState<string[]>(fb?.triggers?.length ? fb.triggers : ["http_5xx"]);
   const [chain, setChain] = useState<string[]>(fb?.chain ?? []);
@@ -362,25 +406,28 @@ function RoutingTab({ consumer, onClose }: { consumer: Consumer; onClose: () => 
   const showSmart = consumer.lb_config?.algorithm === "smart-routing" || strategy === "smart";
 
   function addTier() {
-    setTiers((prev) => [...prev, { min_score: "", registry_id: "" }]);
+    setTiers((prev) => [...prev, { min_score: "", registry_id: "", model: "" }]);
   }
   function removeTier(index: number) {
     setTiers((prev) => prev.filter((_, i) => i !== index));
   }
-  function updateTier(index: number, patch: Partial<{ min_score: string; registry_id: string }>) {
+  function updateTier(index: number, patch: Partial<TierDraft>) {
     setTiers((prev) => prev.map((tier, i) => (i === index ? { ...tier, ...patch } : tier)));
   }
 
-  function displayWeight(r: Registry): string {
-    return weights[r.id] ?? String(weightFromConsumer(r.id) ?? 1);
+  // Mutations rewrite the normalized list so edits survive the merge with attached registries.
+  const poolRoutes = mergePoolRoutes(routes, attached);
+  function addRoute(registryId: string) {
+    if (!registryId) return;
+    setRoutes([...poolRoutes, { registry_id: registryId, model: "", weight: "1" }]);
   }
-  function weightFromConsumer(registryId: string): number | undefined {
-    return (consumer.registry_weights ?? []).find((w) => w.registry_id === registryId)?.weight;
+  function removeRoute(index: number) {
+    setRoutes(poolRoutes.filter((_, i) => i !== index));
   }
-  function weightOf(r: Registry): number {
-    return Math.min(100, Math.max(1, Math.round(Number(displayWeight(r)) || 1)));
+  function updateRoute(index: number, patch: Partial<PoolRoute>) {
+    setRoutes(poolRoutes.map((route, i) => (i === index ? { ...route, ...patch } : route)));
   }
-  const totalWeight = attached.reduce((sum, r) => sum + weightOf(r), 0);
+  const totalWeight = poolRoutes.reduce((sum, route) => sum + routeWeightOf(route), 0);
 
   function toggleTrigger(t: string) {
     setTriggers((prev) => (prev.includes(t) ? prev.filter((x) => x !== t) : [...prev, t]));
@@ -433,10 +480,19 @@ function RoutingTab({ consumer, onClose }: { consumer: Consumer; onClose: () => 
         toast({ variant: "error", title: "Attach at least one registry first (Bindings tab)." });
         return;
       }
+      const routeError = poolRouteError(poolRoutes);
+      if (routeError) {
+        toast({ variant: "error", title: routeError });
+        return;
+      }
       const lb: Record<string, unknown> = {
         enabled: true,
         algorithm: algorithmFor(strategy),
-        members: attached.map((r) => ({ registry_id: r.id })),
+        members: poolRoutes.map((route) => ({
+          registry_id: route.registry_id,
+          ...(route.model.trim() ? { model: route.model.trim() } : {}),
+          ...(strategy === "weighted" ? { weight: routeWeightOf(route) } : {}),
+        })),
       };
 
       if (strategy === "semantic") {
@@ -462,8 +518,12 @@ function RoutingTab({ consumer, onClose }: { consumer: Consumer; onClose: () => 
 
       if (strategy === "smart") {
         const parsed = tiers
-          .map((t) => ({ min_score: Number(t.min_score), registry_id: t.registry_id }))
-          .filter((t) => t.registry_id);
+          .filter((t) => t.registry_id)
+          .map((t) => ({
+            min_score: Number(t.min_score),
+            registry_id: t.registry_id,
+            ...(t.model.trim() ? { model: t.model.trim() } : {}),
+          }));
         if (parsed.length === 0) {
           toast({ variant: "error", title: "Add at least one smart-routing tier with a registry." });
           return;
@@ -472,12 +532,22 @@ function RoutingTab({ consumer, onClose }: { consumer: Consumer; onClose: () => 
           toast({ variant: "error", title: "Each tier min score must be between 0 and 1." });
           return;
         }
+        const ambiguous = parsed.find(
+          (t) => !t.model && routesOf(poolRoutes, t.registry_id).length > 1,
+        );
+        if (ambiguous) {
+          toast({
+            variant: "error",
+            title: "Pick a model for every tier whose registry has more than one route.",
+          });
+          return;
+        }
         lb.smart_routing = { tiers: parsed };
       }
 
       body.lb_config = lb;
       body.fallback = { enabled: false };
-      body.model_policies = poolModelPolicies(consumer, attached);
+      body.model_policies = poolModelPolicies(consumer, attached, poolRoutes);
     } else if (strategy === "fallback") {
       if (chainResolved.length === 0) {
         toast({ variant: "error", title: "Add at least one registry to the fallback order." });
@@ -500,11 +570,11 @@ function RoutingTab({ consumer, onClose }: { consumer: Consumer; onClose: () => 
 
     setSaving(true);
     try {
-      // Weights are stored per registry association, not on the consumer body,
-      // so they are updated through the (idempotent) attach endpoint.
+      // The per-registry weight lives on the association, so it goes through the (idempotent) attach endpoint.
       if (strategy === "weighted") {
         for (const r of attached) {
-          await api.post(`${base}/registries/${r.id}`, { weight: weightOf(r) });
+          const route = routesOf(poolRoutes, r.id)[0];
+          if (route) await api.post(`${base}/registries/${r.id}`, { weight: routeWeightOf(route) });
         }
       }
       await api.put(base, body);
@@ -555,37 +625,80 @@ function RoutingTab({ consumer, onClose }: { consumer: Consumer; onClose: () => 
       </Field>
       <p className="text-[12px] text-muted -mt-2">{meta.hint}</p>
 
-      {strategy === "weighted" && (
+      {isLoadBalanced(strategy) && (
         <div className="flex flex-col gap-2">
-          <p className="text-[13px] font-medium text-fg">Registries</p>
+          <p className="text-[13px] font-medium text-fg">Pool routes</p>
+          <p className="text-[12px] text-muted -mt-1">
+            Each route is a registry with an optional model. Add the same registry twice with different
+            models to balance across them independently; leave the model blank to use the registry
+            default from Model policies.
+          </p>
           {attached.length === 0 ? (
             <p className="text-[12px] text-faint">Attach registries first (Bindings tab).</p>
           ) : (
-            <div className="flex flex-col gap-1.5">
-              {attached.map((r) => {
-                const pct = totalWeight > 0 ? Math.round((weightOf(r) / totalWeight) * 100) : 0;
-                return (
-                  <div
-                    key={r.id}
-                    className="flex items-center gap-3 rounded-(--radius) border border-border bg-surface-2/30 px-3.5 h-12"
-                  >
-                    <span className="flex-1 min-w-0 text-[13px] text-fg truncate">
-                      {r.name} <span className="text-faint">({r.provider})</span>
-                    </span>
-                    <Input
-                      type="number"
-                      min={1}
-                      max={100}
-                      value={displayWeight(r)}
-                      onChange={(e) => setWeights((prev) => ({ ...prev, [r.id]: e.target.value }))}
-                      className="w-20"
-                      aria-label={`Weight for ${r.name}`}
-                    />
-                    <span className="w-10 text-right text-[12px] text-muted tabular-nums">{pct}%</span>
-                  </div>
-                );
-              })}
-            </div>
+            <>
+              <div className="flex flex-col gap-1.5">
+                {poolRoutes.map((route, i) => {
+                  const r = registryById.get(route.registry_id);
+                  const only = routesOf(poolRoutes, route.registry_id).length === 1;
+                  const pct = totalWeight > 0 ? Math.round((routeWeightOf(route) / totalWeight) * 100) : 0;
+                  return (
+                    <div
+                      key={`${route.registry_id}-${i}`}
+                      className="flex items-center gap-3 rounded-(--radius) border border-border bg-surface-2/30 px-3.5 h-12"
+                    >
+                      <span className="w-40 shrink-0 text-[13px] text-fg truncate">
+                        {r?.name} <span className="text-faint">({r?.provider})</span>
+                      </span>
+                      <Input
+                        value={route.model}
+                        onChange={(e) => updateRoute(i, { model: e.target.value })}
+                        placeholder="registry default"
+                        className="flex-1 min-w-0"
+                        aria-label={`Model for ${r?.name}`}
+                      />
+                      {strategy === "weighted" && (
+                        <>
+                          <Input
+                            type="number"
+                            min={1}
+                            max={100}
+                            value={route.weight}
+                            onChange={(e) => updateRoute(i, { weight: e.target.value })}
+                            className="w-20"
+                            aria-label={`Weight for ${r?.name}`}
+                          />
+                          <span className="w-10 text-right text-[12px] text-muted tabular-nums">{pct}%</span>
+                        </>
+                      )}
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        disabled={only}
+                        onClick={() => removeRoute(i)}
+                        aria-label="Remove route"
+                      >
+                        <X className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  );
+                })}
+              </div>
+              <Select
+                value=""
+                onChange={(e) => {
+                  addRoute(e.target.value);
+                  e.target.value = "";
+                }}
+              >
+                <option value="">Add a route…</option>
+                {attached.map((r) => (
+                  <option key={r.id} value={r.id}>
+                    {r.name} ({r.provider})
+                  </option>
+                ))}
+              </Select>
+            </>
           )}
         </div>
       )}
@@ -739,7 +852,7 @@ function RoutingTab({ consumer, onClose }: { consumer: Consumer; onClose: () => 
                     <Field label="Registry">
                       <Select
                         value={tier.registry_id}
-                        onChange={(e) => updateTier(i, { registry_id: e.target.value })}
+                        onChange={(e) => updateTier(i, { registry_id: e.target.value, model: "" })}
                       >
                         <option value="">Select registry…</option>
                         {attached.map((r) => (
@@ -747,6 +860,20 @@ function RoutingTab({ consumer, onClose }: { consumer: Consumer; onClose: () => 
                             {r.name}
                           </option>
                         ))}
+                      </Select>
+                    </Field>
+                  </div>
+                  <div className="flex-1">
+                    <Field label="Route">
+                      <Select value={tier.model} onChange={(e) => updateTier(i, { model: e.target.value })}>
+                        <option value="">Any route</option>
+                        {routesOf(poolRoutes, tier.registry_id)
+                          .filter((route) => route.model.trim() !== "")
+                          .map((route, routeIndex) => (
+                            <option key={`${route.model}-${routeIndex}`} value={route.model.trim()}>
+                              {route.model.trim()}
+                            </option>
+                          ))}
                       </Select>
                     </Field>
                   </div>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -170,11 +170,14 @@ export interface EmbeddingConfig {
 export interface LBPoolMember {
   registry_id: string;
   models?: string[];
+  model?: string;
+  weight?: number;
 }
 
 export interface SmartRoutingTier {
   min_score: number;
   registry_id: string;
+  model?: string;
 }
 
 export interface SmartRoutingConfig {

--- a/pkg/api/handler/http/consumer/request/create_consumer_request.go
+++ b/pkg/api/handler/http/consumer/request/create_consumer_request.go
@@ -115,11 +115,20 @@ type SmartRoutingConfigRequest struct {
 type SmartRoutingTierRequest struct {
 	MinScore   float64 `json:"min_score"`
 	RegistryID string  `json:"registry_id"`
+	// Model selects which route of the registry this tier targets. It is required
+	// when the pool declares the registry more than once.
+	Model string `json:"model,omitempty"`
 }
 
 type LBPoolMemberRequest struct {
 	RegistryID string   `json:"registry_id"`
 	Models     []string `json:"models,omitempty"`
+	// Model pins this pool entry to a single model, which is what allows the same
+	// registry to appear several times as independently balanced routes.
+	Model string `json:"model,omitempty"`
+	// Weight is the relative weighted-round-robin share of this route on a 1..100
+	// scale, defaulting to the consumer's registry weight.
+	Weight *int `json:"weight,omitempty" example:"1" minimum:"1" maximum:"100"`
 }
 
 func (r *FallbackRequest) ToFallback() (*domain.Fallback, error) {
@@ -175,6 +184,7 @@ func (s *SmartRoutingConfigRequest) ToDomain() (*registrydomain.SmartRoutingConf
 		tiers = append(tiers, registrydomain.SmartRoutingTier{
 			MinScore:   tier.MinScore,
 			RegistryID: registryID,
+			Model:      tier.Model,
 		})
 	}
 	return &registrydomain.SmartRoutingConfig{Tiers: tiers}, nil
@@ -337,6 +347,8 @@ func (r *LBConfigRequest) ToDomain() (*domain.LBConfig, error) {
 		members = append(members, domain.LBPoolMember{
 			RegistryID: registryID,
 			Models:     member.Models,
+			Model:      member.Model,
+			Weight:     member.Weight,
 		})
 	}
 	smartRouting, err := r.SmartRouting.ToDomain()

--- a/pkg/api/handler/http/consumer/request/create_consumer_request_test.go
+++ b/pkg/api/handler/http/consumer/request/create_consumer_request_test.go
@@ -67,6 +67,45 @@ func TestCreateConsumerRequest_ToRegistryBindings_RejectsNonPositiveWeight(t *te
 	}
 }
 
+func TestLBConfigRequest_ToDomain_RoutesPerModel(t *testing.T) {
+	t.Parallel()
+	registryID := ids.New[ids.RegistryKind]()
+	req := LBConfigRequest{
+		Enabled:   true,
+		Algorithm: "smart-routing",
+		Members: []LBPoolMemberRequest{
+			{RegistryID: registryID.String(), Model: "gpt-5-mini", Weight: intPtr(3)},
+			{RegistryID: registryID.String(), Model: "gpt-5"},
+		},
+		SmartRouting: &SmartRoutingConfigRequest{
+			Tiers: []SmartRoutingTierRequest{
+				{MinScore: 0, RegistryID: registryID.String(), Model: "gpt-5-mini"},
+				{MinScore: 0.5, RegistryID: registryID.String(), Model: "gpt-5"},
+			},
+		},
+	}
+
+	cfg, err := req.ToDomain()
+	if err != nil {
+		t.Fatalf("ToDomain error: %v", err)
+	}
+	if len(cfg.Members) != 2 {
+		t.Fatalf("members len = %d, want 2", len(cfg.Members))
+	}
+	if got := cfg.Members[0].RouteModel(); got != "gpt-5-mini" {
+		t.Fatalf("members[0].Model = %q, want gpt-5-mini", got)
+	}
+	if got := cfg.Members[0].RouteWeight(1); got != 3 {
+		t.Fatalf("members[0] weight = %d, want 3", got)
+	}
+	if got := cfg.Members[1].RouteWeight(7); got != 7 {
+		t.Fatalf("members[1] weight = %d, want the fallback 7", got)
+	}
+	if got := cfg.SmartRouting.Tiers[1].RouteModel(); got != "gpt-5" {
+		t.Fatalf("tiers[1].Model = %q, want gpt-5", got)
+	}
+}
+
 func TestCreateConsumerRequest_ToRegistryBindings_RejectsWeightAboveMax(t *testing.T) {
 	t.Parallel()
 	req := CreateConsumerRequest{

--- a/pkg/api/handler/http/consumer/response/consumer_response.go
+++ b/pkg/api/handler/http/consumer/response/consumer_response.go
@@ -81,11 +81,14 @@ type SmartRoutingConfigResponse struct {
 type SmartRoutingTierResponse struct {
 	MinScore   float64        `json:"min_score"`
 	RegistryID ids.RegistryID `json:"registry_id"`
+	Model      string         `json:"model,omitempty"`
 }
 
 type LBPoolMemberResponse struct {
 	RegistryID ids.RegistryID `json:"registry_id"`
 	Models     []string       `json:"models,omitempty"`
+	Model      string         `json:"model,omitempty"`
+	Weight     *int           `json:"weight,omitempty"`
 }
 
 type EmbeddingConfigResponse struct {
@@ -177,6 +180,8 @@ func fromLBConfig(config *domain.LBConfig) *LBConfigResponse {
 		members = append(members, LBPoolMemberResponse{
 			RegistryID: member.RegistryID,
 			Models:     member.Models,
+			Model:      member.Model,
+			Weight:     member.Weight,
 		})
 	}
 	var embedding *EmbeddingConfigResponse
@@ -206,6 +211,7 @@ func fromSmartRouting(config *registrydomain.SmartRoutingConfig) *SmartRoutingCo
 		tiers = append(tiers, SmartRoutingTierResponse{
 			MinScore:   tier.MinScore,
 			RegistryID: tier.RegistryID,
+			Model:      tier.Model,
 		})
 	}
 	return &SmartRoutingConfigResponse{Tiers: tiers}

--- a/pkg/app/metrics/builder.go
+++ b/pkg/app/metrics/builder.go
@@ -130,6 +130,7 @@ func (b *Builder) foldLLMSpans(requestTrace *trace.RequestTrace) (*trace.LLMAttr
 			Fallback:   attrs.Fallback,
 			Pinned:     attrs.Pinned,
 			Route:      attrs.Route,
+			RouteModel: attrs.RouteModel,
 			Outcome:    attrs.Outcome,
 			StatusCode: span.StatusCode(),
 			LatencyMs:  span.Latency().Milliseconds(),
@@ -337,7 +338,7 @@ func (b *Builder) fillResponse(evt *events.Event, resp *infracontext.ResponseCon
 		evt.Response.FinishReason = served.FinishReason
 	}
 	if len(resp.Body) > 0 {
-		body := events.SanitizeBodyFull(resp.Body, resp.Headers)
+		body := events.SanitizeBody(resp.Body, resp.Headers)
 		evt.Response.Body = &body
 	}
 }

--- a/pkg/app/proxy/forwarder.go
+++ b/pkg/app/proxy/forwarder.go
@@ -146,7 +146,7 @@ func (f *forwarder) Forward(ctx context.Context, in ForwardInput) (*ForwardResul
 		return nil, err
 	}
 
-	stampTarget(in.Request, route.backend)
+	stampTarget(in.Request, route.route.Registry)
 	resp := &infracontext.ResponseContext{
 		GatewayID:  in.Request.GatewayID,
 		RegistryID: in.Request.RegistryID,
@@ -161,7 +161,7 @@ func (f *forwarder) Forward(ctx context.Context, in ForwardInput) (*ForwardResul
 	}
 
 	dto := &forwardRequestDTO{
-		backend:     route.backend,
+		backend:     route.route.Registry,
 		candidates:  candidates,
 		pinned:      route.pinned,
 		request:     in.Request,
@@ -189,15 +189,16 @@ func (f *forwarder) invokeWithFailover(
 	lb := route.lb
 	excluded := route.excluded
 	if excluded == nil {
-		excluded = make(map[ids.RegistryID]struct{})
+		excluded = make(map[routingdomain.RouteKey]struct{})
 	}
 
 	last := failoverState{}
 	lastKind := failureNone
-	current := dto.backend
+	current := route.route
 	fromFallback := route.fromFallback
-	for current != nil {
-		f.retarget(dto, current)
+	for current.Registry != nil {
+		bk := current.Registry
+		f.retarget(dto, bk)
 		f.stampRoutingPolicy(dto, rc, current)
 		for r := 0; r < attemptsPerBackend; r++ {
 			if budget.exhausted() {
@@ -206,13 +207,13 @@ func (f *forwarder) invokeWithFailover(
 			budget.recordAttempt()
 
 			startedAt := time.Now()
-			resp, err := f.invokeOnce(ctx, current, dto.request, stream)
+			resp, err := f.invokeOnce(ctx, bk, dto.request, stream)
 			elapsed := time.Since(startedAt)
 			outcome := classifyOutcome(resp, err, triggers)
 			span := f.recordSpan(ctx, dto, current, fromFallback, budget.attempts, outcome, resp, elapsed)
 			switch outcome {
 			case OutcomeSuccess:
-				reportSuccess(lb, current)
+				reportSuccess(lb, bk)
 				if stream && resp.Stream != nil {
 					// The provider stream is lazy: invokeOnce only measured
 					// time-to-first-byte. Keep the LLM span open and re-time it
@@ -228,28 +229,32 @@ func (f *forwarder) invokeWithFailover(
 
 				last = failoverState{rejection: result}
 				lastKind = failurePluginRejection
-				f.logRetry(current, pe, budget)
+				f.logRetry(bk, pe, budget)
 			case OutcomeTerminal:
 				if resp == nil {
 					return nil, err
 				}
-				reportSuccess(lb, current)
+				reportSuccess(lb, bk)
 				return f.finalizeBody(ctx, dto, resp), nil
 			case OutcomeRetryable:
 				reason := failureReason(resp, err)
-				reportFailure(lb, current, reason)
+				reportFailure(lb, bk, reason)
 				last = failoverState{resp: resp, err: err}
 				lastKind = classifyFailure(resp, err)
-				f.logRetry(current, reason, budget)
+				f.logRetry(bk, reason, budget)
 				continue
 			}
 			break
 		}
-		excluded[current.ID] = struct{}{}
+		excluded[current.Key()] = struct{}{}
 		if route.pinned {
 			break
 		}
-		current, fromFallback = f.nextCandidate(ctx, lb, rc, dto.request, excluded, triggers.allowsFallback(lastKind))
+		next, viaFallback := f.nextCandidate(ctx, lb, rc, dto.request, excluded, triggers.allowsFallback(lastKind))
+		if next == nil {
+			break
+		}
+		current, fromFallback = *next, viaFallback
 	}
 
 	return f.relayLast(ctx, dto, last)
@@ -290,16 +295,16 @@ func (f *forwarder) nextCandidate(
 	lb *loadbalancer.LoadBalancer,
 	rc *appconsumer.RoutableConsumer,
 	req *infracontext.RequestContext,
-	excluded map[ids.RegistryID]struct{},
+	excluded map[routingdomain.RouteKey]struct{},
 	allowChain bool,
-) (*domain.Registry, bool) {
+) (*routingdomain.Route, bool) {
 	if isRoleBased(rc) {
 		return nil, false
 	}
 	if lb != nil {
-		if bk, err := lb.NextBackend(ctx, req, excluded); err == nil && bk != nil {
-			if _, seen := excluded[bk.ID]; !seen {
-				return bk, false
+		if next, err := lb.NextRoute(ctx, req, excluded); err == nil && next != nil {
+			if _, seen := excluded[next.Key()]; !seen {
+				return next, false
 			}
 		}
 	}
@@ -307,7 +312,8 @@ func (f *forwarder) nextCandidate(
 		return nil, false
 	}
 	if bk := firstAvailableFallback(rc, excluded); bk != nil {
-		return bk, true
+		fallback := routingdomain.RouteForRegistry(bk)
+		return &fallback, true
 	}
 	return nil, false
 }
@@ -327,7 +333,7 @@ func reportFailure(lb *loadbalancer.LoadBalancer, bk *domain.Registry, reason er
 func (f *forwarder) recordSpan(
 	ctx context.Context,
 	dto *forwardRequestDTO,
-	bk *domain.Registry,
+	route routingdomain.Route,
 	fromFallback bool,
 	attempt int,
 	outcome Outcome,
@@ -338,6 +344,7 @@ func (f *forwarder) recordSpan(
 	if rt == nil {
 		return nil
 	}
+	bk := route.Registry
 	span := &trace.Span{
 		Type:      trace.SpanLLM,
 		Name:      bk.Provider(),
@@ -345,6 +352,7 @@ func (f *forwarder) recordSpan(
 		LLM: &trace.LLMAttrs{
 			RegistryID:     bk.ID.String(),
 			Provider:       bk.Provider(),
+			RouteModel:     route.Model,
 			RequestedModel: dto.request.RequestedModel,
 			Attempt:        attempt,
 			Fallback:       fromFallback,

--- a/pkg/app/proxy/load_balancer_cache.go
+++ b/pkg/app/proxy/load_balancer_cache.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	appconsumer "github.com/NeuralTrust/TrustGate/pkg/app/consumer"
+	approuting "github.com/NeuralTrust/TrustGate/pkg/app/routing"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
 	domain "github.com/NeuralTrust/TrustGate/pkg/domain/registry"
 	routingdomain "github.com/NeuralTrust/TrustGate/pkg/domain/routing"
@@ -57,35 +58,55 @@ func newLoadBalancerCache(
 func (c *loadBalancerCache) For(rc *appconsumer.RoutableConsumer) (*loadbalancer.LoadBalancer, error) {
 	key := loadBalancerCacheKey(rc.Consumer.GatewayID, rc.Consumer.ID)
 	return c.getOrBuild(key, func() loadbalancer.Pool {
-		lbAlgorithm, embeddingConfig, smartRouting := lbSettings(rc)
-		return loadbalancer.Pool{
-			ID:                 key,
-			Registries:         rc.Registries,
-			Weights:            rc.Consumer.RegistryWeights,
-			Algorithm:          lbAlgorithm,
-			EmbeddingConfig:    embeddingConfig,
-			SmartRoutingConfig: smartRouting,
-		}
+		return c.pool(rc, key)
 	})
 }
 
 func (c *loadBalancerCache) PoolFor(
 	rc *appconsumer.RoutableConsumer,
 	alias string,
-	candidates *routingdomain.CandidateSet,
 ) (*loadbalancer.LoadBalancer, error) {
 	key := poolLoadBalancerCacheKey(rc.Consumer.GatewayID, rc.Consumer.ID, alias)
 	return c.getOrBuild(key, func() loadbalancer.Pool {
-		lbAlgorithm, embeddingConfig, smartRouting := lbSettings(rc)
-		return loadbalancer.Pool{
-			ID:                 key,
-			Registries:         candidates.Registries(),
-			Weights:            rc.Consumer.RegistryWeights,
-			Algorithm:          lbAlgorithm,
-			EmbeddingConfig:    embeddingConfig,
-			SmartRoutingConfig: smartRouting,
-		}
+		return c.pool(rc, key)
 	})
+}
+
+// The aliased and implicit pools share this derivation and differ only in cache key,
+// so each keeps its own strategy state.
+func (c *loadBalancerCache) pool(rc *appconsumer.RoutableConsumer, key string) loadbalancer.Pool {
+	lbAlgorithm, embeddingConfig, smartRouting := lbSettings(rc)
+	routes := approuting.BuildPoolRoutes(rc)
+	c.warnOnNarrowedPool(rc, routes)
+	return loadbalancer.Pool{
+		ID:                 key,
+		Routes:             routes,
+		Algorithm:          lbAlgorithm,
+		EmbeddingConfig:    embeddingConfig,
+		SmartRoutingConfig: smartRouting,
+	}
+}
+
+func (c *loadBalancerCache) warnOnNarrowedPool(
+	rc *appconsumer.RoutableConsumer,
+	routes []routingdomain.Route,
+) {
+	if c.logger == nil {
+		return
+	}
+	lbCfg := rc.Consumer.LBConfig
+	if lbCfg == nil || !lbCfg.Enabled || len(lbCfg.Members) == 0 {
+		return
+	}
+	covered := len(routingdomain.DistinctRegistries(routes))
+	if covered >= len(rc.Registries) {
+		return
+	}
+	c.logger.Warn("load balancer pool is narrower than the consumer's attached registries",
+		slog.String("consumer_id", rc.Consumer.ID.String()),
+		slog.Int("member_registries", covered),
+		slog.Int("attached_registries", len(rc.Registries)),
+	)
 }
 
 func (c *loadBalancerCache) getOrBuild(

--- a/pkg/app/proxy/routing.go
+++ b/pkg/app/proxy/routing.go
@@ -34,8 +34,8 @@ import (
 
 type routedBackend struct {
 	lb           *loadbalancer.LoadBalancer
-	backend      *domain.Registry
-	excluded     map[ids.RegistryID]struct{}
+	route        routingdomain.Route
+	excluded     map[routingdomain.RouteKey]struct{}
 	fromFallback bool
 	pinned       bool
 }
@@ -178,97 +178,128 @@ func (f *forwarder) routeBackend(
 ) (routedBackend, error) {
 	if isRoleBased(rc) {
 		return routedBackend{
-			backend:  candidates.Candidates()[0].Registry,
-			excluded: make(map[ids.RegistryID]struct{}),
+			route:    routingdomain.RouteForRegistry(candidates.Candidates()[0].Registry),
+			excluded: make(map[routingdomain.RouteKey]struct{}),
 		}, nil
 	}
 	if intent.IsQualified() || intent.IsShortModel() {
 		return routedBackend{
-			backend:  candidates.Candidates()[0].Registry,
-			excluded: make(map[ids.RegistryID]struct{}),
+			route:    routingdomain.RouteForRegistry(candidates.Candidates()[0].Registry),
+			excluded: make(map[routingdomain.RouteKey]struct{}),
 			pinned:   true,
 		}, nil
 	}
 	if len(rc.Registries) == 0 {
 		return routedBackend{}, ErrNoBackendsInPool
 	}
-	lb, err := f.routeLoadBalancer(rc, intent, candidates)
+	lb, err := f.routeLoadBalancer(rc, intent)
 	if err != nil {
 		return routedBackend{}, err
 	}
-	excluded := nonCandidateRegistries(rc, candidates)
-	bk, err := lb.NextBackend(ctx, req, excluded)
+	excluded := nonCandidateRoutes(lb, rc, candidates)
+	route, err := lb.NextRoute(ctx, req, excluded)
 	if err != nil {
 		if fallback := firstAvailableFallback(rc, excluded); fallback != nil {
-			return routedBackend{lb: lb, backend: fallback, excluded: excluded, fromFallback: true}, nil
+			return routedBackend{
+				lb:           lb,
+				route:        routingdomain.RouteForRegistry(fallback),
+				excluded:     excluded,
+				fromFallback: true,
+			}, nil
 		}
 		return routedBackend{}, fmt.Errorf("%w: %s", ErrNoBackendAvailable, err.Error())
 	}
-	return routedBackend{lb: lb, backend: bk, excluded: excluded}, nil
+	return routedBackend{lb: lb, route: *route, excluded: excluded}, nil
 }
 
 func (f *forwarder) routeLoadBalancer(
 	rc *appconsumer.RoutableConsumer,
 	intent routingdomain.Intent,
-	candidates *routingdomain.CandidateSet,
 ) (*loadbalancer.LoadBalancer, error) {
 	if intent.IsPool() {
-		return f.balancers.PoolFor(rc, intent.PoolAlias, candidates)
+		return f.balancers.PoolFor(rc, intent.PoolAlias)
 	}
 	return f.balancers.For(rc)
 }
 
-func nonCandidateRegistries(
+func nonCandidateRoutes(
+	lb *loadbalancer.LoadBalancer,
 	rc *appconsumer.RoutableConsumer,
 	candidates *routingdomain.CandidateSet,
-) map[ids.RegistryID]struct{} {
-	excluded := make(map[ids.RegistryID]struct{})
+) map[routingdomain.RouteKey]struct{} {
+	excluded := make(map[routingdomain.RouteKey]struct{})
 	if candidates == nil {
 		return excluded
 	}
-	for _, reg := range rc.Registries {
-		if !candidates.HasRegistry(reg.ID) {
-			excluded[reg.ID] = struct{}{}
+	for _, route := range lb.Routes() {
+		if !candidates.HasRegistry(route.RegistryID()) {
+			excluded[route.Key()] = struct{}{}
 		}
 	}
 	for _, reg := range rc.FallbackBackends {
 		if !candidates.HasRegistry(reg.ID) {
-			excluded[reg.ID] = struct{}{}
+			excluded[routingdomain.RouteForRegistry(reg).Key()] = struct{}{}
 		}
 	}
 	return excluded
 }
 
+// The fallback chain picks registries, so a registry with any excluded route counts as tried.
+func excludedRegistries(excluded map[routingdomain.RouteKey]struct{}) map[ids.RegistryID]struct{} {
+	out := make(map[ids.RegistryID]struct{}, len(excluded))
+	for key := range excluded {
+		out[key.RegistryID] = struct{}{}
+	}
+	return out
+}
+
 func firstAvailableFallback(
 	rc *appconsumer.RoutableConsumer,
-	excluded map[ids.RegistryID]struct{},
+	excluded map[routingdomain.RouteKey]struct{},
 ) *domain.Registry {
 	if fb := rc.Consumer.Fallback; fb == nil || !fb.Enabled {
 		return nil
 	}
+	skip := excludedRegistries(excluded)
 	for _, bk := range rc.FallbackBackends {
-		if _, skip := excluded[bk.ID]; !skip {
+		if _, blocked := skip[bk.ID]; !blocked {
 			return bk
 		}
 	}
 	return nil
 }
 
-func (f *forwarder) stampRoutingPolicy(dto *forwardRequestDTO, rc *appconsumer.RoutableConsumer, bk *domain.Registry) {
+func (f *forwarder) stampRoutingPolicy(
+	dto *forwardRequestDTO,
+	rc *appconsumer.RoutableConsumer,
+	route routingdomain.Route,
+) {
+	bk := route.Registry
 	dto.routeSource = routeSourceFor(dto.candidates, bk)
-	if candidate, ok := dto.candidates.ForRegistry(bk.ID); ok {
-		dto.request.AllowedModels = candidate.Allowed
-		dto.request.DefaultModel = candidate.Default
-		return
+	allowed, defaultModel := candidatePolicy(dto.candidates, rc, bk)
+	if route.Allowed != nil {
+		allowed = route.Allowed
+	}
+	if route.Default != "" {
+		defaultModel = route.Default
+	}
+	dto.request.AllowedModels = allowed
+	dto.request.DefaultModel = defaultModel
+}
+
+func candidatePolicy(
+	candidates *routingdomain.CandidateSet,
+	rc *appconsumer.RoutableConsumer,
+	bk *domain.Registry,
+) ([]string, string) {
+	if candidate, ok := candidates.ForRegistry(bk.ID); ok {
+		return candidate.Allowed, candidate.Default
 	}
 	policy, ok := rc.Consumer.ModelPolicies.For(bk.ID)
 	if !ok {
-		dto.request.AllowedModels = nil
-		dto.request.DefaultModel = ""
-		return
+		return nil, ""
 	}
-	dto.request.AllowedModels = policy.Allowed
-	dto.request.DefaultModel = policy.Default
+	return policy.Allowed, policy.Default
 }
 
 func routeSourceFor(candidates *routingdomain.CandidateSet, bk *domain.Registry) string {

--- a/pkg/app/routing/resolver.go
+++ b/pkg/app/routing/resolver.go
@@ -69,11 +69,12 @@ func (r *resolver) resolveInline(in ResolveInput) (*routingdomain.CandidateSet, 
 	}
 	base := routingdomain.NewCandidateSet()
 	policies := in.Consumer.Consumer.ModelPolicies
+	pinned := memberPinnedModels(in.Consumer.Consumer.LBConfig)
 	for _, reg := range in.Consumer.Registries {
-		base.Add(inlineCandidate(reg, policies, sourceConsumer))
+		base.Add(inlineCandidate(reg, policies, pinned, sourceConsumer))
 	}
 	for _, reg := range in.Consumer.FallbackBackends {
-		base.Add(inlineCandidate(reg, policies, sourceFallback))
+		base.Add(inlineCandidate(reg, policies, pinned, sourceFallback))
 	}
 	return base.ResolveIntent(in.Intent)
 }
@@ -81,16 +82,25 @@ func (r *resolver) resolveInline(in ResolveInput) (*routingdomain.CandidateSet, 
 func inlineCandidate(
 	reg *registrydomain.Registry,
 	policies consumerdomain.ModelPolicies,
+	pinned map[ids.RegistryID]string,
 	source string,
 ) routingdomain.Candidate {
 	policy, ok := policies.For(reg.ID)
 	if !ok {
-		return routingdomain.Candidate{Registry: reg, Sources: []string{source}}
+		return routingdomain.Candidate{
+			Registry: reg,
+			Default:  pinned[reg.ID],
+			Sources:  []string{source},
+		}
+	}
+	defaultModel := policy.Default
+	if defaultModel == "" {
+		defaultModel = pinned[reg.ID]
 	}
 	return routingdomain.Candidate{
 		Registry: reg,
 		Allowed:  policy.Allowed,
-		Default:  policy.Default,
+		Default:  defaultModel,
 		Sources:  []string{source},
 	}
 }

--- a/pkg/app/routing/routes.go
+++ b/pkg/app/routing/routes.go
@@ -1,0 +1,100 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package routing
+
+import (
+	appconsumer "github.com/NeuralTrust/TrustGate/pkg/app/consumer"
+	consumerdomain "github.com/NeuralTrust/TrustGate/pkg/domain/consumer"
+	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
+	routingdomain "github.com/NeuralTrust/TrustGate/pkg/domain/routing"
+)
+
+// The result is request-independent because balancers are cached per consumer.
+func BuildPoolRoutes(rc *appconsumer.RoutableConsumer) []routingdomain.Route {
+	if rc == nil || rc.Consumer == nil {
+		return nil
+	}
+	policies := rc.Consumer.ModelPolicies
+	lbCfg := rc.Consumer.LBConfig
+	if lbCfg == nil || !lbCfg.Enabled || len(lbCfg.Members) == 0 {
+		return registryRoutes(rc, policies)
+	}
+	byID := registriesByID(rc)
+	routes := make([]routingdomain.Route, 0, len(lbCfg.Members))
+	for _, member := range lbCfg.Members {
+		reg, ok := byID[member.RegistryID]
+		if !ok {
+			continue
+		}
+		policy, _ := policies.For(reg.ID)
+		routes = append(routes, routingdomain.Route{
+			Registry: reg,
+			Model:    member.RouteModel(),
+			Allowed:  memberAllowed(member, policy),
+			Default:  routeDefault(member, policy),
+			Weight:   member.RouteWeight(rc.Consumer.WeightFor(reg.ID)),
+		})
+	}
+	if len(routes) == 0 {
+		return registryRoutes(rc, policies)
+	}
+	return routes
+}
+
+func registryRoutes(
+	rc *appconsumer.RoutableConsumer,
+	policies consumerdomain.ModelPolicies,
+) []routingdomain.Route {
+	routes := make([]routingdomain.Route, 0, len(rc.Registries))
+	for _, reg := range rc.Registries {
+		policy, _ := policies.For(reg.ID)
+		routes = append(routes, routingdomain.Route{
+			Registry: reg,
+			Allowed:  policy.Allowed,
+			Default:  policy.Default,
+			Weight:   rc.Consumer.WeightFor(reg.ID),
+		})
+	}
+	return routes
+}
+
+func routeDefault(member consumerdomain.LBPoolMember, policy consumerdomain.ModelPolicy) string {
+	if model := member.RouteModel(); model != "" {
+		return model
+	}
+	return memberDefault(member, policy)
+}
+
+// Auto routing drops candidates without a default, so a pinned member model must serve as one.
+func memberPinnedModels(lbCfg *consumerdomain.LBConfig) map[ids.RegistryID]string {
+	if lbCfg == nil || !lbCfg.Enabled || len(lbCfg.Members) == 0 {
+		return nil
+	}
+	pinned := make(map[ids.RegistryID]string, len(lbCfg.Members))
+	for _, member := range lbCfg.Members {
+		model := member.RouteModel()
+		if model == "" {
+			continue
+		}
+		if _, seen := pinned[member.RegistryID]; seen {
+			continue
+		}
+		pinned[member.RegistryID] = model
+	}
+	if len(pinned) == 0 {
+		return nil
+	}
+	return pinned
+}

--- a/pkg/app/routing/routes_test.go
+++ b/pkg/app/routing/routes_test.go
@@ -1,0 +1,173 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package routing_test
+
+import (
+	"testing"
+
+	approuting "github.com/NeuralTrust/TrustGate/pkg/app/routing"
+	consumerdomain "github.com/NeuralTrust/TrustGate/pkg/domain/consumer"
+	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
+	registrydomain "github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	routingdomain "github.com/NeuralTrust/TrustGate/pkg/domain/routing"
+)
+
+func intPtr(v int) *int { return &v }
+
+func TestBuildPoolRoutes_SameRegistryDistinctModels(t *testing.T) {
+	t.Parallel()
+	shared := newRegistry("openai")
+	policies := consumerdomain.ModelPolicies{
+		shared.ID: {Allowed: []string{"gpt-4o-mini", "gpt-5"}, Default: "gpt-4o-mini"},
+	}
+	rc := inlineConsumer([]*registrydomain.Registry{shared}, policies, &consumerdomain.LBConfig{
+		Enabled: true,
+		Members: []consumerdomain.LBPoolMember{
+			{RegistryID: shared.ID, Model: "gpt-4o-mini"},
+			{RegistryID: shared.ID, Model: "gpt-5", Weight: intPtr(4)},
+		},
+	})
+
+	routes := approuting.BuildPoolRoutes(rc)
+
+	if len(routes) != 2 {
+		t.Fatalf("routes = %d, want 2", len(routes))
+	}
+	if routes[0].Key() == routes[1].Key() {
+		t.Fatalf("routes share an identity: %+v", routes[0].Key())
+	}
+	for i, want := range []string{"gpt-4o-mini", "gpt-5"} {
+		if routes[i].Model != want {
+			t.Fatalf("routes[%d].Model = %q, want %q", i, routes[i].Model, want)
+		}
+		if routes[i].Default != want {
+			t.Fatalf("routes[%d].Default = %q, want %q", i, routes[i].Default, want)
+		}
+		if routes[i].RegistryID() != shared.ID {
+			t.Fatalf("routes[%d] registry = %s, want %s", i, routes[i].RegistryID(), shared.ID)
+		}
+	}
+	if routes[0].EffectiveWeight() != 1 {
+		t.Fatalf("routes[0] weight = %d, want the consumer fallback 1", routes[0].EffectiveWeight())
+	}
+	if routes[1].EffectiveWeight() != 4 {
+		t.Fatalf("routes[1] weight = %d, want the member weight 4", routes[1].EffectiveWeight())
+	}
+}
+
+func TestBuildPoolRoutes_FallsBackToAttachedRegistries(t *testing.T) {
+	t.Parallel()
+	a := newRegistry("openai")
+	b := newRegistry("anthropic")
+	policies := consumerdomain.ModelPolicies{
+		a.ID: {Allowed: []string{"gpt-5"}, Default: "gpt-5"},
+		b.ID: {Allowed: []string{"claude-4"}, Default: "claude-4"},
+	}
+	tests := []struct {
+		name string
+		lb   *consumerdomain.LBConfig
+	}{
+		{name: "no lb config", lb: nil},
+		{name: "lb disabled", lb: &consumerdomain.LBConfig{Enabled: false}},
+		{name: "lb enabled without members", lb: &consumerdomain.LBConfig{Enabled: true}},
+		{
+			name: "members that are not attached",
+			lb: &consumerdomain.LBConfig{
+				Enabled: true,
+				Members: []consumerdomain.LBPoolMember{{RegistryID: ids.New[ids.RegistryKind]()}},
+			},
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rc := inlineConsumer([]*registrydomain.Registry{a, b}, policies, tc.lb)
+
+			routes := approuting.BuildPoolRoutes(rc)
+
+			if len(routes) != 2 {
+				t.Fatalf("routes = %d, want one per attached registry", len(routes))
+			}
+			for i, route := range routes {
+				if route.Model != "" {
+					t.Fatalf("routes[%d].Model = %q, want unpinned", i, route.Model)
+				}
+			}
+			if routes[0].Default != "gpt-5" || routes[1].Default != "claude-4" {
+				t.Fatalf("defaults = %q/%q, want the policy defaults", routes[0].Default, routes[1].Default)
+			}
+		})
+	}
+}
+
+func TestBuildPoolRoutes_MemberModelsNarrowTheAllowList(t *testing.T) {
+	t.Parallel()
+	reg := newRegistry("openai")
+	policies := consumerdomain.ModelPolicies{
+		reg.ID: {Allowed: []string{"gpt-4o-mini", "gpt-5"}, Default: "gpt-5"},
+	}
+	rc := inlineConsumer([]*registrydomain.Registry{reg}, policies, &consumerdomain.LBConfig{
+		Enabled: true,
+		Members: []consumerdomain.LBPoolMember{
+			{RegistryID: reg.ID, Models: []string{"gpt-4o-mini"}},
+		},
+	})
+
+	routes := approuting.BuildPoolRoutes(rc)
+
+	if len(routes) != 1 {
+		t.Fatalf("routes = %d, want 1", len(routes))
+	}
+	if len(routes[0].Allowed) != 1 || routes[0].Allowed[0] != "gpt-4o-mini" {
+		t.Fatalf("Allowed = %v, want the member narrowing", routes[0].Allowed)
+	}
+	if routes[0].Default != "gpt-4o-mini" {
+		t.Fatalf("Default = %q, want the member narrowing to win over the policy default", routes[0].Default)
+	}
+}
+
+func TestBuildPoolRoutes_NilConsumer(t *testing.T) {
+	t.Parallel()
+	if routes := approuting.BuildPoolRoutes(nil); routes != nil {
+		t.Fatalf("routes = %v, want nil", routes)
+	}
+}
+
+func TestResolver_AutoKeepsRegistryWhoseDefaultComesFromAMember(t *testing.T) {
+	t.Parallel()
+	reg := newRegistry("openai")
+	policies := consumerdomain.ModelPolicies{
+		reg.ID: {Allowed: []string{"gpt-4o-mini", "gpt-5"}},
+	}
+	rc := inlineConsumer([]*registrydomain.Registry{reg}, policies, &consumerdomain.LBConfig{
+		Enabled: true,
+		Members: []consumerdomain.LBPoolMember{
+			{RegistryID: reg.ID, Model: "gpt-4o-mini"},
+			{RegistryID: reg.ID, Model: "gpt-5"},
+		},
+	})
+
+	cs, err := approuting.NewResolver().Resolve(approuting.ResolveInput{
+		Intent:   routingdomain.Intent{Auto: true},
+		Consumer: rc,
+	})
+	if err != nil {
+		t.Fatalf("auto resolution dropped a registry whose default comes from a member: %v", err)
+	}
+	if !cs.HasRegistry(reg.ID) {
+		t.Fatalf("candidates = %v, want the registry to survive auto filtering", cs.Registries())
+	}
+}

--- a/pkg/domain/consumer/lb_config.go
+++ b/pkg/domain/consumer/lb_config.go
@@ -18,6 +18,8 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
+	"slices"
+	"strings"
 
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/registry"
@@ -27,6 +29,19 @@ import (
 type LBPoolMember struct {
 	RegistryID ids.RegistryID `json:"registry_id"`
 	Models     []string       `json:"models,omitempty"`
+	Model      string         `json:"model,omitempty"`
+	Weight     *int           `json:"weight,omitempty"`
+}
+
+func (m LBPoolMember) RouteModel() string {
+	return strings.TrimSpace(m.Model)
+}
+
+func (m LBPoolMember) RouteWeight(fallback int) int {
+	if m.Weight == nil || *m.Weight <= 0 {
+		return fallback
+	}
+	return *m.Weight
 }
 
 type LBConfig struct {
@@ -71,6 +86,9 @@ func (l *LBConfig) Validate(inline ModelPolicies) error {
 			return err
 		}
 	}
+	if err := l.validateRouteIdentity(); err != nil {
+		return err
+	}
 	switch l.Algorithm {
 	case algorithm.Semantic:
 		if l.SmartRouting != nil {
@@ -93,7 +111,7 @@ func (l *LBConfig) Validate(inline ModelPolicies) error {
 		if err := l.SmartRouting.Validate(); err != nil {
 			return fmt.Errorf("%w: %s", ErrInvalidLBConfig, err.Error())
 		}
-		return l.validateSmartRoutingMembers()
+		return l.validateSmartRoutingTiers()
 	default:
 		if l.EmbeddingConfig != nil {
 			return fmt.Errorf("%w: embedding_config is only valid for the semantic algorithm", ErrInvalidLBConfig)
@@ -105,14 +123,58 @@ func (l *LBConfig) Validate(inline ModelPolicies) error {
 	}
 }
 
-func (l *LBConfig) validateSmartRoutingMembers() error {
-	members := make(map[ids.RegistryID]struct{}, len(l.Members))
+func (l *LBConfig) validateRouteIdentity() error {
+	type routeKey struct {
+		registryID ids.RegistryID
+		model      string
+	}
+	perRegistry := make(map[ids.RegistryID]int, len(l.Members))
 	for _, member := range l.Members {
-		members[member.RegistryID] = struct{}{}
+		perRegistry[member.RegistryID]++
+	}
+	seen := make(map[routeKey]struct{}, len(l.Members))
+	for i, member := range l.Members {
+		model := member.RouteModel()
+		if model == "" && perRegistry[member.RegistryID] > 1 {
+			return fmt.Errorf(
+				"%w: members[%d] repeats registry %s without a model; every member sharing a registry must declare one",
+				ErrInvalidLBConfig, i, member.RegistryID)
+		}
+		key := routeKey{registryID: member.RegistryID, model: model}
+		if _, dup := seen[key]; dup {
+			return fmt.Errorf(
+				"%w: members[%d] duplicates route %s/%s", ErrInvalidLBConfig, i, member.RegistryID, model)
+		}
+		seen[key] = struct{}{}
+	}
+	return nil
+}
+
+func (l *LBConfig) validateSmartRoutingTiers() error {
+	routes := make(map[ids.RegistryID][]string, len(l.Members))
+	for _, member := range l.Members {
+		routes[member.RegistryID] = append(routes[member.RegistryID], member.RouteModel())
 	}
 	for i, tier := range l.SmartRouting.Tiers {
-		if _, ok := members[tier.RegistryID]; !ok {
-			return fmt.Errorf("%w: smart_routing.tiers[%d].registry_id %s is not a pool member", ErrInvalidLBConfig, i, tier.RegistryID)
+		models, ok := routes[tier.RegistryID]
+		if !ok {
+			return fmt.Errorf(
+				"%w: smart_routing.tiers[%d].registry_id %s is not a pool member",
+				ErrInvalidLBConfig, i, tier.RegistryID)
+		}
+		model := tier.RouteModel()
+		if model == "" {
+			if len(models) > 1 {
+				return fmt.Errorf(
+					"%w: smart_routing.tiers[%d] targets registry %s, which has %d routes; declare a model",
+					ErrInvalidLBConfig, i, tier.RegistryID, len(models))
+			}
+			continue
+		}
+		if !slices.Contains(models, model) {
+			return fmt.Errorf(
+				"%w: smart_routing.tiers[%d].model %q is not a route of registry %s",
+				ErrInvalidLBConfig, i, model, tier.RegistryID)
 		}
 	}
 	return nil
@@ -125,6 +187,10 @@ func validateLBPoolMember(index int, member LBPoolMember, inline ModelPolicies) 
 	policy, ok := inline.For(member.RegistryID)
 	if !ok {
 		return fmt.Errorf("%w: members[%d].registry_id %s is not in model_policies", ErrInvalidLBConfig, index, member.RegistryID)
+	}
+	if member.Weight != nil && (*member.Weight < DefaultRegistryWeight || *member.Weight > MaxRegistryWeight) {
+		return fmt.Errorf("%w: members[%d].weight %d is out of range [%d,%d]",
+			ErrInvalidLBConfig, index, *member.Weight, DefaultRegistryWeight, MaxRegistryWeight)
 	}
 	allowed := make(map[string]struct{}, len(policy.Allowed))
 	for _, model := range policy.Allowed {
@@ -141,6 +207,35 @@ func validateLBPoolMember(index int, member LBPoolMember, inline ModelPolicies) 
 		seen[model] = struct{}{}
 		if _, ok := allowed[model]; !ok {
 			return fmt.Errorf("%w: members[%d].model %q is not allowed by model_policies", ErrInvalidLBConfig, index, model)
+		}
+	}
+	return validateLBPoolMemberModel(index, member, seen, allowed)
+}
+
+// An open allow-list permits every model, so a pinned model is only checked against a non-empty one.
+func validateLBPoolMemberModel(
+	index int,
+	member LBPoolMember,
+	memberModels map[string]struct{},
+	allowed map[string]struct{},
+) error {
+	model := member.RouteModel()
+	if model == "" {
+		if member.Model != "" {
+			return fmt.Errorf("%w: members[%d].model is blank", ErrInvalidLBConfig, index)
+		}
+		return nil
+	}
+	if len(memberModels) > 0 {
+		if _, ok := memberModels[model]; !ok {
+			return fmt.Errorf("%w: members[%d].model %q is not listed in members[%d].models",
+				ErrInvalidLBConfig, index, model, index)
+		}
+	}
+	if len(allowed) > 0 {
+		if _, ok := allowed[model]; !ok {
+			return fmt.Errorf("%w: members[%d].model %q is not allowed by model_policies",
+				ErrInvalidLBConfig, index, model)
 		}
 	}
 	return nil

--- a/pkg/domain/consumer/lb_config_test.go
+++ b/pkg/domain/consumer/lb_config_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
+	"github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	"github.com/NeuralTrust/TrustGate/pkg/domain/routing/algorithm"
 )
 
 func TestLBConfig_Validate(t *testing.T) {
@@ -62,3 +64,195 @@ func TestLBConfig_Validate(t *testing.T) {
 		})
 	}
 }
+
+func TestLBConfig_ValidateRouteIdentity(t *testing.T) {
+	t.Parallel()
+	shared := ids.New[ids.RegistryKind]()
+	other := ids.New[ids.RegistryKind]()
+	policies := ModelPolicies{
+		shared: {Allowed: []string{"gpt-4o-mini", "gpt-5"}, Default: "gpt-4o-mini"},
+		other:  {Allowed: []string{"claude-4"}, Default: "claude-4"},
+	}
+	tests := []struct {
+		name    string
+		members []LBPoolMember
+		wantErr bool
+	}{
+		{
+			name: "same registry with distinct models",
+			members: []LBPoolMember{
+				{RegistryID: shared, Model: "gpt-4o-mini"},
+				{RegistryID: shared, Model: "gpt-5"},
+			},
+		},
+		{
+			name: "distinct registries without models stay valid",
+			members: []LBPoolMember{
+				{RegistryID: shared},
+				{RegistryID: other},
+			},
+		},
+		{
+			name: "same registry twice without models",
+			members: []LBPoolMember{
+				{RegistryID: shared},
+				{RegistryID: shared},
+			},
+			wantErr: true,
+		},
+		{
+			name: "same registry, one member missing its model",
+			members: []LBPoolMember{
+				{RegistryID: shared, Model: "gpt-5"},
+				{RegistryID: shared},
+			},
+			wantErr: true,
+		},
+		{
+			name: "duplicate route",
+			members: []LBPoolMember{
+				{RegistryID: shared, Model: "gpt-5"},
+				{RegistryID: shared, Model: "gpt-5"},
+			},
+			wantErr: true,
+		},
+		{
+			name:    "model outside the policy allow-list",
+			members: []LBPoolMember{{RegistryID: shared, Model: "gpt-4.1"}},
+			wantErr: true,
+		},
+		{
+			name:    "model outside the member allow-list",
+			members: []LBPoolMember{{RegistryID: shared, Models: []string{"gpt-5"}, Model: "gpt-4o-mini"}},
+			wantErr: true,
+		},
+		{
+			name:    "blank model",
+			members: []LBPoolMember{{RegistryID: shared, Model: "   "}},
+			wantErr: true,
+		},
+		{
+			name:    "weight above the cap",
+			members: []LBPoolMember{{RegistryID: shared, Weight: ptrInt(MaxRegistryWeight + 1)}},
+			wantErr: true,
+		},
+		{
+			name:    "weight below the floor",
+			members: []LBPoolMember{{RegistryID: shared, Weight: ptrInt(0)}},
+			wantErr: true,
+		},
+		{
+			name:    "weight inside the range",
+			members: []LBPoolMember{{RegistryID: shared, Weight: ptrInt(7)}},
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := &LBConfig{Enabled: true, Members: tc.members}
+			err := cfg.Validate(policies)
+			if tc.wantErr && !errors.Is(err, ErrInvalidLBConfig) {
+				t.Fatalf("err = %v, want ErrInvalidLBConfig", err)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestLBConfig_ValidateSmartRoutingTiers(t *testing.T) {
+	t.Parallel()
+	shared := ids.New[ids.RegistryKind]()
+	single := ids.New[ids.RegistryKind]()
+	policies := ModelPolicies{
+		shared: {Allowed: []string{"gpt-4o-mini", "gpt-5"}, Default: "gpt-4o-mini"},
+		single: {Allowed: []string{"claude-4"}, Default: "claude-4"},
+	}
+	sharedMembers := []LBPoolMember{
+		{RegistryID: shared, Model: "gpt-4o-mini"},
+		{RegistryID: shared, Model: "gpt-5"},
+	}
+	tests := []struct {
+		name    string
+		members []LBPoolMember
+		tiers   []registry.SmartRoutingTier
+		wantErr bool
+	}{
+		{
+			name:    "tiers target distinct routes of one registry",
+			members: sharedMembers,
+			tiers: []registry.SmartRoutingTier{
+				{MinScore: 0, RegistryID: shared, Model: "gpt-4o-mini"},
+				{MinScore: 0.5, RegistryID: shared, Model: "gpt-5"},
+			},
+		},
+		{
+			name:    "tier may omit the model for a single-route registry",
+			members: []LBPoolMember{{RegistryID: single}},
+			tiers:   []registry.SmartRoutingTier{{MinScore: 0, RegistryID: single}},
+		},
+		{
+			name:    "tier omits the model on a multi-route registry",
+			members: sharedMembers,
+			tiers:   []registry.SmartRoutingTier{{MinScore: 0, RegistryID: shared}},
+			wantErr: true,
+		},
+		{
+			name:    "tier targets a model that is not a route",
+			members: sharedMembers,
+			tiers:   []registry.SmartRoutingTier{{MinScore: 0, RegistryID: shared, Model: "gpt-4.1"}},
+			wantErr: true,
+		},
+		{
+			name:    "tier targets a registry outside the pool",
+			members: sharedMembers,
+			tiers:   []registry.SmartRoutingTier{{MinScore: 0, RegistryID: single, Model: "claude-4"}},
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := &LBConfig{
+				Enabled:      true,
+				Algorithm:    algorithm.SmartRouting,
+				Members:      tc.members,
+				SmartRouting: &registry.SmartRoutingConfig{Tiers: tc.tiers},
+			}
+			err := cfg.Validate(policies)
+			if tc.wantErr && !errors.Is(err, ErrInvalidLBConfig) {
+				t.Fatalf("err = %v, want ErrInvalidLBConfig", err)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestLBPoolMember_RouteWeight(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		member LBPoolMember
+		want   int
+	}{
+		{name: "unset falls back", member: LBPoolMember{}, want: 3},
+		{name: "zero falls back", member: LBPoolMember{Weight: ptrInt(0)}, want: 3},
+		{name: "declared wins", member: LBPoolMember{Weight: ptrInt(9)}, want: 9},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.member.RouteWeight(3); got != tc.want {
+				t.Fatalf("RouteWeight() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func ptrInt(v int) *int { return &v }

--- a/pkg/domain/registry/smart_routing_config.go
+++ b/pkg/domain/registry/smart_routing_config.go
@@ -16,15 +16,21 @@ package registry
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
 )
 
-// SmartRoutingTier binds a complexity-score threshold to a target registry. A
-// tier is selected when the score is at least MinScore.
+// SmartRoutingTier binds a complexity-score threshold to a target route. A tier
+// is selected when the score is at least MinScore.
 type SmartRoutingTier struct {
 	MinScore   float64        `json:"min_score"`
 	RegistryID ids.RegistryID `json:"registry_id"`
+	Model      string         `json:"model,omitempty"`
+}
+
+func (t SmartRoutingTier) RouteModel() string {
+	return strings.TrimSpace(t.Model)
 }
 
 // SmartRoutingConfig maps complexity scores in [0,1] to registries. The tier
@@ -53,12 +59,12 @@ func (c *SmartRoutingConfig) Validate() error {
 	return nil
 }
 
-// RegistryForScore returns the registry mapped to the given complexity score:
-// the tier with the greatest MinScore that is not above the score. It reports
-// false when no tier applies (e.g. the score is below every threshold).
-func (c *SmartRoutingConfig) RegistryForScore(score float64) (ids.RegistryID, bool) {
+// TierForScore returns the tier mapped to the given complexity score: the one
+// with the greatest MinScore that is not above the score. It reports false when
+// no tier applies (e.g. the score is below every threshold).
+func (c *SmartRoutingConfig) TierForScore(score float64) (SmartRoutingTier, bool) {
 	var (
-		best     ids.RegistryID
+		best     SmartRoutingTier
 		bestMin  float64
 		selected bool
 	)
@@ -67,7 +73,7 @@ func (c *SmartRoutingConfig) RegistryForScore(score float64) (ids.RegistryID, bo
 			continue
 		}
 		if !selected || tier.MinScore > bestMin {
-			best = tier.RegistryID
+			best = tier
 			bestMin = tier.MinScore
 			selected = true
 		}

--- a/pkg/domain/registry/smart_routing_config_test.go
+++ b/pkg/domain/registry/smart_routing_config_test.go
@@ -1,0 +1,81 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"testing"
+
+	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
+)
+
+func TestSmartRoutingConfig_TierForScore(t *testing.T) {
+	t.Parallel()
+	shared := ids.New[ids.RegistryKind]()
+	cfg := &SmartRoutingConfig{
+		Tiers: []SmartRoutingTier{
+			{MinScore: 0, RegistryID: shared, Model: "gpt-4o-mini"},
+			{MinScore: 0.3, RegistryID: shared, Model: "gpt-4.1-mini"},
+			{MinScore: 0.8, RegistryID: shared, Model: "gpt-5"},
+		},
+	}
+	tests := []struct {
+		name  string
+		score float64
+		want  string
+	}{
+		{name: "lowest tier", score: 0.1, want: "gpt-4o-mini"},
+		{name: "at a threshold", score: 0.3, want: "gpt-4.1-mini"},
+		{name: "between thresholds", score: 0.5, want: "gpt-4.1-mini"},
+		{name: "highest tier", score: 0.9, want: "gpt-5"},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tier, ok := cfg.TierForScore(tc.score)
+			if !ok {
+				t.Fatalf("score %g: expected a tier", tc.score)
+			}
+			if tier.RegistryID != shared {
+				t.Fatalf("score %g: registry = %s, want %s", tc.score, tier.RegistryID, shared)
+			}
+			if got := tier.RouteModel(); got != tc.want {
+				t.Fatalf("score %g: model = %q, want %q", tc.score, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSmartRoutingConfig_TierForScoreBelowEveryThreshold(t *testing.T) {
+	t.Parallel()
+	cfg := &SmartRoutingConfig{
+		Tiers: []SmartRoutingTier{
+			{MinScore: 0.4, RegistryID: ids.New[ids.RegistryKind]()},
+		},
+	}
+	if _, ok := cfg.TierForScore(0.1); ok {
+		t.Fatal("expected no tier for a score below every threshold")
+	}
+}
+
+func TestSmartRoutingTier_RouteModelTrimsBlanks(t *testing.T) {
+	t.Parallel()
+	if got := (SmartRoutingTier{Model: "  gpt-5  "}).RouteModel(); got != "gpt-5" {
+		t.Fatalf("RouteModel() = %q, want %q", got, "gpt-5")
+	}
+	if got := (SmartRoutingTier{Model: "   "}).RouteModel(); got != "" {
+		t.Fatalf("RouteModel() = %q, want empty", got)
+	}
+}

--- a/pkg/domain/routing/route.go
+++ b/pkg/domain/routing/route.go
@@ -1,0 +1,76 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package routing
+
+import (
+	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
+	registrydomain "github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+)
+
+const DefaultRouteWeight = 1
+
+type RouteKey struct {
+	RegistryID ids.RegistryID
+	Model      string
+}
+
+type Route struct {
+	Registry *registrydomain.Registry
+	Model    string
+	Allowed  []string
+	Default  string
+	Weight   int
+}
+
+func (r Route) Key() RouteKey {
+	if r.Registry == nil {
+		return RouteKey{}
+	}
+	return RouteKey{RegistryID: r.Registry.ID, Model: r.Model}
+}
+
+func (r Route) RegistryID() ids.RegistryID {
+	if r.Registry == nil {
+		return ids.RegistryID{}
+	}
+	return r.Registry.ID
+}
+
+func (r Route) EffectiveWeight() int {
+	if r.Weight <= 0 {
+		return DefaultRouteWeight
+	}
+	return r.Weight
+}
+
+func RouteForRegistry(reg *registrydomain.Registry) Route {
+	return Route{Registry: reg, Weight: DefaultRouteWeight}
+}
+
+func DistinctRegistries(routes []Route) []*registrydomain.Registry {
+	out := make([]*registrydomain.Registry, 0, len(routes))
+	seen := make(map[ids.RegistryID]struct{}, len(routes))
+	for _, route := range routes {
+		if route.Registry == nil {
+			continue
+		}
+		if _, dup := seen[route.Registry.ID]; dup {
+			continue
+		}
+		seen[route.Registry.ID] = struct{}{}
+		out = append(out, route.Registry)
+	}
+	return out
+}

--- a/pkg/domain/routing/route_test.go
+++ b/pkg/domain/routing/route_test.go
@@ -1,0 +1,121 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package routing
+
+import (
+	"testing"
+
+	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
+	registrydomain "github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+)
+
+func testRegistry() *registrydomain.Registry {
+	return &registrydomain.Registry{
+		ID:        ids.New[ids.RegistryKind](),
+		Type:      registrydomain.TypeLLM,
+		LLMTarget: &registrydomain.LLMTarget{Provider: "openai"},
+	}
+}
+
+func TestRoute_KeySeparatesModelsOnOneRegistry(t *testing.T) {
+	t.Parallel()
+	reg := testRegistry()
+	first := Route{Registry: reg, Model: "gpt-4o-mini"}
+	second := Route{Registry: reg, Model: "gpt-5"}
+
+	if first.Key() == second.Key() {
+		t.Fatal("two models on one registry must not share a route key")
+	}
+	if first.Key() != (Route{Registry: reg, Model: "gpt-4o-mini"}).Key() {
+		t.Fatal("the same registry and model must produce the same key")
+	}
+	exclude := map[RouteKey]struct{}{first.Key(): {}}
+	if _, excluded := exclude[second.Key()]; excluded {
+		t.Fatal("excluding one route must not exclude the registry's other routes")
+	}
+}
+
+func TestRoute_ZeroValues(t *testing.T) {
+	t.Parallel()
+	var route Route
+	if route.Key() != (RouteKey{}) {
+		t.Fatalf("Key() = %+v, want the zero key", route.Key())
+	}
+	if !route.RegistryID().IsNil() {
+		t.Fatalf("RegistryID() = %s, want nil", route.RegistryID())
+	}
+	if route.EffectiveWeight() != DefaultRouteWeight {
+		t.Fatalf("EffectiveWeight() = %d, want %d", route.EffectiveWeight(), DefaultRouteWeight)
+	}
+}
+
+func TestRoute_EffectiveWeight(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		weight int
+		want   int
+	}{
+		{name: "unset", weight: 0, want: DefaultRouteWeight},
+		{name: "negative", weight: -3, want: DefaultRouteWeight},
+		{name: "declared", weight: 6, want: 6},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			route := Route{Registry: testRegistry(), Weight: tc.weight}
+			if got := route.EffectiveWeight(); got != tc.want {
+				t.Fatalf("EffectiveWeight() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRouteForRegistry(t *testing.T) {
+	t.Parallel()
+	reg := testRegistry()
+	route := RouteForRegistry(reg)
+	if route.Model != "" {
+		t.Fatalf("Model = %q, want unpinned", route.Model)
+	}
+	if route.RegistryID() != reg.ID {
+		t.Fatalf("RegistryID() = %s, want %s", route.RegistryID(), reg.ID)
+	}
+	if route.EffectiveWeight() != DefaultRouteWeight {
+		t.Fatalf("EffectiveWeight() = %d, want %d", route.EffectiveWeight(), DefaultRouteWeight)
+	}
+}
+
+func TestDistinctRegistries(t *testing.T) {
+	t.Parallel()
+	shared := testRegistry()
+	other := testRegistry()
+	routes := []Route{
+		{Registry: shared, Model: "gpt-4o-mini"},
+		{Registry: shared, Model: "gpt-5"},
+		{Registry: other},
+		{Registry: nil},
+	}
+
+	got := DistinctRegistries(routes)
+
+	if len(got) != 2 {
+		t.Fatalf("DistinctRegistries() = %d registries, want 2", len(got))
+	}
+	if got[0].ID != shared.ID || got[1].ID != other.ID {
+		t.Fatal("DistinctRegistries() must preserve first-seen order")
+	}
+}

--- a/pkg/infra/loadbalancer/base_factory.go
+++ b/pkg/infra/loadbalancer/base_factory.go
@@ -50,17 +50,17 @@ func NewBaseFactory(
 func (f *BaseFactory) CreateStrategy(input StrategyInput) (Strategy, error) {
 	switch input.Algorithm {
 	case algorithm.RoundRobin:
-		return strategies.NewRoundRobin(input.Registries), nil
+		return strategies.NewRoundRobin(input.Routes), nil
 	case algorithm.Random:
-		return strategies.NewRandom(input.Registries), nil
+		return strategies.NewRandom(input.Routes), nil
 	case algorithm.WeightedRoundRobin:
-		return strategies.NewWeightedRoundRobin(input.Registries, input.Weights), nil
+		return strategies.NewWeightedRoundRobin(input.Routes), nil
 	case algorithm.LeastConnections:
-		return strategies.NewLeastConnections(input.Registries), nil
+		return strategies.NewLeastConnections(input.Routes), nil
 	case algorithm.Semantic:
-		return strategies.NewSemantic(input.EmbeddingConfig, input.Registries, f.embeddingRepo, f.serviceLocator), nil
+		return strategies.NewSemantic(input.EmbeddingConfig, input.Routes, f.embeddingRepo, f.serviceLocator), nil
 	case algorithm.SmartRouting:
-		return strategies.NewSmartRouting(input.Registries, input.SmartRoutingConfig, f.complexity, f.logger), nil
+		return strategies.NewSmartRouting(input.Routes, input.SmartRoutingConfig, f.complexity, f.logger), nil
 	default:
 		return nil, fmt.Errorf("unsupported load balancing algorithm: %s", input.Algorithm)
 	}

--- a/pkg/infra/loadbalancer/base_factory_test.go
+++ b/pkg/infra/loadbalancer/base_factory_test.go
@@ -20,13 +20,20 @@ import (
 
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	routingdomain "github.com/NeuralTrust/TrustGate/pkg/domain/routing"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/loadbalancer"
 )
 
 func TestBaseFactory_CreateStrategy_KnownAlgorithms(t *testing.T) {
 	t.Parallel()
 	factory := loadbalancer.NewBaseFactory(nil, nil, nil, nil)
-	registries := []*registry.Registry{{ID: ids.New[ids.RegistryKind](), Name: "a", LLMTarget: &registry.LLMTarget{Provider: "openai"}}}
+	routes := []routingdomain.Route{
+		routingdomain.RouteForRegistry(&registry.Registry{
+			ID:        ids.New[ids.RegistryKind](),
+			Name:      "a",
+			LLMTarget: &registry.LLMTarget{Provider: "openai"},
+		}),
+	}
 
 	cases := []struct {
 		name     string
@@ -45,8 +52,8 @@ func TestBaseFactory_CreateStrategy_KnownAlgorithms(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			s, err := factory.CreateStrategy(loadbalancer.StrategyInput{
-				Algorithm:  tc.alg,
-				Registries: registries,
+				Algorithm: tc.alg,
+				Routes:    routes,
 			})
 			if err != nil {
 				t.Fatalf("CreateStrategy(%s) returned error: %v", tc.alg, err)

--- a/pkg/infra/loadbalancer/load_balancer.go
+++ b/pkg/infra/loadbalancer/load_balancer.go
@@ -23,8 +23,8 @@ import (
 	"time"
 
 	"github.com/NeuralTrust/TrustGate/pkg/domain/embedding"
-	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	routingdomain "github.com/NeuralTrust/TrustGate/pkg/domain/routing"
 	infracontext "github.com/NeuralTrust/TrustGate/pkg/infra/context"
 	"github.com/redis/go-redis/v9"
 )
@@ -39,8 +39,7 @@ type RedisProvider interface {
 
 type Pool struct {
 	ID                 string
-	Registries         []*registry.Registry
-	Weights            map[ids.RegistryID]int
+	Routes             []routingdomain.Route
 	Algorithm          string
 	EmbeddingConfig    *registry.EmbeddingConfig
 	SmartRoutingConfig *registry.SmartRoutingConfig
@@ -52,6 +51,7 @@ type LoadBalancer struct {
 	cache      RedisProvider
 	poolID     string
 	poolSize   int
+	routes     []routingdomain.Route
 	backendIDs []string
 	successCh  chan *registry.Registry
 	factory    Factory
@@ -67,7 +67,9 @@ func NewLoadBalancer(
 ) (*LoadBalancer, error) {
 	ctx := context.Background()
 
-	seedInitialHealth(ctx, cacheClient, pool.Registries, logger)
+	// Health is tracked per registry, not per route.
+	poolRegistries := routingdomain.DistinctRegistries(pool.Routes)
+	seedInitialHealth(ctx, cacheClient, poolRegistries, logger)
 
 	var embeddingCfg *embedding.Config
 	if pool.EmbeddingConfig != nil {
@@ -76,8 +78,7 @@ func NewLoadBalancer(
 
 	strategy, err := factory.CreateStrategy(StrategyInput{
 		Algorithm:          pool.Algorithm,
-		Registries:         pool.Registries,
-		Weights:            pool.Weights,
+		Routes:             pool.Routes,
 		EmbeddingConfig:    embeddingCfg,
 		SmartRoutingConfig: pool.SmartRoutingConfig,
 	})
@@ -85,8 +86,8 @@ func NewLoadBalancer(
 		return nil, fmt.Errorf("failed to create load balancing strategy: %w", err)
 	}
 
-	backendIDs := make([]string, 0, len(pool.Registries))
-	for _, b := range pool.Registries {
+	backendIDs := make([]string, 0, len(poolRegistries))
+	for _, b := range poolRegistries {
 		backendIDs = append(backendIDs, b.ID.String())
 	}
 
@@ -95,7 +96,8 @@ func NewLoadBalancer(
 		logger:     logger,
 		cache:      cacheClient,
 		poolID:     pool.ID,
-		poolSize:   len(pool.Registries),
+		poolSize:   len(pool.Routes),
+		routes:     pool.Routes,
 		backendIDs: backendIDs,
 		successCh:  make(chan *registry.Registry, 1000),
 		factory:    factory,
@@ -103,6 +105,10 @@ func NewLoadBalancer(
 	}
 	go lb.processSuccessReports()
 	return lb, nil
+}
+
+func (lb *LoadBalancer) Routes() []routingdomain.Route {
+	return lb.routes
 }
 
 func healthKey(backendID string) string {
@@ -187,35 +193,36 @@ func (lb *LoadBalancer) performSuccessUpdate(b *registry.Registry) {
 	}
 }
 
-func (lb *LoadBalancer) NextBackend(
+func (lb *LoadBalancer) NextRoute(
 	ctx context.Context,
 	req *infracontext.RequestContext,
-	exclude map[ids.RegistryID]struct{},
-) (*registry.Registry, error) {
+	exclude map[routingdomain.RouteKey]struct{},
+) (*routingdomain.Route, error) {
 	attempts := lb.poolSize
 	if attempts < 1 {
 		attempts = 1
 	}
 	health := lb.healthMap(ctx)
-	var last *registry.Registry
+	var last *routingdomain.Route
 	for i := 0; i < attempts; i++ {
-		b := lb.strategy.Next(ctx, req, exclude)
-		if b == nil {
+		route := lb.strategy.Next(ctx, req, exclude)
+		if route == nil || route.Registry == nil {
 			break
 		}
-		last = b
-		if isHealthy(health, b.ID.String()) {
-			return b, nil
+		last = route
+		if isHealthy(health, route.Registry.ID.String()) {
+			return route, nil
 		}
 	}
 	if last != nil {
-		lb.logger.Info("all registries unhealthy; using last candidate as fallback",
-			slog.String("registry_id", last.ID.String()),
-			slog.String("provider", last.Provider()),
+		lb.logger.Info("all routes unhealthy; using last candidate as fallback",
+			slog.String("registry_id", last.Registry.ID.String()),
+			slog.String("provider", last.Registry.Provider()),
+			slog.String("model", last.Model),
 		)
 		return last, nil
 	}
-	return nil, fmt.Errorf("no available registries")
+	return nil, fmt.Errorf("no available routes")
 }
 
 // healthMap fetches the health status of every backend in the pool with a

--- a/pkg/infra/loadbalancer/load_balancer_close_test.go
+++ b/pkg/infra/loadbalancer/load_balancer_close_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	routingdomain "github.com/NeuralTrust/TrustGate/pkg/domain/routing"
 	cachemocks "github.com/NeuralTrust/TrustGate/pkg/infra/cache/mocks"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/loadbalancer"
 	"github.com/google/uuid"
@@ -54,9 +55,9 @@ func TestLoadBalancer_Close_IdempotentAndSafe(t *testing.T) {
 	}
 
 	lb, err := loadbalancer.NewLoadBalancer(loadbalancer.NewBaseFactory(nil, nil, nil, nil), loadbalancer.Pool{
-		ID:         uuid.New().String(),
-		Registries: []*registry.Registry{bk},
-		Algorithm:  loadbalancer.AlgorithmRoundRobin,
+		ID:        uuid.New().String(),
+		Routes:    []routingdomain.Route{routingdomain.RouteForRegistry(bk)},
+		Algorithm: loadbalancer.AlgorithmRoundRobin,
 	}, newTestLogger(), cacheClient)
 	if err != nil {
 		t.Fatalf("NewLoadBalancer error: %v", err)

--- a/pkg/infra/loadbalancer/load_balancer_health_test.go
+++ b/pkg/infra/loadbalancer/load_balancer_health_test.go
@@ -21,12 +21,13 @@ import (
 
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	routingdomain "github.com/NeuralTrust/TrustGate/pkg/domain/routing"
 	cachemocks "github.com/NeuralTrust/TrustGate/pkg/infra/cache/mocks"
 	infracontext "github.com/NeuralTrust/TrustGate/pkg/infra/context"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/loadbalancer"
 	"github.com/alicebob/miniredis/v2"
-	"github.com/redis/go-redis/v9"
 	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
 )
 
 func newBackend(t *testing.T, name string) *registry.Registry {
@@ -43,7 +44,7 @@ func newBackend(t *testing.T, name string) *registry.Registry {
 	return b
 }
 
-func TestLoadBalancer_NextBackend_SkipsUnhealthyViaMGet(t *testing.T) {
+func TestLoadBalancer_NextRoute_SkipsUnhealthyViaMGet(t *testing.T) {
 	t.Parallel()
 
 	mr := miniredis.RunT(t)
@@ -61,9 +62,12 @@ func TestLoadBalancer_NextBackend_SkipsUnhealthyViaMGet(t *testing.T) {
 	}
 
 	lb, err := loadbalancer.NewLoadBalancer(loadbalancer.NewBaseFactory(nil, nil, nil, nil), loadbalancer.Pool{
-		ID:         uuid.New().String(),
-		Registries: []*registry.Registry{unhealthy, healthy},
-		Algorithm:  loadbalancer.AlgorithmRoundRobin,
+		ID: uuid.New().String(),
+		Routes: []routingdomain.Route{
+			routingdomain.RouteForRegistry(unhealthy),
+			routingdomain.RouteForRegistry(healthy),
+		},
+		Algorithm: loadbalancer.AlgorithmRoundRobin,
 	}, newTestLogger(), cacheClient)
 	if err != nil {
 		t.Fatalf("NewLoadBalancer error: %v", err)
@@ -72,12 +76,49 @@ func TestLoadBalancer_NextBackend_SkipsUnhealthyViaMGet(t *testing.T) {
 
 	req := &infracontext.RequestContext{}
 	for i := 0; i < 4; i++ {
-		got, nerr := lb.NextBackend(context.Background(), req, nil)
+		got, nerr := lb.NextRoute(context.Background(), req, nil)
 		if nerr != nil {
-			t.Fatalf("NextBackend error: %v", nerr)
+			t.Fatalf("NextRoute error: %v", nerr)
 		}
-		if got.ID != healthy.ID {
-			t.Fatalf("NextBackend returned %q, want the healthy backend", got.Name)
+		if got.RegistryID() != healthy.ID {
+			t.Fatalf("NextRoute returned %q, want the healthy backend", got.Registry.Name)
 		}
+	}
+}
+
+func TestLoadBalancer_NextRoute_HealthIsSharedByRoutesOfOneRegistry(t *testing.T) {
+	t.Parallel()
+
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	cacheClient := cachemocks.NewClient(t)
+	cacheClient.EXPECT().RedisClient().Return(rdb).Maybe()
+
+	shared := newBackend(t, "shared")
+	if err := mr.Set(fmt.Sprintf("lb:health:%s", shared.ID.String()), `{"Healthy":false}`); err != nil {
+		t.Fatalf("seed unhealthy status: %v", err)
+	}
+
+	lb, err := loadbalancer.NewLoadBalancer(loadbalancer.NewBaseFactory(nil, nil, nil, nil), loadbalancer.Pool{
+		ID: uuid.New().String(),
+		Routes: []routingdomain.Route{
+			{Registry: shared, Model: "gpt-4o-mini", Weight: 1},
+			{Registry: shared, Model: "gpt-5", Weight: 1},
+		},
+		Algorithm: loadbalancer.AlgorithmRoundRobin,
+	}, newTestLogger(), cacheClient)
+	if err != nil {
+		t.Fatalf("NewLoadBalancer error: %v", err)
+	}
+	t.Cleanup(lb.Close)
+
+	got, nerr := lb.NextRoute(context.Background(), &infracontext.RequestContext{}, nil)
+	if nerr != nil {
+		t.Fatalf("NextRoute error: %v", nerr)
+	}
+	if got == nil || got.RegistryID() != shared.ID {
+		t.Fatalf("an all-unhealthy pool must still yield its last candidate, got %+v", got)
 	}
 }

--- a/pkg/infra/loadbalancer/strategies/exclude.go
+++ b/pkg/infra/loadbalancer/strategies/exclude.go
@@ -15,27 +15,34 @@
 package strategies
 
 import (
-	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
-	"github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	routingdomain "github.com/NeuralTrust/TrustGate/pkg/domain/routing"
 )
 
-func isExcluded(id ids.RegistryID, exclude map[ids.RegistryID]struct{}) bool {
+func isExcluded(key routingdomain.RouteKey, exclude map[routingdomain.RouteKey]struct{}) bool {
 	if len(exclude) == 0 {
 		return false
 	}
-	_, ok := exclude[id]
+	_, ok := exclude[key]
 	return ok
 }
 
-func filterExcluded(registries []*registry.Registry, exclude map[ids.RegistryID]struct{}) []*registry.Registry {
+func filterExcluded(
+	routes []routingdomain.Route,
+	exclude map[routingdomain.RouteKey]struct{},
+) []routingdomain.Route {
 	if len(exclude) == 0 {
-		return registries
+		return routes
 	}
-	out := make([]*registry.Registry, 0, len(registries))
-	for _, b := range registries {
-		if !isExcluded(b.ID, exclude) {
-			out = append(out, b)
+	out := make([]routingdomain.Route, 0, len(routes))
+	for _, route := range routes {
+		if !isExcluded(route.Key(), exclude) {
+			out = append(out, route)
 		}
 	}
 	return out
+}
+
+// Copies the route so callers cannot mutate the pool through the returned pointer.
+func pick(route routingdomain.Route) *routingdomain.Route {
+	return &route
 }

--- a/pkg/infra/loadbalancer/strategies/least_connections.go
+++ b/pkg/infra/loadbalancer/strategies/least_connections.go
@@ -16,35 +16,40 @@ package strategies
 
 import (
 	"context"
+	"slices"
 	"sync"
 
-	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
-	"github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	routingdomain "github.com/NeuralTrust/TrustGate/pkg/domain/routing"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/routing/algorithm"
 	infracontext "github.com/NeuralTrust/TrustGate/pkg/infra/context"
 )
 
 type LeastConnections struct {
-	mu         sync.Mutex
-	registries []*registry.Registry
+	mu     sync.Mutex
+	routes []routingdomain.Route
 }
 
-func NewLeastConnections(registries []*registry.Registry) *LeastConnections {
-	return &LeastConnections{registries: registries}
+func NewLeastConnections(routes []routingdomain.Route) *LeastConnections {
+	// Rotation happens in place, so the strategy owns its own copy.
+	return &LeastConnections{routes: slices.Clone(routes)}
 }
 
-func (lc *LeastConnections) Next(_ context.Context, _ *infracontext.RequestContext, exclude map[ids.RegistryID]struct{}) *registry.Registry {
+func (lc *LeastConnections) Next(
+	_ context.Context,
+	_ *infracontext.RequestContext,
+	exclude map[routingdomain.RouteKey]struct{},
+) *routingdomain.Route {
 	lc.mu.Lock()
 	defer lc.mu.Unlock()
-	n := len(lc.registries)
+	n := len(lc.routes)
 	if n == 0 {
 		return nil
 	}
 	for i := 0; i < n; i++ {
-		selected := lc.registries[0]
-		lc.registries = append(lc.registries[1:], lc.registries[0])
-		if !isExcluded(selected.ID, exclude) {
-			return selected
+		selected := lc.routes[0]
+		lc.routes = append(lc.routes[1:], lc.routes[0])
+		if !isExcluded(selected.Key(), exclude) {
+			return pick(selected)
 		}
 	}
 	return nil

--- a/pkg/infra/loadbalancer/strategies/random.go
+++ b/pkg/infra/loadbalancer/strategies/random.go
@@ -20,33 +20,36 @@ import (
 	"math/big"
 	"sync"
 
-	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
-	"github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	routingdomain "github.com/NeuralTrust/TrustGate/pkg/domain/routing"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/routing/algorithm"
 	infracontext "github.com/NeuralTrust/TrustGate/pkg/infra/context"
 )
 
 type Random struct {
-	mu         sync.Mutex
-	registries []*registry.Registry
+	mu     sync.Mutex
+	routes []routingdomain.Route
 }
 
-func NewRandom(registries []*registry.Registry) *Random {
-	return &Random{registries: registries}
+func NewRandom(routes []routingdomain.Route) *Random {
+	return &Random{routes: routes}
 }
 
-func (r *Random) Next(_ context.Context, _ *infracontext.RequestContext, exclude map[ids.RegistryID]struct{}) *registry.Registry {
+func (r *Random) Next(
+	_ context.Context,
+	_ *infracontext.RequestContext,
+	exclude map[routingdomain.RouteKey]struct{},
+) *routingdomain.Route {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	candidates := filterExcluded(r.registries, exclude)
+	candidates := filterExcluded(r.routes, exclude)
 	if len(candidates) == 0 {
 		return nil
 	}
 	n, err := rand.Int(rand.Reader, big.NewInt(int64(len(candidates))))
 	if err != nil {
-		return candidates[0]
+		return pick(candidates[0])
 	}
-	return candidates[n.Int64()]
+	return pick(candidates[n.Int64()])
 }
 
 func (r *Random) Name() string {

--- a/pkg/infra/loadbalancer/strategies/round_robin.go
+++ b/pkg/infra/loadbalancer/strategies/round_robin.go
@@ -18,34 +18,37 @@ import (
 	"context"
 	"sync"
 
-	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
-	"github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	routingdomain "github.com/NeuralTrust/TrustGate/pkg/domain/routing"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/routing/algorithm"
 	infracontext "github.com/NeuralTrust/TrustGate/pkg/infra/context"
 )
 
 type RoundRobin struct {
-	mu         sync.Mutex
-	registries []*registry.Registry
-	current    int
+	mu      sync.Mutex
+	routes  []routingdomain.Route
+	current int
 }
 
-func NewRoundRobin(registries []*registry.Registry) *RoundRobin {
-	return &RoundRobin{registries: registries}
+func NewRoundRobin(routes []routingdomain.Route) *RoundRobin {
+	return &RoundRobin{routes: routes}
 }
 
-func (rr *RoundRobin) Next(_ context.Context, _ *infracontext.RequestContext, exclude map[ids.RegistryID]struct{}) *registry.Registry {
+func (rr *RoundRobin) Next(
+	_ context.Context,
+	_ *infracontext.RequestContext,
+	exclude map[routingdomain.RouteKey]struct{},
+) *routingdomain.Route {
 	rr.mu.Lock()
 	defer rr.mu.Unlock()
-	n := len(rr.registries)
+	n := len(rr.routes)
 	if n == 0 {
 		return nil
 	}
 	for i := 0; i < n; i++ {
-		b := rr.registries[rr.current]
+		route := rr.routes[rr.current]
 		rr.current = (rr.current + 1) % n
-		if !isExcluded(b.ID, exclude) {
-			return b
+		if !isExcluded(route.Key(), exclude) {
+			return pick(route)
 		}
 	}
 	return nil

--- a/pkg/infra/loadbalancer/strategies/semantic.go
+++ b/pkg/infra/loadbalancer/strategies/semantic.go
@@ -23,8 +23,7 @@ import (
 	"sync"
 
 	"github.com/NeuralTrust/TrustGate/pkg/domain/embedding"
-	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
-	"github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	routingdomain "github.com/NeuralTrust/TrustGate/pkg/domain/routing"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/routing/algorithm"
 	infracontext "github.com/NeuralTrust/TrustGate/pkg/infra/context"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/embedding/factory"
@@ -35,9 +34,10 @@ type backendVector struct {
 	magnitude float64
 }
 
+// Similarity is a registry property, so sibling routes of one registry score identically.
 type Semantic struct {
 	mu              sync.RWMutex
-	registries      []*registry.Registry
+	routes          []routingdomain.Route
 	embeddingRepo   embedding.Repository
 	serviceLocator  factory.EmbeddingServiceLocator
 	embeddingConfig *embedding.Config
@@ -48,12 +48,12 @@ type Semantic struct {
 
 func NewSemantic(
 	embeddingCfg *embedding.Config,
-	registries []*registry.Registry,
+	routes []routingdomain.Route,
 	embeddingRepo embedding.Repository,
 	serviceLocator factory.EmbeddingServiceLocator,
 ) *Semantic {
 	return &Semantic{
-		registries:      registries,
+		routes:          routes,
 		embeddingRepo:   embeddingRepo,
 		serviceLocator:  serviceLocator,
 		embeddingConfig: embeddingCfg,
@@ -61,30 +61,34 @@ func NewSemantic(
 	}
 }
 
-func (s *Semantic) Next(ctx context.Context, req *infracontext.RequestContext, exclude map[ids.RegistryID]struct{}) *registry.Registry {
+func (s *Semantic) Next(
+	ctx context.Context,
+	req *infracontext.RequestContext,
+	exclude map[routingdomain.RouteKey]struct{},
+) *routingdomain.Route {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	candidates := filterExcluded(s.registries, exclude)
+	candidates := filterExcluded(s.routes, exclude)
 	if len(candidates) == 0 {
 		return nil
 	}
 	if len(candidates) == 1 {
-		return candidates[0]
+		return pick(candidates[0])
 	}
 	if s.embeddingConfig == nil || s.serviceLocator == nil || s.embeddingRepo == nil || req == nil {
-		return candidates[0]
+		return pick(candidates[0])
 	}
 
 	prompt, err := extractPromptFromRequest(req.Body)
 	if err != nil {
-		return candidates[0]
+		return pick(candidates[0])
 	}
 	promptEmbedding, err := s.generateEmbedding(ctx, prompt)
 	if err != nil {
-		return candidates[0]
+		return pick(candidates[0])
 	}
-	return s.findBestRegistry(ctx, promptEmbedding, candidates)
+	return s.findBestRoute(ctx, promptEmbedding, candidates)
 }
 
 func (s *Semantic) Name() string {
@@ -151,32 +155,32 @@ func (s *Semantic) generateEmbedding(ctx context.Context, text string) ([]float6
 	return emb.Value, nil
 }
 
-func (s *Semantic) findBestRegistry(
+func (s *Semantic) findBestRoute(
 	ctx context.Context,
 	promptEmbedding []float64,
-	candidates []*registry.Registry,
-) *registry.Registry {
+	candidates []routingdomain.Route,
+) *routingdomain.Route {
 	promptMagnitude := magnitude(promptEmbedding)
-	var bestBackend *registry.Registry
+	best := -1
 	bestSimilarity := -1.0
-	for _, b := range candidates {
-		if b.Description == "" {
+	for i, route := range candidates {
+		if route.Registry == nil || route.Registry.Description == "" {
 			continue
 		}
-		bv := s.backendVector(ctx, b.ID.String())
+		bv := s.backendVector(ctx, route.Registry.ID.String())
 		if bv == nil {
 			continue
 		}
 		similarity := cosineSimilarity(promptEmbedding, promptMagnitude, bv.value, bv.magnitude)
 		if similarity > bestSimilarity {
 			bestSimilarity = similarity
-			bestBackend = b
+			best = i
 		}
 	}
-	if bestBackend == nil {
-		return candidates[0]
+	if best < 0 {
+		return pick(candidates[0])
 	}
-	return bestBackend
+	return pick(candidates[best])
 }
 
 // backendVector returns the target's embedding and its precomputed magnitude,

--- a/pkg/infra/loadbalancer/strategies/semantic_cache_test.go
+++ b/pkg/infra/loadbalancer/strategies/semantic_cache_test.go
@@ -22,6 +22,7 @@ import (
 	embeddingmocks "github.com/NeuralTrust/TrustGate/pkg/domain/embedding/mocks"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	routingdomain "github.com/NeuralTrust/TrustGate/pkg/domain/routing"
 	infracontext "github.com/NeuralTrust/TrustGate/pkg/infra/context"
 	factorymocks "github.com/NeuralTrust/TrustGate/pkg/infra/embedding/factory/mocks"
 	"github.com/stretchr/testify/mock"
@@ -47,12 +48,15 @@ func TestSemantic_CachesBackendEmbeddingsAcrossRequests(t *testing.T) {
 	locator.EXPECT().GetService(mock.Anything).Return(creator, nil)
 
 	s := NewSemantic(&embedding.Config{Provider: "openai", Model: "m"},
-		[]*registry.Registry{backendA, backendB}, repo, locator)
+		[]routingdomain.Route{
+			routingdomain.RouteForRegistry(backendA),
+			routingdomain.RouteForRegistry(backendB),
+		}, repo, locator)
 
 	req := &infracontext.RequestContext{Body: []byte(`{"prompt":"hello"}`)}
 	for i := 0; i < 3; i++ {
 		got := s.Next(context.Background(), req, nil)
-		if got == nil || got.ID != backendA.ID {
+		if got == nil || got.RegistryID() != backendA.ID {
 			t.Fatalf("request %d: expected backend A (highest similarity), got %+v", i, got)
 		}
 	}

--- a/pkg/infra/loadbalancer/strategies/smart_routing.go
+++ b/pkg/infra/loadbalancer/strategies/smart_routing.go
@@ -19,8 +19,8 @@ import (
 	"log/slog"
 	"sync"
 
-	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	routingdomain "github.com/NeuralTrust/TrustGate/pkg/domain/routing"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/routing/algorithm"
 	infracontext "github.com/NeuralTrust/TrustGate/pkg/infra/context"
 )
@@ -32,30 +32,30 @@ type ComplexityScorer interface {
 }
 
 // SmartRouting routes by the complexity of the incoming message: it asks the
-// Firewall Complexity API for a score and maps that score to a target via the
+// Firewall Complexity API for a score and maps that score to a route via the
 // configured tiers. It fails open to round-robin whenever the scorer is not
 // configured, the score is unavailable, or no candidate matches the score.
 type SmartRouting struct {
-	registries []*registry.Registry
-	config     *registry.SmartRoutingConfig
-	scorer     ComplexityScorer
-	fallback   *RoundRobin
-	logger     *slog.Logger
-	warnOnce   sync.Once
+	routes   []routingdomain.Route
+	config   *registry.SmartRoutingConfig
+	scorer   ComplexityScorer
+	fallback *RoundRobin
+	logger   *slog.Logger
+	warnOnce sync.Once
 }
 
 func NewSmartRouting(
-	registries []*registry.Registry,
+	routes []routingdomain.Route,
 	config *registry.SmartRoutingConfig,
 	scorer ComplexityScorer,
 	logger *slog.Logger,
 ) *SmartRouting {
 	return &SmartRouting{
-		registries: registries,
-		config:     config,
-		scorer:     scorer,
-		fallback:   NewRoundRobin(registries),
-		logger:     logger,
+		routes:   routes,
+		config:   config,
+		scorer:   scorer,
+		fallback: NewRoundRobin(routes),
+		logger:   logger,
 	}
 }
 
@@ -64,14 +64,14 @@ func (s *SmartRouting) Name() string { return algorithm.SmartRouting }
 func (s *SmartRouting) Next(
 	ctx context.Context,
 	req *infracontext.RequestContext,
-	exclude map[ids.RegistryID]struct{},
-) *registry.Registry {
-	candidates := filterExcluded(s.registries, exclude)
+	exclude map[routingdomain.RouteKey]struct{},
+) *routingdomain.Route {
+	candidates := filterExcluded(s.routes, exclude)
 	if len(candidates) == 0 {
 		return nil
 	}
 	if len(candidates) == 1 {
-		return candidates[0]
+		return pick(candidates[0])
 	}
 	if s.config == nil || s.scorer == nil || !s.scorer.Configured() || req == nil {
 		return s.fallbackNext(ctx, req, exclude, "smart routing not configured")
@@ -84,28 +84,34 @@ func (s *SmartRouting) Next(
 	if err != nil {
 		return s.fallbackNext(ctx, req, exclude, "complexity score unavailable")
 	}
-	target := s.registryForScore(score, candidates)
+	target := s.routeForScore(score, candidates)
 	if target == nil {
 		return s.fallbackNext(ctx, req, exclude, "no candidate matched complexity score")
 	}
 	if s.logger != nil {
-		s.logger.Debug("smart routing selected registry",
-			slog.String("registry_id", target.ID.String()),
+		s.logger.Debug("smart routing selected route",
+			slog.String("registry_id", target.Registry.ID.String()),
+			slog.String("model", target.Model),
 			slog.Float64("score", score),
 		)
 	}
 	return target
 }
 
-func (s *SmartRouting) registryForScore(score float64, candidates []*registry.Registry) *registry.Registry {
-	id, ok := s.config.RegistryForScore(score)
+func (s *SmartRouting) routeForScore(score float64, candidates []routingdomain.Route) *routingdomain.Route {
+	tier, ok := s.config.TierForScore(score)
 	if !ok {
 		return nil
 	}
-	for _, b := range candidates {
-		if b.ID == id {
-			return b
+	model := tier.RouteModel()
+	for _, route := range candidates {
+		if route.Registry == nil || route.Registry.ID != tier.RegistryID {
+			continue
 		}
+		if model != "" && route.Model != model {
+			continue
+		}
+		return pick(route)
 	}
 	return nil
 }
@@ -113,9 +119,9 @@ func (s *SmartRouting) registryForScore(score float64, candidates []*registry.Re
 func (s *SmartRouting) fallbackNext(
 	ctx context.Context,
 	req *infracontext.RequestContext,
-	exclude map[ids.RegistryID]struct{},
+	exclude map[routingdomain.RouteKey]struct{},
 	reason string,
-) *registry.Registry {
+) *routingdomain.Route {
 	if s.logger != nil {
 		s.warnOnce.Do(func() {
 			s.logger.Warn("smart routing falling back to round-robin", slog.String("reason", reason))

--- a/pkg/infra/loadbalancer/strategies/smart_routing_test.go
+++ b/pkg/infra/loadbalancer/strategies/smart_routing_test.go
@@ -19,8 +19,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	routingdomain "github.com/NeuralTrust/TrustGate/pkg/domain/routing"
 	infracontext "github.com/NeuralTrust/TrustGate/pkg/infra/context"
 )
 
@@ -38,10 +38,14 @@ func (f *fakeScorer) Score(_ context.Context, _, _, _ string) (float64, error) {
 
 func (f *fakeScorer) Configured() bool { return f.configured }
 
-func tiersFor(backends []*registry.Registry, minScores ...float64) *registry.SmartRoutingConfig {
+func tiersFor(routes []routingdomain.Route, minScores ...float64) *registry.SmartRoutingConfig {
 	cfg := &registry.SmartRoutingConfig{}
 	for i, min := range minScores {
-		cfg.Tiers = append(cfg.Tiers, registry.SmartRoutingTier{MinScore: min, RegistryID: backends[i].ID})
+		cfg.Tiers = append(cfg.Tiers, registry.SmartRoutingTier{
+			MinScore:   min,
+			RegistryID: routes[i].RegistryID(),
+			Model:      routes[i].Model,
+		})
 	}
 	return cfg
 }
@@ -73,12 +77,12 @@ func TestSmartRouting_MapsScoreToTier(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			backends := makeBackends("a", "b", "c")
-			cfg := tiersFor(backends, 0.0, 0.4, 0.8)
+			routes := makeRoutes("a", "b", "c")
+			cfg := tiersFor(routes, 0.0, 0.4, 0.8)
 			scorer := &fakeScorer{score: tc.score, configured: true}
-			s := NewSmartRouting(backends, cfg, scorer, nil)
+			s := NewSmartRouting(routes, cfg, scorer, nil)
 			got := s.Next(context.Background(), promptReq(), nil)
-			if got == nil || got.Name != tc.want {
+			if got == nil || routeName(t, got) != tc.want {
 				t.Fatalf("score %g: got %+v, want %q", tc.score, got, tc.want)
 			}
 			if scorer.calls != 1 {
@@ -88,15 +92,64 @@ func TestSmartRouting_MapsScoreToTier(t *testing.T) {
 	}
 }
 
+func TestSmartRouting_MapsScoreToModelOnOneRegistry(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		score float64
+		want  string
+	}{
+		{"simple", 0.1, "gpt-4o-mini"},
+		{"medium", 0.5, "gpt-4.1-mini"},
+		{"complex", 0.9, "gpt-5"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			routes := modelRoutes("gpt-4o-mini", "gpt-4.1-mini", "gpt-5")
+			cfg := tiersFor(routes, 0.0, 0.4, 0.8)
+			scorer := &fakeScorer{score: tc.score, configured: true}
+			s := NewSmartRouting(routes, cfg, scorer, nil)
+
+			got := s.Next(context.Background(), promptReq(), nil)
+
+			if got == nil {
+				t.Fatalf("score %g: expected a route", tc.score)
+			}
+			if got.Model != tc.want {
+				t.Fatalf("score %g: model = %q, want %q", tc.score, got.Model, tc.want)
+			}
+			if scorer.calls != 1 {
+				t.Fatalf("expected exactly one score call, got %d", scorer.calls)
+			}
+		})
+	}
+}
+
+func TestSmartRouting_ExcludedModelRouteFallsBackToItsSibling(t *testing.T) {
+	t.Parallel()
+	routes := modelRoutes("gpt-4o-mini", "gpt-5")
+	cfg := tiersFor(routes, 0.0, 0.8)
+	scorer := &fakeScorer{score: 0.9, configured: true}
+	s := NewSmartRouting(routes, cfg, scorer, nil)
+
+	got := s.Next(context.Background(), promptReq(), excludeRoutes(routes[1]))
+
+	if got == nil || got.Model != "gpt-4o-mini" {
+		t.Fatalf("excluding the mapped model must leave its sibling on the same registry, got %+v", got)
+	}
+}
+
 func TestSmartRouting_NotConfiguredFallsBackToRoundRobin(t *testing.T) {
 	t.Parallel()
-	backends := makeBackends("a", "b", "c")
-	cfg := tiersFor(backends, 0.0, 0.4, 0.8)
+	routes := makeRoutes("a", "b", "c")
+	cfg := tiersFor(routes, 0.0, 0.4, 0.8)
 	scorer := &fakeScorer{score: 0.9, configured: false}
-	s := NewSmartRouting(backends, cfg, scorer, nil)
+	s := NewSmartRouting(routes, cfg, scorer, nil)
 	got := s.Next(context.Background(), promptReq(), nil)
-	if got == nil || got.Name != "a" {
-		t.Fatalf("unconfigured scorer should round-robin from first backend, got %+v", got)
+	if got == nil || routeName(t, got) != "a" {
+		t.Fatalf("unconfigured scorer should round-robin from first route, got %+v", got)
 	}
 	if scorer.calls != 0 {
 		t.Fatalf("scorer must not be called when unconfigured, calls=%d", scorer.calls)
@@ -105,25 +158,25 @@ func TestSmartRouting_NotConfiguredFallsBackToRoundRobin(t *testing.T) {
 
 func TestSmartRouting_ScoreErrorFallsBackToRoundRobin(t *testing.T) {
 	t.Parallel()
-	backends := makeBackends("a", "b", "c")
-	cfg := tiersFor(backends, 0.0, 0.4, 0.8)
+	routes := makeRoutes("a", "b", "c")
+	cfg := tiersFor(routes, 0.0, 0.4, 0.8)
 	scorer := &fakeScorer{err: errors.New("boom"), configured: true}
-	s := NewSmartRouting(backends, cfg, scorer, nil)
+	s := NewSmartRouting(routes, cfg, scorer, nil)
 	got := s.Next(context.Background(), promptReq(), nil)
-	if got == nil || got.Name != "a" {
-		t.Fatalf("score error should round-robin from first backend, got %+v", got)
+	if got == nil || routeName(t, got) != "a" {
+		t.Fatalf("score error should round-robin from first route, got %+v", got)
 	}
 }
 
 func TestSmartRouting_EmptyBodyFallsBackToRoundRobin(t *testing.T) {
 	t.Parallel()
-	backends := makeBackends("a", "b", "c")
-	cfg := tiersFor(backends, 0.0, 0.4, 0.8)
+	routes := makeRoutes("a", "b", "c")
+	cfg := tiersFor(routes, 0.0, 0.4, 0.8)
 	scorer := &fakeScorer{score: 0.9, configured: true}
-	s := NewSmartRouting(backends, cfg, scorer, nil)
+	s := NewSmartRouting(routes, cfg, scorer, nil)
 	got := s.Next(context.Background(), &infracontext.RequestContext{}, nil)
-	if got == nil || got.Name != "a" {
-		t.Fatalf("empty body should round-robin from first backend, got %+v", got)
+	if got == nil || routeName(t, got) != "a" {
+		t.Fatalf("empty body should round-robin from first route, got %+v", got)
 	}
 	if scorer.calls != 0 {
 		t.Fatalf("scorer must not be called when input cannot be extracted, calls=%d", scorer.calls)
@@ -132,25 +185,24 @@ func TestSmartRouting_EmptyBodyFallsBackToRoundRobin(t *testing.T) {
 
 func TestSmartRouting_MappedRegistryExcludedFallsBack(t *testing.T) {
 	t.Parallel()
-	backends := makeBackends("a", "b", "c")
-	cfg := tiersFor(backends, 0.0, 0.4, 0.8)
+	routes := makeRoutes("a", "b", "c")
+	cfg := tiersFor(routes, 0.0, 0.4, 0.8)
 	scorer := &fakeScorer{score: 0.9, configured: true}
-	s := NewSmartRouting(backends, cfg, scorer, nil)
-	exclude := map[ids.RegistryID]struct{}{backends[2].ID: {}}
-	got := s.Next(context.Background(), promptReq(), exclude)
-	if got == nil || got.Name == "c" {
+	s := NewSmartRouting(routes, cfg, scorer, nil)
+	got := s.Next(context.Background(), promptReq(), excludeRoutes(routes[2]))
+	if got == nil || routeName(t, got) == "c" {
 		t.Fatalf("excluded mapped registry must fall back to a candidate, got %+v", got)
 	}
 }
 
 func TestSmartRouting_SingleCandidateSkipsScorer(t *testing.T) {
 	t.Parallel()
-	backends := makeBackends("only")
-	cfg := tiersFor(backends, 0.0)
+	routes := makeRoutes("only")
+	cfg := tiersFor(routes, 0.0)
 	scorer := &fakeScorer{score: 0.9, configured: true}
-	s := NewSmartRouting(backends, cfg, scorer, nil)
+	s := NewSmartRouting(routes, cfg, scorer, nil)
 	got := s.Next(context.Background(), promptReq(), nil)
-	if got == nil || got.Name != "only" {
+	if got == nil || routeName(t, got) != "only" {
 		t.Fatalf("single candidate should be returned without scoring, got %+v", got)
 	}
 	if scorer.calls != 0 {

--- a/pkg/infra/loadbalancer/strategies/strategies_test.go
+++ b/pkg/infra/loadbalancer/strategies/strategies_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	routingdomain "github.com/NeuralTrust/TrustGate/pkg/domain/routing"
 )
 
 func makeBackends(names ...string) []*registry.Registry {
@@ -30,12 +31,46 @@ func makeBackends(names ...string) []*registry.Registry {
 	return out
 }
 
-func TestRoundRobin_RotatesThroughBackends(t *testing.T) {
+func makeRoutes(names ...string) []routingdomain.Route {
+	registries := makeBackends(names...)
+	out := make([]routingdomain.Route, len(registries))
+	for i, reg := range registries {
+		out[i] = routingdomain.RouteForRegistry(reg)
+	}
+	return out
+}
+
+func modelRoutes(models ...string) []routingdomain.Route {
+	shared := makeBackends("shared")[0]
+	out := make([]routingdomain.Route, len(models))
+	for i, model := range models {
+		out[i] = routingdomain.Route{Registry: shared, Model: model, Weight: 1}
+	}
+	return out
+}
+
+func excludeRoutes(routes ...routingdomain.Route) map[routingdomain.RouteKey]struct{} {
+	out := make(map[routingdomain.RouteKey]struct{}, len(routes))
+	for _, route := range routes {
+		out[route.Key()] = struct{}{}
+	}
+	return out
+}
+
+func routeName(t *testing.T, route *routingdomain.Route) string {
+	t.Helper()
+	if route == nil || route.Registry == nil {
+		t.Fatal("expected a route with a registry")
+	}
+	return route.Registry.Name
+}
+
+func TestRoundRobin_RotatesThroughRoutes(t *testing.T) {
 	t.Parallel()
-	rr := NewRoundRobin(makeBackends("a", "b", "c"))
+	rr := NewRoundRobin(makeRoutes("a", "b", "c"))
 	got := []string{}
 	for i := 0; i < 6; i++ {
-		got = append(got, rr.Next(context.Background(), nil, nil).Name)
+		got = append(got, routeName(t, rr.Next(context.Background(), nil, nil)))
 	}
 	want := []string{"a", "b", "c", "a", "b", "c"}
 	for i := range want {
@@ -45,47 +80,76 @@ func TestRoundRobin_RotatesThroughBackends(t *testing.T) {
 	}
 }
 
+func TestRoundRobin_RotatesThroughModelsOfOneRegistry(t *testing.T) {
+	t.Parallel()
+	rr := NewRoundRobin(modelRoutes("gpt-4o-mini", "gpt-5"))
+	got := make([]string, 0, 4)
+	for i := 0; i < 4; i++ {
+		route := rr.Next(context.Background(), nil, nil)
+		if route == nil {
+			t.Fatalf("step %d: expected a route", i)
+		}
+		got = append(got, route.Model)
+	}
+	want := []string{"gpt-4o-mini", "gpt-5", "gpt-4o-mini", "gpt-5"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("step %d: got %q, want %q (full sequence: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestRoundRobin_ExcludingOneModelKeepsTheSibling(t *testing.T) {
+	t.Parallel()
+	routes := modelRoutes("gpt-4o-mini", "gpt-5")
+	rr := NewRoundRobin(routes)
+	exclude := excludeRoutes(routes[0])
+	for i := 0; i < 4; i++ {
+		route := rr.Next(context.Background(), nil, exclude)
+		if route == nil || route.Model != "gpt-5" {
+			t.Fatalf("step %d: expected the sibling route on the same registry, got %+v", i, route)
+		}
+	}
+}
+
 func TestRoundRobin_SkipsExcluded(t *testing.T) {
 	t.Parallel()
-	registries := makeBackends("a", "b", "c")
-	rr := NewRoundRobin(registries)
-	exclude := map[ids.RegistryID]struct{}{registries[0].ID: {}, registries[1].ID: {}}
+	routes := makeRoutes("a", "b", "c")
+	rr := NewRoundRobin(routes)
+	exclude := excludeRoutes(routes[0], routes[1])
 	for i := 0; i < 4; i++ {
-		b := rr.Next(context.Background(), nil, exclude)
-		if b == nil || b.Name != "c" {
-			t.Fatalf("step %d: expected only non-excluded backend 'c', got %+v", i, b)
+		route := rr.Next(context.Background(), nil, exclude)
+		if route == nil || routeName(t, route) != "c" {
+			t.Fatalf("step %d: expected only non-excluded route 'c', got %+v", i, route)
 		}
 	}
 }
 
 func TestRoundRobin_AllExcludedReturnsNil(t *testing.T) {
 	t.Parallel()
-	registries := makeBackends("a", "b")
-	rr := NewRoundRobin(registries)
-	exclude := map[ids.RegistryID]struct{}{registries[0].ID: {}, registries[1].ID: {}}
-	if rr.Next(context.Background(), nil, exclude) != nil {
-		t.Fatal("expected nil when every backend is excluded")
+	routes := makeRoutes("a", "b")
+	rr := NewRoundRobin(routes)
+	if rr.Next(context.Background(), nil, excludeRoutes(routes...)) != nil {
+		t.Fatal("expected nil when every route is excluded")
 	}
 }
 
 func TestWeightedRoundRobin_AllExcludedReturnsNil(t *testing.T) {
 	t.Parallel()
-	registries := makeBackends("a", "b")
-	wrr := NewWeightedRoundRobin(registries, nil)
-	exclude := map[ids.RegistryID]struct{}{registries[0].ID: {}, registries[1].ID: {}}
-	if wrr.Next(context.Background(), nil, exclude) != nil {
-		t.Fatal("expected nil when every weighted backend is excluded")
+	routes := makeRoutes("a", "b")
+	wrr := NewWeightedRoundRobin(routes)
+	if wrr.Next(context.Background(), nil, excludeRoutes(routes...)) != nil {
+		t.Fatal("expected nil when every weighted route is excluded")
 	}
 }
 
 func TestLeastConnections_SkipsExcluded(t *testing.T) {
 	t.Parallel()
-	registries := makeBackends("a", "b", "c")
-	lc := NewLeastConnections(registries)
-	exclude := map[ids.RegistryID]struct{}{registries[0].ID: {}}
-	b := lc.Next(context.Background(), nil, exclude)
-	if b == nil || b.Name == "a" {
-		t.Fatalf("expected a non-excluded backend, got %+v", b)
+	routes := makeRoutes("a", "b", "c")
+	lc := NewLeastConnections(routes)
+	route := lc.Next(context.Background(), nil, excludeRoutes(routes[0]))
+	if route == nil || routeName(t, route) == "a" {
+		t.Fatalf("expected a non-excluded route, got %+v", route)
 	}
 }
 
@@ -104,16 +168,16 @@ func TestRoundRobin_Name(t *testing.T) {
 	}
 }
 
-func TestRandom_PicksOneOfTheBackends(t *testing.T) {
+func TestRandom_PicksOneOfTheRoutes(t *testing.T) {
 	t.Parallel()
-	r := NewRandom(makeBackends("a", "b", "c"))
+	r := NewRandom(makeRoutes("a", "b", "c"))
 	seen := map[string]bool{}
 	for i := 0; i < 30; i++ {
-		b := r.Next(context.Background(), nil, nil)
-		if b == nil {
+		route := r.Next(context.Background(), nil, nil)
+		if route == nil {
 			break
 		}
-		seen[b.Name] = true
+		seen[routeName(t, route)] = true
 	}
 	if len(seen) == 0 {
 		t.Fatal("Random.Next never returned a backend")
@@ -141,45 +205,62 @@ func TestRandom_Name(t *testing.T) {
 
 func TestWeightedRoundRobin_RespectsWeights(t *testing.T) {
 	t.Parallel()
-	registries := []*registry.Registry{
-		{ID: ids.New[ids.RegistryKind](), Name: "heavy", LLMTarget: &registry.LLMTarget{Provider: "openai"}},
-		{ID: ids.New[ids.RegistryKind](), Name: "light", LLMTarget: &registry.LLMTarget{Provider: "openai"}},
-	}
-	weights := map[ids.RegistryID]int{
-		registries[0].ID: 3,
-		registries[1].ID: 1,
-	}
-	wrr := NewWeightedRoundRobin(registries, weights)
+	routes := makeRoutes("heavy", "light")
+	routes[0].Weight = 3
+	routes[1].Weight = 1
+	wrr := NewWeightedRoundRobin(routes)
 	counts := map[string]int{}
 	for i := 0; i < 40; i++ {
-		b := wrr.Next(context.Background(), nil, nil)
-		if b == nil {
+		route := wrr.Next(context.Background(), nil, nil)
+		if route == nil {
 			break
 		}
-		counts[b.Name]++
+		counts[routeName(t, route)]++
 	}
 	if counts["heavy"] <= counts["light"] {
 		t.Fatalf("heavy=%d should outnumber light=%d", counts["heavy"], counts["light"])
 	}
 }
 
+func TestWeightedRoundRobin_WeighsModelsOfOneRegistryIndependently(t *testing.T) {
+	t.Parallel()
+	routes := modelRoutes("gpt-4o-mini", "gpt-5")
+	routes[0].Weight = 4
+	routes[1].Weight = 1
+	wrr := NewWeightedRoundRobin(routes)
+	counts := map[string]int{}
+	for i := 0; i < 50; i++ {
+		route := wrr.Next(context.Background(), nil, nil)
+		if route == nil {
+			break
+		}
+		counts[route.Model]++
+	}
+	if counts["gpt-4o-mini"] <= counts["gpt-5"] {
+		t.Fatalf("the heavier model route should win: %v", counts)
+	}
+	if counts["gpt-5"] == 0 {
+		t.Fatalf("the lighter model route should still get traffic: %v", counts)
+	}
+}
+
 func TestWeightedRoundRobin_ZeroWeightsServeAsWeightOne(t *testing.T) {
 	t.Parallel()
-	wrr := NewWeightedRoundRobin([]*registry.Registry{
-		{ID: ids.New[ids.RegistryKind](), Name: "a"},
-		{ID: ids.New[ids.RegistryKind](), Name: "b"},
-	}, nil)
+	routes := makeRoutes("a", "b")
+	routes[0].Weight = 0
+	routes[1].Weight = 0
+	wrr := NewWeightedRoundRobin(routes)
 	counts := map[string]int{}
 	for i := 0; i < 10; i++ {
-		b := wrr.Next(context.Background(), nil, nil)
-		if b == nil {
+		route := wrr.Next(context.Background(), nil, nil)
+		if route == nil {
 			t.Fatal("WRR with zero weights must keep serving traffic (weight 0 acts as 1)")
 			return
 		}
-		counts[b.Name]++
+		counts[routeName(t, route)]++
 	}
 	if counts["a"] == 0 || counts["b"] == 0 {
-		t.Fatalf("both registries should receive traffic: %v", counts)
+		t.Fatalf("both routes should receive traffic: %v", counts)
 	}
 }
 
@@ -192,25 +273,25 @@ func TestWeightedRoundRobin_Name(t *testing.T) {
 
 func TestLeastConnections_NameAndRotation(t *testing.T) {
 	t.Parallel()
-	lc := NewLeastConnections(makeBackends("a", "b", "c"))
+	lc := NewLeastConnections(makeRoutes("a", "b", "c"))
 	if lc.Name() != "least-connections" {
 		t.Fatalf("Name() = %q", lc.Name())
 	}
 	got := []string{}
 	for i := 0; i < 3; i++ {
-		got = append(got, lc.Next(context.Background(), nil, nil).Name)
+		got = append(got, routeName(t, lc.Next(context.Background(), nil, nil)))
 	}
 	if got[0] != "a" || got[1] != "b" || got[2] != "c" {
 		t.Fatalf("expected a,b,c got %v", got)
 	}
 }
 
-func TestSemantic_NoConfigReturnsFirstRegistry(t *testing.T) {
+func TestSemantic_NoConfigReturnsFirstRoute(t *testing.T) {
 	t.Parallel()
-	s := NewSemantic(nil, makeBackends("a", "b"), nil, nil)
-	b := s.Next(context.Background(), nil, nil)
-	if b == nil || b.Name != "a" {
-		t.Fatalf("expected first backend a, got %+v", b)
+	s := NewSemantic(nil, makeRoutes("a", "b"), nil, nil)
+	route := s.Next(context.Background(), nil, nil)
+	if route == nil || routeName(t, route) != "a" {
+		t.Fatalf("expected first route a, got %+v", route)
 	}
 }
 
@@ -228,11 +309,11 @@ func TestSemantic_EmptyReturnsNil(t *testing.T) {
 	}
 }
 
-func TestSemantic_SingleRegistry(t *testing.T) {
+func TestSemantic_SingleRoute(t *testing.T) {
 	t.Parallel()
-	s := NewSemantic(nil, makeBackends("only"), nil, nil)
+	s := NewSemantic(nil, makeRoutes("only"), nil, nil)
 	got := s.Next(context.Background(), nil, nil)
-	if got == nil || got.Name != "only" {
+	if got == nil || routeName(t, got) != "only" {
 		t.Fatalf("expected 'only', got %+v", got)
 	}
 }

--- a/pkg/infra/loadbalancer/strategies/weighted_round_robin.go
+++ b/pkg/infra/loadbalancer/strategies/weighted_round_robin.go
@@ -18,51 +18,43 @@ import (
 	"context"
 	"sync"
 
-	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
-	"github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	routingdomain "github.com/NeuralTrust/TrustGate/pkg/domain/routing"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/routing/algorithm"
 	infracontext "github.com/NeuralTrust/TrustGate/pkg/infra/context"
 )
 
 type WeightedRoundRobin struct {
 	mu            sync.Mutex
-	registries    []*registry.Registry
-	weights       map[ids.RegistryID]int
+	routes        []routingdomain.Route
 	currentIndex  int
 	currentWeight int
 	maxWeight     int
 }
 
-func NewWeightedRoundRobin(registries []*registry.Registry, weights map[ids.RegistryID]int) *WeightedRoundRobin {
-	wrr := &WeightedRoundRobin{
-		registries: registries,
-		weights:    weights,
-	}
-	for _, b := range registries {
-		if wrr.effectiveWeight(b) > wrr.maxWeight {
-			wrr.maxWeight = wrr.effectiveWeight(b)
+func NewWeightedRoundRobin(routes []routingdomain.Route) *WeightedRoundRobin {
+	wrr := &WeightedRoundRobin{routes: routes}
+	for _, route := range routes {
+		if w := route.EffectiveWeight(); w > wrr.maxWeight {
+			wrr.maxWeight = w
 		}
 	}
 	return wrr
 }
 
-func (wrr *WeightedRoundRobin) effectiveWeight(b *registry.Registry) int {
-	if w, ok := wrr.weights[b.ID]; ok && w > 0 {
-		return w
-	}
-	return 1
-}
-
-func (wrr *WeightedRoundRobin) Next(_ context.Context, _ *infracontext.RequestContext, exclude map[ids.RegistryID]struct{}) *registry.Registry {
+func (wrr *WeightedRoundRobin) Next(
+	_ context.Context,
+	_ *infracontext.RequestContext,
+	exclude map[routingdomain.RouteKey]struct{},
+) *routingdomain.Route {
 	wrr.mu.Lock()
 	defer wrr.mu.Unlock()
-	if len(wrr.registries) == 0 {
+	if len(wrr.routes) == 0 {
 		return nil
 	}
 
-	maxIterations := len(wrr.registries)*(wrr.maxWeight+1) + 1
+	maxIterations := len(wrr.routes)*(wrr.maxWeight+1) + 1
 	for i := 0; i < maxIterations; i++ {
-		wrr.currentIndex = (wrr.currentIndex + 1) % len(wrr.registries)
+		wrr.currentIndex = (wrr.currentIndex + 1) % len(wrr.routes)
 		if wrr.currentIndex == 0 {
 			wrr.currentWeight = wrr.currentWeight - 1
 			if wrr.currentWeight <= 0 {
@@ -72,9 +64,9 @@ func (wrr *WeightedRoundRobin) Next(_ context.Context, _ *infracontext.RequestCo
 				}
 			}
 		}
-		b := wrr.registries[wrr.currentIndex]
-		if wrr.effectiveWeight(b) >= wrr.currentWeight && !isExcluded(b.ID, exclude) {
-			return b
+		route := wrr.routes[wrr.currentIndex]
+		if route.EffectiveWeight() >= wrr.currentWeight && !isExcluded(route.Key(), exclude) {
+			return pick(route)
 		}
 	}
 	return nil

--- a/pkg/infra/loadbalancer/strategy.go
+++ b/pkg/infra/loadbalancer/strategy.go
@@ -18,8 +18,8 @@ import (
 	"context"
 
 	"github.com/NeuralTrust/TrustGate/pkg/domain/embedding"
-	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	routingdomain "github.com/NeuralTrust/TrustGate/pkg/domain/routing"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/routing/algorithm"
 	infracontext "github.com/NeuralTrust/TrustGate/pkg/infra/context"
 )
@@ -33,15 +33,19 @@ const (
 	AlgorithmSmartRouting       = algorithm.SmartRouting
 )
 
+// Excluding a route by key removes only that (registry, model) pair, never the registry.
 type Strategy interface {
-	Next(ctx context.Context, req *infracontext.RequestContext, exclude map[ids.RegistryID]struct{}) *registry.Registry
+	Next(
+		ctx context.Context,
+		req *infracontext.RequestContext,
+		exclude map[routingdomain.RouteKey]struct{},
+	) *routingdomain.Route
 	Name() string
 }
 
 type StrategyInput struct {
 	Algorithm          string
-	Registries         []*registry.Registry
-	Weights            map[ids.RegistryID]int
+	Routes             []routingdomain.Route
 	EmbeddingConfig    *embedding.Config
 	SmartRoutingConfig *registry.SmartRoutingConfig
 }

--- a/pkg/infra/metrics/events/event.go
+++ b/pkg/infra/metrics/events/event.go
@@ -139,6 +139,10 @@ type Attempt struct {
 	Fallback   bool   `json:"fallback"`
 	Pinned     bool   `json:"pinned"`
 	Route      string `json:"route,omitempty"`
+	// RouteModel is the model pinned by the load balancer route this attempt
+	// used. It is empty when the route deferred to the registry default, and it
+	// is what tells two attempts on the same registry apart.
+	RouteModel string `json:"route_model,omitempty"`
 	Outcome    string `json:"outcome,omitempty"`
 	StatusCode int    `json:"status_code"`
 	LatencyMs  int64  `json:"latency_ms"`

--- a/pkg/infra/trace/span.go
+++ b/pkg/infra/trace/span.go
@@ -33,10 +33,15 @@ const (
 )
 
 type LLMAttrs struct {
-	RegistryID     string
-	Provider       string
-	Model          string
-	SentModel      string
+	RegistryID string
+	Provider   string
+	Model      string
+	SentModel  string
+	// RouteModel is the model the load balancer's route pinned, empty when the
+	// route deferred to the registry's model policy. It separates the balancer's
+	// decision from RequestedModel (what the client asked for) and SentModel
+	// (what actually went upstream), which otherwise coincide.
+	RouteModel     string
 	RequestedModel string
 	FinishReason   string
 	TurnID         string

--- a/postman/TrustGate.postman_collection.json
+++ b/postman/TrustGate.postman_collection.json
@@ -1337,7 +1337,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"team-a-{{$guid}}\",\n  \"type\": \"LLM\",\n  \"routing_mode\": \"inline\",\n  \"active\": true,\n  \"headers\": {},\n  \"registries\": [\n    {\n      \"id\": \"{{registry_id}}\",\n      \"weight\": 1,\n      \"model_policies\": {\n        \"allowed\": [\n          \"gpt-4o\"\n        ],\n        \"default\": \"gpt-4o\"\n      }\n    }\n  ],\n  \"lb_config\": {\n    \"enabled\": true,\n    \"algorithm\": \"round-robin\",\n    \"pool_alias\": \"fast-chat\",\n    \"members\": [\n      {\n        \"registry_id\": \"{{registry_id}}\"\n      }\n    ]\n  },\n  \"fallback\": {\n    \"enabled\": true,\n    \"triggers\": [\n      \"http_5xx\"\n    ],\n    \"chain\": [\n      \"{{registry_id}}\"\n    ],\n    \"budget\": {\n      \"max_attempts\": 2,\n      \"max_total_latency_ms\": 5000\n    }\n  }\n}"
+              "raw": "{\n  \"name\": \"team-a-{{$guid}}\",\n  \"type\": \"LLM\",\n  \"routing_mode\": \"inline\",\n  \"active\": true,\n  \"headers\": {},\n  \"registries\": [\n    {\n      \"id\": \"{{registry_id}}\",\n      \"weight\": 1,\n      \"model_policies\": {\n        \"allowed\": [\n          \"gpt-4o\",\n          \"gpt-4o-mini\"\n        ],\n        \"default\": \"gpt-4o\"\n      }\n    }\n  ],\n  \"lb_config\": {\n    \"enabled\": true,\n    \"algorithm\": \"weighted-round-robin\",\n    \"pool_alias\": \"fast-chat\",\n    \"members\": [\n      {\n        \"registry_id\": \"{{registry_id}}\",\n        \"model\": \"gpt-4o\",\n        \"weight\": 70\n      },\n      {\n        \"registry_id\": \"{{registry_id}}\",\n        \"model\": \"gpt-4o-mini\",\n        \"weight\": 30\n      }\n    ]\n  },\n  \"fallback\": {\n    \"enabled\": true,\n    \"triggers\": [\n      \"http_5xx\"\n    ],\n    \"chain\": [\n      \"{{registry_id}}\"\n    ],\n    \"budget\": {\n      \"max_attempts\": 2,\n      \"max_total_latency_ms\": 5000\n    }\n  }\n}"
             },
             "url": {
               "raw": "{{base_url}}/v1/gateways/{{gateway_id}}/consumers",
@@ -1351,7 +1351,7 @@
                 "consumers"
               ]
             },
-            "description": "`routing_mode` is `inline` (default) or `role_based`. Inline consumers own their registries, model policies, `lb_config` (with optional `pool_alias` addressable as `pool:<alias>` in the payload) and `fallback`. LB and fallback never apply to role_based consumers."
+            "description": "`routing_mode` is `inline` (default) or `role_based`. Inline consumers own their registries, model policies, `lb_config` (with optional `pool_alias` addressable as `pool:<alias>` in the payload) and `fallback`. LB and fallback never apply to role_based consumers.\n\nThe load balancer distributes over routes, not registries: a route is a `(registry_id, model)` pair, so the same registry can appear several times with a different `model` (as in this example, where `gpt-4o` takes 70% of the share and `gpt-4o-mini` 30%). Rules: every member sharing a registry must declare `model`, each `(registry_id, model)` must be unique, and the model must be allowed by `model_policies`. `members[].weight` (`1..100`) applies to weighted-round-robin and defaults to the registry weight when omitted."
           }
         },
         {
@@ -1463,7 +1463,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"team-a-{{$guid}}\",\n  \"routing_mode\": \"inline\",\n  \"active\": true,\n  \"model_policies\": [\n    {\n      \"registry_id\": \"{{registry_id}}\",\n      \"allowed\": [\n        \"gpt-4o\"\n      ],\n      \"default\": \"gpt-4o\"\n    }\n  ],\n  \"lb_config\": {\n    \"enabled\": true,\n    \"algorithm\": \"round-robin\",\n    \"pool_alias\": \"fast-chat\",\n    \"members\": [\n      {\n        \"registry_id\": \"{{registry_id}}\"\n      }\n    ]\n  },\n  \"fallback\": {\n    \"enabled\": true,\n    \"triggers\": [\n      \"http_5xx\"\n    ],\n    \"chain\": [\n      \"{{registry_id}}\"\n    ],\n    \"budget\": {\n      \"max_attempts\": 2,\n      \"max_total_latency_ms\": 5000\n    }\n  }\n}"
+              "raw": "{\n  \"name\": \"team-a-{{$guid}}\",\n  \"routing_mode\": \"inline\",\n  \"active\": true,\n  \"model_policies\": [\n    {\n      \"registry_id\": \"{{registry_id}}\",\n      \"allowed\": [\n        \"gpt-4o-mini\",\n        \"gpt-4o\"\n      ],\n      \"default\": \"gpt-4o-mini\"\n    }\n  ],\n  \"lb_config\": {\n    \"enabled\": true,\n    \"algorithm\": \"smart-routing\",\n    \"pool_alias\": \"fast-chat\",\n    \"members\": [\n      {\n        \"registry_id\": \"{{registry_id}}\",\n        \"model\": \"gpt-4o-mini\"\n      },\n      {\n        \"registry_id\": \"{{registry_id}}\",\n        \"model\": \"gpt-4o\"\n      }\n    ],\n    \"smart_routing\": {\n      \"tiers\": [\n        {\n          \"min_score\": 0,\n          \"registry_id\": \"{{registry_id}}\",\n          \"model\": \"gpt-4o-mini\"\n        },\n        {\n          \"min_score\": 0.5,\n          \"registry_id\": \"{{registry_id}}\",\n          \"model\": \"gpt-4o\"\n        }\n      ]\n    }\n  },\n  \"fallback\": {\n    \"enabled\": true,\n    \"triggers\": [\n      \"http_5xx\"\n    ],\n    \"chain\": [\n      \"{{registry_id}}\"\n    ],\n    \"budget\": {\n      \"max_attempts\": 2,\n      \"max_total_latency_ms\": 5000\n    }\n  }\n}"
             },
             "url": {
               "raw": "{{base_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}",
@@ -1478,7 +1478,7 @@
                 "{{consumer_id}}"
               ]
             },
-            "description": "Partial update. Registries are managed via attach/detach endpoints; `model_policies` here updates policies for already-bound registries. Send `lb_config`/`fallback` with `enabled: false` to clear them."
+            "description": "Partial update. Registries are managed via attach/detach endpoints; `model_policies` here updates policies for already-bound registries. Send `lb_config`/`fallback` with `enabled: false` to clear them.\n\nThis example uses `smart-routing`: the firewall scores prompt complexity in `0..1` and each tier sends everything at or above its `min_score` to one route. `tiers[].model` picks which route of the registry the tier targets and is required whenever the pool declares that registry more than once — here cheap prompts go to `gpt-4o-mini` and complex ones (score >= 0.5) to `gpt-4o` on the same registry."
           }
         },
         {

--- a/tests/functional/lb_strategies_e2e_test.go
+++ b/tests/functional/lb_strategies_e2e_test.go
@@ -1,0 +1,192 @@
+//go:build functional
+
+package functional_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupStrategyPool(
+	t *testing.T,
+	algorithm string,
+	first, second *fakeUpstream,
+	members []map[string]any,
+	extra map[string]any,
+) (string, string) {
+	t.Helper()
+	gatewayID := CreateGateway(t, map[string]any{"slug": uniqueName("lbstrat-gw")})
+	firstID := CreateRegistry(t, gatewayID, openaiBackendPayload(uniqueName("be-first"), first.URL()))
+	secondID := CreateRegistry(t, gatewayID, openaiCompatibleBackendPayload(uniqueName("be-second"), second.URL()))
+
+	ids := []string{firstID, secondID}
+	poolMembers := make([]map[string]any, 0, len(ids))
+	for i, id := range ids {
+		member := map[string]any{"registry_id": id}
+		if i < len(members) {
+			for k, v := range members[i] {
+				member[k] = v
+			}
+		}
+		poolMembers = append(poolMembers, member)
+	}
+
+	lb := map[string]any{"enabled": true, "algorithm": algorithm, "members": poolMembers}
+	for k, v := range extra {
+		lb[k] = v
+	}
+
+	coID := CreateConsumer(t, gatewayID, map[string]any{
+		"name": uniqueName("lbstrat-cons"),
+		"registries": []map[string]any{
+			{"id": firstID, "model_policies": map[string]any{"allowed": []string{firstPoolModel}, "default": firstPoolModel}},
+			{"id": secondID, "model_policies": map[string]any{"allowed": []string{secondPoolModel}, "default": secondPoolModel}},
+		},
+		"lb_config": lb,
+	})
+	return createAndAttachAPIKey(t, gatewayID, coID), chatCompletionsPath(t, coID)
+}
+
+const (
+	firstPoolModel  = "model-first"
+	secondPoolModel = "model-second"
+)
+
+func drivePool(t *testing.T, apiKey, path string, first, second *fakeUpstream, total int) (int, int) {
+	t.Helper()
+	for i := 0; i < total; i++ {
+		status, _, body := proxyPost(t, apiKey, path, chatRequestModel("auto"))
+		require.Equal(t, http.StatusOK, status, "request %d body: %s", i, body)
+	}
+	return first.Hits(), second.Hits()
+}
+
+func TestLBStrategy_RoundRobinRotatesEvenly(t *testing.T) {
+	defer Track(t, "LBStrategies")()
+
+	const total = 4
+	first := newJSONUpstream(t, "first-served")
+	second := newJSONUpstream(t, "second-served")
+	apiKey, path := setupStrategyPool(t, "round-robin", first, second, nil, nil)
+
+	firstHits, secondHits := drivePool(t, apiKey, path, first, second, total)
+
+	assert.Equal(t, total/2, firstHits, "round robin must split the traffic evenly")
+	assert.Equal(t, total/2, secondHits)
+	assert.Contains(t, string(first.LastBody()), `"model":"`+firstPoolModel+`"`,
+		"each member must receive its own default model")
+	assert.Contains(t, string(second.LastBody()), `"model":"`+secondPoolModel+`"`)
+}
+
+func TestLBStrategy_RandomSpreadsOverEveryMember(t *testing.T) {
+	defer Track(t, "LBStrategies")()
+
+	// With a uniform pick over two members, the odds of starving one across 20 requests are 2^-19.
+	const total = 20
+	first := newJSONUpstream(t, "first-served")
+	second := newJSONUpstream(t, "second-served")
+	apiKey, path := setupStrategyPool(t, "random", first, second, nil, nil)
+
+	firstHits, secondHits := drivePool(t, apiKey, path, first, second, total)
+
+	assert.Equal(t, total, firstHits+secondHits, "every request must reach exactly one member")
+	assert.Greater(t, firstHits, 0, "a random pick must be able to select the first member")
+	assert.Greater(t, secondHits, 0, "a random pick must be able to select the second member")
+}
+
+func TestLBStrategy_WeightedFavoursTheHeavierMember(t *testing.T) {
+	defer Track(t, "LBStrategies")()
+
+	const total = 10
+	first := newJSONUpstream(t, "first-served")
+	second := newJSONUpstream(t, "second-served")
+	apiKey, path := setupStrategyPool(t, "weighted-round-robin", first, second, []map[string]any{
+		{"weight": 4},
+		{"weight": 1},
+	}, nil)
+
+	firstHits, secondHits := drivePool(t, apiKey, path, first, second, total)
+
+	assert.Equal(t, total, firstHits+secondHits, "every request must reach exactly one member")
+	assert.Greater(t, firstHits, secondHits, "the heavier member must serve more traffic")
+	assert.Greater(t, secondHits, 0, "the lighter member must still serve some traffic")
+}
+
+func TestLBStrategy_LeastConnectionsSpreadsWhenNothingIsInFlight(t *testing.T) {
+	defer Track(t, "LBStrategies")()
+
+	// Sequential traffic leaves both members at zero in-flight, so this pins the tie-break.
+	const total = 4
+	first := newJSONUpstream(t, "first-served")
+	second := newJSONUpstream(t, "second-served")
+	apiKey, path := setupStrategyPool(t, "least-connections", first, second, nil, nil)
+
+	firstHits, secondHits := drivePool(t, apiKey, path, first, second, total)
+
+	assert.Equal(t, total, firstHits+secondHits, "every request must reach exactly one member")
+	assert.Greater(t, firstHits, 0)
+	assert.Greater(t, secondHits, 0)
+}
+
+func TestLBStrategy_SemanticKeepsServingWhenEmbeddingsAreUnavailable(t *testing.T) {
+	defer Track(t, "LBStrategies")()
+
+	// An unregistered provider stands in for an embedding API that is down.
+	const total = 3
+	first := newJSONUpstream(t, "first-served")
+	second := newJSONUpstream(t, "second-served")
+	apiKey, path := setupStrategyPool(t, "semantic", first, second, nil, map[string]any{
+		"embedding_config": map[string]any{
+			"provider": "unavailable-provider",
+			"model":    "text-embedding-3-small",
+			"auth":     map[string]any{"api_key": "sk-test"},
+		},
+	})
+
+	firstHits, secondHits := drivePool(t, apiKey, path, first, second, total)
+
+	assert.Equal(t, total, firstHits, "semantic must fall back to the first member when it cannot embed")
+	assert.Equal(t, 0, secondHits)
+}
+
+func TestLBStrategy_SmartRoutingPicksTheTierMember(t *testing.T) {
+	defer Track(t, "LBStrategies")()
+
+	first := newJSONUpstream(t, "first-served")
+	second := newJSONUpstream(t, "second-served")
+	gatewayID := CreateGateway(t, map[string]any{"slug": uniqueName("lbsmart-gw")})
+	firstID := CreateRegistry(t, gatewayID, openaiBackendPayload(uniqueName("be-first"), first.URL()))
+	secondID := CreateRegistry(t, gatewayID, openaiCompatibleBackendPayload(uniqueName("be-second"), second.URL()))
+	coID := CreateConsumer(t, gatewayID, map[string]any{
+		"name": uniqueName("lbsmart-cons"),
+		"registries": []map[string]any{
+			{"id": firstID, "model_policies": map[string]any{"allowed": []string{firstPoolModel}, "default": firstPoolModel}},
+			{"id": secondID, "model_policies": map[string]any{"allowed": []string{secondPoolModel}, "default": secondPoolModel}},
+		},
+		"lb_config": map[string]any{
+			"enabled":   true,
+			"algorithm": "smart-routing",
+			"members": []map[string]any{
+				{"registry_id": firstID},
+				{"registry_id": secondID},
+			},
+			"smart_routing": map[string]any{
+				"tiers": []map[string]any{
+					{"min_score": 0.0, "registry_id": firstID},
+					{"min_score": 0.5, "registry_id": secondID},
+				},
+			},
+		},
+	})
+	apiKey := createAndAttachAPIKey(t, gatewayID, coID)
+	path := chatCompletionsPath(t, coID)
+
+	status, _, body := proxyPost(t, apiKey, path, smartChatRequest(smartRouteHighContent))
+
+	require.Equal(t, http.StatusOK, status, "body: %s", body)
+	assert.Equal(t, 1, second.Hits(), "a high score must select the upper tier")
+	assert.Equal(t, 0, first.Hits())
+}

--- a/tests/functional/route_aware_lb_e2e_test.go
+++ b/tests/functional/route_aware_lb_e2e_test.go
@@ -1,0 +1,253 @@
+//go:build functional
+
+package functional_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Sibling routes share a base URL, so the model on the wire is the only evidence of the pick.
+type modelSpy struct {
+	server      *httptest.Server
+	brokenModel string
+	mu          sync.Mutex
+	models      []string
+}
+
+func newModelSpy(t *testing.T, brokenModel string) *modelSpy {
+	t.Helper()
+	spy := &modelSpy{brokenModel: brokenModel}
+	spy.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		model := spy.record(r)
+		w.Header().Set("Content-Type", "application/json")
+		if model != "" && model == spy.brokenModel {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = io.WriteString(w, `{"error":{"message":"model unavailable","type":"server_error"}}`)
+			return
+		}
+		_, _ = io.WriteString(w,
+			`{"id":"chatcmpl-test","object":"chat.completion",`+
+				`"choices":[{"index":0,"message":{"role":"assistant","content":"route-served"},"finish_reason":"stop"}]}`)
+	}))
+	t.Cleanup(spy.server.Close)
+	return spy
+}
+
+func (s *modelSpy) record(r *http.Request) string {
+	body, _ := io.ReadAll(r.Body)
+	var parsed struct {
+		Model string `json:"model"`
+	}
+	_ = json.Unmarshal(body, &parsed)
+	s.mu.Lock()
+	s.models = append(s.models, parsed.Model)
+	s.mu.Unlock()
+	return parsed.Model
+}
+
+func (s *modelSpy) URL() string { return s.server.URL }
+
+func (s *modelSpy) Models() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.models...)
+}
+
+func (s *modelSpy) Count(model string) int {
+	n := 0
+	for _, seen := range s.Models() {
+		if seen == model {
+			n++
+		}
+	}
+	return n
+}
+
+func setupRouteAwarePool(t *testing.T, spy *modelSpy, algorithm string, members, tiers []map[string]any) (string, string) {
+	t.Helper()
+	gatewayID := CreateGateway(t, map[string]any{"slug": uniqueName("routelb-gw")})
+	registryID := CreateRegistry(t, gatewayID, openaiBackendPayload(uniqueName("be"), spy.URL()))
+
+	models := make([]string, 0, len(members))
+	withIDs := make([]map[string]any, 0, len(members))
+	for _, member := range members {
+		copied := map[string]any{"registry_id": registryID}
+		for k, v := range member {
+			copied[k] = v
+		}
+		withIDs = append(withIDs, copied)
+		if model, ok := member["model"].(string); ok {
+			models = append(models, model)
+		}
+	}
+	lb := map[string]any{"enabled": true, "algorithm": algorithm, "members": withIDs}
+	if tiers != nil {
+		withRegistry := make([]map[string]any, 0, len(tiers))
+		for _, tier := range tiers {
+			copied := map[string]any{"registry_id": registryID}
+			for k, v := range tier {
+				copied[k] = v
+			}
+			withRegistry = append(withRegistry, copied)
+		}
+		lb["smart_routing"] = map[string]any{"tiers": withRegistry}
+	}
+
+	coID := CreateConsumer(t, gatewayID, map[string]any{
+		"name": uniqueName("routelb-cons"),
+		"registries": []map[string]any{
+			{"id": registryID, "model_policies": map[string]any{"allowed": models, "default": models[0]}},
+		},
+		"lb_config": lb,
+	})
+	return createAndAttachAPIKey(t, gatewayID, coID), chatCompletionsPath(t, coID)
+}
+
+func TestRouteAwareLB_RoundRobinAlternatesModelsOfOneRegistry(t *testing.T) {
+	defer Track(t, "RouteAwareLB")()
+
+	const (
+		cheap   = "model-cheap"
+		premium = "model-premium"
+		total   = 4
+	)
+	spy := newModelSpy(t, "")
+	apiKey, path := setupRouteAwarePool(t, spy, "round-robin", []map[string]any{
+		{"model": cheap},
+		{"model": premium},
+	}, nil)
+
+	for i := 0; i < total; i++ {
+		status, _, body := proxyPost(t, apiKey, path, chatRequestModel("auto"))
+		require.Equal(t, http.StatusOK, status, "request %d body: %s", i, body)
+	}
+
+	assert.Equal(t, total/2, spy.Count(cheap), "round robin must send half the traffic to the cheap route")
+	assert.Equal(t, total/2, spy.Count(premium), "round robin must send half the traffic to the premium route")
+}
+
+func TestRouteAwareLB_WeightedFavoursTheHeavierRouteOfOneRegistry(t *testing.T) {
+	defer Track(t, "RouteAwareLB")()
+
+	const (
+		heavy = "model-heavy"
+		light = "model-light"
+		total = 10
+	)
+	spy := newModelSpy(t, "")
+	apiKey, path := setupRouteAwarePool(t, spy, "weighted-round-robin", []map[string]any{
+		{"model": heavy, "weight": 4},
+		{"model": light, "weight": 1},
+	}, nil)
+
+	for i := 0; i < total; i++ {
+		status, _, body := proxyPost(t, apiKey, path, chatRequestModel("auto"))
+		require.Equal(t, http.StatusOK, status, "request %d body: %s", i, body)
+	}
+
+	assert.Equal(t, total, spy.Count(heavy)+spy.Count(light), "every request must take one of the two routes")
+	assert.Greater(t, spy.Count(heavy), spy.Count(light), "the heavier route must serve more traffic")
+	assert.Greater(t, spy.Count(light), 0, "the lighter route must still serve some traffic")
+}
+
+func TestRouteAwareLB_SmartRoutingPicksTheTierModelOfOneRegistry(t *testing.T) {
+	defer Track(t, "RouteAwareLB")()
+
+	const (
+		cheap   = "model-cheap"
+		premium = "model-premium"
+	)
+	members := []map[string]any{{"model": cheap}, {"model": premium}}
+	tiers := []map[string]any{
+		{"min_score": 0.0, "model": cheap},
+		{"min_score": 0.5, "model": premium},
+	}
+
+	t.Run("a low score takes the cheap route", func(t *testing.T) {
+		spy := newModelSpy(t, "")
+		apiKey, path := setupRouteAwarePool(t, spy, "smart-routing", members, tiers)
+
+		status, _, body := proxyPost(t, apiKey, path, smartChatRequest(smartRouteLowContent))
+
+		require.Equal(t, http.StatusOK, status, "body: %s", body)
+		assert.Equal(t, 1, spy.Count(cheap))
+		assert.Equal(t, 0, spy.Count(premium))
+	})
+
+	t.Run("a high score takes the premium route of the same registry", func(t *testing.T) {
+		spy := newModelSpy(t, "")
+		apiKey, path := setupRouteAwarePool(t, spy, "smart-routing", members, tiers)
+
+		status, _, body := proxyPost(t, apiKey, path, smartChatRequest(smartRouteHighContent))
+
+		require.Equal(t, http.StatusOK, status, "body: %s", body)
+		assert.Equal(t, 1, spy.Count(premium))
+		assert.Equal(t, 0, spy.Count(cheap))
+	})
+}
+
+func TestRouteAwareLB_FailoverRetriesTheSameRegistryWithAnotherModel(t *testing.T) {
+	defer Track(t, "RouteAwareLB")()
+
+	const (
+		broken = "model-broken"
+		good   = "model-good"
+	)
+	spy := newModelSpy(t, broken)
+	apiKey, path := setupRouteAwarePool(t, spy, "round-robin", []map[string]any{
+		{"model": broken},
+		{"model": good},
+	}, nil)
+
+	status, _, body := proxyPost(t, apiKey, path, chatRequestModel("auto"))
+
+	require.Equal(t, http.StatusOK, status, "the healthy route of the same registry must rescue the request, body: %s", body)
+	assert.Equal(t, expectedAttempts(), spy.Count(broken), "the broken route must exhaust its retry budget first")
+	assert.Equal(t, 1, spy.Count(good), "failover must retry the same registry with the other model")
+}
+
+func TestRouteAwareLB_MembersWithoutModelKeepBalancingPerRegistry(t *testing.T) {
+	defer Track(t, "RouteAwareLB")()
+
+	openai := newJSONUpstream(t, "openai-served")
+	compat := newJSONUpstream(t, "compat-served")
+	gatewayID := CreateGateway(t, map[string]any{"slug": uniqueName("legacylb-gw")})
+	openaiID := CreateRegistry(t, gatewayID, openaiBackendPayload(uniqueName("be-oai"), openai.URL()))
+	compatID := CreateRegistry(t, gatewayID, openaiCompatibleBackendPayload(uniqueName("be-compat"), compat.URL()))
+	coID := CreateConsumer(t, gatewayID, map[string]any{
+		"name": uniqueName("legacylb-cons"),
+		"registries": []map[string]any{
+			{"id": openaiID, "model_policies": map[string]any{"allowed": []string{"gpt-4o-mini"}, "default": "gpt-4o-mini"}},
+			{"id": compatID, "model_policies": map[string]any{"allowed": []string{"compat-model"}, "default": "compat-model"}},
+		},
+		"lb_config": map[string]any{
+			"enabled":   true,
+			"algorithm": "round-robin",
+			"members": []map[string]any{
+				{"registry_id": openaiID},
+				{"registry_id": compatID},
+			},
+		},
+	})
+	apiKey := createAndAttachAPIKey(t, gatewayID, coID)
+	path := chatCompletionsPath(t, coID)
+
+	const total = 4
+	for i := 0; i < total; i++ {
+		status, _, body := proxyPost(t, apiKey, path, chatRequestModel("auto"))
+		require.Equal(t, http.StatusOK, status, "request %d body: %s", i, body)
+	}
+
+	assert.Equal(t, total/2, openai.Hits(), "a pool without models must still rotate per registry")
+	assert.Equal(t, total/2, compat.Hits())
+	assert.Contains(t, string(openai.LastBody()), `"model":"gpt-4o-mini"`)
+	assert.Contains(t, string(compat.LastBody()), `"model":"compat-model"`)
+}


### PR DESCRIPTION
## Summary

A load balancer pool could only name registries, and a registry carries a single default model, so declaring the same upstream twice to balance across two of its models silently collapsed into one candidate. The unit of balancing is now a **route**: a `(registry, model)` pair.

- `lb_config.members` and `smart_routing.tiers` accept a `model`, and members accept an optional `weight` that overrides the registry association weight. A member without a model behaves exactly as before.
- Pools are built from `lb_config.members` rather than from the request's candidate set, which also fixes a latent bug: an aliased pool used to freeze its membership from whatever the first request resolved.
- Exclusions are keyed by route, so a failing model leaves its sibling models on the same registry available to the same request's failover.
- Configuration ambiguity is rejected at validation time: a registry declared twice needs a model on every one of its members, and a tier whose registry has more than one route must name the model.
- Traces and metric attempts carry the route model, which is what tells two attempts on the same registry apart.
- The routing tab in the dashboard becomes a pool-route editor, with the weight field folded into each row and a route selector on every smart-routing tier.

Health remains per registry, not per route: sibling routes of one upstream share its health state.

## Review order

The five commits are meant to be read in order — `refactor(lb)` carries the logic, the rest are the surfaces around it (observability, API + regenerated OpenAPI, dashboard, functional tests).

> Size note: the diff is above the 400-line review budget. It is one indivisible interface change (the `Strategy` contract, the balancer and the forwarder must move together), so splitting it would produce non-compiling intermediate PRs. Commits are scoped to make review sequential.

## Test plan

- [x] `go test -race ./...` — full unit suite green, including new tables for `Route`, `BuildPoolRoutes`, member/tier validation and every strategy
- [x] `golangci-lint run ./...` and `go vet ./...` clean
- [x] `tsc --noEmit` clean
- [x] Functional suite: 267/268. New `TestLBStrategy_*` (one per algorithm) and `TestRouteAwareLB_*` (same registry, two models: round-robin, weights, smart-routing tier, failover to the sibling model, plus a regression that model-less members still balance per registry) all pass
- [ ] The one functional failure, `TestPlaygroundTraceE2E`, is pre-existing and unrelated: it fails identically on a clean checkout of this branch's base because the local `.env.functional` disables telemetry, so the proxy never sets `X-AG-Trace-Id`

Made with [Cursor](https://cursor.com)