### PR TITLE
fix(proxy): drop map capacity hint that tripped CodeQL

### DIFF
--- a/pkg/app/proxy/provider.go
+++ b/pkg/app/proxy/provider.go
@@ -460,7 +460,9 @@ func withSelectionHeaders(
 	bk *registry.Registry,
 	sentModel string,
 ) map[string][]string {
-	out := make(map[string][]string, len(headers)+2)
+	// No capacity hint: len(headers)+N trips CodeQL's allocation-overflow check
+	// and HTTP header maps are tiny, so the hint buys nothing.
+	out := make(map[string][]string)
 	for name, values := range headers {
 		out[name] = values
 	}


### PR DESCRIPTION
## Summary
- Unblocks the `develop` → `main` release PR (#417): CodeQL failed on `make(map[...], len(headers)+2)` in `withSelectionHeaders` ("Size computation for allocation may overflow").
- Drop the capacity hint. HTTP header maps are tiny; the hint buys nothing and the allocation-overflow alert is a false positive on `len + N`.

## Test plan
- [x] `go test ./pkg/app/proxy/ -count=1 -run 'Advertise|Selected|Stream_Advertises|PreStream'`
- [ ] CodeQL green on this PR
- [ ] After merge, CodeQL green on #417

Made with [Cursor](https://cursor.com)