### PR TITLE
test(mcp): add dual-era conformance matrix and Postman flows (RUN-1105)

### DIFF
--- a/docs/mcp/testing-guide.md
+++ b/docs/mcp/testing-guide.md
@@ -283,9 +283,75 @@ make test-functional
 | Plugin enforce / observe | TrustGuard (or stub) on tool call chain | `tests/functional/mcp_plugin_chain_test.go` |
 | Per-tool rate limit | Rate limiter deny on `tools/call` | `TestPluginE2E_PerToolRateLimiter_MCPToolCallDeny` |
 | DB-less OAuth vault | Redis-backed vault without Postgres session store | `tests/functional/dbless_mcp_vault_test.go` |
+| Dual-era client×upstream matrix | modern/legacy client × modern/legacy upstream | `TestMCPServer_DualEraClientUpstreamMatrix` |
+| Modern `server/discover` | local discovery, cache hints, no session header | `TestMCPServer_ModernServerDiscoverAndNoSession` |
+| Modern northbound validation | unsupported version, missing `_meta`, mismatches | `TestMCPServer_ModernNorthboundValidation` |
+| Strict `protocol_mode=modern` | fail closed against legacy-only upstream | `TestMCPServer_StrictModernModeFailsClosedAgainstLegacyUpstream` |
+| Cached era under concurrency | one legacy initialize for concurrent modern clients | `TestMCPServer_CachedEraSurvivesConcurrentModernClients` |
 
-Living documentation: [`tests/functional/mcp_e2e_test.go`](../../tests/functional/mcp_e2e_test.go).
+Living documentation: [`tests/functional/mcp_e2e_test.go`](../../tests/functional/mcp_e2e_test.go)
+and [`tests/functional/mcp_dual_era_test.go`](../../tests/functional/mcp_dual_era_test.go).
 
+## 5.1 Dual-era matrix (MCP `2026-07-28`)
+
+TrustGate accepts both legacy (≤`2025-06-18`) and modern (`2026-07-28`) on the
+same `POST /{consumer_slug}/mcp` endpoint. Era is selected at the wire boundary;
+composer/policy layers stay era-neutral.
+
+| Client → Upstream | How to select | Functional coverage |
+|-------------------|---------------|---------------------|
+| modern → modern | Client sends modern headers + `_meta`; upstream `protocol_mode=auto\|modern` with a stateless server | `TestMCPServer_DualEraClientUpstreamMatrix` / `modern→modern` |
+| modern → legacy | Same modern client; legacy/stateful upstream under `auto` | `modern→legacy` |
+| legacy → modern | Legacy initialize path; modern upstream under `auto` | `legacy→modern` |
+| legacy → legacy | Unchanged happy path | `legacy→legacy`, Flow A |
+
+Modern requests **must** include:
+
+```http
+MCP-Protocol-Version: 2026-07-28
+Mcp-Method: tools/list
+Content-Type: application/json
+X-AG-API-Key: <consumer key>
+```
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/list",
+  "params": {
+    "_meta": {
+      "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+      "io.modelcontextprotocol/clientCapabilities": {}
+    }
+  }
+}
+```
+
+For `tools/call` / `prompts/get` also send `Mcp-Name` matching `params.name`.
+Modern responses include `resultType`, `ttlMs`, and `cacheScope` on list/discover
+results and **must not** set `Mcp-Session-Id`.
+
+Registry field `mcp_target.protocol_mode`:
+
+| Value | Behaviour |
+|-------|-----------|
+| `auto` (default) | Probe once per origin, cache era, no steady-state probe latency |
+| `modern` | Skip probe; fail closed if the upstream is not modern |
+| `legacy` | Skip probe; use initialized session caching |
+
+Local commands:
+
+```bash
+# Unit packages for dual-era boundary + southbound negotiation
+go test -race ./pkg/api/handler/http/mcp/... ./pkg/infra/mcp/client/...
+
+# Functional MCP suite (requires make up / CI harness)
+go test -race -tags=functional ./tests/functional -run 'TestMCPServer_'
+```
+
+Postman: under **MCP Gateway**, use **Legacy (≤2025-06-18)** for Flows A–I and
+**MCP 2026-07-28** for discover/list/call plus negative mismatch examples.
 ## 6. Catalog health / hide broken vendors
 
 The curated list lives in

--- a/postman/TrustGate.postman_collection.json
+++ b/postman/TrustGate.postman_collection.json
@@ -335,6 +335,11 @@
       "key": "tenant_id",
       "value": "postman-tenant",
       "type": "string"
+    },
+    {
+      "key": "mcp_protocol_version",
+      "value": "2026-07-28",
+      "type": "string"
     }
   ],
   "item": [
@@ -486,11 +491,11 @@
                 "gateways"
               ]
             },
-            "description": "Optional slug (lowercase DNS label); omitted → server generates. Tenant JWT must not send entitlements (422). Platform create requires full stamped entitlements and body tenant_id (create-for-tenant). With RATE_LIMIT_ENABLED, 409 at MaxInstances; free create inherits highest sibling tier. Ownership tenant_id is required (JWT claim or body for platform admins)."
+            "description": "Optional slug (lowercase DNS label); omitted \u2192 server generates. Tenant JWT must not send entitlements (422). Platform create requires full stamped entitlements and body tenant_id (create-for-tenant). With RATE_LIMIT_ENABLED, 409 at MaxInstances; free create inherits highest sibling tier. Ownership tenant_id is required (JWT claim or body for platform admins)."
           }
         },
         {
-          "name": "Create Gateway with entitlements (tenant → 422)",
+          "name": "Create Gateway with entitlements (tenant \u2192 422)",
           "event": [
             {
               "listen": "test",
@@ -602,7 +607,7 @@
                 "{{gateway_id}}"
               ]
             },
-            "description": "Update gateway fields. Tenant JWT + entitlements → 422. Platform tier downgrade when count > new MaxInstances → 409 (delete excess first)."
+            "description": "Update gateway fields. Tenant JWT + entitlements \u2192 422. Platform tier downgrade when count > new MaxInstances \u2192 409 (delete excess first)."
           }
         },
         {
@@ -1478,7 +1483,7 @@
                 "{{consumer_id}}"
               ]
             },
-            "description": "Partial update. Registries are managed via attach/detach endpoints; `model_policies` here updates policies for already-bound registries. Send `lb_config`/`fallback` with `enabled: false` to clear them.\n\nThis example uses `smart-routing`: the firewall scores prompt complexity in `0..1` and each tier sends everything at or above its `min_score` to one route. `tiers[].model` picks which route of the registry the tier targets and is required whenever the pool declares that registry more than once — here cheap prompts go to `gpt-4o-mini` and complex ones (score >= 0.5) to `gpt-4o` on the same registry."
+            "description": "Partial update. Registries are managed via attach/detach endpoints; `model_policies` here updates policies for already-bound registries. Send `lb_config`/`fallback` with `enabled: false` to clear them.\n\nThis example uses `smart-routing`: the firewall scores prompt complexity in `0..1` and each tier sends everything at or above its `min_score` to one route. `tiers[].model` picks which route of the registry the tier targets and is required whenever the pool declares that registry more than once \u2014 here cheap prompts go to `gpt-4o-mini` and complex ones (score >= 0.5) to `gpt-4o` on the same registry."
           }
         },
         {
@@ -4729,3169 +4734,3980 @@
     },
     {
       "name": "MCP Gateway",
-      "description": "One folder per flow, every folder SELF-CONTAINED: it creates its own gateway, auths, registries and consumers, exercises the flow, and tears everything down at the end. Run any single folder top to bottom - no cross-folder prerequisites.\n\nFolders:\n1. Flow A - Simple proxy: one upstream (DeepWiki) behind a virtual MCP, API-key auth, JSON-RPC surface, toolkit curation.\n2. Flow B - Composition hub: several upstream MCP servers federated behind one virtual path.\n3. Flow C - Inbound OAuth with Microsoft Entra ID (JWT validation, M2M tokens, anti-downgrade).\n4. Flow D - OAuth 2.1 discovery surface: every step an MCP client (Cursor) performs automatically.\n5. Flow E - Downstream credentials: registry auth modes (static, exchange/STS, forwarded manual/auto).\n6. Flow F - Linear end-to-end: forwarded + auto registration (DCR), consent flow, Cursor walkthrough.\n7. Flow G - Full MCP surface: prompts, resources and resource templates federation, toolkit as per-surface allowlist (needs the local 'everything' reference server).\n8. Diagnostics - admin introspection, catalog, health (standalone utilities).\n\nFolders share collection variable slots (gateway_id, registry_id, consumer_id, ...): run ONE folder at a time, top to bottom, finishing with its Cleanup. Jumping between half-run folders overwrites the ids.\n\nIMPORTANT (Entra folders C, D, F): the admin API rejects (409) a second ENABLED oauth2 auth covering the same (issuer, audience) pair. Run a folder's Cleanup before starting another Entra folder, or the 'Create oauth2 auth' step fails with 409.\n\nCollection variables to set first:\n- admin_url (default http://localhost:8080)\n- mcp_url (default http://localhost:8082)\n- admin_token (mint with: set -a; source .env; set +a; bash scripts/generate_jwt_token.sh)\n\nFor flows C, D and F also set entra_tenant_id / entra_client_id / entra_client_secret. Entra app prerequisites (skipping any causes a silent 'Authenticating...' loop in Cursor):\n1. Expose an API: Application ID URI api://{client_id} and a SCOPE named mcp.access (admins and users) - else AADSTS65005.\n2. API permissions: add the app's own delegated mcp.access permission, grant admin consent.\n3. Manifest: requestedAccessTokenVersion: 2 (tokens must carry the /v2.0 issuer).\n4. Authentication: Web redirect URI {{mcp_url}}/oauth/callback.\n\nMULTI-TENANT (enterprise): multiple gateways/consumers may share the same IdP. Resolution is path-first: the request path picks the consumer(s) and only their ATTACHED auths can authenticate the request. The AS facade is resource-scoped: when several issuers are enabled, clients must send the RFC 8707 'resource' parameter (the virtual MCP URL) on authorize and token requests so the gateway picks the right IdP; with a single issuer the resource is optional. Guardrails: the admin API rejects (409) a second ENABLED oauth2 auth covering the same (issuer, audience) pair - scope each tenant with a distinct audience. Optional host isolation: set 'domain' on a gateway (e.g. tenant-a.gw.example.com) and requests carrying that Host resolve against that gateway only.",
+      "description": "Dual-era MCP Gateway collection. Legacy flows preserve initialize/session semantics. MCP 2026-07-28 is stateless and asserts the absence of Mcp-Session-Id.",
       "item": [
         {
-          "name": "1. Flow A - Simple proxy (API key + DeepWiki)",
-          "description": "Self-contained. One upstream MCP server behind one virtual path with API-key auth: gateway -> auth -> registry -> consumer -> attach -> JSON-RPC surface -> toolkit curation -> cleanup. DeepWiki needs no upstream auth, so this flow works out of the box.\n\nMCP endpoint: {{mcp_url}}/{{consumer_slug}}/mcp - the consumer slug is generated on creation and captured by the create request.",
+          "name": "Legacy (\u22642025-06-18)",
+          "description": "Existing legacy Flows A\u2013I and diagnostics. Behavior unchanged.",
           "item": [
             {
-              "name": "Create gateway",
-              "event": [
+              "name": "1. Flow A - Simple proxy (API key + DeepWiki)",
+              "description": "Self-contained. One upstream MCP server behind one virtual path with API-key auth: gateway -> auth -> registry -> consumer -> attach -> JSON-RPC surface -> toolkit curation -> cleanup. DeepWiki needs no upstream auth, so this flow works out of the box.\n\nMCP endpoint: {{mcp_url}}/{{consumer_slug}}/mcp - the consumer slug is generated on creation and captured by the create request.",
+              "item": [
                 {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.environment.set('gateway_id', pm.response.json().id);"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"tenant_id\": \"{{tenant_id}}\",\n  \"entitlements\": {\n    \"tier\": \"free\",\n    \"burst_per_min\": 60,\n    \"quota_per_month\": 10000,\n    \"max_instances\": 5\n  },\n  \"name\": \"flow-a-simple\"\n}"
-                },
-                "description": "Optionally add \"domain\": \"tenant-a.gw.example.com\" (bare hostname) for host-based tenant isolation: requests carrying that Host header resolve against this gateway only. Domains are unique across gateways. Ownership tenant_id is required (JWT claim or body for platform admins)."
-              }
-            },
-            {
-              "name": "Create api_key auth",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "const res = pm.response.json();",
-                      "pm.environment.set('auth_id', res.id);",
-                      "pm.environment.set('api_key', res.api_key);"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"name\": \"flow-a-key\",\n  \"type\": \"api_key\",\n  \"config\": {}\n}"
-                },
-                "description": "The api_key value is only returned once, on create; the test script stores it in {{api_key}}."
-              }
-            },
-            {
-              "name": "Create MCP registry (DeepWiki, auth none)",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.environment.set('registry_id', pm.response.json().id);"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"name\": \"deepwiki\",\n  \"type\": \"MCP\",\n  \"mcp_target\": {\n    \"url\": \"https://mcp.deepwiki.com/mcp\",\n    \"transport\": \"streamable-http\"\n  }\n}"
-                }
-              }
-            },
-            {
-              "name": "Create MCP consumer",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.environment.set('consumer_id', pm.response.json().id);",
-                      "pm.environment.set('consumer_slug', pm.response.json().slug);"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"name\": \"flow-a-simple\",\n  \"type\": \"MCP\",\n  \"fail_mode\": \"closed\"\n}"
-                }
-              }
-            },
-            {
-              "name": "Attach auth to consumer",
-              "request": {
-                "method": "POST",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/auths/{{auth_id}}"
-              }
-            },
-            {
-              "name": "Attach registry to consumer",
-              "request": {
-                "method": "POST",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/registries/{{registry_id}}"
-              }
-            },
-            {
-              "name": "initialize",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "const sid = pm.response.headers.get('Mcp-Session-Id');",
-                      "if (sid) pm.environment.set('mcp_session_id', sid);"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "X-AG-API-Key",
-                    "value": "{{api_key}}"
-                  }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"initialize\",\n  \"params\": {\n    \"protocolVersion\": \"2025-06-18\",\n    \"capabilities\": {},\n    \"clientInfo\": { \"name\": \"postman\", \"version\": \"1.0\" }\n  }\n}"
-                }
-              }
-            },
-            {
-              "name": "notifications/initialized",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "X-AG-API-Key",
-                    "value": "{{api_key}}"
-                  }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"method\": \"notifications/initialized\"\n}"
-                }
-              }
-            },
-            {
-              "name": "ping",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "X-AG-API-Key",
-                    "value": "{{api_key}}"
-                  }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 2,\n  \"method\": \"ping\"\n}"
-                }
-              }
-            },
-            {
-              "name": "tools/list",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "X-AG-API-Key",
-                    "value": "{{api_key}}"
-                  }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 3,\n  \"method\": \"tools/list\"\n}"
-                }
-              }
-            },
-            {
-              "name": "tools/call read_wiki_structure",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "X-AG-API-Key",
-                    "value": "{{api_key}}"
-                  }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 4,\n  \"method\": \"tools/call\",\n  \"params\": {\n    \"name\": \"read_wiki_structure\",\n    \"arguments\": { \"repoName\": \"gofiber/fiber\" }\n  }\n}"
-                }
-              }
-            },
-            {
-              "name": "Curate toolkit (select + rename)",
-              "request": {
-                "method": "PUT",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"toolkit\": [\n    {\n      \"registry_id\": \"{{registry_id}}\",\n      \"tool\": \"ask_question\",\n      \"expose_as\": \"deepwiki_ask\"\n    }\n  ],\n  \"fail_mode\": \"closed\"\n}"
-                },
-                "description": "The consumer now exposes exactly one tool, renamed. Re-run tools/list to verify."
-              }
-            },
-            {
-              "name": "tools/call deepwiki_ask (renamed via toolkit)",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "X-AG-API-Key",
-                    "value": "{{api_key}}"
-                  }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 5,\n  \"method\": \"tools/call\",\n  \"params\": {\n    \"name\": \"deepwiki_ask\",\n    \"arguments\": {\n      \"repoName\": \"gofiber/fiber\",\n      \"question\": \"How does routing work?\"\n    }\n  }\n}"
-                }
-              }
-            },
-            {
-              "name": "Clear toolkit (expose all tools)",
-              "request": {
-                "method": "PUT",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"toolkit\": []\n}"
-                }
-              }
-            },
-            {
-              "name": "resources/list (DeepWiki exposes none)",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "X-AG-API-Key",
-                    "value": "{{api_key}}"
-                  }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 6,\n  \"method\": \"resources/list\"\n}"
-                },
-                "description": "Resources ARE federated now (see Flow G), but DeepWiki is a tools-only upstream, so the merged list is empty here."
-              }
-            },
-            {
-              "name": "prompts/list (DeepWiki exposes none)",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "X-AG-API-Key",
-                    "value": "{{api_key}}"
-                  }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 7,\n  \"method\": \"prompts/list\"\n}"
-                },
-                "description": "Prompts ARE federated now (see Flow G), but DeepWiki is a tools-only upstream, so the merged list is empty here."
-              }
-            },
-            {
-              "name": "Cleanup: delete consumer",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}"
-              }
-            },
-            {
-              "name": "Cleanup: delete registry",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries/{{registry_id}}"
-              }
-            },
-            {
-              "name": "Cleanup: delete api_key auth",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths/{{auth_id}}"
-              }
-            },
-            {
-              "name": "Cleanup: delete gateway",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}",
-                "description": "Children first, gateway last (else 409)."
-              }
-            }
-          ]
-        },
-        {
-          "name": "2. Flow B - Composition hub (many servers, one MCP)",
-          "description": "Self-contained. Federate several upstream MCP servers behind ONE consumer: builds it from DeepWiki and Hugging Face, proves federation through a single tools/list and per-upstream routing, then curates a cross-server toolkit, then cleans up.\n\nNaming: tools keep their upstream name unless two registries expose the same name, in which case the composer auto-prefixes them with the registry name ({registry}_{tool}). The toolkit shows the curated alternative: cherry-pick and rename explicitly.",
-          "item": [
-            {
-              "name": "Create gateway",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.environment.set('gateway_id', pm.response.json().id);"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"tenant_id\": \"{{tenant_id}}\",\n  \"entitlements\": {\n    \"tier\": \"free\",\n    \"burst_per_min\": 60,\n    \"quota_per_month\": 10000,\n    \"max_instances\": 5\n  },\n  \"name\": \"flow-b-hub\"\n}"
-                }
-              }
-            },
-            {
-              "name": "Create api_key auth",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "const res = pm.response.json();",
-                      "pm.environment.set('auth_id', res.id);",
-                      "pm.environment.set('api_key', res.api_key);"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"name\": \"flow-b-key\",\n  \"type\": \"api_key\",\n  \"config\": {}\n}"
-                }
-              }
-            },
-            {
-              "name": "Create MCP registry (DeepWiki, auth none)",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.environment.set('registry_id', pm.response.json().id);"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"name\": \"deepwiki\",\n  \"type\": \"MCP\",\n  \"mcp_target\": {\n    \"url\": \"https://mcp.deepwiki.com/mcp\",\n    \"transport\": \"streamable-http\"\n  }\n}"
-                }
-              }
-            },
-            {
-              "name": "Create MCP registry (Hugging Face, auth none)",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.environment.set('registry_hf_id', pm.response.json().id);"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"name\": \"huggingface\",\n  \"type\": \"MCP\",\n  \"mcp_target\": {\n    \"url\": \"https://huggingface.co/mcp\",\n    \"transport\": \"streamable-http\"\n  }\n}"
-                },
-                "description": "Second upstream. Hugging Face's MCP works anonymously (rate-limited); both servers are listed in GET /v1/mcp-servers-catalog."
-              }
-            },
-            {
-              "name": "Create composed MCP consumer",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.environment.set('consumer_id', pm.response.json().id);",
-                      "pm.environment.set('consumer_slug', pm.response.json().slug);"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"name\": \"flow-b-hub\",\n  \"type\": \"MCP\",\n  \"fail_mode\": \"open\"\n}"
-                },
-                "description": "fail_mode=open: if one upstream is unreachable, the hub still serves the tools of the healthy ones (closed would fail the whole consumer)."
-              }
-            },
-            {
-              "name": "Attach auth to hub consumer",
-              "request": {
-                "method": "POST",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/auths/{{auth_id}}"
-              }
-            },
-            {
-              "name": "Attach DeepWiki registry to hub",
-              "request": {
-                "method": "POST",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/registries/{{registry_id}}"
-              }
-            },
-            {
-              "name": "Attach Hugging Face registry to hub",
-              "request": {
-                "method": "POST",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/registries/{{registry_hf_id}}"
-              }
-            },
-            {
-              "name": "tools/list (federated from both servers)",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "const tools = (pm.response.json().result || {}).tools || [];",
-                      "const names = tools.map(t => t.name);",
-                      "console.log('federated tools', names);",
-                      "pm.test('DeepWiki tools present', () => pm.expect(names).to.include('ask_question'));",
-                      "pm.test('Hugging Face tools present', () => pm.expect(names).to.include('hub_repo_search'));"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "X-AG-API-Key",
-                    "value": "{{api_key}}"
-                  }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"tools/list\"\n}"
-                },
-                "description": "One list, two servers: DeepWiki's ask_question / read_wiki_* next to Hugging Face's hub_repo_search / paper_search / hf_doc_*. No name collisions here, so no prefixes are added."
-              }
-            },
-            {
-              "name": "tools/call ask_question (routed to DeepWiki)",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "X-AG-API-Key",
-                    "value": "{{api_key}}"
-                  }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 2,\n  \"method\": \"tools/call\",\n  \"params\": {\n    \"name\": \"ask_question\",\n    \"arguments\": {\n      \"repoName\": \"gofiber/fiber\",\n      \"question\": \"How does middleware chaining work?\"\n    }\n  }\n}"
-                },
-                "description": "The composer resolves the tool to the DeepWiki registry and proxies the call there with that registry's credentials (none here)."
-              }
-            },
-            {
-              "name": "tools/call hub_repo_search (routed to Hugging Face)",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "X-AG-API-Key",
-                    "value": "{{api_key}}"
-                  }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 3,\n  \"method\": \"tools/call\",\n  \"params\": {\n    \"name\": \"hub_repo_search\",\n    \"arguments\": {\n      \"query\": \"llama\",\n      \"repo_type\": \"model\",\n      \"limit\": 3\n    }\n  }\n}"
-                },
-                "description": "Same virtual path, different upstream: routed to Hugging Face."
-              }
-            },
-            {
-              "name": "Curate hub toolkit (cherry-pick + rename across servers)",
-              "request": {
-                "method": "PUT",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"toolkit\": [\n    {\n      \"registry_id\": \"{{registry_id}}\",\n      \"tool\": \"ask_question\",\n      \"expose_as\": \"wiki_ask\"\n    },\n    {\n      \"registry_id\": \"{{registry_hf_id}}\",\n      \"tool\": \"hub_repo_search\",\n      \"expose_as\": \"hf_models\"\n    },\n    {\n      \"registry_id\": \"{{registry_hf_id}}\",\n      \"tool\": \"paper_search\"\n    }\n  ],\n  \"fail_mode\": \"open\"\n}"
-                },
-                "description": "The hub now exposes exactly three tools: wiki_ask (DeepWiki), hf_models (renamed) and paper_search (original name) from Hugging Face. Everything else is hidden. Re-run tools/list to verify; PUT {\"toolkit\": []} to expose everything again."
-              }
-            },
-            {
-              "name": "tools/call hf_models (renamed via toolkit)",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "X-AG-API-Key",
-                    "value": "{{api_key}}"
-                  }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 4,\n  \"method\": \"tools/call\",\n  \"params\": {\n    \"name\": \"hf_models\",\n    \"arguments\": {\n      \"query\": \"whisper\",\n      \"repo_type\": \"model\",\n      \"limit\": 3\n    }\n  }\n}"
-                },
-                "description": "Clients only ever see the curated name; the composer maps hf_models back to hub_repo_search on the Hugging Face upstream."
-              }
-            },
-            {
-              "name": "Cleanup: delete hub consumer",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}"
-              }
-            },
-            {
-              "name": "Cleanup: delete DeepWiki registry",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries/{{registry_id}}"
-              }
-            },
-            {
-              "name": "Cleanup: delete Hugging Face registry",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries/{{registry_hf_id}}"
-              }
-            },
-            {
-              "name": "Cleanup: delete api_key auth",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths/{{auth_id}}"
-              }
-            },
-            {
-              "name": "Cleanup: delete gateway",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}"
-              }
-            }
-          ]
-        },
-        {
-          "name": "3. Flow C - Inbound OAuth (Entra ID)",
-          "description": "Self-contained. JWT validation with Microsoft Entra ID: gateway -> oauth2 auth -> DeepWiki registry -> consumer -> M2M token -> authenticated JSON-RPC -> anti-downgrade -> cleanup. See the collection description for the Entra app prerequisites.\n\nMCP endpoint: {{mcp_url}}/{{consumer_slug}}/mcp - the consumer slug is generated on creation and captured by the create request.\n\nNOTE: only one ENABLED oauth2 auth may cover the same (issuer, audience) pair - run another Entra folder's Cleanup first or 'Create oauth2 auth' answers 409.",
-          "item": [
-            {
-              "name": "Create gateway",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.environment.set('gateway_id', pm.response.json().id);"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"tenant_id\": \"{{tenant_id}}\",\n  \"entitlements\": {\n    \"tier\": \"free\",\n    \"burst_per_min\": 60,\n    \"quota_per_month\": 10000,\n    \"max_instances\": 5\n  },\n  \"name\": \"flow-c-entra\"\n}"
-                }
-              }
-            },
-            {
-              "name": "Create oauth2 auth (Entra)",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.environment.set('oauth2_auth_id', pm.response.json().id);"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"name\": \"entra\",\n  \"type\": \"oauth2\",\n  \"config\": {\n    \"oauth2\": {\n      \"issuer\": \"https://login.microsoftonline.com/{{entra_tenant_id}}/v2.0\",\n      \"audiences\": [\"api://{{entra_client_id}}\"],\n      \"client_id\": \"{{entra_client_id}}\",\n      \"client_secret\": \"{{entra_client_secret}}\",\n      \"required_scopes\": [\"api://{{entra_client_id}}/mcp.access\", \"offline_access\"]\n    }\n  }\n}"
-                },
-                "description": "issuer must match the token's iss claim exactly (v2.0 suffix); jwks_url is resolved via OIDC discovery. client_id + client_secret are what the AS facade uses to broker the browser authorization-code flow against Entra (redirect URI {{mcp_url}}/oauth/callback must be registered as a Web platform redirect on the Entra app). required_scopes must be FULLY QUALIFIED (api://{client_id}/mcp.access): the facade forwards them verbatim to Entra's authorize endpoint, which rejects bare leaf names; the scope must actually EXIST under the app's 'Expose an API' or Entra fails with AADSTS65005. audiences accepts either form: Entra v2.0 tokens carry the bare client id GUID in aud while v1.0 used the api:// URI - the validator treats them as equivalent. offline_access makes Entra return a refresh token; it is request-only and never enforced against access tokens (protocol scopes - openid/profile/email/offline_access - are skipped by inbound scope validation). 409 here means another ENABLED oauth2 auth already covers this (issuer, audience): run that folder's Cleanup or disable it."
-              }
-            },
-            {
-              "name": "Create api_key auth (for anti-downgrade demo)",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "const res = pm.response.json();",
-                      "pm.environment.set('auth_id', res.id);",
-                      "pm.environment.set('api_key', res.api_key);"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"name\": \"flow-c-key\",\n  \"type\": \"api_key\",\n  \"config\": {}\n}"
-                },
-                "description": "Used only by the 'Invalid JWT is rejected' request to prove the chain never falls back from a failed Bearer to a valid API key."
-              }
-            },
-            {
-              "name": "Create MCP registry (DeepWiki, auth none)",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.environment.set('registry_id', pm.response.json().id);"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"name\": \"deepwiki\",\n  \"type\": \"MCP\",\n  \"mcp_target\": {\n    \"url\": \"https://mcp.deepwiki.com/mcp\",\n    \"transport\": \"streamable-http\"\n  }\n}"
-                }
-              }
-            },
-            {
-              "name": "Create MCP consumer",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.environment.set('consumer_id', pm.response.json().id);",
-                      "pm.environment.set('consumer_slug', pm.response.json().slug);"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"name\": \"flow-c-entra\",\n  \"type\": \"MCP\",\n  \"fail_mode\": \"closed\"\n}"
-                }
-              }
-            },
-            {
-              "name": "Attach oauth2 auth to consumer",
-              "request": {
-                "method": "POST",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/auths/{{oauth2_auth_id}}",
-                "description": "Consumer-first resolution: only auths ATTACHED to this consumer can authenticate requests to its MCP endpoint ({{mcp_url}}/{{consumer_slug}}/mcp)."
-              }
-            },
-            {
-              "name": "Attach api_key auth to consumer",
-              "request": {
-                "method": "POST",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/auths/{{auth_id}}"
-              }
-            },
-            {
-              "name": "Attach registry to consumer",
-              "request": {
-                "method": "POST",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/registries/{{registry_id}}"
-              }
-            },
-            {
-              "name": "Get Entra token (client credentials)",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "const res = pm.response.json();",
-                      "pm.test('access token issued', () => pm.expect(res.access_token).to.be.a('string'));",
-                      "pm.environment.set('entra_token', res.access_token);",
-                      "let b64 = res.access_token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');",
-                      "while (b64.length % 4) b64 += '=';",
-                      "const claims = JSON.parse(atob(b64));",
-                      "console.log('token claims', { iss: claims.iss, aud: claims.aud, oid: claims.oid, roles: claims.roles });",
-                      "pm.test('v2.0 issuer (else set requestedAccessTokenVersion=2 in the manifest)', () => {",
-                      "  pm.expect(claims.iss).to.include('/v2.0');",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "url": "https://login.microsoftonline.com/{{entra_tenant_id}}/oauth2/v2.0/token",
-                "body": {
-                  "mode": "urlencoded",
-                  "urlencoded": [
+                  "name": "Create gateway",
+                  "event": [
                     {
-                      "key": "grant_type",
-                      "value": "client_credentials"
-                    },
-                    {
-                      "key": "client_id",
-                      "value": "{{entra_client_id}}"
-                    },
-                    {
-                      "key": "client_secret",
-                      "value": "{{entra_client_secret}}"
-                    },
-                    {
-                      "key": "scope",
-                      "value": "api://{{entra_client_id}}/.default"
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.environment.set('gateway_id', pm.response.json().id);"
+                        ],
+                        "type": "text/javascript"
+                      }
                     }
-                  ]
-                },
-                "description": "M2M token for Postman testing; the scope must be your own app's .default (a Graph scope produces a token TrustGate cannot validate). NOTE: client-credentials tokens carry app permissions in the roles claim (no scp). For required_scopes validation to pass, the Entra app must also define an APPLICATION permission (app role) named mcp.access and assign it to itself - otherwise this M2M token is rejected with 401 and only the browser user flow works."
-              }
-            },
-            {
-              "name": "tools/list with Entra JWT",
-              "request": {
-                "auth": {
-                  "type": "bearer",
-                  "bearer": [
-                    {
-                      "key": "token",
-                      "value": "{{entra_token}}",
-                      "type": "string"
-                    }
-                  ]
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"tools/list\"\n}"
-                },
-                "description": "Path-first: the request path resolves the consumer, then the token is validated against the consumer's ATTACHED oauth2 auth (signature via JWKS/OIDC discovery, issuer, audience, scopes)."
-              }
-            },
-            {
-              "name": "tools/call with Entra JWT",
-              "request": {
-                "auth": {
-                  "type": "bearer",
-                  "bearer": [
-                    {
-                      "key": "token",
-                      "value": "{{entra_token}}",
-                      "type": "string"
-                    }
-                  ]
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 2,\n  \"method\": \"tools/call\",\n  \"params\": {\n    \"name\": \"read_wiki_structure\",\n    \"arguments\": { \"repoName\": \"gofiber/fiber\" }\n  }\n}"
-                }
-              }
-            },
-            {
-              "name": "Invalid JWT is rejected (anti-downgrade)",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test('401 with challenge, no API-key fallback', () => {",
-                      "  pm.response.to.have.status(401);",
-                      "  pm.expect(pm.response.headers.get('WWW-Authenticate')).to.include('resource_metadata=');",
-                      "});"
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
                     ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "Authorization",
-                    "value": "Bearer eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJodHRwczovL2V2aWwuZXhhbXBsZS5jb20ifQ.invalid"
-                  },
-                  {
-                    "key": "X-AG-API-Key",
-                    "value": "{{api_key}}"
-                  }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 3,\n  \"method\": \"ping\"\n}"
-                },
-                "description": "Sends a bogus Bearer token AND a valid API key: the chain takes the Bearer path first and fails without falling back to the API key (anti-downgrade by design)."
-              }
-            },
-            {
-              "name": "Cleanup: delete consumer",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}"
-              }
-            },
-            {
-              "name": "Cleanup: delete registry",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries/{{registry_id}}"
-              }
-            },
-            {
-              "name": "Cleanup: delete oauth2 auth",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths/{{oauth2_auth_id}}",
-                "description": "Frees the (issuer, audience) pair so flows D and F can create their own Entra auth without a 409."
-              }
-            },
-            {
-              "name": "Cleanup: delete api_key auth",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths/{{auth_id}}"
-              }
-            },
-            {
-              "name": "Cleanup: delete gateway",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}"
-              }
-            }
-          ]
-        },
-        {
-          "name": "4. Flow D - OAuth 2.1 discovery (what MCP clients do)",
-          "description": "Self-contained. Sets up a protected MCP consumer (addressed by its generated slug, {{mcp_url}}/{{consumer_slug}}/mcp) with an Entra oauth2 auth, then replays every step an MCP client (Cursor) performs automatically: 401 challenge -> protected-resource metadata (RFC 9728) -> AS metadata (RFC 8414) -> DCR (RFC 7591) -> brokered authorize -> cleanup.\n\nNOTE: only one ENABLED oauth2 auth may cover the same (issuer, audience) pair - run another Entra folder's Cleanup first or 'Create oauth2 auth' answers 409.",
-          "item": [
-            {
-              "name": "Create gateway",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.environment.set('gateway_id', pm.response.json().id);"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"tenant_id\": \"{{tenant_id}}\",\n  \"entitlements\": {\n    \"tier\": \"free\",\n    \"burst_per_min\": 60,\n    \"quota_per_month\": 10000,\n    \"max_instances\": 5\n  },\n  \"name\": \"flow-d-discovery\"\n}"
-                }
-              }
-            },
-            {
-              "name": "Create oauth2 auth (Entra)",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.environment.set('oauth2_auth_id', pm.response.json().id);"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"name\": \"entra\",\n  \"type\": \"oauth2\",\n  \"config\": {\n    \"oauth2\": {\n      \"issuer\": \"https://login.microsoftonline.com/{{entra_tenant_id}}/v2.0\",\n      \"audiences\": [\"api://{{entra_client_id}}\"],\n      \"client_id\": \"{{entra_client_id}}\",\n      \"client_secret\": \"{{entra_client_secret}}\",\n      \"required_scopes\": [\"api://{{entra_client_id}}/mcp.access\", \"offline_access\"]\n    }\n  }\n}"
-                },
-                "description": "See Flow C's 'Create oauth2 auth' for the full field-by-field explanation. 409 here means another ENABLED oauth2 auth already covers this (issuer, audience): run that folder's Cleanup or disable it."
-              }
-            },
-            {
-              "name": "Create MCP registry (DeepWiki, auth none)",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.environment.set('registry_id', pm.response.json().id);"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"name\": \"deepwiki\",\n  \"type\": \"MCP\",\n  \"mcp_target\": {\n    \"url\": \"https://mcp.deepwiki.com/mcp\",\n    \"transport\": \"streamable-http\"\n  }\n}"
-                }
-              }
-            },
-            {
-              "name": "Create MCP consumer",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.environment.set('consumer_id', pm.response.json().id);",
-                      "pm.environment.set('consumer_slug', pm.response.json().slug);"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"name\": \"flow-d-discovery\",\n  \"type\": \"MCP\",\n  \"fail_mode\": \"closed\"\n}"
-                }
-              }
-            },
-            {
-              "name": "Attach oauth2 auth to consumer",
-              "request": {
-                "method": "POST",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/auths/{{oauth2_auth_id}}"
-              }
-            },
-            {
-              "name": "Attach registry to consumer",
-              "request": {
-                "method": "POST",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/registries/{{registry_id}}"
-              }
-            },
-            {
-              "name": "401 challenge carries WWW-Authenticate",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test('401 with resource_metadata challenge', () => {",
-                      "  pm.response.to.have.status(401);",
-                      "  pm.expect(pm.response.headers.get('WWW-Authenticate')).to.include('resource_metadata=');",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"ping\"\n}"
-                },
-                "description": "No credential on purpose: the MCP plane answers 401 + WWW-Authenticate: Bearer resource_metadata=\"...\" so MCP clients bootstrap the OAuth flow."
-              }
-            },
-            {
-              "name": "GET on the MCP path answers 405 (SSE not offered)",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test('405 Method Not Allowed with Allow: POST', () => {",
-                      "  pm.response.to.have.status(405);",
-                      "  pm.expect(pm.response.headers.get('Allow')).to.eql('POST');",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "GET",
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "description": "Streamable HTTP clients probe GET for the optional server-initiated SSE stream. The gateway does not offer one and must answer 405 per spec - a 401/404 here makes clients misread it as a credential problem and loop on re-authentication. Same for DELETE (session termination)."
-              }
-            },
-            {
-              "name": "Protected resource metadata (RFC 9728)",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "GET",
-                "url": "{{mcp_url}}/.well-known/oauth-protected-resource",
-                "description": "Lists the authorization servers (issuers of enabled oauth2 auths) that can issue tokens for this MCP plane."
-              }
-            },
-            {
-              "name": "Protected resource metadata, path-scoped",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "GET",
-                "url": "{{mcp_url}}/.well-known/oauth-protected-resource/{{consumer_slug}}/mcp",
-                "description": "Same document scoped to a specific virtual MCP path, per the MCP authorization spec: scopes_supported reflects only the auths attached to the consumer on this path."
-              }
-            },
-            {
-              "name": "Authorization server metadata (RFC 8414)",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "GET",
-                "url": "{{mcp_url}}/.well-known/oauth-authorization-server",
-                "description": "The gateway advertises itself as the authorization server (AS facade): authorize/token/register endpoints all point at the gateway, which brokers to the IdP. 404 until an oauth2 auth exists. With several distinct issuers enabled, clients must pass the RFC 8707 resource parameter on authorize/token so the facade picks the right IdP."
-              }
-            },
-            {
-              "name": "Dynamic client registration (RFC 7591)",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{mcp_url}}/oauth/register",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"client_name\": \"postman\",\n  \"redirect_uris\": [\"http://localhost:1234/callback\"],\n  \"grant_types\": [\"authorization_code\"],\n  \"response_types\": [\"code\"],\n  \"token_endpoint_auth_method\": \"none\"\n}"
-                },
-                "description": "Returns the registered public client (PKCE). 400 if no oauth2 auth has a client_id configured."
-              }
-            },
-            {
-              "name": "Authorize redirects to IdP (sanity check)",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test('302 to Entra with scope and PKCE', () => {",
-                      "  pm.response.to.have.status(302);",
-                      "  const loc = pm.response.headers.get('Location') || '';",
-                      "  pm.expect(loc).to.include('login.microsoftonline.com');",
-                      "  pm.expect(loc).to.include('scope=');",
-                      "  pm.expect(loc).to.include('code_challenge=');",
-                      "});",
-                      "console.log('Location:', pm.response.headers.get('Location'));"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "protocolProfileBehavior": {
-                "followRedirects": false
-              },
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "GET",
-                "url": "{{mcp_url}}/oauth/authorize?response_type=code&client_id={{entra_client_id}}&redirect_uri=http%3A%2F%2Flocalhost%3A1234%2Fcallback&state=sanity&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM&code_challenge_method=S256&resource={{mcp_url}}%2F{{consumer_slug}}%2Fmcp",
-                "description": "Replays the first leg of the browser flow without a browser. The Location header must point at login.microsoftonline.com AND carry a scope parameter (api://{client_id}/mcp.access). The resource parameter (RFC 8707, the virtual MCP URL) selects which consumer's IdP brokers the flow - required when several issuers are enabled on the plane, optional with one. The same parameter is honored on POST /oauth/token (refresh grants). A redirect without scope means the facade picked a stale oauth2 auth entry without required_scopes - find and delete it."
-              }
-            },
-            {
-              "name": "STS JWKS (public)",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "GET",
-                "url": "{{mcp_url}}/.well-known/jwks.json",
-                "description": "Verification keys for TrustGate-minted downstream tokens (Flow E exchange modes). Configure upstreams to trust iss = STS_ISSUER with this JWKS."
-              }
-            },
-            {
-              "name": "Cleanup: delete consumer",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}"
-              }
-            },
-            {
-              "name": "Cleanup: delete registry",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries/{{registry_id}}"
-              }
-            },
-            {
-              "name": "Cleanup: delete oauth2 auth",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths/{{oauth2_auth_id}}"
-              }
-            },
-            {
-              "name": "Cleanup: delete gateway",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}"
-              }
-            }
-          ]
-        },
-        {
-          "name": "5. Flow E - Downstream credentials (STS & forwarded)",
-          "description": "Self-contained. How the gateway authenticates AGAINST upstream MCP servers, per registry (mcp_target.auth.mode): none, static (fixed header), passthrough, exchange (STS-minted or IdP-brokered tokens), forwarded (per-user third-party OAuth vaulted by the gateway). Creates a scratch gateway + registry, applies each auth mode in turn as examples, then cleans up - adapt url/audience to a real upstream.",
-          "item": [
-            {
-              "name": "Create gateway",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.environment.set('gateway_id', pm.response.json().id);"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"tenant_id\": \"{{tenant_id}}\",\n  \"entitlements\": {\n    \"tier\": \"free\",\n    \"burst_per_min\": 60,\n    \"quota_per_month\": 10000,\n    \"max_instances\": 5\n  },\n  \"name\": \"flow-e-downstream\"\n}"
-                }
-              }
-            },
-            {
-              "name": "Create scratch MCP registry (auth none)",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.environment.set('registry_id', pm.response.json().id);"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"name\": \"downstream-demo\",\n  \"type\": \"MCP\",\n  \"mcp_target\": {\n    \"url\": \"{{upstream_mcp_url}}\",\n    \"transport\": \"streamable-http\"\n  }\n}"
-                },
-                "description": "Scratch registry the following PUT requests mutate to demonstrate each downstream auth mode."
-              }
-            },
-            {
-              "name": "Set registry auth: static header",
-              "request": {
-                "method": "PUT",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries/{{registry_id}}",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"mcp_target\": {\n    \"url\": \"{{upstream_mcp_url}}\",\n    \"auth\": {\n      \"mode\": \"static\",\n      \"header\": \"Authorization\",\n      \"value\": \"Bearer YOUR_UPSTREAM_TOKEN\"\n    }\n  }\n}"
-                },
-                "description": "Service-account style: one fixed credential for all principals (e.g. Stripe or Context7 API keys). The value is write-only: reads return it masked."
-              }
-            },
-            {
-              "name": "Set registry auth: exchange/impersonation (STS)",
-              "request": {
-                "method": "PUT",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries/{{registry_id}}",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"mcp_target\": {\n    \"url\": \"{{upstream_mcp_url}}\",\n    \"auth\": {\n      \"mode\": \"exchange\",\n      \"pattern\": \"impersonation\",\n      \"audience\": \"{{upstream_mcp_url}}\"\n    }\n  }\n}"
-                },
-                "description": "The STS mints a short-lived RS256 JWT (same sub, aud = audience, iss = TrustGate) per principal and injects it as Authorization on every upstream connection. Use pattern=delegation (+actor), obo (+scope) or token_exchange (+audience) for the other RFC 8693 patterns."
-              }
-            },
-            {
-              "name": "Set registry auth: forwarded + manual registration (GitHub)",
-              "request": {
-                "method": "PUT",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries/{{registry_id}}",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"mcp_target\": {\n    \"url\": \"{{upstream_mcp_url}}\",\n    \"auth\": {\n      \"mode\": \"forwarded\",\n      \"provider\": \"github\",\n      \"client_id\": \"{{github_client_id}}\",\n      \"client_secret\": \"{{github_client_secret}}\",\n      \"authorize_url\": \"https://github.com/login/oauth/authorize\",\n      \"token_url\": \"https://github.com/login/oauth/access_token\",\n      \"scopes\": [\"repo\"]\n    }\n  }\n}"
-                },
-                "description": "Manual registration: the gateway uses an admin pre-registered OAuth app. Set the OAuth app callback to {{mcp_url}}/oauth/callback/github. After this, a tools call by a user without a linked account returns JSON-RPC error -32003 with data.connect_url - Flow F shows the full consent loop."
-              }
-            },
-            {
-              "name": "Set registry auth: forwarded + auto registration (DCR)",
-              "request": {
-                "method": "PUT",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries/{{registry_id}}",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"mcp_target\": {\n    \"url\": \"{{upstream_mcp_url}}\",\n    \"auth\": {\n      \"mode\": \"forwarded\",\n      \"provider\": \"example\",\n      \"registration\": \"auto\"\n    }\n  }\n}"
-                },
-                "description": "Auto registration: no OAuth app, no client secret. At consent time the gateway discovers the upstream's authorization server via its MCP protected-resource metadata (RFC 9728/8414) and registers itself once via Dynamic Client Registration (RFC 7591) as a public client with PKCE. Works with any spec-compliant remote MCP (Linear, Notion, ...); scopes and the RFC 8707 resource indicator default from the upstream's metadata. If the upstream does not publish OAuth metadata, the connect flow returns an error telling you to fall back to manual registration. Flow F runs this for real against Linear."
-              }
-            },
-            {
-              "name": "Cleanup: delete registry",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries/{{registry_id}}"
-              }
-            },
-            {
-              "name": "Cleanup: delete gateway",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}"
-              }
-            }
-          ]
-        },
-        {
-          "name": "6. Flow F - Linear end-to-end (forwarded + auto, Cursor)",
-          "description": "Self-contained. The full story on real services: inbound Entra ID, downstream Linear with forwarded mode + auto registration - no Linear OAuth app or client secret needed.\n\nRun the admin requests top to bottom, then 'Get Entra token', then the MCP plane requests. The first tools/list returns -32003 with data.connect_url: open it in a browser, click Connect Linear, approve, re-run. Finish with the Cleanup requests.\n\nMCP endpoint: {{mcp_url}}/{{consumer_slug}}/mcp - the consumer slug is generated on creation and captured by the create request.\n\nIn Cursor you skip the Postman token entirely: add {{mcp_url}}/{{consumer_slug}}/mcp to mcp.json and Cursor bootstraps the OAuth flow from the 401 challenge (Flow D shows every step it performs). After the Entra login, if you have unlinked providers the browser detours to the connect page (chained consent) - link Linear, click Continue, done. Already linked? The browser hands the code straight back to Cursor via its cursor:// deep link ('Open Cursor?' dialog; tick 'Always allow' to never see it again).\n\nNote (M2M): the Postman client-credentials token links Linear to the service principal. Real users in Cursor each link their own Linear account.\n\nNOTE: only one ENABLED oauth2 auth may cover the same (issuer, audience) pair - run another Entra folder's Cleanup first or 'Create oauth2 auth' answers 409.",
-          "item": [
-            {
-              "name": "Create gateway",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.environment.set('gateway_id', pm.response.json().id);"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"tenant_id\": \"{{tenant_id}}\",\n  \"entitlements\": {\n    \"tier\": \"free\",\n    \"burst_per_min\": 60,\n    \"quota_per_month\": 10000,\n    \"max_instances\": 5\n  },\n  \"name\": \"flow-f-linear\"\n}"
-                }
-              }
-            },
-            {
-              "name": "Create oauth2 auth (Entra)",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.environment.set('oauth2_auth_id', pm.response.json().id);"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"name\": \"entra\",\n  \"type\": \"oauth2\",\n  \"config\": {\n    \"oauth2\": {\n      \"issuer\": \"https://login.microsoftonline.com/{{entra_tenant_id}}/v2.0\",\n      \"audiences\": [\"api://{{entra_client_id}}\"],\n      \"client_id\": \"{{entra_client_id}}\",\n      \"client_secret\": \"{{entra_client_secret}}\",\n      \"required_scopes\": [\"api://{{entra_client_id}}/mcp.access\", \"offline_access\"]\n    }\n  }\n}"
-                },
-                "description": "See Flow C's 'Create oauth2 auth' for the full field-by-field explanation. 409 here means another ENABLED oauth2 auth already covers this (issuer, audience): run that folder's Cleanup or disable it."
-              }
-            },
-            {
-              "name": "Create Linear MCP registry (forwarded + auto)",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.environment.set('registry_id', pm.response.json().id);"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"name\": \"linear-mcp\",\n  \"type\": \"MCP\",\n  \"mcp_target\": {\n    \"url\": \"https://mcp.linear.app/mcp\",\n    \"transport\": \"streamable-http\",\n    \"auth\": {\n      \"mode\": \"forwarded\",\n      \"provider\": \"linear\",\n      \"registration\": \"auto\"\n    }\n  }\n}"
-                },
-                "description": "registration: auto means zero per-provider config: at consent time the gateway fetches https://mcp.linear.app/.well-known/oauth-protected-resource/mcp, resolves Linear's authorization server (RFC 8414), registers itself once via DCR (RFC 7591) as a public client with PKCE, and stores the issued client_id in Redis keyed (gateway, registry). Scopes and the RFC 8707 resource indicator default from Linear's metadata."
-              }
-            },
-            {
-              "name": "Create Linear MCP consumer",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.environment.set('consumer_id', pm.response.json().id);",
-                      "pm.environment.set('consumer_slug', pm.response.json().slug);"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"name\": \"flow-f-linear\",\n  \"type\": \"MCP\",\n  \"fail_mode\": \"closed\"\n}"
-                }
-              }
-            },
-            {
-              "name": "Attach oauth2 auth to consumer",
-              "request": {
-                "method": "POST",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/auths/{{oauth2_auth_id}}"
-              }
-            },
-            {
-              "name": "Attach Linear registry to consumer",
-              "request": {
-                "method": "POST",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/registries/{{registry_id}}"
-              }
-            },
-            {
-              "name": "Set toolkit (all Linear tools)",
-              "request": {
-                "method": "PUT",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"toolkit\": [\n    {\n      \"registry_id\": \"{{registry_id}}\",\n      \"tool\": \"*\"\n    }\n  ],\n  \"fail_mode\": \"closed\"\n}"
-                },
-                "description": "Wildcard exposes every Linear tool. Replace with explicit {tool, expose_as} entries to curate or rename."
-              }
-            },
-            {
-              "name": "Get Entra token (client credentials)",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "const res = pm.response.json();",
-                      "pm.test('access token issued', () => pm.expect(res.access_token).to.be.a('string'));",
-                      "pm.environment.set('entra_token', res.access_token);",
-                      "let b64 = res.access_token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');",
-                      "while (b64.length % 4) b64 += '=';",
-                      "const claims = JSON.parse(atob(b64));",
-                      "console.log('token claims', { iss: claims.iss, aud: claims.aud, oid: claims.oid, roles: claims.roles });",
-                      "pm.test('v2.0 issuer (else set requestedAccessTokenVersion=2 in the manifest)', () => {",
-                      "  pm.expect(claims.iss).to.include('/v2.0');",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "url": "https://login.microsoftonline.com/{{entra_tenant_id}}/oauth2/v2.0/token",
-                "body": {
-                  "mode": "urlencoded",
-                  "urlencoded": [
-                    {
-                      "key": "grant_type",
-                      "value": "client_credentials"
+                    "url": "{{admin_url}}/v1/gateways",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"tenant_id\": \"{{tenant_id}}\",\n  \"entitlements\": {\n    \"tier\": \"free\",\n    \"burst_per_min\": 60,\n    \"quota_per_month\": 10000,\n    \"max_instances\": 5\n  },\n  \"name\": \"flow-a-simple\"\n}"
                     },
+                    "description": "Optionally add \"domain\": \"tenant-a.gw.example.com\" (bare hostname) for host-based tenant isolation: requests carrying that Host header resolve against this gateway only. Domains are unique across gateways. Ownership tenant_id is required (JWT claim or body for platform admins)."
+                  }
+                },
+                {
+                  "name": "Create api_key auth",
+                  "event": [
                     {
-                      "key": "client_id",
-                      "value": "{{entra_client_id}}"
-                    },
-                    {
-                      "key": "client_secret",
-                      "value": "{{entra_client_secret}}"
-                    },
-                    {
-                      "key": "scope",
-                      "value": "api://{{entra_client_id}}/.default"
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "const res = pm.response.json();",
+                          "pm.environment.set('auth_id', res.id);",
+                          "pm.environment.set('api_key', res.api_key);"
+                        ],
+                        "type": "text/javascript"
+                      }
                     }
-                  ]
-                },
-                "description": "M2M token for Postman testing; the scope must be your own app's .default (a Graph scope produces a token TrustGate cannot validate). NOTE: client-credentials tokens carry app permissions in the roles claim (no scp). For required_scopes validation to pass, the Entra app must also define an APPLICATION permission (app role) named mcp.access and assign it to itself - otherwise this M2M token is rejected with 401 and only the browser user flow works."
-              }
-            },
-            {
-              "name": "initialize (Entra JWT)",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "const sid = pm.response.headers.get('Mcp-Session-Id');",
-                      "if (sid) pm.environment.set('mcp_session_id', sid);"
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
                     ],
-                    "type": "text/javascript"
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"name\": \"flow-a-key\",\n  \"type\": \"api_key\",\n  \"config\": {}\n}"
+                    },
+                    "description": "The api_key value is only returned once, on create; the test script stores it in {{api_key}}."
                   }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
                 },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "Authorization",
-                    "value": "Bearer {{entra_token}}"
-                  }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"initialize\",\n  \"params\": {\n    \"protocolVersion\": \"2025-06-18\",\n    \"capabilities\": {},\n    \"clientInfo\": { \"name\": \"postman\", \"version\": \"1.0\" }\n  }\n}"
-                },
-                "description": "Get {{entra_token}} first via this folder's 'Get Entra token (client credentials)'."
-              }
-            },
-            {
-              "name": "tools/list -> consent error on first run",
-              "event": [
                 {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "const body = pm.response.json();",
-                      "if (body.error && body.error.code === -32003) {",
-                      "  const url = body.error.data.connect_url;",
-                      "  const ticket = (url.split('ticket=')[1] || '').split('&')[0];",
-                      "  pm.environment.set('connect_ticket', ticket);",
-                      "  console.log('Open in a browser to link Linear:', url);",
-                      "} else if (body.result) {",
-                      "  console.log('Linked: ' + body.result.tools.length + ' Linear tools exposed');",
-                      "}"
+                  "name": "Create MCP registry (DeepWiki, auth none)",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.environment.set('registry_id', pm.response.json().id);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
                     ],
-                    "type": "text/javascript"
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"name\": \"deepwiki\",\n  \"type\": \"MCP\",\n  \"mcp_target\": {\n    \"url\": \"https://mcp.deepwiki.com/mcp\",\n    \"transport\": \"streamable-http\"\n  }\n}"
+                    }
                   }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
                 },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "Authorization",
-                    "value": "Bearer {{entra_token}}"
-                  }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 2,\n  \"method\": \"tools/list\"\n}"
-                },
-                "description": "First run: no vaulted Linear token for this principal, so the gateway answers JSON-RPC error -32003 with data.connect_url (the script saves the ticket and logs the URL). Open it in a browser, click Connect Linear - the gateway performs upstream discovery + DCR right there - approve at Linear, then re-run: the result lists Linear's tools."
-              }
-            },
-            {
-              "name": "Connect page (browser UI)",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "GET",
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp/connect?ticket={{connect_ticket}}",
-                "description": "The ticket-authenticated consent page: one button per forwarded provider behind this virtual MCP, with linked/unlinked status. Normally opened in a browser via the connect_url from the -32003 error, or automatically right after the Entra leg (chained consent). Tickets expire after 15 minutes."
-              }
-            },
-            {
-              "name": "tools/call list_issues (after linking)",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "Authorization",
-                    "value": "Bearer {{entra_token}}"
-                  }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 3,\n  \"method\": \"tools/call\",\n  \"params\": {\n    \"name\": \"list_issues\",\n    \"arguments\": {}\n  }\n}"
-                },
-                "description": "Check the exact tool names in the tools/list result (the composer prefixes with the registry name only on collisions). The call runs with YOUR vaulted Linear token; another principal calling the same consumer gets their own consent flow."
-              }
-            },
-            {
-              "name": "Disconnect Linear (revoke vaulted token)",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "url": "{{mcp_url}}/oauth/disconnect/linear?ticket={{connect_ticket}}",
-                "description": "Deletes the vaulted credential for (gateway, principal, linear). The next tools call returns the -32003 consent error again - also handy to re-trigger the chained consent page."
-              }
-            },
-            {
-              "name": "Cleanup: delete consumer",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}"
-              }
-            },
-            {
-              "name": "Cleanup: delete Linear registry",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries/{{registry_id}}"
-              }
-            },
-            {
-              "name": "Cleanup: delete oauth2 auth",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths/{{oauth2_auth_id}}"
-              }
-            },
-            {
-              "name": "Cleanup: delete gateway",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}"
-              }
-            }
-          ]
-        },
-        {
-          "name": "7. Flow G - Full MCP surface (prompts, resources, toolkit governance)",
-          "description": "Self-contained. Demonstrates the full federated MCP surface - tools, prompts, resources, resource templates - and the toolkit as a per-surface allowlist.\n\nPREREQUISITE - start the reference 'everything' MCP server locally (it exposes tools, prompts AND resources):\n\n    npx -y @modelcontextprotocol/server-everything streamableHttp\n\nIt listens on http://localhost:3001/mcp. The registry below uses host.docker.internal:3001 so the dockerized gateway can reach it; change it to localhost:3001 if you run the gateway natively.\n\nFlow: full surface first (everything exposed - empty toolkit), then curate the toolkit and watch each surface shrink to the allowlist: one tool, one renamed prompt, one resource URI. Reads outside the allowlist fail with the spec error -32002.\n\nToolkit semantics: an EMPTY toolkit exposes every tool, prompt and resource. A NON-EMPTY toolkit is an allowlist per surface - a registry with only tool entries exposes NO prompts and NO resources. Resource selectors accept exact URIs, trailing-asterisk prefixes (repo://github/*) or *.\n\nMCP endpoint: {{mcp_url}}/{{consumer_slug}}/mcp - the consumer slug is generated on creation and captured by the create request.",
-          "item": [
-            {
-              "name": "Create gateway",
-              "request": {
-                "method": "POST",
-                "url": "{{admin_url}}/v1/gateways",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"tenant_id\": \"{{tenant_id}}\",\n  \"entitlements\": {\n    \"tier\": \"free\",\n    \"burst_per_min\": 60,\n    \"quota_per_month\": 10000,\n    \"max_instances\": 5\n  },\n  \"name\": \"flow-g-surface\"\n}"
-                }
-              },
-              "event": [
                 {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.environment.set('gateway_id', pm.response.json().id);"
+                  "name": "Create MCP consumer",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.environment.set('consumer_id', pm.response.json().id);",
+                          "pm.environment.set('consumer_slug', pm.response.json().slug);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
                     ],
-                    "type": "text/javascript"
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"name\": \"flow-a-simple\",\n  \"type\": \"MCP\",\n  \"fail_mode\": \"closed\"\n}"
+                    }
+                  }
+                },
+                {
+                  "name": "Attach auth to consumer",
+                  "request": {
+                    "method": "POST",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/auths/{{auth_id}}"
+                  }
+                },
+                {
+                  "name": "Attach registry to consumer",
+                  "request": {
+                    "method": "POST",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/registries/{{registry_id}}"
+                  }
+                },
+                {
+                  "name": "initialize",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "const sid = pm.response.headers.get('Mcp-Session-Id');",
+                          "if (sid) pm.environment.set('mcp_session_id', sid);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"initialize\",\n  \"params\": {\n    \"protocolVersion\": \"2025-06-18\",\n    \"capabilities\": {},\n    \"clientInfo\": { \"name\": \"postman\", \"version\": \"1.0\" }\n  }\n}"
+                    }
+                  }
+                },
+                {
+                  "name": "notifications/initialized",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"method\": \"notifications/initialized\"\n}"
+                    }
+                  }
+                },
+                {
+                  "name": "ping",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 2,\n  \"method\": \"ping\"\n}"
+                    }
+                  }
+                },
+                {
+                  "name": "tools/list",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 3,\n  \"method\": \"tools/list\"\n}"
+                    }
+                  }
+                },
+                {
+                  "name": "tools/call read_wiki_structure",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 4,\n  \"method\": \"tools/call\",\n  \"params\": {\n    \"name\": \"read_wiki_structure\",\n    \"arguments\": { \"repoName\": \"gofiber/fiber\" }\n  }\n}"
+                    }
+                  }
+                },
+                {
+                  "name": "Curate toolkit (select + rename)",
+                  "request": {
+                    "method": "PUT",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"toolkit\": [\n    {\n      \"registry_id\": \"{{registry_id}}\",\n      \"tool\": \"ask_question\",\n      \"expose_as\": \"deepwiki_ask\"\n    }\n  ],\n  \"fail_mode\": \"closed\"\n}"
+                    },
+                    "description": "The consumer now exposes exactly one tool, renamed. Re-run tools/list to verify."
+                  }
+                },
+                {
+                  "name": "tools/call deepwiki_ask (renamed via toolkit)",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 5,\n  \"method\": \"tools/call\",\n  \"params\": {\n    \"name\": \"deepwiki_ask\",\n    \"arguments\": {\n      \"repoName\": \"gofiber/fiber\",\n      \"question\": \"How does routing work?\"\n    }\n  }\n}"
+                    }
+                  }
+                },
+                {
+                  "name": "Clear toolkit (expose all tools)",
+                  "request": {
+                    "method": "PUT",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"toolkit\": []\n}"
+                    }
+                  }
+                },
+                {
+                  "name": "resources/list (DeepWiki exposes none)",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 6,\n  \"method\": \"resources/list\"\n}"
+                    },
+                    "description": "Resources ARE federated now (see Flow G), but DeepWiki is a tools-only upstream, so the merged list is empty here."
+                  }
+                },
+                {
+                  "name": "prompts/list (DeepWiki exposes none)",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 7,\n  \"method\": \"prompts/list\"\n}"
+                    },
+                    "description": "Prompts ARE federated now (see Flow G), but DeepWiki is a tools-only upstream, so the merged list is empty here."
+                  }
+                },
+                {
+                  "name": "Cleanup: delete consumer",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}"
+                  }
+                },
+                {
+                  "name": "Cleanup: delete registry",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries/{{registry_id}}"
+                  }
+                },
+                {
+                  "name": "Cleanup: delete api_key auth",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths/{{auth_id}}"
+                  }
+                },
+                {
+                  "name": "Cleanup: delete gateway",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}",
+                    "description": "Children first, gateway last (else 409)."
                   }
                 }
               ]
             },
             {
-              "name": "Create api_key auth",
-              "request": {
-                "method": "POST",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"name\": \"flow-g-key\",\n  \"type\": \"api_key\",\n  \"config\": {}\n}"
-                },
-                "description": "The api_key value is only returned once, on create; the test script stores it in {{api_key}}."
-              },
-              "event": [
+              "name": "2. Flow B - Composition hub (many servers, one MCP)",
+              "description": "Self-contained. Federate several upstream MCP servers behind ONE consumer: builds it from DeepWiki and Hugging Face, proves federation through a single tools/list and per-upstream routing, then curates a cross-server toolkit, then cleans up.\n\nNaming: tools keep their upstream name unless two registries expose the same name, in which case the composer auto-prefixes them with the registry name ({registry}_{tool}). The toolkit shows the curated alternative: cherry-pick and rename explicitly.",
+              "item": [
                 {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "const res = pm.response.json();",
-                      "pm.environment.set('auth_id', res.id);",
-                      "pm.environment.set('api_key', res.api_key);"
+                  "name": "Create gateway",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.environment.set('gateway_id', pm.response.json().id);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
                     ],
-                    "type": "text/javascript"
+                    "url": "{{admin_url}}/v1/gateways",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"tenant_id\": \"{{tenant_id}}\",\n  \"entitlements\": {\n    \"tier\": \"free\",\n    \"burst_per_min\": 60,\n    \"quota_per_month\": 10000,\n    \"max_instances\": 5\n  },\n  \"name\": \"flow-b-hub\"\n}"
+                    }
+                  }
+                },
+                {
+                  "name": "Create api_key auth",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "const res = pm.response.json();",
+                          "pm.environment.set('auth_id', res.id);",
+                          "pm.environment.set('api_key', res.api_key);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"name\": \"flow-b-key\",\n  \"type\": \"api_key\",\n  \"config\": {}\n}"
+                    }
+                  }
+                },
+                {
+                  "name": "Create MCP registry (DeepWiki, auth none)",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.environment.set('registry_id', pm.response.json().id);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"name\": \"deepwiki\",\n  \"type\": \"MCP\",\n  \"mcp_target\": {\n    \"url\": \"https://mcp.deepwiki.com/mcp\",\n    \"transport\": \"streamable-http\"\n  }\n}"
+                    }
+                  }
+                },
+                {
+                  "name": "Create MCP registry (Hugging Face, auth none)",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.environment.set('registry_hf_id', pm.response.json().id);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"name\": \"huggingface\",\n  \"type\": \"MCP\",\n  \"mcp_target\": {\n    \"url\": \"https://huggingface.co/mcp\",\n    \"transport\": \"streamable-http\"\n  }\n}"
+                    },
+                    "description": "Second upstream. Hugging Face's MCP works anonymously (rate-limited); both servers are listed in GET /v1/mcp-servers-catalog."
+                  }
+                },
+                {
+                  "name": "Create composed MCP consumer",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.environment.set('consumer_id', pm.response.json().id);",
+                          "pm.environment.set('consumer_slug', pm.response.json().slug);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"name\": \"flow-b-hub\",\n  \"type\": \"MCP\",\n  \"fail_mode\": \"open\"\n}"
+                    },
+                    "description": "fail_mode=open: if one upstream is unreachable, the hub still serves the tools of the healthy ones (closed would fail the whole consumer)."
+                  }
+                },
+                {
+                  "name": "Attach auth to hub consumer",
+                  "request": {
+                    "method": "POST",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/auths/{{auth_id}}"
+                  }
+                },
+                {
+                  "name": "Attach DeepWiki registry to hub",
+                  "request": {
+                    "method": "POST",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/registries/{{registry_id}}"
+                  }
+                },
+                {
+                  "name": "Attach Hugging Face registry to hub",
+                  "request": {
+                    "method": "POST",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/registries/{{registry_hf_id}}"
+                  }
+                },
+                {
+                  "name": "tools/list (federated from both servers)",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "const tools = (pm.response.json().result || {}).tools || [];",
+                          "const names = tools.map(t => t.name);",
+                          "console.log('federated tools', names);",
+                          "pm.test('DeepWiki tools present', () => pm.expect(names).to.include('ask_question'));",
+                          "pm.test('Hugging Face tools present', () => pm.expect(names).to.include('hub_repo_search'));"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"tools/list\"\n}"
+                    },
+                    "description": "One list, two servers: DeepWiki's ask_question / read_wiki_* next to Hugging Face's hub_repo_search / paper_search / hf_doc_*. No name collisions here, so no prefixes are added."
+                  }
+                },
+                {
+                  "name": "tools/call ask_question (routed to DeepWiki)",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 2,\n  \"method\": \"tools/call\",\n  \"params\": {\n    \"name\": \"ask_question\",\n    \"arguments\": {\n      \"repoName\": \"gofiber/fiber\",\n      \"question\": \"How does middleware chaining work?\"\n    }\n  }\n}"
+                    },
+                    "description": "The composer resolves the tool to the DeepWiki registry and proxies the call there with that registry's credentials (none here)."
+                  }
+                },
+                {
+                  "name": "tools/call hub_repo_search (routed to Hugging Face)",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 3,\n  \"method\": \"tools/call\",\n  \"params\": {\n    \"name\": \"hub_repo_search\",\n    \"arguments\": {\n      \"query\": \"llama\",\n      \"repo_type\": \"model\",\n      \"limit\": 3\n    }\n  }\n}"
+                    },
+                    "description": "Same virtual path, different upstream: routed to Hugging Face."
+                  }
+                },
+                {
+                  "name": "Curate hub toolkit (cherry-pick + rename across servers)",
+                  "request": {
+                    "method": "PUT",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"toolkit\": [\n    {\n      \"registry_id\": \"{{registry_id}}\",\n      \"tool\": \"ask_question\",\n      \"expose_as\": \"wiki_ask\"\n    },\n    {\n      \"registry_id\": \"{{registry_hf_id}}\",\n      \"tool\": \"hub_repo_search\",\n      \"expose_as\": \"hf_models\"\n    },\n    {\n      \"registry_id\": \"{{registry_hf_id}}\",\n      \"tool\": \"paper_search\"\n    }\n  ],\n  \"fail_mode\": \"open\"\n}"
+                    },
+                    "description": "The hub now exposes exactly three tools: wiki_ask (DeepWiki), hf_models (renamed) and paper_search (original name) from Hugging Face. Everything else is hidden. Re-run tools/list to verify; PUT {\"toolkit\": []} to expose everything again."
+                  }
+                },
+                {
+                  "name": "tools/call hf_models (renamed via toolkit)",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 4,\n  \"method\": \"tools/call\",\n  \"params\": {\n    \"name\": \"hf_models\",\n    \"arguments\": {\n      \"query\": \"whisper\",\n      \"repo_type\": \"model\",\n      \"limit\": 3\n    }\n  }\n}"
+                    },
+                    "description": "Clients only ever see the curated name; the composer maps hf_models back to hub_repo_search on the Hugging Face upstream."
+                  }
+                },
+                {
+                  "name": "Cleanup: delete hub consumer",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}"
+                  }
+                },
+                {
+                  "name": "Cleanup: delete DeepWiki registry",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries/{{registry_id}}"
+                  }
+                },
+                {
+                  "name": "Cleanup: delete Hugging Face registry",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries/{{registry_hf_id}}"
+                  }
+                },
+                {
+                  "name": "Cleanup: delete api_key auth",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths/{{auth_id}}"
+                  }
+                },
+                {
+                  "name": "Cleanup: delete gateway",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}"
                   }
                 }
               ]
             },
             {
-              "name": "Create MCP registry (everything server, local)",
-              "request": {
-                "method": "POST",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"name\": \"everything\",\n  \"type\": \"MCP\",\n  \"mcp_target\": {\n    \"url\": \"http://host.docker.internal:3001/mcp\",\n    \"transport\": \"streamable-http\"\n  }\n}"
-                },
-                "description": "The reference server @modelcontextprotocol/server-everything: tools (echo, add, ...), prompts (simple_prompt, complex_prompt) and 100 test resources (test://static/resource/{1..100}) plus a resource template."
-              },
-              "event": [
+              "name": "3. Flow C - Inbound OAuth (Entra ID)",
+              "description": "Self-contained. JWT validation with Microsoft Entra ID: gateway -> oauth2 auth -> DeepWiki registry -> consumer -> M2M token -> authenticated JSON-RPC -> anti-downgrade -> cleanup. See the collection description for the Entra app prerequisites.\n\nMCP endpoint: {{mcp_url}}/{{consumer_slug}}/mcp - the consumer slug is generated on creation and captured by the create request.\n\nNOTE: only one ENABLED oauth2 auth may cover the same (issuer, audience) pair - run another Entra folder's Cleanup first or 'Create oauth2 auth' answers 409.",
+              "item": [
                 {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.environment.set('registry_id', pm.response.json().id);"
+                  "name": "Create gateway",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.environment.set('gateway_id', pm.response.json().id);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
                     ],
-                    "type": "text/javascript"
+                    "url": "{{admin_url}}/v1/gateways",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"tenant_id\": \"{{tenant_id}}\",\n  \"entitlements\": {\n    \"tier\": \"free\",\n    \"burst_per_min\": 60,\n    \"quota_per_month\": 10000,\n    \"max_instances\": 5\n  },\n  \"name\": \"flow-c-entra\"\n}"
+                    }
+                  }
+                },
+                {
+                  "name": "Create oauth2 auth (Entra)",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.environment.set('oauth2_auth_id', pm.response.json().id);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"name\": \"entra\",\n  \"type\": \"oauth2\",\n  \"config\": {\n    \"oauth2\": {\n      \"issuer\": \"https://login.microsoftonline.com/{{entra_tenant_id}}/v2.0\",\n      \"audiences\": [\"api://{{entra_client_id}}\"],\n      \"client_id\": \"{{entra_client_id}}\",\n      \"client_secret\": \"{{entra_client_secret}}\",\n      \"required_scopes\": [\"api://{{entra_client_id}}/mcp.access\", \"offline_access\"]\n    }\n  }\n}"
+                    },
+                    "description": "issuer must match the token's iss claim exactly (v2.0 suffix); jwks_url is resolved via OIDC discovery. client_id + client_secret are what the AS facade uses to broker the browser authorization-code flow against Entra (redirect URI {{mcp_url}}/oauth/callback must be registered as a Web platform redirect on the Entra app). required_scopes must be FULLY QUALIFIED (api://{client_id}/mcp.access): the facade forwards them verbatim to Entra's authorize endpoint, which rejects bare leaf names; the scope must actually EXIST under the app's 'Expose an API' or Entra fails with AADSTS65005. audiences accepts either form: Entra v2.0 tokens carry the bare client id GUID in aud while v1.0 used the api:// URI - the validator treats them as equivalent. offline_access makes Entra return a refresh token; it is request-only and never enforced against access tokens (protocol scopes - openid/profile/email/offline_access - are skipped by inbound scope validation). 409 here means another ENABLED oauth2 auth already covers this (issuer, audience): run that folder's Cleanup or disable it."
+                  }
+                },
+                {
+                  "name": "Create api_key auth (for anti-downgrade demo)",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "const res = pm.response.json();",
+                          "pm.environment.set('auth_id', res.id);",
+                          "pm.environment.set('api_key', res.api_key);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"name\": \"flow-c-key\",\n  \"type\": \"api_key\",\n  \"config\": {}\n}"
+                    },
+                    "description": "Used only by the 'Invalid JWT is rejected' request to prove the chain never falls back from a failed Bearer to a valid API key."
+                  }
+                },
+                {
+                  "name": "Create MCP registry (DeepWiki, auth none)",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.environment.set('registry_id', pm.response.json().id);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"name\": \"deepwiki\",\n  \"type\": \"MCP\",\n  \"mcp_target\": {\n    \"url\": \"https://mcp.deepwiki.com/mcp\",\n    \"transport\": \"streamable-http\"\n  }\n}"
+                    }
+                  }
+                },
+                {
+                  "name": "Create MCP consumer",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.environment.set('consumer_id', pm.response.json().id);",
+                          "pm.environment.set('consumer_slug', pm.response.json().slug);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"name\": \"flow-c-entra\",\n  \"type\": \"MCP\",\n  \"fail_mode\": \"closed\"\n}"
+                    }
+                  }
+                },
+                {
+                  "name": "Attach oauth2 auth to consumer",
+                  "request": {
+                    "method": "POST",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/auths/{{oauth2_auth_id}}",
+                    "description": "Consumer-first resolution: only auths ATTACHED to this consumer can authenticate requests to its MCP endpoint ({{mcp_url}}/{{consumer_slug}}/mcp)."
+                  }
+                },
+                {
+                  "name": "Attach api_key auth to consumer",
+                  "request": {
+                    "method": "POST",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/auths/{{auth_id}}"
+                  }
+                },
+                {
+                  "name": "Attach registry to consumer",
+                  "request": {
+                    "method": "POST",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/registries/{{registry_id}}"
+                  }
+                },
+                {
+                  "name": "Get Entra token (client credentials)",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "const res = pm.response.json();",
+                          "pm.test('access token issued', () => pm.expect(res.access_token).to.be.a('string'));",
+                          "pm.environment.set('entra_token', res.access_token);",
+                          "let b64 = res.access_token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');",
+                          "while (b64.length % 4) b64 += '=';",
+                          "const claims = JSON.parse(atob(b64));",
+                          "console.log('token claims', { iss: claims.iss, aud: claims.aud, oid: claims.oid, roles: claims.roles });",
+                          "pm.test('v2.0 issuer (else set requestedAccessTokenVersion=2 in the manifest)', () => {",
+                          "  pm.expect(claims.iss).to.include('/v2.0');",
+                          "});"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "url": "https://login.microsoftonline.com/{{entra_tenant_id}}/oauth2/v2.0/token",
+                    "body": {
+                      "mode": "urlencoded",
+                      "urlencoded": [
+                        {
+                          "key": "grant_type",
+                          "value": "client_credentials"
+                        },
+                        {
+                          "key": "client_id",
+                          "value": "{{entra_client_id}}"
+                        },
+                        {
+                          "key": "client_secret",
+                          "value": "{{entra_client_secret}}"
+                        },
+                        {
+                          "key": "scope",
+                          "value": "api://{{entra_client_id}}/.default"
+                        }
+                      ]
+                    },
+                    "description": "M2M token for Postman testing; the scope must be your own app's .default (a Graph scope produces a token TrustGate cannot validate). NOTE: client-credentials tokens carry app permissions in the roles claim (no scp). For required_scopes validation to pass, the Entra app must also define an APPLICATION permission (app role) named mcp.access and assign it to itself - otherwise this M2M token is rejected with 401 and only the browser user flow works."
+                  }
+                },
+                {
+                  "name": "tools/list with Entra JWT",
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{entra_token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"tools/list\"\n}"
+                    },
+                    "description": "Path-first: the request path resolves the consumer, then the token is validated against the consumer's ATTACHED oauth2 auth (signature via JWKS/OIDC discovery, issuer, audience, scopes)."
+                  }
+                },
+                {
+                  "name": "tools/call with Entra JWT",
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{entra_token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 2,\n  \"method\": \"tools/call\",\n  \"params\": {\n    \"name\": \"read_wiki_structure\",\n    \"arguments\": { \"repoName\": \"gofiber/fiber\" }\n  }\n}"
+                    }
+                  }
+                },
+                {
+                  "name": "Invalid JWT is rejected (anti-downgrade)",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.test('401 with challenge, no API-key fallback', () => {",
+                          "  pm.response.to.have.status(401);",
+                          "  pm.expect(pm.response.headers.get('WWW-Authenticate')).to.include('resource_metadata=');",
+                          "});"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJodHRwczovL2V2aWwuZXhhbXBsZS5jb20ifQ.invalid"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 3,\n  \"method\": \"ping\"\n}"
+                    },
+                    "description": "Sends a bogus Bearer token AND a valid API key: the chain takes the Bearer path first and fails without falling back to the API key (anti-downgrade by design)."
+                  }
+                },
+                {
+                  "name": "Cleanup: delete consumer",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}"
+                  }
+                },
+                {
+                  "name": "Cleanup: delete registry",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries/{{registry_id}}"
+                  }
+                },
+                {
+                  "name": "Cleanup: delete oauth2 auth",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths/{{oauth2_auth_id}}",
+                    "description": "Frees the (issuer, audience) pair so flows D and F can create their own Entra auth without a 409."
+                  }
+                },
+                {
+                  "name": "Cleanup: delete api_key auth",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths/{{auth_id}}"
+                  }
+                },
+                {
+                  "name": "Cleanup: delete gateway",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}"
                   }
                 }
               ]
             },
             {
-              "name": "Create MCP consumer",
-              "request": {
-                "method": "POST",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"name\": \"flow-g-surface\",\n  \"type\": \"MCP\",\n  \"fail_mode\": \"closed\"\n}"
-                }
-              },
-              "event": [
+              "name": "4. Flow D - OAuth 2.1 discovery (what MCP clients do)",
+              "description": "Self-contained. Sets up a protected MCP consumer (addressed by its generated slug, {{mcp_url}}/{{consumer_slug}}/mcp) with an Entra oauth2 auth, then replays every step an MCP client (Cursor) performs automatically: 401 challenge -> protected-resource metadata (RFC 9728) -> AS metadata (RFC 8414) -> DCR (RFC 7591) -> brokered authorize -> cleanup.\n\nNOTE: only one ENABLED oauth2 auth may cover the same (issuer, audience) pair - run another Entra folder's Cleanup first or 'Create oauth2 auth' answers 409.",
+              "item": [
                 {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.environment.set('consumer_id', pm.response.json().id);",
-                      "pm.environment.set('consumer_slug', pm.response.json().slug);"
+                  "name": "Create gateway",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.environment.set('gateway_id', pm.response.json().id);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
                     ],
-                    "type": "text/javascript"
+                    "url": "{{admin_url}}/v1/gateways",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"tenant_id\": \"{{tenant_id}}\",\n  \"entitlements\": {\n    \"tier\": \"free\",\n    \"burst_per_min\": 60,\n    \"quota_per_month\": 10000,\n    \"max_instances\": 5\n  },\n  \"name\": \"flow-d-discovery\"\n}"
+                    }
+                  }
+                },
+                {
+                  "name": "Create oauth2 auth (Entra)",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.environment.set('oauth2_auth_id', pm.response.json().id);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"name\": \"entra\",\n  \"type\": \"oauth2\",\n  \"config\": {\n    \"oauth2\": {\n      \"issuer\": \"https://login.microsoftonline.com/{{entra_tenant_id}}/v2.0\",\n      \"audiences\": [\"api://{{entra_client_id}}\"],\n      \"client_id\": \"{{entra_client_id}}\",\n      \"client_secret\": \"{{entra_client_secret}}\",\n      \"required_scopes\": [\"api://{{entra_client_id}}/mcp.access\", \"offline_access\"]\n    }\n  }\n}"
+                    },
+                    "description": "See Flow C's 'Create oauth2 auth' for the full field-by-field explanation. 409 here means another ENABLED oauth2 auth already covers this (issuer, audience): run that folder's Cleanup or disable it."
+                  }
+                },
+                {
+                  "name": "Create MCP registry (DeepWiki, auth none)",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.environment.set('registry_id', pm.response.json().id);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"name\": \"deepwiki\",\n  \"type\": \"MCP\",\n  \"mcp_target\": {\n    \"url\": \"https://mcp.deepwiki.com/mcp\",\n    \"transport\": \"streamable-http\"\n  }\n}"
+                    }
+                  }
+                },
+                {
+                  "name": "Create MCP consumer",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.environment.set('consumer_id', pm.response.json().id);",
+                          "pm.environment.set('consumer_slug', pm.response.json().slug);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"name\": \"flow-d-discovery\",\n  \"type\": \"MCP\",\n  \"fail_mode\": \"closed\"\n}"
+                    }
+                  }
+                },
+                {
+                  "name": "Attach oauth2 auth to consumer",
+                  "request": {
+                    "method": "POST",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/auths/{{oauth2_auth_id}}"
+                  }
+                },
+                {
+                  "name": "Attach registry to consumer",
+                  "request": {
+                    "method": "POST",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/registries/{{registry_id}}"
+                  }
+                },
+                {
+                  "name": "401 challenge carries WWW-Authenticate",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.test('401 with resource_metadata challenge', () => {",
+                          "  pm.response.to.have.status(401);",
+                          "  pm.expect(pm.response.headers.get('WWW-Authenticate')).to.include('resource_metadata=');",
+                          "});"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"ping\"\n}"
+                    },
+                    "description": "No credential on purpose: the MCP plane answers 401 + WWW-Authenticate: Bearer resource_metadata=\"...\" so MCP clients bootstrap the OAuth flow."
+                  }
+                },
+                {
+                  "name": "GET on the MCP path answers 405 (SSE not offered)",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.test('405 Method Not Allowed with Allow: POST', () => {",
+                          "  pm.response.to.have.status(405);",
+                          "  pm.expect(pm.response.headers.get('Allow')).to.eql('POST');",
+                          "});"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "GET",
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "description": "Streamable HTTP clients probe GET for the optional server-initiated SSE stream. The gateway does not offer one and must answer 405 per spec - a 401/404 here makes clients misread it as a credential problem and loop on re-authentication. Same for DELETE (session termination)."
+                  }
+                },
+                {
+                  "name": "Protected resource metadata (RFC 9728)",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "GET",
+                    "url": "{{mcp_url}}/.well-known/oauth-protected-resource",
+                    "description": "Lists the authorization servers (issuers of enabled oauth2 auths) that can issue tokens for this MCP plane."
+                  }
+                },
+                {
+                  "name": "Protected resource metadata, path-scoped",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "GET",
+                    "url": "{{mcp_url}}/.well-known/oauth-protected-resource/{{consumer_slug}}/mcp",
+                    "description": "Same document scoped to a specific virtual MCP path, per the MCP authorization spec: scopes_supported reflects only the auths attached to the consumer on this path."
+                  }
+                },
+                {
+                  "name": "Authorization server metadata (RFC 8414)",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "GET",
+                    "url": "{{mcp_url}}/.well-known/oauth-authorization-server",
+                    "description": "The gateway advertises itself as the authorization server (AS facade): authorize/token/register endpoints all point at the gateway, which brokers to the IdP. 404 until an oauth2 auth exists. With several distinct issuers enabled, clients must pass the RFC 8707 resource parameter on authorize/token so the facade picks the right IdP."
+                  }
+                },
+                {
+                  "name": "Dynamic client registration (RFC 7591)",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/oauth/register",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"client_name\": \"postman\",\n  \"redirect_uris\": [\"http://localhost:1234/callback\"],\n  \"grant_types\": [\"authorization_code\"],\n  \"response_types\": [\"code\"],\n  \"token_endpoint_auth_method\": \"none\"\n}"
+                    },
+                    "description": "Returns the registered public client (PKCE). 400 if no oauth2 auth has a client_id configured."
+                  }
+                },
+                {
+                  "name": "Authorize redirects to IdP (sanity check)",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.test('302 to Entra with scope and PKCE', () => {",
+                          "  pm.response.to.have.status(302);",
+                          "  const loc = pm.response.headers.get('Location') || '';",
+                          "  pm.expect(loc).to.include('login.microsoftonline.com');",
+                          "  pm.expect(loc).to.include('scope=');",
+                          "  pm.expect(loc).to.include('code_challenge=');",
+                          "});",
+                          "console.log('Location:', pm.response.headers.get('Location'));"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "protocolProfileBehavior": {
+                    "followRedirects": false
+                  },
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "GET",
+                    "url": "{{mcp_url}}/oauth/authorize?response_type=code&client_id={{entra_client_id}}&redirect_uri=http%3A%2F%2Flocalhost%3A1234%2Fcallback&state=sanity&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM&code_challenge_method=S256&resource={{mcp_url}}%2F{{consumer_slug}}%2Fmcp",
+                    "description": "Replays the first leg of the browser flow without a browser. The Location header must point at login.microsoftonline.com AND carry a scope parameter (api://{client_id}/mcp.access). The resource parameter (RFC 8707, the virtual MCP URL) selects which consumer's IdP brokers the flow - required when several issuers are enabled on the plane, optional with one. The same parameter is honored on POST /oauth/token (refresh grants). A redirect without scope means the facade picked a stale oauth2 auth entry without required_scopes - find and delete it."
+                  }
+                },
+                {
+                  "name": "STS JWKS (public)",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "GET",
+                    "url": "{{mcp_url}}/.well-known/jwks.json",
+                    "description": "Verification keys for TrustGate-minted downstream tokens (Flow E exchange modes). Configure upstreams to trust iss = STS_ISSUER with this JWKS."
+                  }
+                },
+                {
+                  "name": "Cleanup: delete consumer",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}"
+                  }
+                },
+                {
+                  "name": "Cleanup: delete registry",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries/{{registry_id}}"
+                  }
+                },
+                {
+                  "name": "Cleanup: delete oauth2 auth",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths/{{oauth2_auth_id}}"
+                  }
+                },
+                {
+                  "name": "Cleanup: delete gateway",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}"
                   }
                 }
               ]
             },
             {
-              "name": "Attach auth to consumer",
-              "request": {
-                "method": "POST",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/auths/{{auth_id}}"
-              }
-            },
-            {
-              "name": "Attach registry to consumer",
-              "request": {
-                "method": "POST",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/registries/{{registry_id}}"
-              }
-            },
-            {
-              "name": "initialize",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "X-AG-API-Key",
-                    "value": "{{api_key}}"
+              "name": "5. Flow E - Downstream credentials (STS & forwarded)",
+              "description": "Self-contained. How the gateway authenticates AGAINST upstream MCP servers, per registry (mcp_target.auth.mode): none, static (fixed header), passthrough, exchange (STS-minted or IdP-brokered tokens), forwarded (per-user third-party OAuth vaulted by the gateway). Creates a scratch gateway + registry, applies each auth mode in turn as examples, then cleans up - adapt url/audience to a real upstream.",
+              "item": [
+                {
+                  "name": "Create gateway",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.environment.set('gateway_id', pm.response.json().id);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"tenant_id\": \"{{tenant_id}}\",\n  \"entitlements\": {\n    \"tier\": \"free\",\n    \"burst_per_min\": 60,\n    \"quota_per_month\": 10000,\n    \"max_instances\": 5\n  },\n  \"name\": \"flow-e-downstream\"\n}"
+                    }
                   }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"initialize\",\n  \"params\": {\n    \"protocolVersion\": \"2025-06-18\",\n    \"capabilities\": {},\n    \"clientInfo\": {\n      \"name\": \"postman\",\n      \"version\": \"1.0\"\n    }\n  }\n}"
                 },
-                "description": "The gateway negotiates the protocol version (echoes 2025-06-18) and advertises tools, resources AND prompts capabilities."
-              }
-            },
-            {
-              "name": "notifications/initialized",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "X-AG-API-Key",
-                    "value": "{{api_key}}"
+                {
+                  "name": "Create scratch MCP registry (auth none)",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.environment.set('registry_id', pm.response.json().id);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"name\": \"downstream-demo\",\n  \"type\": \"MCP\",\n  \"mcp_target\": {\n    \"url\": \"{{upstream_mcp_url}}\",\n    \"transport\": \"streamable-http\"\n  }\n}"
+                    },
+                    "description": "Scratch registry the following PUT requests mutate to demonstrate each downstream auth mode."
                   }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"method\": \"notifications/initialized\"\n}"
+                },
+                {
+                  "name": "Set registry auth: static header",
+                  "request": {
+                    "method": "PUT",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries/{{registry_id}}",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"mcp_target\": {\n    \"url\": \"{{upstream_mcp_url}}\",\n    \"auth\": {\n      \"mode\": \"static\",\n      \"header\": \"Authorization\",\n      \"value\": \"Bearer YOUR_UPSTREAM_TOKEN\"\n    }\n  }\n}"
+                    },
+                    "description": "Service-account style: one fixed credential for all principals (e.g. Stripe or Context7 API keys). The value is write-only: reads return it masked."
+                  }
+                },
+                {
+                  "name": "Set registry auth: exchange/impersonation (STS)",
+                  "request": {
+                    "method": "PUT",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries/{{registry_id}}",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"mcp_target\": {\n    \"url\": \"{{upstream_mcp_url}}\",\n    \"auth\": {\n      \"mode\": \"exchange\",\n      \"pattern\": \"impersonation\",\n      \"audience\": \"{{upstream_mcp_url}}\"\n    }\n  }\n}"
+                    },
+                    "description": "The STS mints a short-lived RS256 JWT (same sub, aud = audience, iss = TrustGate) per principal and injects it as Authorization on every upstream connection. Use pattern=delegation (+actor), obo (+scope) or token_exchange (+audience) for the other RFC 8693 patterns."
+                  }
+                },
+                {
+                  "name": "Set registry auth: forwarded + manual registration (GitHub)",
+                  "request": {
+                    "method": "PUT",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries/{{registry_id}}",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"mcp_target\": {\n    \"url\": \"{{upstream_mcp_url}}\",\n    \"auth\": {\n      \"mode\": \"forwarded\",\n      \"provider\": \"github\",\n      \"client_id\": \"{{github_client_id}}\",\n      \"client_secret\": \"{{github_client_secret}}\",\n      \"authorize_url\": \"https://github.com/login/oauth/authorize\",\n      \"token_url\": \"https://github.com/login/oauth/access_token\",\n      \"scopes\": [\"repo\"]\n    }\n  }\n}"
+                    },
+                    "description": "Manual registration: the gateway uses an admin pre-registered OAuth app. Set the OAuth app callback to {{mcp_url}}/oauth/callback/github. After this, a tools call by a user without a linked account returns JSON-RPC error -32003 with data.connect_url - Flow F shows the full consent loop."
+                  }
+                },
+                {
+                  "name": "Set registry auth: forwarded + auto registration (DCR)",
+                  "request": {
+                    "method": "PUT",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries/{{registry_id}}",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"mcp_target\": {\n    \"url\": \"{{upstream_mcp_url}}\",\n    \"auth\": {\n      \"mode\": \"forwarded\",\n      \"provider\": \"example\",\n      \"registration\": \"auto\"\n    }\n  }\n}"
+                    },
+                    "description": "Auto registration: no OAuth app, no client secret. At consent time the gateway discovers the upstream's authorization server via its MCP protected-resource metadata (RFC 9728/8414) and registers itself once via Dynamic Client Registration (RFC 7591) as a public client with PKCE. Works with any spec-compliant remote MCP (Linear, Notion, ...); scopes and the RFC 8707 resource indicator default from the upstream's metadata. If the upstream does not publish OAuth metadata, the connect flow returns an error telling you to fall back to manual registration. Flow F runs this for real against Linear."
+                  }
+                },
+                {
+                  "name": "Cleanup: delete registry",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries/{{registry_id}}"
+                  }
+                },
+                {
+                  "name": "Cleanup: delete gateway",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}"
+                  }
                 }
-              }
+              ]
             },
             {
-              "name": "tools/list (full surface)",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "X-AG-API-Key",
-                    "value": "{{api_key}}"
+              "name": "6. Flow F - Linear end-to-end (forwarded + auto, Cursor)",
+              "description": "Self-contained. The full story on real services: inbound Entra ID, downstream Linear with forwarded mode + auto registration - no Linear OAuth app or client secret needed.\n\nRun the admin requests top to bottom, then 'Get Entra token', then the MCP plane requests. The first tools/list returns -32003 with data.connect_url: open it in a browser, click Connect Linear, approve, re-run. Finish with the Cleanup requests.\n\nMCP endpoint: {{mcp_url}}/{{consumer_slug}}/mcp - the consumer slug is generated on creation and captured by the create request.\n\nIn Cursor you skip the Postman token entirely: add {{mcp_url}}/{{consumer_slug}}/mcp to mcp.json and Cursor bootstraps the OAuth flow from the 401 challenge (Flow D shows every step it performs). After the Entra login, if you have unlinked providers the browser detours to the connect page (chained consent) - link Linear, click Continue, done. Already linked? The browser hands the code straight back to Cursor via its cursor:// deep link ('Open Cursor?' dialog; tick 'Always allow' to never see it again).\n\nNote (M2M): the Postman client-credentials token links Linear to the service principal. Real users in Cursor each link their own Linear account.\n\nNOTE: only one ENABLED oauth2 auth may cover the same (issuer, audience) pair - run another Entra folder's Cleanup first or 'Create oauth2 auth' answers 409.",
+              "item": [
+                {
+                  "name": "Create gateway",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.environment.set('gateway_id', pm.response.json().id);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"tenant_id\": \"{{tenant_id}}\",\n  \"entitlements\": {\n    \"tier\": \"free\",\n    \"burst_per_min\": 60,\n    \"quota_per_month\": 10000,\n    \"max_instances\": 5\n  },\n  \"name\": \"flow-f-linear\"\n}"
+                    }
                   }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 2,\n  \"method\": \"tools/list\"\n}"
                 },
-                "description": "Empty toolkit: every upstream tool is exposed."
-              }
-            },
-            {
-              "name": "prompts/list (full surface)",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "X-AG-API-Key",
-                    "value": "{{api_key}}"
+                {
+                  "name": "Create oauth2 auth (Entra)",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.environment.set('oauth2_auth_id', pm.response.json().id);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"name\": \"entra\",\n  \"type\": \"oauth2\",\n  \"config\": {\n    \"oauth2\": {\n      \"issuer\": \"https://login.microsoftonline.com/{{entra_tenant_id}}/v2.0\",\n      \"audiences\": [\"api://{{entra_client_id}}\"],\n      \"client_id\": \"{{entra_client_id}}\",\n      \"client_secret\": \"{{entra_client_secret}}\",\n      \"required_scopes\": [\"api://{{entra_client_id}}/mcp.access\", \"offline_access\"]\n    }\n  }\n}"
+                    },
+                    "description": "See Flow C's 'Create oauth2 auth' for the full field-by-field explanation. 409 here means another ENABLED oauth2 auth already covers this (issuer, audience): run that folder's Cleanup or disable it."
                   }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 3,\n  \"method\": \"prompts/list\"\n}"
                 },
-                "description": "Empty toolkit: every upstream prompt is exposed. Name collisions across registries would be auto-prefixed {server}_{prompt}, like tools."
-              }
-            },
-            {
-              "name": "prompts/get simple_prompt",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "X-AG-API-Key",
-                    "value": "{{api_key}}"
+                {
+                  "name": "Create Linear MCP registry (forwarded + auto)",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.environment.set('registry_id', pm.response.json().id);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"name\": \"linear-mcp\",\n  \"type\": \"MCP\",\n  \"mcp_target\": {\n    \"url\": \"https://mcp.linear.app/mcp\",\n    \"transport\": \"streamable-http\",\n    \"auth\": {\n      \"mode\": \"forwarded\",\n      \"provider\": \"linear\",\n      \"registration\": \"auto\"\n    }\n  }\n}"
+                    },
+                    "description": "registration: auto means zero per-provider config: at consent time the gateway fetches https://mcp.linear.app/.well-known/oauth-protected-resource/mcp, resolves Linear's authorization server (RFC 8414), registers itself once via DCR (RFC 7591) as a public client with PKCE, and stores the issued client_id in Redis keyed (gateway, registry). Scopes and the RFC 8707 resource indicator default from Linear's metadata."
                   }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 4,\n  \"method\": \"prompts/get\",\n  \"params\": {\n    \"name\": \"simple_prompt\"\n  }\n}"
                 },
-                "description": "Routed to the owning upstream and rendered there; the result passes through verbatim."
-              }
-            },
-            {
-              "name": "resources/list (full surface)",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "X-AG-API-Key",
-                    "value": "{{api_key}}"
+                {
+                  "name": "Create Linear MCP consumer",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.environment.set('consumer_id', pm.response.json().id);",
+                          "pm.environment.set('consumer_slug', pm.response.json().slug);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"name\": \"flow-f-linear\",\n  \"type\": \"MCP\",\n  \"fail_mode\": \"closed\"\n}"
+                    }
                   }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 5,\n  \"method\": \"resources/list\"\n}"
                 },
-                "description": "Resources are URI-addressed: merged across upstreams, no renaming."
-              }
-            },
-            {
-              "name": "resources/templates/list",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "X-AG-API-Key",
-                    "value": "{{api_key}}"
+                {
+                  "name": "Attach oauth2 auth to consumer",
+                  "request": {
+                    "method": "POST",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/auths/{{oauth2_auth_id}}"
                   }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 6,\n  \"method\": \"resources/templates/list\"\n}"
+                },
+                {
+                  "name": "Attach Linear registry to consumer",
+                  "request": {
+                    "method": "POST",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/registries/{{registry_id}}"
+                  }
+                },
+                {
+                  "name": "Set toolkit (all Linear tools)",
+                  "request": {
+                    "method": "PUT",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"toolkit\": [\n    {\n      \"registry_id\": \"{{registry_id}}\",\n      \"tool\": \"*\"\n    }\n  ],\n  \"fail_mode\": \"closed\"\n}"
+                    },
+                    "description": "Wildcard exposes every Linear tool. Replace with explicit {tool, expose_as} entries to curate or rename."
+                  }
+                },
+                {
+                  "name": "Get Entra token (client credentials)",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "const res = pm.response.json();",
+                          "pm.test('access token issued', () => pm.expect(res.access_token).to.be.a('string'));",
+                          "pm.environment.set('entra_token', res.access_token);",
+                          "let b64 = res.access_token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');",
+                          "while (b64.length % 4) b64 += '=';",
+                          "const claims = JSON.parse(atob(b64));",
+                          "console.log('token claims', { iss: claims.iss, aud: claims.aud, oid: claims.oid, roles: claims.roles });",
+                          "pm.test('v2.0 issuer (else set requestedAccessTokenVersion=2 in the manifest)', () => {",
+                          "  pm.expect(claims.iss).to.include('/v2.0');",
+                          "});"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "url": "https://login.microsoftonline.com/{{entra_tenant_id}}/oauth2/v2.0/token",
+                    "body": {
+                      "mode": "urlencoded",
+                      "urlencoded": [
+                        {
+                          "key": "grant_type",
+                          "value": "client_credentials"
+                        },
+                        {
+                          "key": "client_id",
+                          "value": "{{entra_client_id}}"
+                        },
+                        {
+                          "key": "client_secret",
+                          "value": "{{entra_client_secret}}"
+                        },
+                        {
+                          "key": "scope",
+                          "value": "api://{{entra_client_id}}/.default"
+                        }
+                      ]
+                    },
+                    "description": "M2M token for Postman testing; the scope must be your own app's .default (a Graph scope produces a token TrustGate cannot validate). NOTE: client-credentials tokens carry app permissions in the roles claim (no scp). For required_scopes validation to pass, the Entra app must also define an APPLICATION permission (app role) named mcp.access and assign it to itself - otherwise this M2M token is rejected with 401 and only the browser user flow works."
+                  }
+                },
+                {
+                  "name": "initialize (Entra JWT)",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "const sid = pm.response.headers.get('Mcp-Session-Id');",
+                          "if (sid) pm.environment.set('mcp_session_id', sid);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{entra_token}}"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"initialize\",\n  \"params\": {\n    \"protocolVersion\": \"2025-06-18\",\n    \"capabilities\": {},\n    \"clientInfo\": { \"name\": \"postman\", \"version\": \"1.0\" }\n  }\n}"
+                    },
+                    "description": "Get {{entra_token}} first via this folder's 'Get Entra token (client credentials)'."
+                  }
+                },
+                {
+                  "name": "tools/list -> consent error on first run",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "const body = pm.response.json();",
+                          "if (body.error && body.error.code === -32003) {",
+                          "  const url = body.error.data.connect_url;",
+                          "  const ticket = (url.split('ticket=')[1] || '').split('&')[0];",
+                          "  pm.environment.set('connect_ticket', ticket);",
+                          "  console.log('Open in a browser to link Linear:', url);",
+                          "} else if (body.result) {",
+                          "  console.log('Linked: ' + body.result.tools.length + ' Linear tools exposed');",
+                          "}"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{entra_token}}"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 2,\n  \"method\": \"tools/list\"\n}"
+                    },
+                    "description": "First run: no vaulted Linear token for this principal, so the gateway answers JSON-RPC error -32003 with data.connect_url (the script saves the ticket and logs the URL). Open it in a browser, click Connect Linear - the gateway performs upstream discovery + DCR right there - approve at Linear, then re-run: the result lists Linear's tools."
+                  }
+                },
+                {
+                  "name": "Connect page (browser UI)",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "GET",
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp/connect?ticket={{connect_ticket}}",
+                    "description": "The ticket-authenticated consent page: one button per forwarded provider behind this virtual MCP, with linked/unlinked status. Normally opened in a browser via the connect_url from the -32003 error, or automatically right after the Entra leg (chained consent). Tickets expire after 15 minutes."
+                  }
+                },
+                {
+                  "name": "tools/call list_issues (after linking)",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer {{entra_token}}"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 3,\n  \"method\": \"tools/call\",\n  \"params\": {\n    \"name\": \"list_issues\",\n    \"arguments\": {}\n  }\n}"
+                    },
+                    "description": "Check the exact tool names in the tools/list result (the composer prefixes with the registry name only on collisions). The call runs with YOUR vaulted Linear token; another principal calling the same consumer gets their own consent flow."
+                  }
+                },
+                {
+                  "name": "Disconnect Linear (revoke vaulted token)",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "url": "{{mcp_url}}/oauth/disconnect/linear?ticket={{connect_ticket}}",
+                    "description": "Deletes the vaulted credential for (gateway, principal, linear). The next tools call returns the -32003 consent error again - also handy to re-trigger the chained consent page."
+                  }
+                },
+                {
+                  "name": "Cleanup: delete consumer",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}"
+                  }
+                },
+                {
+                  "name": "Cleanup: delete Linear registry",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries/{{registry_id}}"
+                  }
+                },
+                {
+                  "name": "Cleanup: delete oauth2 auth",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths/{{oauth2_auth_id}}"
+                  }
+                },
+                {
+                  "name": "Cleanup: delete gateway",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}"
+                  }
                 }
-              }
+              ]
             },
             {
-              "name": "resources/read test://static/resource/1",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
+              "name": "7. Flow G - Full MCP surface (prompts, resources, toolkit governance)",
+              "description": "Self-contained. Demonstrates the full federated MCP surface - tools, prompts, resources, resource templates - and the toolkit as a per-surface allowlist.\n\nPREREQUISITE - start the reference 'everything' MCP server locally (it exposes tools, prompts AND resources):\n\n    npx -y @modelcontextprotocol/server-everything streamableHttp\n\nIt listens on http://localhost:3001/mcp. The registry below uses host.docker.internal:3001 so the dockerized gateway can reach it; change it to localhost:3001 if you run the gateway natively.\n\nFlow: full surface first (everything exposed - empty toolkit), then curate the toolkit and watch each surface shrink to the allowlist: one tool, one renamed prompt, one resource URI. Reads outside the allowlist fail with the spec error -32002.\n\nToolkit semantics: an EMPTY toolkit exposes every tool, prompt and resource. A NON-EMPTY toolkit is an allowlist per surface - a registry with only tool entries exposes NO prompts and NO resources. Resource selectors accept exact URIs, trailing-asterisk prefixes (repo://github/*) or *.\n\nMCP endpoint: {{mcp_url}}/{{consumer_slug}}/mcp - the consumer slug is generated on creation and captured by the create request.",
+              "item": [
+                {
+                  "name": "Create gateway",
+                  "request": {
+                    "method": "POST",
+                    "url": "{{admin_url}}/v1/gateways",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"tenant_id\": \"{{tenant_id}}\",\n  \"entitlements\": {\n    \"tier\": \"free\",\n    \"burst_per_min\": 60,\n    \"quota_per_month\": 10000,\n    \"max_instances\": 5\n  },\n  \"name\": \"flow-g-surface\"\n}"
+                    }
                   },
-                  {
-                    "key": "X-AG-API-Key",
-                    "value": "{{api_key}}"
-                  }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 7,\n  \"method\": \"resources/read\",\n  \"params\": {\n    \"uri\": \"test://static/resource/1\"\n  }\n}"
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.environment.set('gateway_id', pm.response.json().id);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ]
                 },
-                "description": "The gateway routes the URI to the upstream that lists it; template-addressed URIs fall back to trying each resource-capable upstream."
-              }
-            },
-            {
-              "name": "Curate toolkit (allowlist all three surfaces)",
-              "request": {
-                "method": "PUT",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"toolkit\": [\n    {\n      \"registry_id\": \"{{registry_id}}\",\n      \"tool\": \"echo\"\n    },\n    {\n      \"registry_id\": \"{{registry_id}}\",\n      \"prompt\": \"simple_prompt\",\n      \"expose_as\": \"demo_prompt\"\n    },\n    {\n      \"registry_id\": \"{{registry_id}}\",\n      \"resource\": \"test://static/resource/1\"\n    }\n  ]\n}"
-                },
-                "description": "One entry per surface: only the echo tool, only simple_prompt (renamed demo_prompt), only resource URI test://static/resource/1. Everything else disappears from the virtual MCP. Exactly one of tool|prompt|resource per entry; expose_as renames tools and prompts (not resources)."
-              }
-            },
-            {
-              "name": "tools/list (only echo)",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
+                {
+                  "name": "Create api_key auth",
+                  "request": {
+                    "method": "POST",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"name\": \"flow-g-key\",\n  \"type\": \"api_key\",\n  \"config\": {}\n}"
+                    },
+                    "description": "The api_key value is only returned once, on create; the test script stores it in {{api_key}}."
                   },
-                  {
-                    "key": "X-AG-API-Key",
-                    "value": "{{api_key}}"
-                  }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 8,\n  \"method\": \"tools/list\"\n}"
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "const res = pm.response.json();",
+                          "pm.environment.set('auth_id', res.id);",
+                          "pm.environment.set('api_key', res.api_key);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ]
                 },
-                "description": "The toolkit is now a per-surface allowlist: expect exactly one tool."
-              }
-            },
-            {
-              "name": "prompts/list (only demo_prompt)",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
+                {
+                  "name": "Create MCP registry (everything server, local)",
+                  "request": {
+                    "method": "POST",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"name\": \"everything\",\n  \"type\": \"MCP\",\n  \"mcp_target\": {\n    \"url\": \"http://host.docker.internal:3001/mcp\",\n    \"transport\": \"streamable-http\"\n  }\n}"
+                    },
+                    "description": "The reference server @modelcontextprotocol/server-everything: tools (echo, add, ...), prompts (simple_prompt, complex_prompt) and 100 test resources (test://static/resource/{1..100}) plus a resource template."
                   },
-                  {
-                    "key": "X-AG-API-Key",
-                    "value": "{{api_key}}"
-                  }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 9,\n  \"method\": \"prompts/list\"\n}"
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.environment.set('registry_id', pm.response.json().id);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ]
                 },
-                "description": "simple_prompt is exposed under its alias demo_prompt; complex_prompt is gone."
-              }
-            },
-            {
-              "name": "prompts/get demo_prompt (renamed)",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
+                {
+                  "name": "Create MCP consumer",
+                  "request": {
+                    "method": "POST",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"name\": \"flow-g-surface\",\n  \"type\": \"MCP\",\n  \"fail_mode\": \"closed\"\n}"
+                    }
                   },
-                  {
-                    "key": "X-AG-API-Key",
-                    "value": "{{api_key}}"
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.environment.set('consumer_id', pm.response.json().id);",
+                          "pm.environment.set('consumer_slug', pm.response.json().slug);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "name": "Attach auth to consumer",
+                  "request": {
+                    "method": "POST",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/auths/{{auth_id}}"
                   }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 10,\n  \"method\": \"prompts/get\",\n  \"params\": {\n    \"name\": \"demo_prompt\"\n  }\n}"
                 },
-                "description": "The alias resolves back to the upstream prompt name. Calling the original name simple_prompt now fails."
-              }
-            },
-            {
-              "name": "resources/list (only resource/1)",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "X-AG-API-Key",
-                    "value": "{{api_key}}"
+                {
+                  "name": "Attach registry to consumer",
+                  "request": {
+                    "method": "POST",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/registries/{{registry_id}}"
                   }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 11,\n  \"method\": \"resources/list\"\n}"
                 },
-                "description": "Only URIs matching a resource entry survive. Use a prefix selector (test://static/resource/*) to allow a subtree."
-              }
-            },
-            {
-              "name": "resources/read denied (resource/2 -> -32002)",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "X-AG-API-Key",
-                    "value": "{{api_key}}"
+                {
+                  "name": "initialize",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"initialize\",\n  \"params\": {\n    \"protocolVersion\": \"2025-06-18\",\n    \"capabilities\": {},\n    \"clientInfo\": {\n      \"name\": \"postman\",\n      \"version\": \"1.0\"\n    }\n  }\n}"
+                    },
+                    "description": "The gateway negotiates the protocol version (echoes 2025-06-18) and advertises tools, resources AND prompts capabilities."
                   }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 12,\n  \"method\": \"resources/read\",\n  \"params\": {\n    \"uri\": \"test://static/resource/2\"\n  }\n}"
                 },
-                "description": "The URI is outside the allowlist: expect JSON-RPC error -32002 (resource not found). Enforced at read time too, so template-expanded URIs cannot bypass the list filter."
-              }
-            },
-            {
-              "name": "Clear toolkit (expose everything again)",
-              "request": {
-                "method": "PUT",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
+                {
+                  "name": "notifications/initialized",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"method\": \"notifications/initialized\"\n}"
+                    }
                   }
-                ],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"toolkit\": []\n}"
+                },
+                {
+                  "name": "tools/list (full surface)",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 2,\n  \"method\": \"tools/list\"\n}"
+                    },
+                    "description": "Empty toolkit: every upstream tool is exposed."
+                  }
+                },
+                {
+                  "name": "prompts/list (full surface)",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 3,\n  \"method\": \"prompts/list\"\n}"
+                    },
+                    "description": "Empty toolkit: every upstream prompt is exposed. Name collisions across registries would be auto-prefixed {server}_{prompt}, like tools."
+                  }
+                },
+                {
+                  "name": "prompts/get simple_prompt",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 4,\n  \"method\": \"prompts/get\",\n  \"params\": {\n    \"name\": \"simple_prompt\"\n  }\n}"
+                    },
+                    "description": "Routed to the owning upstream and rendered there; the result passes through verbatim."
+                  }
+                },
+                {
+                  "name": "resources/list (full surface)",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 5,\n  \"method\": \"resources/list\"\n}"
+                    },
+                    "description": "Resources are URI-addressed: merged across upstreams, no renaming."
+                  }
+                },
+                {
+                  "name": "resources/templates/list",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 6,\n  \"method\": \"resources/templates/list\"\n}"
+                    }
+                  }
+                },
+                {
+                  "name": "resources/read test://static/resource/1",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 7,\n  \"method\": \"resources/read\",\n  \"params\": {\n    \"uri\": \"test://static/resource/1\"\n  }\n}"
+                    },
+                    "description": "The gateway routes the URI to the upstream that lists it; template-addressed URIs fall back to trying each resource-capable upstream."
+                  }
+                },
+                {
+                  "name": "Curate toolkit (allowlist all three surfaces)",
+                  "request": {
+                    "method": "PUT",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"toolkit\": [\n    {\n      \"registry_id\": \"{{registry_id}}\",\n      \"tool\": \"echo\"\n    },\n    {\n      \"registry_id\": \"{{registry_id}}\",\n      \"prompt\": \"simple_prompt\",\n      \"expose_as\": \"demo_prompt\"\n    },\n    {\n      \"registry_id\": \"{{registry_id}}\",\n      \"resource\": \"test://static/resource/1\"\n    }\n  ]\n}"
+                    },
+                    "description": "One entry per surface: only the echo tool, only simple_prompt (renamed demo_prompt), only resource URI test://static/resource/1. Everything else disappears from the virtual MCP. Exactly one of tool|prompt|resource per entry; expose_as renames tools and prompts (not resources)."
+                  }
+                },
+                {
+                  "name": "tools/list (only echo)",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 8,\n  \"method\": \"tools/list\"\n}"
+                    },
+                    "description": "The toolkit is now a per-surface allowlist: expect exactly one tool."
+                  }
+                },
+                {
+                  "name": "prompts/list (only demo_prompt)",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 9,\n  \"method\": \"prompts/list\"\n}"
+                    },
+                    "description": "simple_prompt is exposed under its alias demo_prompt; complex_prompt is gone."
+                  }
+                },
+                {
+                  "name": "prompts/get demo_prompt (renamed)",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 10,\n  \"method\": \"prompts/get\",\n  \"params\": {\n    \"name\": \"demo_prompt\"\n  }\n}"
+                    },
+                    "description": "The alias resolves back to the upstream prompt name. Calling the original name simple_prompt now fails."
+                  }
+                },
+                {
+                  "name": "resources/list (only resource/1)",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 11,\n  \"method\": \"resources/list\"\n}"
+                    },
+                    "description": "Only URIs matching a resource entry survive. Use a prefix selector (test://static/resource/*) to allow a subtree."
+                  }
+                },
+                {
+                  "name": "resources/read denied (resource/2 -> -32002)",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 12,\n  \"method\": \"resources/read\",\n  \"params\": {\n    \"uri\": \"test://static/resource/2\"\n  }\n}"
+                    },
+                    "description": "The URI is outside the allowlist: expect JSON-RPC error -32002 (resource not found). Enforced at read time too, so template-expanded URIs cannot bypass the list filter."
+                  }
+                },
+                {
+                  "name": "Clear toolkit (expose everything again)",
+                  "request": {
+                    "method": "PUT",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"toolkit\": []\n}"
+                    }
+                  }
+                },
+                {
+                  "name": "Cleanup: delete consumer",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}"
+                  }
+                },
+                {
+                  "name": "Cleanup: delete registry",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries/{{registry_id}}"
+                  }
+                },
+                {
+                  "name": "Cleanup: delete api_key auth",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths/{{auth_id}}"
+                  }
+                },
+                {
+                  "name": "Cleanup: delete gateway",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}"
+                  }
                 }
-              }
+              ]
             },
             {
-              "name": "Cleanup: delete consumer",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}"
-              }
+              "name": "8. Flow H - Inbound OAuth + discovery (Okta)",
+              "description": "Self-contained. Interactive MCP login brokered through Okta as the identity provider: gateway -> oauth2 auth (Okta) -> DeepWiki registry -> MCP consumer -> the OAuth 2.1 discovery surface an MCP client (Cursor) replays automatically -> M2M-authenticated JSON-RPC -> anti-downgrade -> cleanup.\n\nConsumers have NO path field: the server assigns a random slug on create and the virtual MCP endpoint is {{mcp_url}}/{slug}/mcp. The 'Create MCP consumer' step captures it into {{consumer_slug}}.\n\nWhy `oauth2` and not `oidc`? For MCP, the gateway BROKERS the browser authorization-code flow (the client has no Okta token yet): it needs client_id + client_secret to drive Okta, which only the `oauth2` auth type carries. An `oidc` auth only VALIDATES a token the caller already has (LLM proxy), so an MCP consumer is rejected if you attach an `oidc` auth. 'Okta as IDP' here means Okta is the identity provider behind an `oauth2` auth.\n\nRole-based variant: an MCP consumer may also be role_based; it still requires exactly one `oauth2` auth, plus a role whose oidc_mapping matches the Okta token claims (see 'E2E Role-Based Flow (Okta / IDP)' for the role + oidc_mapping shape). This folder uses an inline MCP consumer to keep the OAuth surface front and center.\n\nSet before running: `okta_domain` (e.g. dev-12345.okta.com, no scheme), `okta_auth_server_id` (e.g. `default`), `okta_client_id`, `okta_client_secret`, `okta_scope` (a custom scope exposed AND granted on the authorization server, e.g. `mcp.access`) and `okta_audience` (the authorization server audience, e.g. `api://default`).\n\nOkta app prerequisites (skipping any makes Cursor loop on 'Authenticating...'): 1) an Authorization Server (Security > API) with a custom scope = {{okta_scope}} and audience = {{okta_audience}}; 2) an OIDC app with the Authorization Code grant and a Web redirect URI {{mcp_url}}/oauth/callback; 3) for the M2M test step below, the Client Credentials grant enabled and the scope granted to the app. The gateway validates the Okta JWT via JWKS; the client_secret is only used to broker the browser flow.\n\nNOTE: only one ENABLED oauth2 auth may cover the same (issuer, audience) pair on the plane - run another oauth2 folder's Cleanup first or 'Create oauth2 auth (Okta)' answers 409.",
+              "item": [
+                {
+                  "name": "Create gateway",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.environment.set('gateway_id', pm.response.json().id);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"tenant_id\": \"{{tenant_id}}\",\n  \"entitlements\": {\n    \"tier\": \"free\",\n    \"burst_per_min\": 60,\n    \"quota_per_month\": 10000,\n    \"max_instances\": 5\n  },\n  \"name\": \"flow-h-okta\"\n}"
+                    }
+                  }
+                },
+                {
+                  "name": "Create oauth2 auth (Okta)",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.test('oauth2 auth created', () => pm.response.code === 201);",
+                          "if (pm.response.code === 201) pm.environment.set('oauth2_auth_id', pm.response.json().id);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"name\": \"okta\",\n  \"type\": \"oauth2\",\n  \"config\": {\n    \"oauth2\": {\n      \"issuer\": \"https://{{okta_domain}}/oauth2/{{okta_auth_server_id}}\",\n      \"audiences\": [\"{{okta_audience}}\"],\n      \"jwks_url\": \"https://{{okta_domain}}/oauth2/{{okta_auth_server_id}}/v1/keys\",\n      \"client_id\": \"{{okta_client_id}}\",\n      \"client_secret\": \"{{okta_client_secret}}\",\n      \"required_scopes\": [\"{{okta_scope}}\"]\n    }\n  }\n}"
+                    },
+                    "description": "issuer must equal the token's iss claim exactly (the authorization server base URL, https://{domain}/oauth2/{authServerId}). jwks_url is the server's signing keys ({issuer}/v1/keys); it can be omitted to let the gateway resolve it via OIDC discovery. client_id + client_secret let the AS facade broker the browser authorization-code flow against Okta (redirect URI {{mcp_url}}/oauth/callback must be a Web redirect on the Okta app). required_scopes must be a custom scope EXPOSED on the authorization server (Okta rejects unknown scopes; openid/profile/email are user-only). audiences must match the token aud (the authorization server audience, default api://default). 409 means another ENABLED oauth2 auth already covers this (issuer, audience): run that folder's Cleanup or scope this one with a distinct audience."
+                  }
+                },
+                {
+                  "name": "Create api_key auth (for anti-downgrade demo)",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "const res = pm.response.json();",
+                          "pm.environment.set('auth_id', res.id);",
+                          "pm.environment.set('api_key', res.api_key);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"name\": \"flow-h-key\",\n  \"type\": \"api_key\",\n  \"config\": {}\n}"
+                    },
+                    "description": "Used only by 'Invalid JWT is rejected' to prove the chain never falls back from a failed Bearer to a valid API key."
+                  }
+                },
+                {
+                  "name": "Create MCP registry (DeepWiki, auth none)",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.environment.set('registry_id', pm.response.json().id);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"name\": \"deepwiki\",\n  \"type\": \"MCP\",\n  \"mcp_target\": {\n    \"url\": \"https://mcp.deepwiki.com/mcp\",\n    \"transport\": \"streamable-http\"\n  }\n}"
+                    }
+                  }
+                },
+                {
+                  "name": "Create MCP consumer (captures slug)",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "const res = pm.response.json();",
+                          "pm.environment.set('consumer_id', res.id);",
+                          "pm.environment.set('consumer_slug', res.slug);",
+                          "console.log('MCP endpoint:', pm.variables.get('mcp_url') + '/' + res.slug + '/mcp');"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"name\": \"flow-h-okta\",\n  \"type\": \"MCP\",\n  \"fail_mode\": \"closed\"\n}"
+                    },
+                    "description": "Consumers have no path: the server assigns a random slug and the MCP endpoint is {{mcp_url}}/{slug}/mcp. The test captures the slug into {{consumer_slug}}; every MCP call below addresses {{mcp_url}}/{{consumer_slug}}/mcp.\n\nFor the role-based variant add \"routing_mode\": \"role_based\" here, then create a role with an oidc_mapping over the Okta claims and attach it - the oauth2 auth stays the same."
+                  }
+                },
+                {
+                  "name": "Attach oauth2 auth to consumer",
+                  "request": {
+                    "method": "POST",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/auths/{{oauth2_auth_id}}",
+                    "description": "Path-first resolution: only auths ATTACHED to the consumer can authenticate or broker requests to {{mcp_url}}/{{consumer_slug}}/mcp."
+                  }
+                },
+                {
+                  "name": "Attach api_key auth to consumer",
+                  "request": {
+                    "method": "POST",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/auths/{{auth_id}}"
+                  }
+                },
+                {
+                  "name": "Attach registry to consumer",
+                  "request": {
+                    "method": "POST",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/registries/{{registry_id}}"
+                  }
+                },
+                {
+                  "name": "401 challenge carries WWW-Authenticate",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.test('401 with resource_metadata challenge', () => {",
+                          "  pm.response.to.have.status(401);",
+                          "  pm.expect(pm.response.headers.get('WWW-Authenticate')).to.include('resource_metadata=');",
+                          "});"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"ping\"\n}"
+                    },
+                    "description": "No credential on purpose: the MCP plane answers 401 + WWW-Authenticate: Bearer resource_metadata=\"...\" so MCP clients bootstrap the OAuth flow."
+                  }
+                },
+                {
+                  "name": "Protected resource metadata, path-scoped (RFC 9728)",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "GET",
+                    "url": "{{mcp_url}}/.well-known/oauth-protected-resource/{{consumer_slug}}/mcp",
+                    "description": "Document scoped to this virtual MCP path ({{consumer_slug}}/mcp): authorization_servers lists the Okta issuer of the oauth2 auth attached to the consumer, and scopes_supported reflects only that auth."
+                  }
+                },
+                {
+                  "name": "Authorization server metadata (RFC 8414)",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "GET",
+                    "url": "{{mcp_url}}/.well-known/oauth-authorization-server",
+                    "description": "The gateway advertises itself as the authorization server (AS facade): authorize/token/register point at the gateway, which brokers to Okta. With several distinct issuers enabled, clients must pass the RFC 8707 resource parameter (the virtual MCP URL) on authorize/token so the facade picks the right IdP."
+                  }
+                },
+                {
+                  "name": "Dynamic client registration (RFC 7591)",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/oauth/register",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"client_name\": \"postman\",\n  \"redirect_uris\": [\"http://localhost:1234/callback\"],\n  \"grant_types\": [\"authorization_code\"],\n  \"response_types\": [\"code\"],\n  \"token_endpoint_auth_method\": \"none\"\n}"
+                    },
+                    "description": "Returns the registered public client (PKCE). 400 if the resolved oauth2 auth has no client_id configured."
+                  }
+                },
+                {
+                  "name": "Authorize redirects to Okta (sanity check)",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.test('302 to Okta with scope and PKCE', () => {",
+                          "  pm.response.to.have.status(302);",
+                          "  const loc = pm.response.headers.get('Location') || '';",
+                          "  pm.expect(loc).to.include(pm.variables.get('okta_domain'));",
+                          "  pm.expect(loc).to.include('scope=');",
+                          "  pm.expect(loc).to.include('code_challenge=');",
+                          "});",
+                          "console.log('Location:', pm.response.headers.get('Location'));"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "protocolProfileBehavior": {
+                    "followRedirects": false
+                  },
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "GET",
+                    "url": "{{mcp_url}}/oauth/authorize?response_type=code&client_id={{okta_client_id}}&redirect_uri=http%3A%2F%2Flocalhost%3A1234%2Fcallback&state=sanity&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM&code_challenge_method=S256&resource={{mcp_url}}%2F{{consumer_slug}}%2Fmcp",
+                    "description": "Replays the first leg of the browser flow without a browser. The Location header must point at the Okta authorization server AND carry a scope parameter ({{okta_scope}}) and the PKCE code_challenge. The resource parameter (RFC 8707, the virtual MCP URL) selects which consumer's IdP brokers the flow - required when several issuers are enabled, optional with one."
+                  }
+                },
+                {
+                  "name": "Get Okta token (client credentials)",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "const res = pm.response.json();",
+                          "pm.test('access token issued', () => pm.expect(res.access_token).to.be.a('string'));",
+                          "if (res.access_token) {",
+                          "  pm.environment.set('okta_bearer_token', res.access_token);",
+                          "  let b64 = res.access_token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');",
+                          "  while (b64.length % 4) b64 += '=';",
+                          "  const claims = JSON.parse(atob(b64));",
+                          "  console.log('token claims', { iss: claims.iss, aud: claims.aud, sub: claims.sub, scp: claims.scp });",
+                          "  pm.test('issuer matches the Okta authorization server', () => pm.expect(claims.iss).to.include('/oauth2/'));",
+                          "}"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [],
+                    "url": "https://{{okta_domain}}/oauth2/{{okta_auth_server_id}}/v1/token",
+                    "body": {
+                      "mode": "urlencoded",
+                      "urlencoded": [
+                        {
+                          "key": "grant_type",
+                          "value": "client_credentials"
+                        },
+                        {
+                          "key": "client_id",
+                          "value": "{{okta_client_id}}"
+                        },
+                        {
+                          "key": "client_secret",
+                          "value": "{{okta_client_secret}}"
+                        },
+                        {
+                          "key": "scope",
+                          "value": "{{okta_scope}}"
+                        }
+                      ]
+                    },
+                    "description": "M2M token for Postman testing, captured into {{okta_bearer_token}}. The scope MUST be a custom scope defined on the authorization server and granted to this app; openid/profile/email are user-only and won't work for client_credentials. The aud equals the authorization server audience ({{okta_audience}}). For a real USER token (browser/device-code) the same token validates - this step only avoids the interactive browser leg in Postman."
+                  }
+                },
+                {
+                  "name": "tools/list with Okta JWT",
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{okta_bearer_token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 2,\n  \"method\": \"tools/list\"\n}"
+                    },
+                    "description": "Path-first: the request path resolves the consumer, then the token is validated against the consumer's ATTACHED oauth2 auth (signature via JWKS, issuer, audience, required_scopes)."
+                  }
+                },
+                {
+                  "name": "tools/call with Okta JWT",
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{okta_bearer_token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 3,\n  \"method\": \"tools/call\",\n  \"params\": {\n    \"name\": \"read_wiki_structure\",\n    \"arguments\": { \"repoName\": \"gofiber/fiber\" }\n  }\n}"
+                    }
+                  }
+                },
+                {
+                  "name": "Invalid JWT is rejected (anti-downgrade)",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.test('401 with challenge, no API-key fallback', () => {",
+                          "  pm.response.to.have.status(401);",
+                          "  pm.expect(pm.response.headers.get('WWW-Authenticate')).to.include('resource_metadata=');",
+                          "});"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "Authorization",
+                        "value": "Bearer eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJodHRwczovL2V2aWwuZXhhbXBsZS5jb20ifQ.invalid"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 4,\n  \"method\": \"ping\"\n}"
+                    },
+                    "description": "Sends a bogus Bearer token AND a valid API key: the chain takes the Bearer path first and fails without falling back to the API key (anti-downgrade by design)."
+                  }
+                },
+                {
+                  "name": "Cleanup: delete consumer",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}"
+                  }
+                },
+                {
+                  "name": "Cleanup: delete registry",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries/{{registry_id}}"
+                  }
+                },
+                {
+                  "name": "Cleanup: delete oauth2 auth",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths/{{oauth2_auth_id}}",
+                    "description": "Frees the (issuer, audience) pair so other oauth2 folders can create their own Okta auth without a 409. Detach order: consumer first (else the auth is still referenced)."
+                  }
+                },
+                {
+                  "name": "Cleanup: delete api_key auth",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths/{{auth_id}}"
+                  }
+                },
+                {
+                  "name": "Cleanup: delete gateway",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}",
+                    "description": "Children first, gateway last (else 409)."
+                  }
+                }
+              ]
             },
             {
-              "name": "Cleanup: delete registry",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries/{{registry_id}}"
-              }
+              "name": "9. Flow I - GitHub MCP (oauth2 inbound + forwarded upstream, NO role)",
+              "description": "Minimal provisioning, no roles. Four admin steps as requested:\n1. Create registry -> GitHub (MCP, forwarded upstream GitHub OAuth).\n2. Create auth type oauth2 -> GitHub (inbound, session_mode for GitHub's opaque tokens).\n3. Create consumer (type MCP).\n4. Associate auth + registry to the consumer.\n(A gateway is created first as the parent container, and Cleanup deletes everything at the end.)\n\nPrereqs: a GitHub OAuth app. Set github_client_id / github_client_secret. Authorization callback URL = {{mcp_url}}/oauth/callback (inbound) and {{mcp_url}}/oauth/callback/github (upstream) - register both.\n\nHEADS-UP about the inbound oauth2 -> GitHub: creation of all four resources succeeds (the admin API accepts a session_mode GitHub auth). But the runtime interactive login at GET /oauth/authorize resolves the IdP's authorize/token endpoints via issuer discovery ({issuer}/.well-known/oauth-authorization-server then /openid-configuration). github.com returns 404 on both (verified), so the browser login leg fails with 'lacks authorization/token endpoints' (HTTP 500) until the gateway gains a way to set authorize_url/token_url for inbound (today only the upstream/forwarded leg has those). M2M (Bearer-token) inbound is unaffected. The four resources below are still created exactly as asked.",
+              "item": [
+                {
+                  "name": "Create gateway",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.environment.set('gateway_id', pm.response.json().id);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"tenant_id\": \"{{tenant_id}}\",\n  \"entitlements\": {\n    \"tier\": \"free\",\n    \"burst_per_min\": 60,\n    \"quota_per_month\": 10000,\n    \"max_instances\": 5\n  },\n  \"name\": \"flow-i-github\"\n}"
+                    }
+                  }
+                },
+                {
+                  "name": "1. Create registry -> GitHub (MCP, forwarded upstream)",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.environment.set('registry_id', pm.response.json().id);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"name\": \"github-mcp\",\n  \"type\": \"MCP\",\n  \"mcp_target\": {\n    \"url\": \"https://api.githubcopilot.com/mcp/\",\n    \"transport\": \"streamable-http\",\n    \"auth\": {\n      \"mode\": \"forwarded\",\n      \"provider\": \"github\",\n      \"registration\": \"manual\",\n      \"client_id\": \"{{github_client_id}}\",\n      \"client_secret\": \"{{github_client_secret}}\",\n      \"authorize_url\": \"https://github.com/login/oauth/authorize\",\n      \"token_url\": \"https://github.com/login/oauth/access_token\",\n      \"scopes\": [\"repo\", \"read:org\", \"read:user\", \"user:email\"],\n      \"resource\": \"https://api.githubcopilot.com/mcp/\"\n    }\n  }\n}"
+                    },
+                    "description": "UPSTREAM GitHub OAuth. forwarded + manual: the gateway drives a per-user authorization-code flow against your GitHub OAuth app (github.com publishes no discovery, hence explicit authorize_url/token_url). GitHub app Authorization callback URL must be {{mcp_url}}/oauth/callback/github. client_secret is write-only (reads return it masked)."
+                  }
+                },
+                {
+                  "name": "2. Create auth type oauth2 -> GitHub (inbound, session_mode)",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.environment.set('oauth2_auth_id', pm.response.json().id);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"name\": \"github\",\n  \"type\": \"oauth2\",\n  \"config\": {\n    \"oauth2\": {\n      \"issuer\": \"https://github.com\",\n      \"audiences\": [\"{{mcp_url}}\"],\n      \"client_id\": \"{{github_client_id}}\",\n      \"client_secret\": \"{{github_client_secret}}\",\n      \"session_mode\": true,\n      \"userinfo_url\": \"https://api.github.com/user\",\n      \"subject_claim\": \"id\",\n      \"authorize_url\": \"https://github.com/login/oauth/authorize\",\n      \"token_url\": \"https://github.com/login/oauth/access_token\",\n      \"required_scopes\": [\"read:user\"]\n    }\n  }\n}"
+                    },
+                    "description": "INBOUND oauth2 -> GitHub. GitHub publishes no authorization-server discovery, so authorize_url/token_url are pinned explicitly (the gateway skips the {issuer}/.well-known lookup when both are set). session_mode mints gateway session tokens from GitHub's opaque access tokens; subject_claim=id reads the stable user id from userinfo_url. GitHub OAuth app Authorization callback URL must be {{mcp_url}}/oauth/callback. client_id is required (pre-registered client). 409 means another ENABLED oauth2 auth already covers this (issuer, audience). For a discovery-capable IdP (Okta/Entra/Auth0/Google) omit authorize_url/token_url/session_mode and just set issuer + jwks_url."
+                  }
+                },
+                {
+                  "name": "3. Create consumer (type MCP)",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.environment.set('consumer_id', pm.response.json().id);",
+                          "pm.environment.set('consumer_slug', pm.response.json().slug);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"name\": \"flow-i-github\",\n  \"type\": \"MCP\",\n  \"fail_mode\": \"closed\"\n}"
+                    }
+                  }
+                },
+                {
+                  "name": "4. Associate auth to consumer",
+                  "request": {
+                    "method": "POST",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/auths/{{oauth2_auth_id}}"
+                  }
+                },
+                {
+                  "name": "4. Associate registry to consumer",
+                  "request": {
+                    "method": "POST",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/registries/{{registry_id}}"
+                  }
+                },
+                {
+                  "name": "Cleanup: delete consumer",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}"
+                  }
+                },
+                {
+                  "name": "Cleanup: delete GitHub registry",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries/{{registry_id}}"
+                  }
+                },
+                {
+                  "name": "Cleanup: delete oauth2 auth",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths/{{oauth2_auth_id}}"
+                  }
+                },
+                {
+                  "name": "Cleanup: delete gateway",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}"
+                  }
+                }
+              ]
             },
             {
-              "name": "Cleanup: delete api_key auth",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths/{{auth_id}}"
-              }
-            },
-            {
-              "name": "Cleanup: delete gateway",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}"
-              }
+              "name": "10. Diagnostics (standalone)",
+              "description": "Utilities that need no setup of their own. The id-based requests (introspect/get) read whatever {{gateway_id}}/{{registry_id}}/{{consumer_id}} the last-run flow stored - run them mid-flow, before that flow's Cleanup.",
+              "item": [
+                {
+                  "name": "List gateways (spot stale oauth2 auths)",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "const gateways = pm.response.json();",
+                          "console.log('Existing gateways:', gateways.map(g => g.id + ' (' + g.slug + ')'));",
+                          "console.log('Multiple gateways may share an IdP, but no two ENABLED oauth2 auths may cover the same (issuer, audience) pair - the admin API rejects that with 409.');",
+                          "console.log('If an old gateway still has an enabled oauth2 auth with the same Entra issuer AND audience, delete it (or scope it with a different audience) before running an Entra flow.');"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "GET",
+                    "url": "{{admin_url}}/v1/gateways",
+                    "description": "Lists gateways so you can spot leftovers from earlier flows that skipped their Cleanup. Stale enabled oauth2 auth entries sharing the Entra (issuer, audience) block the Entra folders with 409."
+                  }
+                },
+                {
+                  "name": "Introspect registry tools (admin)",
+                  "request": {
+                    "method": "GET",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries/{{registry_id}}/tools",
+                    "description": "Lists the upstream's tools using the registry's configured credential. Works for auth modes none/static; forwarded-mode registries have no service-level credential, so introspection is empty until a principal links an account."
+                  }
+                },
+                {
+                  "name": "MCP servers catalog",
+                  "request": {
+                    "method": "GET",
+                    "url": "{{admin_url}}/v1/mcp-servers-catalog",
+                    "description": "Curated list of well-known remote MCP servers with auth hints (none/static/oauth)."
+                  }
+                },
+                {
+                  "name": "Get consumer (verify toolkit + fail_mode)",
+                  "request": {
+                    "method": "GET",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}"
+                  }
+                },
+                {
+                  "name": "Get registry (verify mcp_target, secrets masked)",
+                  "request": {
+                    "method": "GET",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries/{{registry_id}}"
+                  }
+                },
+                {
+                  "name": "MCP plane health (no auth)",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "GET",
+                    "url": "{{mcp_url}}/healthz"
+                  }
+                }
+              ]
             }
           ]
         },
         {
-          "name": "8. Flow H - Inbound OAuth + discovery (Okta)",
-          "description": "Self-contained. Interactive MCP login brokered through Okta as the identity provider: gateway -> oauth2 auth (Okta) -> DeepWiki registry -> MCP consumer -> the OAuth 2.1 discovery surface an MCP client (Cursor) replays automatically -> M2M-authenticated JSON-RPC -> anti-downgrade -> cleanup.\n\nConsumers have NO path field: the server assigns a random slug on create and the virtual MCP endpoint is {{mcp_url}}/{slug}/mcp. The 'Create MCP consumer' step captures it into {{consumer_slug}}.\n\nWhy `oauth2` and not `oidc`? For MCP, the gateway BROKERS the browser authorization-code flow (the client has no Okta token yet): it needs client_id + client_secret to drive Okta, which only the `oauth2` auth type carries. An `oidc` auth only VALIDATES a token the caller already has (LLM proxy), so an MCP consumer is rejected if you attach an `oidc` auth. 'Okta as IDP' here means Okta is the identity provider behind an `oauth2` auth.\n\nRole-based variant: an MCP consumer may also be role_based; it still requires exactly one `oauth2` auth, plus a role whose oidc_mapping matches the Okta token claims (see 'E2E Role-Based Flow (Okta / IDP)' for the role + oidc_mapping shape). This folder uses an inline MCP consumer to keep the OAuth surface front and center.\n\nSet before running: `okta_domain` (e.g. dev-12345.okta.com, no scheme), `okta_auth_server_id` (e.g. `default`), `okta_client_id`, `okta_client_secret`, `okta_scope` (a custom scope exposed AND granted on the authorization server, e.g. `mcp.access`) and `okta_audience` (the authorization server audience, e.g. `api://default`).\n\nOkta app prerequisites (skipping any makes Cursor loop on 'Authenticating...'): 1) an Authorization Server (Security > API) with a custom scope = {{okta_scope}} and audience = {{okta_audience}}; 2) an OIDC app with the Authorization Code grant and a Web redirect URI {{mcp_url}}/oauth/callback; 3) for the M2M test step below, the Client Credentials grant enabled and the scope granted to the app. The gateway validates the Okta JWT via JWKS; the client_secret is only used to broker the browser flow.\n\nNOTE: only one ENABLED oauth2 auth may cover the same (issuer, audience) pair on the plane - run another oauth2 folder's Cleanup first or 'Create oauth2 auth (Okta)' answers 409.",
+          "name": "MCP 2026-07-28",
+          "description": "Stateless MCP 2026-07-28 northbound examples. Modern responses must not include Mcp-Session-Id.",
           "item": [
             {
-              "name": "Create gateway",
-              "event": [
+              "name": "0. Setup (reuse Flow A objects)",
+              "item": [
                 {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.environment.set('gateway_id', pm.response.json().id);"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"tenant_id\": \"{{tenant_id}}\",\n  \"entitlements\": {\n    \"tier\": \"free\",\n    \"burst_per_min\": 60,\n    \"quota_per_month\": 10000,\n    \"max_instances\": 5\n  },\n  \"name\": \"flow-h-okta\"\n}"
-                }
-              }
-            },
-            {
-              "name": "Create oauth2 auth (Okta)",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test('oauth2 auth created', () => pm.response.code === 201);",
-                      "if (pm.response.code === 201) pm.environment.set('oauth2_auth_id', pm.response.json().id);"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"name\": \"okta\",\n  \"type\": \"oauth2\",\n  \"config\": {\n    \"oauth2\": {\n      \"issuer\": \"https://{{okta_domain}}/oauth2/{{okta_auth_server_id}}\",\n      \"audiences\": [\"{{okta_audience}}\"],\n      \"jwks_url\": \"https://{{okta_domain}}/oauth2/{{okta_auth_server_id}}/v1/keys\",\n      \"client_id\": \"{{okta_client_id}}\",\n      \"client_secret\": \"{{okta_client_secret}}\",\n      \"required_scopes\": [\"{{okta_scope}}\"]\n    }\n  }\n}"
-                },
-                "description": "issuer must equal the token's iss claim exactly (the authorization server base URL, https://{domain}/oauth2/{authServerId}). jwks_url is the server's signing keys ({issuer}/v1/keys); it can be omitted to let the gateway resolve it via OIDC discovery. client_id + client_secret let the AS facade broker the browser authorization-code flow against Okta (redirect URI {{mcp_url}}/oauth/callback must be a Web redirect on the Okta app). required_scopes must be a custom scope EXPOSED on the authorization server (Okta rejects unknown scopes; openid/profile/email are user-only). audiences must match the token aud (the authorization server audience, default api://default). 409 means another ENABLED oauth2 auth already covers this (issuer, audience): run that folder's Cleanup or scope this one with a distinct audience."
-              }
-            },
-            {
-              "name": "Create api_key auth (for anti-downgrade demo)",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "const res = pm.response.json();",
-                      "pm.environment.set('auth_id', res.id);",
-                      "pm.environment.set('api_key', res.api_key);"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"name\": \"flow-h-key\",\n  \"type\": \"api_key\",\n  \"config\": {}\n}"
-                },
-                "description": "Used only by 'Invalid JWT is rejected' to prove the chain never falls back from a failed Bearer to a valid API key."
-              }
-            },
-            {
-              "name": "Create MCP registry (DeepWiki, auth none)",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.environment.set('registry_id', pm.response.json().id);"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"name\": \"deepwiki\",\n  \"type\": \"MCP\",\n  \"mcp_target\": {\n    \"url\": \"https://mcp.deepwiki.com/mcp\",\n    \"transport\": \"streamable-http\"\n  }\n}"
-                }
-              }
-            },
-            {
-              "name": "Create MCP consumer (captures slug)",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "const res = pm.response.json();",
-                      "pm.environment.set('consumer_id', res.id);",
-                      "pm.environment.set('consumer_slug', res.slug);",
-                      "console.log('MCP endpoint:', pm.variables.get('mcp_url') + '/' + res.slug + '/mcp');"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"name\": \"flow-h-okta\",\n  \"type\": \"MCP\",\n  \"fail_mode\": \"closed\"\n}"
-                },
-                "description": "Consumers have no path: the server assigns a random slug and the MCP endpoint is {{mcp_url}}/{slug}/mcp. The test captures the slug into {{consumer_slug}}; every MCP call below addresses {{mcp_url}}/{{consumer_slug}}/mcp.\n\nFor the role-based variant add \"routing_mode\": \"role_based\" here, then create a role with an oidc_mapping over the Okta claims and attach it - the oauth2 auth stays the same."
-              }
-            },
-            {
-              "name": "Attach oauth2 auth to consumer",
-              "request": {
-                "method": "POST",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/auths/{{oauth2_auth_id}}",
-                "description": "Path-first resolution: only auths ATTACHED to the consumer can authenticate or broker requests to {{mcp_url}}/{{consumer_slug}}/mcp."
-              }
-            },
-            {
-              "name": "Attach api_key auth to consumer",
-              "request": {
-                "method": "POST",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/auths/{{auth_id}}"
-              }
-            },
-            {
-              "name": "Attach registry to consumer",
-              "request": {
-                "method": "POST",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/registries/{{registry_id}}"
-              }
-            },
-            {
-              "name": "401 challenge carries WWW-Authenticate",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test('401 with resource_metadata challenge', () => {",
-                      "  pm.response.to.have.status(401);",
-                      "  pm.expect(pm.response.headers.get('WWW-Authenticate')).to.include('resource_metadata=');",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"ping\"\n}"
-                },
-                "description": "No credential on purpose: the MCP plane answers 401 + WWW-Authenticate: Bearer resource_metadata=\"...\" so MCP clients bootstrap the OAuth flow."
-              }
-            },
-            {
-              "name": "Protected resource metadata, path-scoped (RFC 9728)",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "GET",
-                "url": "{{mcp_url}}/.well-known/oauth-protected-resource/{{consumer_slug}}/mcp",
-                "description": "Document scoped to this virtual MCP path ({{consumer_slug}}/mcp): authorization_servers lists the Okta issuer of the oauth2 auth attached to the consumer, and scopes_supported reflects only that auth."
-              }
-            },
-            {
-              "name": "Authorization server metadata (RFC 8414)",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "GET",
-                "url": "{{mcp_url}}/.well-known/oauth-authorization-server",
-                "description": "The gateway advertises itself as the authorization server (AS facade): authorize/token/register point at the gateway, which brokers to Okta. With several distinct issuers enabled, clients must pass the RFC 8707 resource parameter (the virtual MCP URL) on authorize/token so the facade picks the right IdP."
-              }
-            },
-            {
-              "name": "Dynamic client registration (RFC 7591)",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{mcp_url}}/oauth/register",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"client_name\": \"postman\",\n  \"redirect_uris\": [\"http://localhost:1234/callback\"],\n  \"grant_types\": [\"authorization_code\"],\n  \"response_types\": [\"code\"],\n  \"token_endpoint_auth_method\": \"none\"\n}"
-                },
-                "description": "Returns the registered public client (PKCE). 400 if the resolved oauth2 auth has no client_id configured."
-              }
-            },
-            {
-              "name": "Authorize redirects to Okta (sanity check)",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test('302 to Okta with scope and PKCE', () => {",
-                      "  pm.response.to.have.status(302);",
-                      "  const loc = pm.response.headers.get('Location') || '';",
-                      "  pm.expect(loc).to.include(pm.variables.get('okta_domain'));",
-                      "  pm.expect(loc).to.include('scope=');",
-                      "  pm.expect(loc).to.include('code_challenge=');",
-                      "});",
-                      "console.log('Location:', pm.response.headers.get('Location'));"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "protocolProfileBehavior": {
-                "followRedirects": false
-              },
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "GET",
-                "url": "{{mcp_url}}/oauth/authorize?response_type=code&client_id={{okta_client_id}}&redirect_uri=http%3A%2F%2Flocalhost%3A1234%2Fcallback&state=sanity&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM&code_challenge_method=S256&resource={{mcp_url}}%2F{{consumer_slug}}%2Fmcp",
-                "description": "Replays the first leg of the browser flow without a browser. The Location header must point at the Okta authorization server AND carry a scope parameter ({{okta_scope}}) and the PKCE code_challenge. The resource parameter (RFC 8707, the virtual MCP URL) selects which consumer's IdP brokers the flow - required when several issuers are enabled, optional with one."
-              }
-            },
-            {
-              "name": "Get Okta token (client credentials)",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "const res = pm.response.json();",
-                      "pm.test('access token issued', () => pm.expect(res.access_token).to.be.a('string'));",
-                      "if (res.access_token) {",
-                      "  pm.environment.set('okta_bearer_token', res.access_token);",
-                      "  let b64 = res.access_token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');",
-                      "  while (b64.length % 4) b64 += '=';",
-                      "  const claims = JSON.parse(atob(b64));",
-                      "  console.log('token claims', { iss: claims.iss, aud: claims.aud, sub: claims.sub, scp: claims.scp });",
-                      "  pm.test('issuer matches the Okta authorization server', () => pm.expect(claims.iss).to.include('/oauth2/'));",
-                      "}"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [],
-                "url": "https://{{okta_domain}}/oauth2/{{okta_auth_server_id}}/v1/token",
-                "body": {
-                  "mode": "urlencoded",
-                  "urlencoded": [
+                  "name": "Create gateway",
+                  "event": [
                     {
-                      "key": "grant_type",
-                      "value": "client_credentials"
-                    },
-                    {
-                      "key": "client_id",
-                      "value": "{{okta_client_id}}"
-                    },
-                    {
-                      "key": "client_secret",
-                      "value": "{{okta_client_secret}}"
-                    },
-                    {
-                      "key": "scope",
-                      "value": "{{okta_scope}}"
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.environment.set('gateway_id', pm.response.json().id);"
+                        ],
+                        "type": "text/javascript"
+                      }
                     }
-                  ]
-                },
-                "description": "M2M token for Postman testing, captured into {{okta_bearer_token}}. The scope MUST be a custom scope defined on the authorization server and granted to this app; openid/profile/email are user-only and won't work for client_credentials. The aud equals the authorization server audience ({{okta_audience}}). For a real USER token (browser/device-code) the same token validates - this step only avoids the interactive browser leg in Postman."
-              }
-            },
-            {
-              "name": "tools/list with Okta JWT",
-              "request": {
-                "auth": {
-                  "type": "bearer",
-                  "bearer": [
-                    {
-                      "key": "token",
-                      "value": "{{okta_bearer_token}}",
-                      "type": "string"
-                    }
-                  ]
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 2,\n  \"method\": \"tools/list\"\n}"
-                },
-                "description": "Path-first: the request path resolves the consumer, then the token is validated against the consumer's ATTACHED oauth2 auth (signature via JWKS, issuer, audience, required_scopes)."
-              }
-            },
-            {
-              "name": "tools/call with Okta JWT",
-              "request": {
-                "auth": {
-                  "type": "bearer",
-                  "bearer": [
-                    {
-                      "key": "token",
-                      "value": "{{okta_bearer_token}}",
-                      "type": "string"
-                    }
-                  ]
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 3,\n  \"method\": \"tools/call\",\n  \"params\": {\n    \"name\": \"read_wiki_structure\",\n    \"arguments\": { \"repoName\": \"gofiber/fiber\" }\n  }\n}"
-                }
-              }
-            },
-            {
-              "name": "Invalid JWT is rejected (anti-downgrade)",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test('401 with challenge, no API-key fallback', () => {",
-                      "  pm.response.to.have.status(401);",
-                      "  pm.expect(pm.response.headers.get('WWW-Authenticate')).to.include('resource_metadata=');",
-                      "});"
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
                     ],
-                    "type": "text/javascript"
+                    "url": "{{admin_url}}/v1/gateways",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"tenant_id\": \"{{tenant_id}}\",\n  \"entitlements\": {\n    \"tier\": \"free\",\n    \"burst_per_min\": 60,\n    \"quota_per_month\": 10000,\n    \"max_instances\": 5\n  },\n  \"name\": \"flow-a-simple\"\n}"
+                    },
+                    "description": "Optionally add \"domain\": \"tenant-a.gw.example.com\" (bare hostname) for host-based tenant isolation: requests carrying that Host header resolve against this gateway only. Domains are unique across gateways. Ownership tenant_id is required (JWT claim or body for platform admins)."
+                  }
+                },
+                {
+                  "name": "Create api_key auth",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "const res = pm.response.json();",
+                          "pm.environment.set('auth_id', res.id);",
+                          "pm.environment.set('api_key', res.api_key);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"name\": \"flow-a-key\",\n  \"type\": \"api_key\",\n  \"config\": {}\n}"
+                    },
+                    "description": "The api_key value is only returned once, on create; the test script stores it in {{api_key}}."
+                  }
+                },
+                {
+                  "name": "Create MCP registry (DeepWiki, auth none)",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.environment.set('registry_id', pm.response.json().id);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"name\": \"deepwiki\",\n  \"type\": \"MCP\",\n  \"mcp_target\": {\n    \"url\": \"https://mcp.deepwiki.com/mcp\",\n    \"transport\": \"streamable-http\"\n  }\n}"
+                    }
+                  }
+                },
+                {
+                  "name": "Create MCP consumer",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "pm.environment.set('consumer_id', pm.response.json().id);",
+                          "pm.environment.set('consumer_slug', pm.response.json().slug);"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"name\": \"flow-a-simple\",\n  \"type\": \"MCP\",\n  \"fail_mode\": \"closed\"\n}"
+                    }
+                  }
+                },
+                {
+                  "name": "Attach auth to consumer",
+                  "request": {
+                    "method": "POST",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/auths/{{auth_id}}"
+                  }
+                },
+                {
+                  "name": "Attach registry to consumer",
+                  "request": {
+                    "method": "POST",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/registries/{{registry_id}}"
                   }
                 }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
+              ]
+            },
+            {
+              "name": "Happy path",
+              "item": [
+                {
+                  "name": "server/discover",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      },
+                      {
+                        "key": "MCP-Protocol-Version",
+                        "value": "{{mcp_protocol_version}}"
+                      },
+                      {
+                        "key": "Mcp-Method",
+                        "value": "server/discover"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"server/discover\",\n  \"params\": {\n    \"_meta\": {\n      \"io.modelcontextprotocol/protocolVersion\": \"{{mcp_protocol_version}}\",\n      \"io.modelcontextprotocol/clientCapabilities\": {}\n    }\n  }\n}"
+                    }
                   },
-                  {
-                    "key": "Authorization",
-                    "value": "Bearer eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJodHRwczovL2V2aWwuZXhhbXBsZS5jb20ifQ.invalid"
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('HTTP 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "pm.test('JSON-RPC result present', function () { pm.expect(body.error).to.eql(undefined); pm.expect(body.result).to.be.an('object'); });",
+                          "pm.test('modern responses omit Mcp-Session-Id', function () {",
+                          "  pm.expect(pm.response.headers.get('Mcp-Session-Id')).to.eql(undefined);",
+                          "});",
+                          "pm.test('modern list cache hints', function () {",
+                          "  const r = pm.response.json().result;",
+                          "  pm.expect(r.resultType).to.eql('complete');",
+                          "  pm.expect(r.ttlMs).to.eql(300000);",
+                          "  pm.expect(r.cacheScope).to.eql('private');",
+                          "});",
+                          "pm.test('supportedVersions includes 2026-07-28', function () {",
+                          "  pm.expect(pm.response.json().result.supportedVersions).to.include('2026-07-28');",
+                          "});"
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "name": "tools/list",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      },
+                      {
+                        "key": "MCP-Protocol-Version",
+                        "value": "{{mcp_protocol_version}}"
+                      },
+                      {
+                        "key": "Mcp-Method",
+                        "value": "tools/list"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"tools/list\",\n  \"params\": {\n    \"_meta\": {\n      \"io.modelcontextprotocol/protocolVersion\": \"{{mcp_protocol_version}}\",\n      \"io.modelcontextprotocol/clientCapabilities\": {}\n    }\n  }\n}"
+                    }
                   },
-                  {
-                    "key": "X-AG-API-Key",
-                    "value": "{{api_key}}"
-                  }
-                ],
-                "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 4,\n  \"method\": \"ping\"\n}"
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('HTTP 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "pm.test('JSON-RPC result present', function () { pm.expect(body.error).to.eql(undefined); pm.expect(body.result).to.be.an('object'); });",
+                          "pm.test('modern responses omit Mcp-Session-Id', function () {",
+                          "  pm.expect(pm.response.headers.get('Mcp-Session-Id')).to.eql(undefined);",
+                          "});",
+                          "pm.test('modern list cache hints', function () {",
+                          "  const r = pm.response.json().result;",
+                          "  pm.expect(r.resultType).to.eql('complete');",
+                          "  pm.expect(r.ttlMs).to.eql(300000);",
+                          "  pm.expect(r.cacheScope).to.eql('private');",
+                          "});"
+                        ]
+                      }
+                    }
+                  ]
                 },
-                "description": "Sends a bogus Bearer token AND a valid API key: the chain takes the Bearer path first and fails without falling back to the API key (anti-downgrade by design)."
-              }
-            },
-            {
-              "name": "Cleanup: delete consumer",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}"
-              }
-            },
-            {
-              "name": "Cleanup: delete registry",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries/{{registry_id}}"
-              }
-            },
-            {
-              "name": "Cleanup: delete oauth2 auth",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths/{{oauth2_auth_id}}",
-                "description": "Frees the (issuer, audience) pair so other oauth2 folders can create their own Okta auth without a 409. Detach order: consumer first (else the auth is still referenced)."
-              }
-            },
-            {
-              "name": "Cleanup: delete api_key auth",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths/{{auth_id}}"
-              }
-            },
-            {
-              "name": "Cleanup: delete gateway",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}",
-                "description": "Children first, gateway last (else 409)."
-              }
-            }
-          ]
-        },
-        {
-          "name": "9. Flow I - GitHub MCP (oauth2 inbound + forwarded upstream, NO role)",
-          "description": "Minimal provisioning, no roles. Four admin steps as requested:\n1. Create registry -> GitHub (MCP, forwarded upstream GitHub OAuth).\n2. Create auth type oauth2 -> GitHub (inbound, session_mode for GitHub's opaque tokens).\n3. Create consumer (type MCP).\n4. Associate auth + registry to the consumer.\n(A gateway is created first as the parent container, and Cleanup deletes everything at the end.)\n\nPrereqs: a GitHub OAuth app. Set github_client_id / github_client_secret. Authorization callback URL = {{mcp_url}}/oauth/callback (inbound) and {{mcp_url}}/oauth/callback/github (upstream) - register both.\n\nHEADS-UP about the inbound oauth2 -> GitHub: creation of all four resources succeeds (the admin API accepts a session_mode GitHub auth). But the runtime interactive login at GET /oauth/authorize resolves the IdP's authorize/token endpoints via issuer discovery ({issuer}/.well-known/oauth-authorization-server then /openid-configuration). github.com returns 404 on both (verified), so the browser login leg fails with 'lacks authorization/token endpoints' (HTTP 500) until the gateway gains a way to set authorize_url/token_url for inbound (today only the upstream/forwarded leg has those). M2M (Bearer-token) inbound is unaffected. The four resources below are still created exactly as asked.",
-          "item": [
-            {
-              "name": "Create gateway",
-              "event": [
                 {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.environment.set('gateway_id', pm.response.json().id);"
+                  "name": "tools/call read_wiki_structure",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      },
+                      {
+                        "key": "MCP-Protocol-Version",
+                        "value": "{{mcp_protocol_version}}"
+                      },
+                      {
+                        "key": "Mcp-Method",
+                        "value": "tools/call"
+                      },
+                      {
+                        "key": "Mcp-Name",
+                        "value": "read_wiki_structure"
+                      }
                     ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"tenant_id\": \"{{tenant_id}}\",\n  \"entitlements\": {\n    \"tier\": \"free\",\n    \"burst_per_min\": 60,\n    \"quota_per_month\": 10000,\n    \"max_instances\": 5\n  },\n  \"name\": \"flow-i-github\"\n}"
-                }
-              }
-            },
-            {
-              "name": "1. Create registry -> GitHub (MCP, forwarded upstream)",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.environment.set('registry_id', pm.response.json().id);"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"name\": \"github-mcp\",\n  \"type\": \"MCP\",\n  \"mcp_target\": {\n    \"url\": \"https://api.githubcopilot.com/mcp/\",\n    \"transport\": \"streamable-http\",\n    \"auth\": {\n      \"mode\": \"forwarded\",\n      \"provider\": \"github\",\n      \"registration\": \"manual\",\n      \"client_id\": \"{{github_client_id}}\",\n      \"client_secret\": \"{{github_client_secret}}\",\n      \"authorize_url\": \"https://github.com/login/oauth/authorize\",\n      \"token_url\": \"https://github.com/login/oauth/access_token\",\n      \"scopes\": [\"repo\", \"read:org\", \"read:user\", \"user:email\"],\n      \"resource\": \"https://api.githubcopilot.com/mcp/\"\n    }\n  }\n}"
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"tools/call\",\n  \"params\": {\n    \"_meta\": {\n      \"io.modelcontextprotocol/protocolVersion\": \"{{mcp_protocol_version}}\",\n      \"io.modelcontextprotocol/clientCapabilities\": {}\n    },\n    \"name\": \"read_wiki_structure\",\n    \"arguments\": {\n      \"repoName\": \"microsoft/vscode\"\n    }\n  }\n}"
+                    }
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('HTTP 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "pm.test('JSON-RPC result present', function () { pm.expect(body.error).to.eql(undefined); pm.expect(body.result).to.be.an('object'); });",
+                          "pm.test('modern responses omit Mcp-Session-Id', function () {",
+                          "  pm.expect(pm.response.headers.get('Mcp-Session-Id')).to.eql(undefined);",
+                          "});"
+                        ]
+                      }
+                    }
+                  ]
                 },
-                "description": "UPSTREAM GitHub OAuth. forwarded + manual: the gateway drives a per-user authorization-code flow against your GitHub OAuth app (github.com publishes no discovery, hence explicit authorize_url/token_url). GitHub app Authorization callback URL must be {{mcp_url}}/oauth/callback/github. client_secret is write-only (reads return it masked)."
-              }
-            },
-            {
-              "name": "2. Create auth type oauth2 -> GitHub (inbound, session_mode)",
-              "event": [
                 {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.environment.set('oauth2_auth_id', pm.response.json().id);"
+                  "name": "resources/list",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      },
+                      {
+                        "key": "MCP-Protocol-Version",
+                        "value": "{{mcp_protocol_version}}"
+                      },
+                      {
+                        "key": "Mcp-Method",
+                        "value": "resources/list"
+                      }
                     ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"name\": \"github\",\n  \"type\": \"oauth2\",\n  \"config\": {\n    \"oauth2\": {\n      \"issuer\": \"https://github.com\",\n      \"audiences\": [\"{{mcp_url}}\"],\n      \"client_id\": \"{{github_client_id}}\",\n      \"client_secret\": \"{{github_client_secret}}\",\n      \"session_mode\": true,\n      \"userinfo_url\": \"https://api.github.com/user\",\n      \"subject_claim\": \"id\",\n      \"authorize_url\": \"https://github.com/login/oauth/authorize\",\n      \"token_url\": \"https://github.com/login/oauth/access_token\",\n      \"required_scopes\": [\"read:user\"]\n    }\n  }\n}"
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"resources/list\",\n  \"params\": {\n    \"_meta\": {\n      \"io.modelcontextprotocol/protocolVersion\": \"{{mcp_protocol_version}}\",\n      \"io.modelcontextprotocol/clientCapabilities\": {}\n    }\n  }\n}"
+                    }
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('HTTP 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "pm.test('JSON-RPC result present', function () { pm.expect(body.error).to.eql(undefined); pm.expect(body.result).to.be.an('object'); });",
+                          "pm.test('modern responses omit Mcp-Session-Id', function () {",
+                          "  pm.expect(pm.response.headers.get('Mcp-Session-Id')).to.eql(undefined);",
+                          "});",
+                          "pm.test('modern list cache hints', function () {",
+                          "  const r = pm.response.json().result;",
+                          "  pm.expect(r.resultType).to.eql('complete');",
+                          "  pm.expect(r.ttlMs).to.eql(300000);",
+                          "  pm.expect(r.cacheScope).to.eql('private');",
+                          "});"
+                        ]
+                      }
+                    }
+                  ]
                 },
-                "description": "INBOUND oauth2 -> GitHub. GitHub publishes no authorization-server discovery, so authorize_url/token_url are pinned explicitly (the gateway skips the {issuer}/.well-known lookup when both are set). session_mode mints gateway session tokens from GitHub's opaque access tokens; subject_claim=id reads the stable user id from userinfo_url. GitHub OAuth app Authorization callback URL must be {{mcp_url}}/oauth/callback. client_id is required (pre-registered client). 409 means another ENABLED oauth2 auth already covers this (issuer, audience). For a discovery-capable IdP (Okta/Entra/Auth0/Google) omit authorize_url/token_url/session_mode and just set issuer + jwks_url."
-              }
-            },
-            {
-              "name": "3. Create consumer (type MCP)",
-              "event": [
                 {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.environment.set('consumer_id', pm.response.json().id);",
-                      "pm.environment.set('consumer_slug', pm.response.json().slug);"
+                  "name": "resources/read",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      },
+                      {
+                        "key": "MCP-Protocol-Version",
+                        "value": "{{mcp_protocol_version}}"
+                      },
+                      {
+                        "key": "Mcp-Method",
+                        "value": "resources/read"
+                      }
                     ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  }
-                ],
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n  \"name\": \"flow-i-github\",\n  \"type\": \"MCP\",\n  \"fail_mode\": \"closed\"\n}"
-                }
-              }
-            },
-            {
-              "name": "4. Associate auth to consumer",
-              "request": {
-                "method": "POST",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/auths/{{oauth2_auth_id}}"
-              }
-            },
-            {
-              "name": "4. Associate registry to consumer",
-              "request": {
-                "method": "POST",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}/registries/{{registry_id}}"
-              }
-            },
-            {
-              "name": "Cleanup: delete consumer",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}"
-              }
-            },
-            {
-              "name": "Cleanup: delete GitHub registry",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries/{{registry_id}}"
-              }
-            },
-            {
-              "name": "Cleanup: delete oauth2 auth",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths/{{oauth2_auth_id}}"
-              }
-            },
-            {
-              "name": "Cleanup: delete gateway",
-              "request": {
-                "method": "DELETE",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}"
-              }
-            }
-          ]
-        },
-        {
-          "name": "10. Diagnostics (standalone)",
-          "description": "Utilities that need no setup of their own. The id-based requests (introspect/get) read whatever {{gateway_id}}/{{registry_id}}/{{consumer_id}} the last-run flow stored - run them mid-flow, before that flow's Cleanup.",
-          "item": [
-            {
-              "name": "List gateways (spot stale oauth2 auths)",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "const gateways = pm.response.json();",
-                      "console.log('Existing gateways:', gateways.map(g => g.id + ' (' + g.slug + ')'));",
-                      "console.log('Multiple gateways may share an IdP, but no two ENABLED oauth2 auths may cover the same (issuer, audience) pair - the admin API rejects that with 409.');",
-                      "console.log('If an old gateway still has an enabled oauth2 auth with the same Entra issuer AND audience, delete it (or scope it with a different audience) before running an Entra flow.');"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "url": "{{admin_url}}/v1/gateways",
-                "description": "Lists gateways so you can spot leftovers from earlier flows that skipped their Cleanup. Stale enabled oauth2 auth entries sharing the Entra (issuer, audience) block the Entra folders with 409."
-              }
-            },
-            {
-              "name": "Introspect registry tools (admin)",
-              "request": {
-                "method": "GET",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries/{{registry_id}}/tools",
-                "description": "Lists the upstream's tools using the registry's configured credential. Works for auth modes none/static; forwarded-mode registries have no service-level credential, so introspection is empty until a principal links an account."
-              }
-            },
-            {
-              "name": "MCP servers catalog",
-              "request": {
-                "method": "GET",
-                "url": "{{admin_url}}/v1/mcp-servers-catalog",
-                "description": "Curated list of well-known remote MCP servers with auth hints (none/static/oauth)."
-              }
-            },
-            {
-              "name": "Get consumer (verify toolkit + fail_mode)",
-              "request": {
-                "method": "GET",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}"
-              }
-            },
-            {
-              "name": "Get registry (verify mcp_target, secrets masked)",
-              "request": {
-                "method": "GET",
-                "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries/{{registry_id}}"
-              }
-            },
-            {
-              "name": "MCP plane health (no auth)",
-              "request": {
-                "auth": {
-                  "type": "noauth"
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"resources/read\",\n  \"params\": {\n    \"_meta\": {\n      \"io.modelcontextprotocol/protocolVersion\": \"{{mcp_protocol_version}}\",\n      \"io.modelcontextprotocol/clientCapabilities\": {}\n    },\n    \"uri\": \"test://example\"\n  }\n}"
+                    }
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('HTTP 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "pm.test('JSON-RPC result present', function () { pm.expect(body.error).to.eql(undefined); pm.expect(body.result).to.be.an('object'); });",
+                          "pm.test('modern responses omit Mcp-Session-Id', function () {",
+                          "  pm.expect(pm.response.headers.get('Mcp-Session-Id')).to.eql(undefined);",
+                          "});",
+                          "pm.test('resource reads are uncached when adapted', function () {",
+                          "  const r = pm.response.json().result;",
+                          "  if (r && r.ttlMs !== undefined) pm.expect(r.ttlMs).to.eql(0);",
+                          "});"
+                        ]
+                      }
+                    }
+                  ]
                 },
-                "method": "GET",
-                "url": "{{mcp_url}}/healthz"
-              }
+                {
+                  "name": "prompts/list",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      },
+                      {
+                        "key": "MCP-Protocol-Version",
+                        "value": "{{mcp_protocol_version}}"
+                      },
+                      {
+                        "key": "Mcp-Method",
+                        "value": "prompts/list"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"prompts/list\",\n  \"params\": {\n    \"_meta\": {\n      \"io.modelcontextprotocol/protocolVersion\": \"{{mcp_protocol_version}}\",\n      \"io.modelcontextprotocol/clientCapabilities\": {}\n    }\n  }\n}"
+                    }
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('HTTP 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "pm.test('JSON-RPC result present', function () { pm.expect(body.error).to.eql(undefined); pm.expect(body.result).to.be.an('object'); });",
+                          "pm.test('modern responses omit Mcp-Session-Id', function () {",
+                          "  pm.expect(pm.response.headers.get('Mcp-Session-Id')).to.eql(undefined);",
+                          "});",
+                          "pm.test('modern list cache hints', function () {",
+                          "  const r = pm.response.json().result;",
+                          "  pm.expect(r.resultType).to.eql('complete');",
+                          "  pm.expect(r.ttlMs).to.eql(300000);",
+                          "  pm.expect(r.cacheScope).to.eql('private');",
+                          "});"
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "name": "prompts/get",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      },
+                      {
+                        "key": "MCP-Protocol-Version",
+                        "value": "{{mcp_protocol_version}}"
+                      },
+                      {
+                        "key": "Mcp-Method",
+                        "value": "prompts/get"
+                      },
+                      {
+                        "key": "Mcp-Name",
+                        "value": "greet"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"prompts/get\",\n  \"params\": {\n    \"_meta\": {\n      \"io.modelcontextprotocol/protocolVersion\": \"{{mcp_protocol_version}}\",\n      \"io.modelcontextprotocol/clientCapabilities\": {}\n    },\n    \"name\": \"greet\",\n    \"arguments\": {\n      \"name\": \"postman\"\n    }\n  }\n}"
+                    }
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('HTTP 200', function () { pm.response.to.have.status(200); });",
+                          "const body = pm.response.json();",
+                          "pm.test('JSON-RPC result present', function () { pm.expect(body.error).to.eql(undefined); pm.expect(body.result).to.be.an('object'); });",
+                          "pm.test('modern responses omit Mcp-Session-Id', function () {",
+                          "  pm.expect(pm.response.headers.get('Mcp-Session-Id')).to.eql(undefined);",
+                          "});"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "Negative",
+              "item": [
+                {
+                  "name": "unsupported version",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      },
+                      {
+                        "key": "MCP-Protocol-Version",
+                        "value": "2099-01-01"
+                      },
+                      {
+                        "key": "Mcp-Method",
+                        "value": "tools/list"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"tools/list\",\n  \"params\": {\n    \"_meta\": {\n      \"io.modelcontextprotocol/protocolVersion\": \"2099-01-01\",\n      \"io.modelcontextprotocol/clientCapabilities\": {}\n    }\n  }\n}"
+                    }
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('HTTP 400', function () { pm.response.to.have.status(400); });",
+                          "const body = pm.response.json();",
+                          "pm.test('JSON-RPC error present', function () { pm.expect(body.error).to.be.an('object'); });",
+                          "pm.test('UnsupportedProtocolVersion (-32022)', function () {",
+                          "  pm.expect(pm.response.json().error.code).to.eql(-32022);",
+                          "});"
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "name": "missing _meta",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      },
+                      {
+                        "key": "MCP-Protocol-Version",
+                        "value": "{{mcp_protocol_version}}"
+                      },
+                      {
+                        "key": "Mcp-Method",
+                        "value": "tools/list"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"tools/list\",\n  \"params\": {}\n}"
+                    }
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('HTTP 400', function () { pm.response.to.have.status(400); });",
+                          "const body = pm.response.json();",
+                          "pm.test('JSON-RPC error present', function () { pm.expect(body.error).to.be.an('object'); });",
+                          "pm.test('Invalid params (-32602)', function () {",
+                          "  pm.expect(pm.response.json().error.code).to.eql(-32602);",
+                          "});"
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "name": "header/body protocol mismatch",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      },
+                      {
+                        "key": "MCP-Protocol-Version",
+                        "value": "{{mcp_protocol_version}}"
+                      },
+                      {
+                        "key": "Mcp-Method",
+                        "value": "tools/list"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"tools/list\",\n  \"params\": {\n    \"_meta\": {\n      \"io.modelcontextprotocol/protocolVersion\": \"2025-06-18\",\n      \"io.modelcontextprotocol/clientCapabilities\": {}\n    }\n  }\n}"
+                    }
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('HTTP 400', function () { pm.response.to.have.status(400); });",
+                          "const body = pm.response.json();",
+                          "pm.test('JSON-RPC error present', function () { pm.expect(body.error).to.be.an('object'); });",
+                          "pm.test('Invalid params (-32602)', function () {",
+                          "  pm.expect(pm.response.json().error.code).to.eql(-32602);",
+                          "});"
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "name": "Mcp-Method mismatch",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      },
+                      {
+                        "key": "MCP-Protocol-Version",
+                        "value": "{{mcp_protocol_version}}"
+                      },
+                      {
+                        "key": "Mcp-Method",
+                        "value": "tools/call"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"tools/list\",\n  \"params\": {\n    \"_meta\": {\n      \"io.modelcontextprotocol/protocolVersion\": \"{{mcp_protocol_version}}\",\n      \"io.modelcontextprotocol/clientCapabilities\": {}\n    }\n  }\n}"
+                    }
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('HTTP 400', function () { pm.response.to.have.status(400); });",
+                          "const body = pm.response.json();",
+                          "pm.test('JSON-RPC error present', function () { pm.expect(body.error).to.be.an('object'); });",
+                          "pm.test('Invalid params (-32602)', function () {",
+                          "  pm.expect(pm.response.json().error.code).to.eql(-32602);",
+                          "});"
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "name": "Mcp-Name mismatch",
+                  "request": {
+                    "auth": {
+                      "type": "noauth"
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      },
+                      {
+                        "key": "X-AG-API-Key",
+                        "value": "{{api_key}}"
+                      },
+                      {
+                        "key": "MCP-Protocol-Version",
+                        "value": "{{mcp_protocol_version}}"
+                      },
+                      {
+                        "key": "Mcp-Method",
+                        "value": "tools/call"
+                      },
+                      {
+                        "key": "Mcp-Name",
+                        "value": "other_tool"
+                      }
+                    ],
+                    "url": "{{mcp_url}}/{{consumer_slug}}/mcp",
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"tools/call\",\n  \"params\": {\n    \"_meta\": {\n      \"io.modelcontextprotocol/protocolVersion\": \"{{mcp_protocol_version}}\",\n      \"io.modelcontextprotocol/clientCapabilities\": {}\n    },\n    \"name\": \"read_wiki_structure\",\n    \"arguments\": {}\n  }\n}"
+                    }
+                  },
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('HTTP 400', function () { pm.response.to.have.status(400); });",
+                          "const body = pm.response.json();",
+                          "pm.test('JSON-RPC error present', function () { pm.expect(body.error).to.be.an('object'); });",
+                          "pm.test('Invalid params (-32602)', function () {",
+                          "  pm.expect(pm.response.json().error.code).to.eql(-32602);",
+                          "});"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "Cleanup",
+              "item": [
+                {
+                  "name": "Cleanup: delete consumer",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/consumers/{{consumer_id}}"
+                  }
+                },
+                {
+                  "name": "Cleanup: delete registry",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/registries/{{registry_id}}"
+                  }
+                },
+                {
+                  "name": "Cleanup: delete api_key auth",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}/auths/{{auth_id}}"
+                  }
+                },
+                {
+                  "name": "Cleanup: delete gateway",
+                  "request": {
+                    "method": "DELETE",
+                    "url": "{{admin_url}}/v1/gateways/{{gateway_id}}",
+                    "description": "Children first, gateway last (else 409)."
+                  }
+                }
+              ]
             }
           ]
         }
@@ -10034,7 +10850,7 @@
                     "type": "text/javascript",
                     "exec": [
                       "pm.test('proxy returned 200', () => pm.response.code === 200);",
-                      "pm.test('model was downgraded', () => pm.response.headers.get('X-NeuralTrust-Model-Downgraded') === 'gpt-4o→gpt-4o-mini');",
+                      "pm.test('model was downgraded', () => pm.response.headers.get('X-NeuralTrust-Model-Downgraded') === 'gpt-4o\u2192gpt-4o-mini');",
                       "pm.test('selected provider is openai', () => pm.response.headers.get('X-Selected-Provider') === 'openai');",
                       "pm.test('served model is advertised', () => !!pm.response.headers.get('X-Selected-Model'));"
                     ]
@@ -10076,7 +10892,7 @@
                     "completions"
                   ]
                 },
-                "description": "Same over-ceiling `gpt-4o` request as step 9, but the cost cap is now in `downgrade` mode, so the plugin rewrites the outbound model to `gpt-4o-mini`, emits `X-NeuralTrust-Model-Downgraded: gpt-4o→gpt-4o-mini`, and the request succeeds against OpenAI."
+                "description": "Same over-ceiling `gpt-4o` request as step 9, but the cost cap is now in `downgrade` mode, so the plugin rewrites the outbound model to `gpt-4o-mini`, emits `X-NeuralTrust-Model-Downgraded: gpt-4o\u2192gpt-4o-mini`, and the request succeeds against OpenAI."
               }
             },
             {

--- a/tests/functional/mcp_dual_era_test.go
+++ b/tests/functional/mcp_dual_era_test.go
@@ -1,0 +1,338 @@
+//go:build functional
+
+package functional_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	sdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+const modernProtocolVersion = "2026-07-28"
+
+func modernMeta() map[string]any {
+	return map[string]any{
+		"io.modelcontextprotocol/protocolVersion":    modernProtocolVersion,
+		"io.modelcontextprotocol/clientCapabilities": map[string]any{},
+	}
+}
+
+func withModernMeta(params map[string]any) map[string]any {
+	if params == nil {
+		params = map[string]any{}
+	}
+	params["_meta"] = modernMeta()
+	return params
+}
+
+func modernClientHeaders(apiKey, method, name string) map[string]string {
+	headers := apiKeyHeaders(apiKey)
+	headers["MCP-Protocol-Version"] = modernProtocolVersion
+	headers["Mcp-Method"] = method
+	if name != "" {
+		headers["Mcp-Name"] = name
+	}
+	return headers
+}
+
+func mcpRPCModern(
+	t *testing.T,
+	gatewayID, consumerID, apiKey, method string,
+	params map[string]any,
+	name string,
+) (int, http.Header, map[string]any) {
+	t.Helper()
+	body := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  method,
+		"params":  withModernMeta(params),
+	}
+	return mcpExchange(t, gatewayID, consumerID, modernClientHeaders(apiKey, method, name), body)
+}
+
+func requireNoModernSessionHeader(t *testing.T, headers http.Header) {
+	t.Helper()
+	for key := range headers {
+		require.False(t, strings.EqualFold(key, "Mcp-Session-Id"), "modern response leaked %s", key)
+	}
+}
+
+func requireModernListHints(t *testing.T, result map[string]any) {
+	t.Helper()
+	require.Equal(t, "complete", result["resultType"])
+	require.Equal(t, float64(300000), result["ttlMs"])
+	require.Equal(t, "private", result["cacheScope"])
+}
+
+func TestMCPServer_DualEraClientUpstreamMatrix(t *testing.T) {
+	cases := []struct {
+		name       string
+		client     string
+		upstream   string
+		mode       string
+		legacyOnly bool
+	}{
+		{name: "modern→modern", client: "modern", upstream: "modern", mode: "auto"},
+		{name: "modern→legacy", client: "modern", upstream: "legacy", mode: "auto", legacyOnly: true},
+		{name: "legacy→modern", client: "legacy", upstream: "modern", mode: "auto"},
+		{name: "legacy→legacy", client: "legacy", upstream: "legacy", mode: "auto", legacyOnly: true},
+		{name: "modern→modern pinned", client: "modern", upstream: "modern", mode: "modern"},
+		{name: "legacy→legacy pinned", client: "legacy", upstream: "legacy", mode: "legacy", legacyOnly: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			toolName := "echo-" + strings.ReplaceAll(tc.name, "→", "-")
+			toolName = strings.ReplaceAll(toolName, " ", "-")
+			fixture := startEraMCPUpstream(t, tc.legacyOnly, toolName)
+
+			gatewayID := CreateGateway(t, map[string]any{"slug": uniqueName("mcp-gw")})
+			registryID := CreateRegistry(
+				t,
+				gatewayID,
+				mcpRegistryPayloadMode(uniqueName("mcp-reg"), fixture.server.URL, tc.mode),
+			)
+			consumerID, key := createMCPConsumer(t, gatewayID, []string{registryID}, nil, "")
+
+			if tc.client == "modern" {
+				status, headers, body := mcpRPCModern(t, gatewayID, consumerID, key, "tools/list", nil, "")
+				result := rpcResult(t, status, body)
+				require.Equal(t, []string{toolName}, listedNames(t, result, "tools"))
+				requireModernListHints(t, result)
+				requireNoModernSessionHeader(t, headers)
+
+				status, headers, body = mcpRPCModern(
+					t,
+					gatewayID,
+					consumerID,
+					key,
+					"tools/call",
+					map[string]any{"name": toolName, "arguments": map[string]any{"message": "ok"}},
+					toolName,
+				)
+				raw, err := json.Marshal(rpcResult(t, status, body))
+				require.NoError(t, err)
+				require.Contains(t, string(raw), toolName+":ok")
+				requireNoModernSessionHeader(t, headers)
+			} else {
+				status, body := mcpRPC(t, gatewayID, consumerID, apiKeyHeaders(key), "tools/list", nil)
+				require.Equal(t, []string{toolName}, listedNames(t, rpcResult(t, status, body), "tools"))
+				status, body = mcpRPC(
+					t,
+					gatewayID,
+					consumerID,
+					apiKeyHeaders(key),
+					"tools/call",
+					map[string]any{"name": toolName, "arguments": map[string]any{"message": "ok"}},
+				)
+				raw, err := json.Marshal(rpcResult(t, status, body))
+				require.NoError(t, err)
+				require.Contains(t, string(raw), toolName+":ok")
+			}
+
+			if !tc.legacyOnly {
+				require.Equal(t, int64(0), fixture.initializes.Load(), "modern upstream must stay sessionless")
+			}
+		})
+	}
+}
+
+func TestMCPServer_ModernServerDiscoverAndNoSession(t *testing.T) {
+	upstream := startModernMCPUpstream(t, func(s *sdk.Server) { addTool(s, "echo") })
+	gatewayID := CreateGateway(t, map[string]any{"slug": uniqueName("mcp-gw")})
+	registryID := CreateRegistry(t, gatewayID, mcpRegistryPayloadMode(uniqueName("mcp-reg"), upstream.URL, "auto"))
+	consumerID, key := createMCPConsumer(t, gatewayID, []string{registryID}, nil, "")
+
+	status, headers, body := mcpRPCModern(t, gatewayID, consumerID, key, "server/discover", nil, "")
+	result := rpcResult(t, status, body)
+	require.Contains(t, result["supportedVersions"], modernProtocolVersion)
+	caps, ok := result["capabilities"].(map[string]any)
+	require.True(t, ok)
+	require.Contains(t, caps, "tools")
+	requireModernListHints(t, result)
+	requireNoModernSessionHeader(t, headers)
+
+	status, headers, body = mcpRPCModern(t, gatewayID, consumerID, key, "tools/list", nil, "")
+	require.Equal(t, []string{"echo"}, listedNames(t, rpcResult(t, status, body), "tools"))
+	requireNoModernSessionHeader(t, headers)
+}
+
+func TestMCPServer_ModernNorthboundValidation(t *testing.T) {
+	upstream := startMCPUpstream(t, func(s *sdk.Server) { addTool(s, "echo") })
+	gatewayID := CreateGateway(t, map[string]any{"slug": uniqueName("mcp-gw")})
+	registryID := CreateRegistry(t, gatewayID, mcpRegistryPayload(uniqueName("mcp-reg"), upstream.URL))
+	consumerID, key := createMCPConsumer(t, gatewayID, []string{registryID}, nil, "")
+
+	t.Run("unsupported version", func(t *testing.T) {
+		headers := apiKeyHeaders(key)
+		headers["MCP-Protocol-Version"] = "2099-01-01"
+		headers["Mcp-Method"] = "tools/list"
+		status, body := mcpPost(t, gatewayID, consumerID, headers, map[string]any{
+			"jsonrpc": "2.0",
+			"id":      1,
+			"method":  "tools/list",
+			"params":  withModernMeta(nil),
+		})
+		require.Equal(t, http.StatusBadRequest, status)
+		require.Equal(t, float64(-32022), rpcErrorCode(t, status, body))
+	})
+
+	t.Run("missing _meta", func(t *testing.T) {
+		status, _, body := mcpExchange(
+			t,
+			gatewayID,
+			consumerID,
+			modernClientHeaders(key, "tools/list", ""),
+			map[string]any{"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": map[string]any{}},
+		)
+		require.Equal(t, http.StatusBadRequest, status)
+		require.Equal(t, float64(-32602), rpcErrorCode(t, status, body))
+	})
+
+	t.Run("header body protocol mismatch", func(t *testing.T) {
+		params := map[string]any{
+			"_meta": map[string]any{
+				"io.modelcontextprotocol/protocolVersion":    "2025-06-18",
+				"io.modelcontextprotocol/clientCapabilities": map[string]any{},
+			},
+		}
+		status, _, body := mcpExchange(
+			t,
+			gatewayID,
+			consumerID,
+			modernClientHeaders(key, "tools/list", ""),
+			map[string]any{"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": params},
+		)
+		require.Equal(t, http.StatusBadRequest, status)
+		require.Equal(t, float64(-32602), rpcErrorCode(t, status, body))
+	})
+
+	t.Run("method mismatch", func(t *testing.T) {
+		status, _, body := mcpExchange(
+			t,
+			gatewayID,
+			consumerID,
+			modernClientHeaders(key, "tools/call", "echo"),
+			map[string]any{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"method":  "tools/list",
+				"params":  withModernMeta(nil),
+			},
+		)
+		require.Equal(t, http.StatusBadRequest, status)
+		require.Equal(t, float64(-32602), rpcErrorCode(t, status, body))
+	})
+
+	t.Run("name mismatch", func(t *testing.T) {
+		status, _, body := mcpRPCModern(
+			t,
+			gatewayID,
+			consumerID,
+			key,
+			"tools/call",
+			map[string]any{"name": "echo", "arguments": map[string]any{"message": "x"}},
+			"other",
+		)
+		require.Equal(t, http.StatusBadRequest, status)
+		require.Equal(t, float64(-32602), rpcErrorCode(t, status, body))
+	})
+}
+
+func TestMCPServer_StrictModernModeFailsClosedAgainstLegacyUpstream(t *testing.T) {
+	fixture := startEraMCPUpstream(t, true, "legacy-only-tool")
+	gatewayID := CreateGateway(t, map[string]any{"slug": uniqueName("mcp-gw")})
+	registryID := CreateRegistry(
+		t,
+		gatewayID,
+		mcpRegistryPayloadMode(uniqueName("mcp-reg"), fixture.server.URL, "modern"),
+	)
+	consumerID, key := createMCPConsumer(t, gatewayID, []string{registryID}, nil, "closed")
+
+	status, body := mcpRPC(t, gatewayID, consumerID, apiKeyHeaders(key), "tools/list", nil)
+	require.NotNil(t, body["error"], "strict modern mode must fail closed against legacy-only upstream: http=%d body=%v", status, body)
+	require.Equal(t, int64(0), fixture.initializes.Load())
+}
+
+func TestMCPServer_CachedEraSurvivesConcurrentModernClients(t *testing.T) {
+	fixture := startEraMCPUpstream(t, true, "concurrent-echo")
+	gatewayID := CreateGateway(t, map[string]any{"slug": uniqueName("mcp-gw")})
+	registryID := CreateRegistry(
+		t,
+		gatewayID,
+		mcpRegistryPayloadMode(uniqueName("mcp-reg"), fixture.server.URL, "auto"),
+	)
+	consumerID, key := createMCPConsumer(t, gatewayID, []string{registryID}, nil, "")
+
+	status, _, body := mcpRPCModern(t, gatewayID, consumerID, key, "tools/list", nil, "")
+	require.Equal(t, []string{"concurrent-echo"}, listedNames(t, rpcResult(t, status, body), "tools"))
+	require.Equal(t, int64(1), fixture.initializes.Load())
+
+	host, ok := gatewayHosts.Load(gatewayID)
+	require.True(t, ok)
+	url := MCPURL + "/" + ConsumerSlug(t, consumerID) + "/mcp"
+	payload, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/list",
+		"params":  withModernMeta(nil),
+	})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	type outcome struct {
+		status  int
+		session string
+		errCode any
+		tools   int
+	}
+	out := make(chan outcome, 8)
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req, reqErr := http.NewRequest(http.MethodPost, url, strings.NewReader(string(payload)))
+			if reqErr != nil {
+				out <- outcome{status: -1}
+				return
+			}
+			req.Header.Set("Content-Type", "application/json")
+			for k, v := range modernClientHeaders(key, "tools/list", "") {
+				req.Header.Set(k, v)
+			}
+			req.Host = host.(string)
+			resp, doErr := http.DefaultClient.Do(req)
+			if doErr != nil {
+				out <- outcome{status: -1}
+				return
+			}
+			defer func() { _ = resp.Body.Close() }()
+			var decoded map[string]any
+			_ = json.NewDecoder(resp.Body).Decode(&decoded)
+			got := outcome{status: resp.StatusCode, session: resp.Header.Get("Mcp-Session-Id")}
+			if rpcErr, ok := decoded["error"].(map[string]any); ok {
+				got.errCode = rpcErr["code"]
+			}
+			if result, ok := decoded["result"].(map[string]any); ok {
+				if tools, ok := result["tools"].([]any); ok {
+					got.tools = len(tools)
+				}
+			}
+			out <- got
+		}()
+	}
+	wg.Wait()
+	close(out)
+	for got := range out {
+		require.Equal(t, http.StatusOK, got.status)
+		require.Nil(t, got.errCode)
+		require.Empty(t, got.session)
+		require.Equal(t, 1, got.tools)
+	}
+	require.Equal(t, int64(1), fixture.initializes.Load())
+}

--- a/tests/functional/mcp_e2e_test.go
+++ b/tests/functional/mcp_e2e_test.go
@@ -173,6 +173,17 @@ func addReadmeResource(server *sdk.Server, uri, text string) {
 // gateway domain so the path-first auth scope resolves.
 func mcpPost(t *testing.T, gatewayID, consumerID string, headers map[string]string, body any) (int, map[string]any) {
 	t.Helper()
+	status, _, out := mcpExchange(t, gatewayID, consumerID, headers, body)
+	return status, out
+}
+
+func mcpExchange(
+	t *testing.T,
+	gatewayID, consumerID string,
+	headers map[string]string,
+	body any,
+) (int, http.Header, map[string]any) {
+	t.Helper()
 	raw, err := json.Marshal(body)
 	require.NoError(t, err)
 	url := MCPURL + "/" + ConsumerSlug(t, consumerID) + "/mcp"
@@ -197,7 +208,7 @@ func mcpPost(t *testing.T, gatewayID, consumerID string, headers map[string]stri
 			out = map[string]any{"_raw": string(decoded)}
 		}
 	}
-	return resp.StatusCode, out
+	return resp.StatusCode, resp.Header.Clone(), out
 }
 
 // mcpRPC posts a JSON-RPC request to the virtual MCP server and returns the


### PR DESCRIPTION
## Summary

- Add functional coverage for the modern/legacy client × upstream matrix, including `server/discover`, northbound validation, strict `protocol_mode=modern` fail-closed, and concurrent cached-era behaviour.
- Split Postman **MCP Gateway** into **Legacy (≤2025-06-18)** and **MCP 2026-07-28** with happy-path and negative assertions (no `Mcp-Session-Id` on modern).
- Document the dual-era matrix and local commands in `docs/mcp/testing-guide.md`.

## Stack

Depends on [#400](https://github.com/NeuralTrust/TrustGate/pull/400) (RUN-1103 + RUN-1108 dual-era core). Merge #400 first, then retarget this PR to `develop` if needed.

## Linear

RUN-1105 — https://linear.app/neuraltrust/issue/RUN-1105/testmcp-add-dual-era-conformance-matrix-and-postman-flows

## Test plan

- [x] `go test -tags=functional -c ./tests/functional` (compiles)
- [x] Pre-commit hook (lint + gosec + unit coverage) passed on commit
- [ ] CI functional suite on this PR
- [ ] Spot-check Postman **MCP 2026-07-28** happy path + negative folder after #400 lands


Made with [Cursor](https://cursor.com)