### PR TITLE
feat: advertise the served route in proxy response headers

### DIFF
--- a/pkg/app/proxy/provider.go
+++ b/pkg/app/proxy/provider.go
@@ -34,6 +34,8 @@ import (
 
 const (
 	headerSelectedProvider = "X-Selected-Provider"
+	headerSelectedRegistry = "X-Selected-Registry"
+	headerSelectedModel    = "X-Selected-Model"
 	headerContentType      = "Content-Type"
 	contentTypeJSON        = "application/json"
 
@@ -139,7 +141,7 @@ func (p *providerInvoker) Invoke(
 		if be, ok := registry.IsBackendError(err); ok {
 			return &ProviderResponse{
 				StatusCode: be.StatusCode,
-				Headers:    be.PassthroughHeaders(),
+				Headers:    withSelectionHeaders(be.PassthroughHeaders(), bk, prep.sentModel),
 				Body:       be.Body,
 			}, nil
 		}
@@ -160,10 +162,11 @@ func (p *providerInvoker) Invoke(
 
 	return &ProviderResponse{
 		StatusCode: http.StatusOK,
-		Headers: map[string][]string{
-			headerSelectedProvider: {bk.Provider()},
-			headerContentType:      {contentTypeJSON},
-		},
+		Headers: withSelectionHeaders(
+			map[string][]string{headerContentType: {contentTypeJSON}},
+			bk,
+			prep.sentModel,
+		),
 		Body:         respBody,
 		Usage:        usage,
 		Model:        model,
@@ -207,7 +210,7 @@ func (p *providerInvoker) InvokeStream(
 		if be, ok := registry.IsBackendError(err); ok {
 			return &ProviderResponse{
 				StatusCode: be.StatusCode,
-				Headers:    be.PassthroughHeaders(),
+				Headers:    withSelectionHeaders(be.PassthroughHeaders(), bk, prep.sentModel),
 				Body:       be.Body,
 			}, nil
 		}
@@ -218,7 +221,7 @@ func (p *providerInvoker) InvokeStream(
 
 	return &ProviderResponse{
 		StatusCode: http.StatusOK,
-		Headers:    streamHeaders(bk.Provider()),
+		Headers:    withSelectionHeaders(streamHeaders(), bk, prep.sentModel),
 		Stream:     stream,
 		SentModel:  prep.sentModel,
 	}, nil
@@ -444,14 +447,34 @@ func (p *providerInvoker) streamObserver(ctx context.Context, req *infracontext.
 	}
 }
 
-func streamHeaders(provider string) map[string][]string {
+func streamHeaders() map[string][]string {
 	return map[string][]string{
-		headerContentType:      {"text/event-stream"},
-		"Cache-Control":        {"no-cache"},
-		"Connection":           {"keep-alive"},
-		"X-Accel-Buffering":    {"no"},
-		headerSelectedProvider: {provider},
+		headerContentType:   {"text/event-stream"},
+		"Cache-Control":     {"no-cache"},
+		"Connection":        {"keep-alive"},
+		"X-Accel-Buffering": {"no"},
 	}
+}
+
+func withSelectionHeaders(
+	headers map[string][]string,
+	bk *registry.Registry,
+	sentModel string,
+) map[string][]string {
+	out := make(map[string][]string, len(headers)+3)
+	for name, values := range headers {
+		out[name] = values
+	}
+	if provider := bk.Provider(); provider != "" {
+		out[headerSelectedProvider] = []string{provider}
+	}
+	if !bk.ID.IsNil() {
+		out[headerSelectedRegistry] = []string{bk.ID.String()}
+	}
+	if sentModel != "" {
+		out[headerSelectedModel] = []string{sentModel}
+	}
+	return out
 }
 
 func sourceFormatFromRequest(req *infracontext.RequestContext) adapter.Format {

--- a/pkg/app/proxy/provider_invoker_test.go
+++ b/pkg/app/proxy/provider_invoker_test.go
@@ -77,6 +77,34 @@ func TestProviderInvoke_SameFormatPassthrough(t *testing.T) {
 	assert.Equal(t, "openai", req.TargetFormat)
 }
 
+func TestProviderInvoke_AdvertisesServedRoute(t *testing.T) {
+	const defaultModel = "gpt-4o-mini"
+	client := providermocks.NewClient(t)
+	client.EXPECT().
+		Completions(mock.Anything, mock.Anything, mock.Anything).
+		Return([]byte(openaiResponseBody), nil).
+		Once()
+
+	locator := factorymocks.NewProviderLocator(t)
+	locator.EXPECT().Get("openai").Return(client, nil).Once()
+
+	inv := appproxy.NewProviderInvoker(locator, adapter.NewRegistry(), newTestLogger())
+
+	target := apiKeyTarget("openai")
+	req := &infracontext.RequestContext{
+		Body:          []byte(`{"messages":[{"role":"user","content":"hi"}]}`),
+		AllowedModels: []string{defaultModel},
+		DefaultModel:  defaultModel,
+	}
+	resp, err := inv.Invoke(context.Background(), target, req)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"openai"}, resp.Headers["X-Selected-Provider"])
+	assert.Equal(t, []string{target.ID.String()}, resp.Headers["X-Selected-Registry"])
+	assert.Equal(t, []string{defaultModel}, resp.Headers["X-Selected-Model"],
+		"the header must carry the model the route resolved to, which the client never sent")
+}
+
 func TestProviderInvoke_DecodesUsageOnFinish(t *testing.T) {
 	client := providermocks.NewClient(t)
 	client.EXPECT().
@@ -177,6 +205,9 @@ func TestProviderInvoke_BackendErrorPassthrough(t *testing.T) {
 	assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
 	assert.Equal(t, errBody, resp.Body)
 	assert.Equal(t, []string{"application/json"}, resp.Headers["Content-Type"])
+	assert.Equal(t, []string{"openai"}, resp.Headers["X-Selected-Provider"])
+	assert.Equal(t, []string{"gpt-4"}, resp.Headers["X-Selected-Model"],
+		"a failed attempt must still say which route was tried")
 }
 
 func TestProviderInvoke_SourceFormatFromPath(t *testing.T) {

--- a/pkg/app/proxy/provider_stream_test.go
+++ b/pkg/app/proxy/provider_stream_test.go
@@ -91,6 +91,31 @@ func TestInvokeStream_PassthroughStream(t *testing.T) {
 	}, got)
 }
 
+func TestInvokeStream_AdvertisesServedRouteBeforeFirstChunk(t *testing.T) {
+	const defaultModel = "gpt-4o-mini"
+	client := providermocks.NewClient(t)
+	client.EXPECT().
+		CompletionsStream(mock.Anything, mock.Anything, mock.Anything).
+		Return(seqOf([]byte("data: [DONE]")), nil).
+		Once()
+
+	inv := newStreamInvoker(t, "openai", client)
+	target := apiKeyTarget("openai")
+	req := &infracontext.RequestContext{
+		Body:          []byte(`{"stream":true,"messages":[{"role":"user","content":"hi"}]}`),
+		AllowedModels: []string{defaultModel},
+		DefaultModel:  defaultModel,
+	}
+
+	resp, err := inv.InvokeStream(context.Background(), target, req)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"openai"}, resp.Headers["X-Selected-Provider"])
+	assert.Equal(t, []string{target.ID.String()}, resp.Headers["X-Selected-Registry"])
+	assert.Equal(t, []string{defaultModel}, resp.Headers["X-Selected-Model"])
+
+	collectStream(t, resp.Stream)
+}
+
 func TestInvokeStream_CrossFormatAdapt(t *testing.T) {
 	// Registry (anthropic) emits an anthropic content delta; the client speaks
 	// openai, so adaptStream converts anthropic -> openai.
@@ -153,11 +178,16 @@ func TestInvokeStream_PreStreamBackendErrorPassthrough(t *testing.T) {
 	inv := newStreamInvoker(t, "openai", client)
 	req := &infracontext.RequestContext{Body: []byte(openaiRequestBody)}
 
-	resp, err := inv.InvokeStream(context.Background(), apiKeyTarget("openai"), req)
+	target := apiKeyTarget("openai")
+	resp, err := inv.InvokeStream(context.Background(), target, req)
 	require.NoError(t, err)
 	assert.Nil(t, resp.Stream, "pre-stream error must not open a stream")
 	assert.Equal(t, 429, resp.StatusCode)
 	assert.Equal(t, errBody, resp.Body)
+	assert.Equal(t, []string{"openai"}, resp.Headers["X-Selected-Provider"])
+	assert.Equal(t, []string{target.ID.String()}, resp.Headers["X-Selected-Registry"])
+	assert.Equal(t, []string{"gpt-4"}, resp.Headers["X-Selected-Model"],
+		"a route that fails before streaming must still be identifiable")
 }
 
 func TestInvokeStream_UsageObserverRecordsFinalUsage(t *testing.T) {

--- a/postman/TrustGate.postman_collection.json
+++ b/postman/TrustGate.postman_collection.json
@@ -2966,7 +2966,9 @@
                 "type": "text/javascript",
                 "exec": [
                   "pm.test('proxy returned 200', () => pm.response.code === 200);",
-                  "pm.test('selected provider is openai', () => pm.response.headers.get('X-Selected-Provider') === 'openai');"
+                  "pm.test('selected provider is openai', () => pm.response.headers.get('X-Selected-Provider') === 'openai');",
+                  "pm.test('served model is advertised', () => !!pm.response.headers.get('X-Selected-Model'));",
+                  "pm.test('served registry is advertised', () => /^[0-9a-f-]{36}$/.test(pm.response.headers.get('X-Selected-Registry')));"
                 ]
               }
             }
@@ -3303,7 +3305,8 @@
                 "type": "text/javascript",
                 "exec": [
                   "pm.test('proxy returned 200', () => pm.response.code === 200);",
-                  "pm.test('selected provider is openai', () => pm.response.headers.get('X-Selected-Provider') === 'openai');"
+                  "pm.test('selected provider is openai', () => pm.response.headers.get('X-Selected-Provider') === 'openai');",
+                  "pm.test('served model is advertised', () => !!pm.response.headers.get('X-Selected-Model'));"
                 ]
               }
             }
@@ -3714,7 +3717,8 @@
                 "type": "text/javascript",
                 "exec": [
                   "pm.test('proxy returned 200', () => pm.response.code === 200);",
-                  "pm.test('selected provider is openai', () => pm.response.headers.get('X-Selected-Provider') === 'openai');"
+                  "pm.test('selected provider is openai', () => pm.response.headers.get('X-Selected-Provider') === 'openai');",
+                  "pm.test('served model is advertised', () => !!pm.response.headers.get('X-Selected-Model'));"
                 ]
               }
             }
@@ -4195,7 +4199,8 @@
                 "type": "text/javascript",
                 "exec": [
                   "pm.test('proxy returned 200', () => pm.response.code === 200);",
-                  "pm.test('selected provider is openai', () => pm.response.headers.get('X-Selected-Provider') === 'openai');"
+                  "pm.test('selected provider is openai', () => pm.response.headers.get('X-Selected-Provider') === 'openai');",
+                  "pm.test('served model is advertised', () => !!pm.response.headers.get('X-Selected-Model'));"
                 ]
               }
             }
@@ -4675,7 +4680,8 @@
                 "type": "text/javascript",
                 "exec": [
                   "pm.test('proxy returned 200', () => pm.response.code === 200);",
-                  "pm.test('selected provider is openai', () => pm.response.headers.get('X-Selected-Provider') === 'openai');"
+                  "pm.test('selected provider is openai', () => pm.response.headers.get('X-Selected-Provider') === 'openai');",
+                  "pm.test('served model is advertised', () => !!pm.response.headers.get('X-Selected-Model'));"
                 ]
               }
             }
@@ -8190,7 +8196,8 @@
                     "type": "text/javascript",
                     "exec": [
                       "pm.test('proxy returned 200', () => pm.response.code === 200);",
-                      "pm.test('selected provider is openai', () => pm.response.headers.get('X-Selected-Provider') === 'openai');"
+                      "pm.test('selected provider is openai', () => pm.response.headers.get('X-Selected-Provider') === 'openai');",
+                      "pm.test('served model is advertised', () => !!pm.response.headers.get('X-Selected-Model'));"
                     ]
                   }
                 }
@@ -8338,7 +8345,8 @@
                     "type": "text/javascript",
                     "exec": [
                       "pm.test('proxy returned 200', () => pm.response.code === 200);",
-                      "pm.test('selected provider is openai', () => pm.response.headers.get('X-Selected-Provider') === 'openai');"
+                      "pm.test('selected provider is openai', () => pm.response.headers.get('X-Selected-Provider') === 'openai');",
+                      "pm.test('served model is advertised', () => !!pm.response.headers.get('X-Selected-Model'));"
                     ]
                   }
                 }
@@ -8678,7 +8686,8 @@
                     "type": "text/javascript",
                     "exec": [
                       "pm.test('proxy returned 200', () => pm.response.code === 200);",
-                      "pm.test('selected provider is openai', () => pm.response.headers.get('X-Selected-Provider') === 'openai');"
+                      "pm.test('selected provider is openai', () => pm.response.headers.get('X-Selected-Provider') === 'openai');",
+                      "pm.test('served model is advertised', () => !!pm.response.headers.get('X-Selected-Model'));"
                     ]
                   }
                 }
@@ -8829,7 +8838,8 @@
                     "type": "text/javascript",
                     "exec": [
                       "pm.test('proxy returned 200', () => pm.response.code === 200);",
-                      "pm.test('selected provider is openai', () => pm.response.headers.get('X-Selected-Provider') === 'openai');"
+                      "pm.test('selected provider is openai', () => pm.response.headers.get('X-Selected-Provider') === 'openai');",
+                      "pm.test('served model is advertised', () => !!pm.response.headers.get('X-Selected-Model'));"
                     ]
                   }
                 }
@@ -9385,7 +9395,8 @@
                     "type": "text/javascript",
                     "exec": [
                       "pm.test('proxy returned 200', () => pm.response.code === 200);",
-                      "pm.test('selected provider is openai', () => pm.response.headers.get('X-Selected-Provider') === 'openai');"
+                      "pm.test('selected provider is openai', () => pm.response.headers.get('X-Selected-Provider') === 'openai');",
+                      "pm.test('served model is advertised', () => !!pm.response.headers.get('X-Selected-Model'));"
                     ]
                   }
                 }
@@ -9533,7 +9544,8 @@
                     "type": "text/javascript",
                     "exec": [
                       "pm.test('proxy returned 200', () => pm.response.code === 200);",
-                      "pm.test('selected provider is openai', () => pm.response.headers.get('X-Selected-Provider') === 'openai');"
+                      "pm.test('selected provider is openai', () => pm.response.headers.get('X-Selected-Provider') === 'openai');",
+                      "pm.test('served model is advertised', () => !!pm.response.headers.get('X-Selected-Model'));"
                     ]
                   }
                 }
@@ -9873,7 +9885,8 @@
                     "type": "text/javascript",
                     "exec": [
                       "pm.test('proxy returned 200', () => pm.response.code === 200);",
-                      "pm.test('selected provider is openai', () => pm.response.headers.get('X-Selected-Provider') === 'openai');"
+                      "pm.test('selected provider is openai', () => pm.response.headers.get('X-Selected-Provider') === 'openai');",
+                      "pm.test('served model is advertised', () => !!pm.response.headers.get('X-Selected-Model'));"
                     ]
                   }
                 }
@@ -10022,7 +10035,8 @@
                     "exec": [
                       "pm.test('proxy returned 200', () => pm.response.code === 200);",
                       "pm.test('model was downgraded', () => pm.response.headers.get('X-NeuralTrust-Model-Downgraded') === 'gpt-4o→gpt-4o-mini');",
-                      "pm.test('selected provider is openai', () => pm.response.headers.get('X-Selected-Provider') === 'openai');"
+                      "pm.test('selected provider is openai', () => pm.response.headers.get('X-Selected-Provider') === 'openai');",
+                      "pm.test('served model is advertised', () => !!pm.response.headers.get('X-Selected-Model'));"
                     ]
                   }
                 }
@@ -10115,7 +10129,8 @@
                     "type": "text/javascript",
                     "exec": [
                       "pm.test('proxy returned 200', () => pm.response.code === 200);",
-                      "pm.test('selected provider is openai', () => pm.response.headers.get('X-Selected-Provider') === 'openai');"
+                      "pm.test('selected provider is openai', () => pm.response.headers.get('X-Selected-Provider') === 'openai');",
+                      "pm.test('served model is advertised', () => !!pm.response.headers.get('X-Selected-Model'));"
                     ]
                   }
                 }

--- a/tests/functional/proxy_e2e_test.go
+++ b/tests/functional/proxy_e2e_test.go
@@ -243,6 +243,8 @@ func TestProxyE2E_NonStreaming_NoLB(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, status, "body: %s", body)
 		assert.Equal(t, "openai", headers.Get("X-Selected-Provider"))
+		assert.Equal(t, "gpt-4o-mini", headers.Get("X-Selected-Model"))
+		assert.NotEmpty(t, headers.Get("X-Selected-Registry"))
 		assert.Contains(t, string(body), "hello-from-upstream")
 		assert.Equal(t, 1, up.Hits(), "a successful call must hit the upstream exactly once")
 	})


### PR DESCRIPTION
## Summary

Proxy responses already carried `X-Selected-Provider`. They now also carry:

| Header | Value |
| --- | --- |
| `X-Selected-Registry` | Id of the registry that served the request, which tells apart two registries of the same provider. |
| `X-Selected-Model` | `ProviderResponse.SentModel` — the model the gateway actually put on the outbound request, after routing-ref parsing, pool/LB resolution and model enforcement. |

Set on three paths: buffered responses, stream headers (flushed **before** the first chunk), and upstream `BackendError` passthrough, so a route that fails with a 429/5xx stays identifiable.

## Why

With route-aware pools (#412) a consumer can hold two routes of the same registry, and `model: "auto"` means the client never names the model that runs. Today the only in-band signal is the `model` field the provider echoes in the body, which Bedrock Titan/Llama/Mistral leave empty and which does not exist yet when stream headers are written. The value already existed internally (it feeds cost attribution and the LLM span) — this just exposes it.

Concretely: a consumer whose smart-routing pool had collapsed to a single route was serving every request on the medium-tier model, and diagnosing it required probing each model explicitly. `X-Selected-Model` answers it in one call.

## Notes for reviewers

- The three headers are present only when a route was actually invoked. A plugin short-circuit (e.g. a semantic-cache hit) returns before any upstream call, so consumers should treat them as optional.
- `X-Selected-Registry` exposes a registry UUID. Nothing routes by registry id (routing refs accept only `@provider/model`, `pool:<alias>` and `auto`), so it grants no new capability; it is documented as part of the contract in the docs PR below.
- `streamHeaders` lost its `provider` parameter — the shared `withSelectionHeaders` helper sets it now, and it builds a new map rather than mutating the caller's.
- Header duplication under failover is not reachable: the buffered path resets headers to the per-attempt baseline before merging, and the streaming path merges once.

## Test plan

- [x] `go test -race ./pkg/app/proxy/...` — new cases cover the buffered, streamed and pre-stream-error paths, including that the header carries the resolved model when the client sent none
- [x] `go test ./pkg/...`
- [x] `golangci-lint run ./pkg/app/proxy/...`
- [x] `go vet -tags functional ./tests/functional/...`; `TestProxyE2E_NonStreaming_NoLB` now asserts both new headers cross the HTTP boundary
- [x] Postman: `X-Selected-Model` asserted wherever the collection already asserted the provider, plus one registry-shape assertion

Docs: NeuralTrust/docs PR (linked below once open).

Made with [Cursor](https://cursor.com)