### PR TITLE
fix: stop trusting the client-supplied X-AG-Trace-Id (RUN-1138)

### DIFF
--- a/pkg/api/middleware/mcp_metrics.go
+++ b/pkg/api/middleware/mcp_metrics.go
@@ -24,7 +24,6 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/infra/metrics/events"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/trace"
 	"github.com/gofiber/fiber/v2"
-	"github.com/google/uuid"
 )
 
 type MCPMetricsMiddleware struct {
@@ -54,7 +53,7 @@ func (m *MCPMetricsMiddleware) Middleware() fiber.Handler {
 		gw := gatewayFromContext(c)
 		exporters := gatewayExporters(gw)
 
-		traceID := m.resolveTraceID(c)
+		traceID := newTraceID()
 		c.Set(HeaderTraceID, traceID)
 		requestTrace := trace.New(traceID, m.buildTraceMetadata(c, gatewayID, gw))
 		requestTrace.SetGating(m.enableRequestTraces, m.enablePluginTraces)
@@ -76,13 +75,6 @@ func (m *MCPMetricsMiddleware) Middleware() fiber.Handler {
 
 		return c.Next()
 	}
-}
-
-func (m *MCPMetricsMiddleware) resolveTraceID(c *fiber.Ctx) string {
-	if tid := c.Get(HeaderTraceID); tid != "" {
-		return tid
-	}
-	return uuid.New().String()
 }
 
 func (m *MCPMetricsMiddleware) buildTraceMetadata(c *fiber.Ctx, gatewayID string, gw *gatewaydomain.Gateway) trace.Metadata {

--- a/pkg/api/middleware/metrics.go
+++ b/pkg/api/middleware/metrics.go
@@ -27,7 +27,6 @@ import (
 	infracontext "github.com/NeuralTrust/TrustGate/pkg/infra/context"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/trace"
 	"github.com/gofiber/fiber/v2"
-	"github.com/google/uuid"
 )
 
 type MetricsMiddleware struct {
@@ -57,7 +56,7 @@ func (m *MetricsMiddleware) Middleware() fiber.Handler {
 		gw := gatewayFromContext(c)
 		exporters := gatewayExporters(gw)
 
-		traceID := m.resolveTraceID(c)
+		traceID := newTraceID()
 		c.Set(HeaderTraceID, traceID)
 		requestTrace := trace.New(traceID, m.buildTraceMetadata(c, gatewayID, gw))
 		// Gating is set once here, before the trace is shared with any
@@ -120,13 +119,6 @@ func (m *MetricsMiddleware) enabled() bool {
 	return m.telemetryEnabled
 }
 
-func (m *MetricsMiddleware) resolveTraceID(c *fiber.Ctx) string {
-	if tid := c.Get(HeaderTraceID); tid != "" {
-		return tid
-	}
-	return uuid.New().String()
-}
-
 func (m *MetricsMiddleware) attachTrace(c *fiber.Ctx, requestTrace *trace.RequestTrace) {
 	c.SetUserContext(trace.NewContext(c.UserContext(), requestTrace))
 }
@@ -134,7 +126,7 @@ func (m *MetricsMiddleware) attachTrace(c *fiber.Ctx, requestTrace *trace.Reques
 func (m *MetricsMiddleware) buildTraceMetadata(c *fiber.Ctx, gatewayID string, gw *gatewaydomain.Gateway) trace.Metadata {
 	meta := trace.Metadata{
 		GatewayID: gatewayID,
-		TenantID:    gw.TenantID(),
+		TenantID:  gw.TenantID(),
 		Path:      c.Path(),
 		Method:    c.Method(),
 		IP:        c.IP(),

--- a/pkg/api/middleware/metrics_test.go
+++ b/pkg/api/middleware/metrics_test.go
@@ -33,6 +33,7 @@ import (
 	infracontext "github.com/NeuralTrust/TrustGate/pkg/infra/context"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/trace"
 	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -137,6 +138,55 @@ func TestMetricsMiddleware_TraceIDMatchesTraceIDHeader(t *testing.T) {
 	defer mu.Unlock()
 	require.Equal(t, 1, processCalls)
 	assert.Equal(t, respTraceID, gotTraceID, "event TraceID must equal the X-AG-Trace-Id returned to the client")
+}
+
+func TestMetricsMiddleware_IgnoresInboundTraceIDHeader(t *testing.T) {
+	const inbound = "550e8400-e29b-41d4-a716-446655440000"
+	worker := appmetricsmocks.NewWorker(t)
+
+	var (
+		mu         sync.Mutex
+		gotTraceID string
+	)
+	worker.EXPECT().
+		Process(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Run(func(rt *trace.RequestTrace, _ *infracontext.RequestContext, _ *infracontext.ResponseContext, _ time.Time, _ time.Time, _ []telemetrydomain.ExporterConfig) {
+			mu.Lock()
+			defer mu.Unlock()
+			gotTraceID = rt.TraceID()
+		}).
+		Return().
+		Once()
+
+	cfg := &config.Config{}
+	cfg.Telemetry.Enabled = true
+	mw := middleware.NewMetricsMiddleware(worker, cfg)
+
+	gatewayID := ids.New[ids.GatewayKind]()
+	app := fiber.New()
+	app.Use(func(c *fiber.Ctx) error {
+		c.SetUserContext(appconsumer.WithGatewayID(c.UserContext(), gatewayID))
+		return c.Next()
+	})
+	app.Use(mw.Middleware())
+	app.Post("/v1/chat/completions", func(c *fiber.Ctx) error {
+		return c.Status(fiber.StatusOK).SendString("ok")
+	})
+
+	req := httptest.NewRequest(fiber.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set(middleware.HeaderTraceID, inbound)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	respTraceID := resp.Header.Get(middleware.HeaderTraceID)
+	assert.NotEqual(t, inbound, respTraceID, "a caller must not choose the trace id that keys telemetry")
+	_, parseErr := uuid.Parse(respTraceID)
+	require.NoError(t, parseErr, "minted trace id must be a UUID, got %q", respTraceID)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, respTraceID, gotTraceID)
 }
 
 func TestMetricsMiddleware_StreamingEmitsViaFinalizer(t *testing.T) {

--- a/pkg/api/middleware/trace_id.go
+++ b/pkg/api/middleware/trace_id.go
@@ -14,9 +14,19 @@
 
 package middleware
 
+import "github.com/google/uuid"
+
 // HeaderTraceID is the response header the proxy sets with the request trace id.
 // A gateway-specific name avoids the upstream X-Request-Id some providers emit.
 const HeaderTraceID = "X-AG-Trace-Id"
+
+// newTraceID mints the identity of a gateway request. An inbound HeaderTraceID
+// is never reused: the trace id keys telemetry storage, so honouring a
+// caller-supplied value lets any client silently drop another request's row,
+// including one belonging to a different tenant (RUN-1138).
+func newTraceID() string {
+	return uuid.New().String()
+}
 
 // StrippedProxyResponseHeaders lists upstream headers that must not be forwarded to clients.
 var StrippedProxyResponseHeaders = map[string]struct{}{


### PR DESCRIPTION
## Summary

The HTTP and MCP metrics middlewares read the inbound `X-AG-Trace-Id` request header and, when present, used it verbatim as the trace identity for the whole request. That value keys telemetry storage, so any caller could steer it:

- **Silent telemetry loss** — repeating the same header makes the second request's row disappear (`ON CONFLICT (trace_id) DO NOTHING` in Postgres, and dedup in `ReplacingMergeTree` on ClickHouse).
- **Cross-tenant suppression** — the primary key is `trace_id` alone, not scoped by tenant, so a guessed or leaked id could suppress a row belonging to a different tenant.
- **Broken correlation** — a non-UUID value propagated downstream as `X-Trace-ID`, leaving TrustGuard with an unusable correlation id.

The header is documented as a *response* header, so no client is supposed to send it. The gateway now always mints its own UUID and ignores whatever arrives.

## Changes

- `pkg/api/middleware/trace_id.go` — new `newTraceID()` helper, with the rationale for never honouring the inbound header.
- `pkg/api/middleware/metrics.go`, `pkg/api/middleware/mcp_metrics.go` — call `newTraceID()` directly; removed the `resolveTraceID` methods that preferred the request header.
- `pkg/api/middleware/metrics_test.go` — `TestMetricsMiddleware_IgnoresInboundTraceIDHeader` asserts a client value is neither stored nor echoed back.

Tenant-scoping the telemetry primary keys is a separate hardening step (a Postgres migration): it is not needed to close this hole, since the gateway no longer lets a client choose the key.

## Linear

RUN-1138 — https://linear.app/neuraltrust/issue/RUN-1138

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/api/middleware/...`
- [x] `golangci-lint run` on the touched package
- [ ] Manual: two requests with the same `X-AG-Trace-Id` → two distinct rows in `trustgate_raw`

Made with [Cursor](https://cursor.com)