### PR TITLE
fix(proxy): stop advertising X-Selected-Registry on responses

### DIFF
--- a/pkg/app/proxy/provider.go
+++ b/pkg/app/proxy/provider.go
@@ -34,7 +34,6 @@ import (
 
 const (
 	headerSelectedProvider = "X-Selected-Provider"
-	headerSelectedRegistry = "X-Selected-Registry"
 	headerSelectedModel    = "X-Selected-Model"
 	headerContentType      = "Content-Type"
 	contentTypeJSON        = "application/json"
@@ -461,15 +460,12 @@ func withSelectionHeaders(
 	bk *registry.Registry,
 	sentModel string,
 ) map[string][]string {
-	out := make(map[string][]string, len(headers)+3)
+	out := make(map[string][]string, len(headers)+2)
 	for name, values := range headers {
 		out[name] = values
 	}
 	if provider := bk.Provider(); provider != "" {
 		out[headerSelectedProvider] = []string{provider}
-	}
-	if !bk.ID.IsNil() {
-		out[headerSelectedRegistry] = []string{bk.ID.String()}
 	}
 	if sentModel != "" {
 		out[headerSelectedModel] = []string{sentModel}

--- a/pkg/app/proxy/provider_invoker_test.go
+++ b/pkg/app/proxy/provider_invoker_test.go
@@ -100,7 +100,7 @@ func TestProviderInvoke_AdvertisesServedRoute(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, []string{"openai"}, resp.Headers["X-Selected-Provider"])
-	assert.Equal(t, []string{target.ID.String()}, resp.Headers["X-Selected-Registry"])
+	assert.Empty(t, resp.Headers["X-Selected-Registry"])
 	assert.Equal(t, []string{defaultModel}, resp.Headers["X-Selected-Model"],
 		"the header must carry the model the route resolved to, which the client never sent")
 }

--- a/pkg/app/proxy/provider_stream_test.go
+++ b/pkg/app/proxy/provider_stream_test.go
@@ -110,7 +110,7 @@ func TestInvokeStream_AdvertisesServedRouteBeforeFirstChunk(t *testing.T) {
 	resp, err := inv.InvokeStream(context.Background(), target, req)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"openai"}, resp.Headers["X-Selected-Provider"])
-	assert.Equal(t, []string{target.ID.String()}, resp.Headers["X-Selected-Registry"])
+	assert.Empty(t, resp.Headers["X-Selected-Registry"])
 	assert.Equal(t, []string{defaultModel}, resp.Headers["X-Selected-Model"])
 
 	collectStream(t, resp.Stream)
@@ -185,7 +185,7 @@ func TestInvokeStream_PreStreamBackendErrorPassthrough(t *testing.T) {
 	assert.Equal(t, 429, resp.StatusCode)
 	assert.Equal(t, errBody, resp.Body)
 	assert.Equal(t, []string{"openai"}, resp.Headers["X-Selected-Provider"])
-	assert.Equal(t, []string{target.ID.String()}, resp.Headers["X-Selected-Registry"])
+	assert.Empty(t, resp.Headers["X-Selected-Registry"])
 	assert.Equal(t, []string{"gpt-4"}, resp.Headers["X-Selected-Model"],
 		"a route that fails before streaming must still be identifiable")
 }

--- a/postman/TrustGate.postman_collection.json
+++ b/postman/TrustGate.postman_collection.json
@@ -2968,7 +2968,7 @@
                   "pm.test('proxy returned 200', () => pm.response.code === 200);",
                   "pm.test('selected provider is openai', () => pm.response.headers.get('X-Selected-Provider') === 'openai');",
                   "pm.test('served model is advertised', () => !!pm.response.headers.get('X-Selected-Model'));",
-                  "pm.test('served registry is advertised', () => /^[0-9a-f-]{36}$/.test(pm.response.headers.get('X-Selected-Registry')));"
+                  "pm.test('served registry is not advertised', () => !pm.response.headers.get('X-Selected-Registry'));"
                 ]
               }
             }

--- a/tests/functional/proxy_e2e_test.go
+++ b/tests/functional/proxy_e2e_test.go
@@ -244,7 +244,7 @@ func TestProxyE2E_NonStreaming_NoLB(t *testing.T) {
 		assert.Equal(t, http.StatusOK, status, "body: %s", body)
 		assert.Equal(t, "openai", headers.Get("X-Selected-Provider"))
 		assert.Equal(t, "gpt-4o-mini", headers.Get("X-Selected-Model"))
-		assert.NotEmpty(t, headers.Get("X-Selected-Registry"))
+		assert.Empty(t, headers.Get("X-Selected-Registry"))
 		assert.Contains(t, string(body), "hello-from-upstream")
 		assert.Equal(t, 1, up.Hits(), "a successful call must hit the upstream exactly once")
 	})


### PR DESCRIPTION
## Summary
- Stops writing `X-Selected-Registry` on proxy responses so clients no longer see the internal registry UUID.
- Keeps `X-Selected-Provider` and `X-Selected-Model`.
- Updates unit, functional, and Postman assertions accordingly.

## Test plan
- [x] `go test ./pkg/app/proxy/ -count=1`
- [ ] Confirm a live proxy response no longer includes `x-selected-registry`
- [ ] Confirm `x-selected-provider` and `x-selected-model` still appear

Made with [Cursor](https://cursor.com)