### PR TITLE
fix: mint Vertex AI access tokens from GCP service accounts (ENG-1319)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 )
 
 require (
+	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 // indirect
 	github.com/KyleBanks/depth v1.2.1 // indirect
@@ -116,7 +117,6 @@ require (
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
-	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/term v0.44.0 // indirect
 	golang.org/x/text v0.39.0 // indirect
@@ -134,6 +134,7 @@ require (
 	github.com/redis/go-redis/v9 v9.21.0
 	go.opentelemetry.io/otel/metric v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
+	golang.org/x/oauth2 v0.36.0
 )
 
 replace github.com/NeuralTrust/TrustGate/pkg/metrics => ./pkg/metrics

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
+cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1 h1:jHb/wfvRikGdxMXYV3QG/SzUOPYN9KEUUuC0Yd0/vC0=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1/go.mod h1:pzBXCYn05zvYIrwLgtK8Ap8QcjRg+0i76tMQdWN6wOk=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 h1:Hk5QBxZQC1jb2Fwj6mpzme37xbCDdNTxU7O9eb5+LB4=

--- a/pkg/app/registry/connection_tester.go
+++ b/pkg/app/registry/connection_tester.go
@@ -147,8 +147,6 @@ func unsupportedReason(auth *domain.TargetAuth) (bool, string) {
 	switch auth.Type {
 	case domain.AuthTypeOAuth2:
 		return true, "connection testing is not supported for oauth2 credentials yet"
-	case domain.AuthTypeGCPServiceAccount:
-		return true, "connection testing is not supported for gcp service account credentials yet"
 	default:
 		return false, ""
 	}

--- a/pkg/infra/providers/client.go
+++ b/pkg/infra/providers/client.go
@@ -57,6 +57,11 @@ type Credentials struct {
 	ApiKey     string      `json:"api_key"` // #nosec G117 -- DTO field for provider API key configuration
 	AwsBedrock *AwsBedrock `json:"aws,omitempty"`
 	Azure      *Azure      `json:"azure,omitempty"`
+	GCP        *GCP        `json:"gcp,omitempty"`
+}
+
+type GCP struct {
+	ServiceAccountJSON string `json:"service_account_json"` // #nosec G117 -- DTO field for GCP service account configuration
 }
 
 type AwsBedrock struct {

--- a/pkg/infra/providers/client.go
+++ b/pkg/infra/providers/client.go
@@ -21,9 +21,6 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/domain/provider"
 )
 
-// Provider name constants. Use these as keys for HTTPClientPool.Get() and
-// anywhere a provider needs to be identified by name. They alias the domain
-// provider source of truth.
 const (
 	ProviderOpenAI           = provider.OpenAI
 	ProviderOpenAICompatible = provider.OpenAICompatible
@@ -98,10 +95,7 @@ type Client interface {
 		config *Config,
 		reqBody []byte,
 	) ([]byte, error)
-	// CompletionsStream performs the streaming request. The outer error carries
-	// pre-stream failures (e.g. a registry.BackendError on a non-2xx response, for
-	// verbatim passthrough). The returned sequence yields raw SSE lines and
-	// surfaces mid-stream read errors as the second value.
+	// The outer error carries pre-stream failures; mid-stream read errors surface as the sequence's second value.
 	CompletionsStream(
 		ctx context.Context,
 		config *Config,
@@ -109,12 +103,10 @@ type Client interface {
 	) (iter.Seq2[[]byte, error], error)
 }
 
-// EmbeddingsClient performs non-streaming embedding requests.
 type EmbeddingsClient interface {
 	Embeddings(ctx context.Context, config *Config, reqBody []byte) ([]byte, error)
 }
 
-// RerankClient performs non-streaming rerank requests.
 type RerankClient interface {
 	Rerank(ctx context.Context, config *Config, reqBody []byte) ([]byte, error)
 }

--- a/pkg/infra/providers/credentials.go
+++ b/pkg/infra/providers/credentials.go
@@ -55,7 +55,11 @@ func CredentialsFromTargetAuth(a *registry.TargetAuth) Credentials {
 				ClientSecret: a.Azure.ClientSecret,
 			}
 		}
-	case registry.AuthTypeOAuth2, registry.AuthTypeGCPServiceAccount:
+	case registry.AuthTypeGCPServiceAccount:
+		if a.GCPServiceAccount != nil && *a.GCPServiceAccount != "" {
+			creds.GCP = &GCP{ServiceAccountJSON: *a.GCPServiceAccount}
+		}
+	case registry.AuthTypeOAuth2:
 	}
 	return creds
 }

--- a/pkg/infra/providers/credentials.go
+++ b/pkg/infra/providers/credentials.go
@@ -18,8 +18,6 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/domain/registry"
 )
 
-// CredentialsFromTargetAuth maps a registry target's auth configuration onto
-// the provider credentials DTO consumed by the provider clients.
 func CredentialsFromTargetAuth(a *registry.TargetAuth) Credentials {
 	creds := Credentials{}
 	if a == nil {

--- a/pkg/infra/providers/credentials_test.go
+++ b/pkg/infra/providers/credentials_test.go
@@ -92,3 +92,53 @@ func TestCredentialsFromTargetAuth_Azure(t *testing.T) {
 		})
 	}
 }
+
+func TestCredentialsFromTargetAuth_GCPServiceAccount(t *testing.T) {
+	t.Parallel()
+
+	serviceAccount := `{"type":"service_account","client_email":"sa@proj.iam.gserviceaccount.com"}`
+	empty := ""
+
+	tests := []struct {
+		name    string
+		auth    *registry.TargetAuth
+		wantSA  string
+		wantNil bool
+	}{
+		{
+			name:   "service account json is carried over",
+			auth:   registry.NewGCPServiceAccountAuth(serviceAccount),
+			wantSA: serviceAccount,
+		},
+		{
+			name:    "empty payload yields no credentials",
+			auth:    &registry.TargetAuth{Type: registry.AuthTypeGCPServiceAccount, GCPServiceAccount: &empty},
+			wantNil: true,
+		},
+		{
+			name:    "missing payload yields no credentials",
+			auth:    &registry.TargetAuth{Type: registry.AuthTypeGCPServiceAccount},
+			wantNil: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			creds := providers.CredentialsFromTargetAuth(tc.auth)
+			if tc.wantNil {
+				if creds.GCP != nil {
+					t.Fatalf("GCP credentials = %+v, want nil", *creds.GCP)
+				}
+				return
+			}
+			if creds.GCP == nil {
+				t.Fatal("GCP credentials are nil: the service account payload never reaches the provider client")
+			}
+			if creds.GCP.ServiceAccountJSON != tc.wantSA {
+				t.Fatalf("ServiceAccountJSON = %q, want %q", creds.GCP.ServiceAccountJSON, tc.wantSA)
+			}
+		})
+	}
+}

--- a/pkg/infra/providers/options.go
+++ b/pkg/infra/providers/options.go
@@ -98,7 +98,8 @@ func DecodeVertexOptions(options map[string]any) (VertexOptions, error) {
 	}
 
 	opts.Project = strings.TrimSpace(opts.Project)
-	opts.Location = strings.TrimSpace(opts.Location)
+	// The location reaches both the host and the URL path, where mixed case would not resolve.
+	opts.Location = strings.ToLower(strings.TrimSpace(opts.Location))
 	opts.Version = strings.TrimSpace(opts.Version)
 
 	if opts.Project == "" {

--- a/pkg/infra/providers/vertex/client.go
+++ b/pkg/infra/providers/vertex/client.go
@@ -33,14 +33,20 @@ const (
 	streamAction  = "streamGenerateContent"
 
 	optKeyAction = "action"
+
+	globalLocation = "global"
 )
 
 type client struct {
-	pool *providers.HTTPClientPool
+	pool        *providers.HTTPClientPool
+	tokenSource tokenSource
 }
 
 func NewVertexClient() providers.Client {
-	return &client{pool: providers.NewHTTPClientPool()}
+	return &client{
+		pool:        providers.NewHTTPClientPool(),
+		tokenSource: defaultTokenCache.token,
+	}
 }
 
 func (c *client) Completions(
@@ -53,7 +59,12 @@ func (c *client) Completions(
 		return nil, err
 	}
 
-	req, err := c.newHTTPRequest(ctx, url, config.Credentials.ApiKey, reqBody)
+	token, err := c.bearerToken(ctx, config)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := c.newHTTPRequest(ctx, url, token, reqBody)
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +96,12 @@ func (c *client) CompletionsStream(
 		return nil, err
 	}
 
-	req, err := c.newHTTPRequest(ctx, url, config.Credentials.ApiKey, reqBody)
+	token, err := c.bearerToken(ctx, config)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := c.newHTTPRequest(ctx, url, token, reqBody)
 	if err != nil {
 		return nil, err
 	}
@@ -104,11 +120,29 @@ func (c *client) CompletionsStream(
 	return providers.StreamResponse(ctx, resp.Body), nil
 }
 
-func (c *client) buildRequestURL(config *providers.Config, reqBody []byte, stream bool) (string, error) {
-	if config.Credentials.ApiKey == "" {
-		return "", fmt.Errorf("bearer token (api_key) is required for Vertex AI")
+func (c *client) bearerToken(ctx context.Context, config *providers.Config) (string, error) {
+	if config.Credentials.GCP != nil {
+		source := c.tokenSource
+		if source == nil {
+			source = defaultTokenCache.token
+		}
+		token, err := source(ctx, config.Credentials.GCP)
+		if err != nil {
+			return "", fmt.Errorf("%w: failed to get Vertex AI bearer token: %w", registry.ErrCredentialAcquisition, err)
+		}
+		return token, nil
 	}
 
+	if config.Credentials.ApiKey == "" {
+		return "", fmt.Errorf(
+			"%w: vertex requires either gcp service account credentials or a bearer token (api_key)",
+			registry.ErrCredentialAcquisition,
+		)
+	}
+	return config.Credentials.ApiKey, nil
+}
+
+func (c *client) buildRequestURL(config *providers.Config, reqBody []byte, stream bool) (string, error) {
 	opts, err := providers.DecodeVertexOptions(config.Options)
 	if err != nil {
 		return "", err
@@ -178,11 +212,19 @@ func isModelAllowed(model string, allowed []string) bool {
 	return false
 }
 
+// The global endpoint is the only location reached through an unprefixed host.
+func vertexHost(location string) string {
+	if location == globalLocation {
+		return "aiplatform.googleapis.com"
+	}
+	return location + "-aiplatform.googleapis.com"
+}
+
 func buildVertexURL(opts providers.VertexOptions, model, action string) string {
 	var sb strings.Builder
 	sb.WriteString("https://")
-	sb.WriteString(opts.Location)
-	sb.WriteString("-aiplatform.googleapis.com/")
+	sb.WriteString(vertexHost(opts.Location))
+	sb.WriteByte('/')
 	sb.WriteString(opts.Version)
 	sb.WriteString("/projects/")
 	sb.WriteString(opts.Project)

--- a/pkg/infra/providers/vertex/client_test.go
+++ b/pkg/infra/providers/vertex/client_test.go
@@ -43,6 +43,25 @@ func TestBuildVertexURL(t *testing.T) {
 	)
 }
 
+func TestBuildVertexURLGlobalEndpoint(t *testing.T) {
+	opts := providers.VertexOptions{Project: "my-proj", Location: "global", Version: "v1"}
+
+	assert.Equal(t,
+		"https://aiplatform.googleapis.com/v1/projects/my-proj/locations/global/publishers/google/models/gemini-2.5-flash:generateContent",
+		buildVertexURL(opts, "gemini-2.5-flash", "generateContent"),
+		"the global endpoint has no region prefix in the host",
+	)
+	assert.Equal(t,
+		"https://aiplatform.googleapis.com/v1/projects/my-proj/locations/global/publishers/google/models/gemini-2.5-flash:streamGenerateContent?alt=sse",
+		buildVertexURL(opts, "gemini-2.5-flash", "streamGenerateContent"),
+	)
+}
+
+func TestVertexHost(t *testing.T) {
+	assert.Equal(t, "aiplatform.googleapis.com", vertexHost("global"))
+	assert.Equal(t, "europe-west1-aiplatform.googleapis.com", vertexHost("europe-west1"))
+}
+
 func TestResolveModel(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -97,10 +116,13 @@ func TestIsModelAllowed(t *testing.T) {
 func TestBuildRequestURL(t *testing.T) {
 	c := &client{}
 
-	t.Run("missing credentials", func(t *testing.T) {
-		_, err := c.buildRequestURL(&providers.Config{}, []byte(`{}`), false)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "bearer token")
+	t.Run("credentials are not needed to build the URL", func(t *testing.T) {
+		cfg := &providers.Config{
+			Model:   "gemini-2.5-flash",
+			Options: map[string]any{"project": "p", "location": "us-central1"},
+		}
+		_, err := c.buildRequestURL(cfg, []byte(`{}`), false)
+		require.NoError(t, err)
 	})
 
 	t.Run("missing project", func(t *testing.T) {
@@ -112,6 +134,34 @@ func TestBuildRequestURL(t *testing.T) {
 		_, err := c.buildRequestURL(cfg, []byte(`{}`), false)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "project")
+	})
+
+	t.Run("global location", func(t *testing.T) {
+		cfg := &providers.Config{
+			Credentials: providers.Credentials{ApiKey: "tok"},
+			Model:       "gemini-2.5-flash",
+			Options:     map[string]any{"project": "p", "location": "global"},
+		}
+		url, err := c.buildRequestURL(cfg, []byte(`{}`), false)
+		require.NoError(t, err)
+		assert.Equal(t,
+			"https://aiplatform.googleapis.com/v1/projects/p/locations/global/publishers/google/models/gemini-2.5-flash:generateContent",
+			url,
+		)
+	})
+
+	t.Run("location casing is normalized", func(t *testing.T) {
+		cfg := &providers.Config{
+			Credentials: providers.Credentials{ApiKey: "tok"},
+			Model:       "gemini-2.5-flash",
+			Options:     map[string]any{"project": "p", "location": " Europe-West1 "},
+		}
+		url, err := c.buildRequestURL(cfg, []byte(`{}`), false)
+		require.NoError(t, err)
+		assert.Equal(t,
+			"https://europe-west1-aiplatform.googleapis.com/v1/projects/p/locations/europe-west1/publishers/google/models/gemini-2.5-flash:generateContent",
+			url,
+		)
 	})
 
 	t.Run("full pipeline non-streaming", func(t *testing.T) {

--- a/pkg/infra/providers/vertex/connection.go
+++ b/pkg/infra/providers/vertex/connection.go
@@ -1,0 +1,42 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vertex
+
+import (
+	"context"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+)
+
+// The probe stops at credential acquisition: reaching a model would need a model name and would bill tokens.
+func (c *client) TestConnection(ctx context.Context, config *providers.Config) providers.ProbeResult {
+	if _, err := providers.DecodeVertexOptions(config.Options); err != nil {
+		return providers.ProbeResult{
+			OK:      false,
+			Stage:   providers.StageConnectivity,
+			Message: err.Error(),
+		}
+	}
+
+	if _, err := c.bearerToken(ctx, config); err != nil {
+		return providers.ProbeResult{
+			OK:      false,
+			Stage:   providers.StageAuthentication,
+			Message: err.Error(),
+		}
+	}
+
+	return providers.ProbeResult{OK: true, Stage: providers.StageAuthentication}
+}

--- a/pkg/infra/providers/vertex/connection_test.go
+++ b/pkg/infra/providers/vertex/connection_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vertex
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+)
+
+func TestVertexClientImplementsConnectionTester(t *testing.T) {
+	_, ok := NewVertexClient().(providers.ConnectionTester)
+	assert.True(t, ok, "vertex must expose a connection tester so the UI can validate a registry")
+}
+
+func TestTestConnection(t *testing.T) {
+	validOptions := map[string]any{"project": "careplus-poc", "location": "europe-west1"}
+	serviceAccount := providers.Credentials{GCP: &providers.GCP{ServiceAccountJSON: `{"type":"service_account"}`}}
+
+	tests := []struct {
+		name      string
+		config    *providers.Config
+		token     tokenSource
+		wantOK    bool
+		wantStage providers.ProbeStage
+		wantMsg   string
+	}{
+		{
+			name:      "valid service account",
+			config:    &providers.Config{Options: validOptions, Credentials: serviceAccount},
+			token:     func(context.Context, *providers.GCP) (string, error) { return "ya29.minted", nil },
+			wantOK:    true,
+			wantStage: providers.StageAuthentication,
+		},
+		{
+			name:      "google rejects the service account",
+			config:    &providers.Config{Options: validOptions, Credentials: serviceAccount},
+			token:     func(context.Context, *providers.GCP) (string, error) { return "", fmt.Errorf("invalid_grant") },
+			wantOK:    false,
+			wantStage: providers.StageAuthentication,
+			wantMsg:   "invalid_grant",
+		},
+		{
+			name:      "missing location",
+			config:    &providers.Config{Options: map[string]any{"project": "careplus-poc"}, Credentials: serviceAccount},
+			wantOK:    false,
+			wantStage: providers.StageConnectivity,
+			wantMsg:   "location",
+		},
+		{
+			name:      "no credentials configured",
+			config:    &providers.Config{Options: validOptions},
+			wantOK:    false,
+			wantStage: providers.StageAuthentication,
+			wantMsg:   "gcp service account credentials or a bearer token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := (&client{tokenSource: tt.token}).TestConnection(context.Background(), tt.config)
+
+			assert.Equal(t, tt.wantOK, result.OK)
+			assert.Equal(t, tt.wantStage, result.Stage)
+			if tt.wantMsg != "" {
+				assert.Contains(t, result.Message, tt.wantMsg)
+			}
+		})
+	}
+}

--- a/pkg/infra/providers/vertex/token.go
+++ b/pkg/infra/providers/vertex/token.go
@@ -1,0 +1,111 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vertex
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+)
+
+const (
+	cloudPlatformScope    = "https://www.googleapis.com/auth/cloud-platform" // #nosec G101 -- OAuth scope, not a credential value
+	tokenRequestTimeout   = 10 * time.Second
+	maxCachedTokenSources = 256
+)
+
+var defaultTokenCache = newTokenCache()
+
+type tokenSource func(context.Context, *providers.GCP) (string, error)
+
+type tokenCache struct {
+	httpClient *http.Client
+	mu         sync.RWMutex
+	sources    map[string]oauth2.TokenSource
+}
+
+func newTokenCache() *tokenCache {
+	return &tokenCache{
+		httpClient: &http.Client{Timeout: tokenRequestTimeout},
+		sources:    make(map[string]oauth2.TokenSource),
+	}
+}
+
+func (c *tokenCache) token(ctx context.Context, gcp *providers.GCP) (string, error) {
+	if gcp == nil || gcp.ServiceAccountJSON == "" {
+		return "", fmt.Errorf("gcp service account credentials are required for Vertex AI")
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	source, err := c.source(gcp.ServiceAccountJSON)
+	if err != nil {
+		return "", err
+	}
+
+	token, err := source.Token()
+	if err != nil {
+		return "", fmt.Errorf("exchanging gcp service account for an access token: %w", err)
+	}
+	return token.AccessToken, nil
+}
+
+func (c *tokenCache) source(serviceAccountJSON string) (oauth2.TokenSource, error) {
+	key := serviceAccountKey(serviceAccountJSON)
+
+	c.mu.RLock()
+	cached, ok := c.sources[key]
+	c.mu.RUnlock()
+	if ok {
+		return cached, nil
+	}
+
+	// Rejects external_account configs, which can name a tenant-controlled local executable as their credential source.
+	config, err := google.JWTConfigFromJSON([]byte(serviceAccountJSON), cloudPlatformScope)
+	if err != nil {
+		return nil, fmt.Errorf("parsing gcp service account credentials: %w", err)
+	}
+
+	// A cached source outlives the request that created it, so a request context here would break every later refresh.
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, c.httpClient)
+	source := config.TokenSource(ctx)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if existing, ok := c.sources[key]; ok {
+		return existing, nil
+	}
+	// Rebuilding a source is cheap, so drop the cache rather than let key rotations grow it without bound.
+	if len(c.sources) >= maxCachedTokenSources {
+		clear(c.sources)
+	}
+	c.sources[key] = source
+	return source, nil
+}
+
+func serviceAccountKey(serviceAccountJSON string) string {
+	sum := sha256.Sum256([]byte(serviceAccountJSON))
+	return hex.EncodeToString(sum[:])
+}

--- a/pkg/infra/providers/vertex/token_test.go
+++ b/pkg/infra/providers/vertex/token_test.go
@@ -1,0 +1,247 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vertex
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+)
+
+func serviceAccountJSON(t *testing.T, tokenURI, email string) string {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	privateKey := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+
+	raw, err := json.Marshal(map[string]string{
+		"type":         "service_account",
+		"project_id":   "careplus-poc",
+		"private_key":  string(privateKey),
+		"client_email": email,
+		"token_uri":    tokenURI,
+	})
+	require.NoError(t, err)
+
+	return string(raw)
+}
+
+func tokenEndpoint(t *testing.T, calls *atomic.Int64) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"access_token":"ya29.minted","token_type":"Bearer","expires_in":3600}`)
+	}))
+	t.Cleanup(server.Close)
+
+	return server
+}
+
+func TestTokenCacheMintsAccessToken(t *testing.T) {
+	var calls atomic.Int64
+	server := tokenEndpoint(t, &calls)
+
+	token, err := newTokenCache().token(context.Background(), &providers.GCP{
+		ServiceAccountJSON: serviceAccountJSON(t, server.URL, "sa@careplus-poc.iam.gserviceaccount.com"),
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "ya29.minted", token)
+	assert.Equal(t, int64(1), calls.Load())
+}
+
+func TestTokenCacheReusesValidToken(t *testing.T) {
+	var calls atomic.Int64
+	server := tokenEndpoint(t, &calls)
+	cache := newTokenCache()
+	gcp := &providers.GCP{ServiceAccountJSON: serviceAccountJSON(t, server.URL, "sa@careplus-poc.iam.gserviceaccount.com")}
+
+	for range 5 {
+		token, err := cache.token(context.Background(), gcp)
+		require.NoError(t, err)
+		assert.Equal(t, "ya29.minted", token)
+	}
+
+	assert.Equal(t, int64(1), calls.Load(),
+		"a valid access token must be reused instead of signing a new JWT on every request")
+}
+
+func TestTokenCacheIsolatesServiceAccounts(t *testing.T) {
+	var calls atomic.Int64
+	server := tokenEndpoint(t, &calls)
+	cache := newTokenCache()
+
+	for _, email := range []string{"one@careplus-poc.iam.gserviceaccount.com", "two@careplus-poc.iam.gserviceaccount.com"} {
+		_, err := cache.token(context.Background(), &providers.GCP{
+			ServiceAccountJSON: serviceAccountJSON(t, server.URL, email),
+		})
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, int64(2), calls.Load(), "each service account needs its own token")
+}
+
+func TestTokenCacheConcurrentCallers(t *testing.T) {
+	var calls atomic.Int64
+	server := tokenEndpoint(t, &calls)
+	cache := newTokenCache()
+	gcp := &providers.GCP{ServiceAccountJSON: serviceAccountJSON(t, server.URL, "sa@careplus-poc.iam.gserviceaccount.com")}
+
+	var wg sync.WaitGroup
+	for range 20 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			token, err := cache.token(context.Background(), gcp)
+			assert.NoError(t, err)
+			assert.Equal(t, "ya29.minted", token)
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, int64(1), calls.Load(), "concurrent requests must share a single token exchange")
+}
+
+func TestTokenCacheErrors(t *testing.T) {
+	var calls atomic.Int64
+	server := tokenEndpoint(t, &calls)
+
+	rejecting := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = fmt.Fprint(w, `{"error":"invalid_grant","error_description":"Invalid JWT Signature."}`)
+	}))
+	t.Cleanup(rejecting.Close)
+
+	tests := []struct {
+		name        string
+		gcp         *providers.GCP
+		cancel      bool
+		errContains string
+	}{
+		{name: "nil credentials", gcp: nil, errContains: "required"},
+		{name: "empty json", gcp: &providers.GCP{}, errContains: "required"},
+		{
+			name:        "malformed json",
+			gcp:         &providers.GCP{ServiceAccountJSON: "{not-json"},
+			errContains: "parsing gcp service account credentials",
+		},
+		{
+			name: "external account config is rejected",
+			gcp: &providers.GCP{ServiceAccountJSON: `{"type":"external_account","audience":"//iam.googleapis.com/x",` +
+				`"token_url":"https://sts.googleapis.com/v1/token","credential_source":{"executable":{"command":"/bin/sh -c id"}}}`},
+			errContains: "parsing gcp service account credentials",
+		},
+		{
+			name:        "google rejects the assertion",
+			gcp:         &providers.GCP{ServiceAccountJSON: serviceAccountJSON(t, rejecting.URL, "sa@careplus-poc.iam.gserviceaccount.com")},
+			errContains: "exchanging gcp service account for an access token",
+		},
+		{
+			name:        "cancelled context",
+			gcp:         &providers.GCP{ServiceAccountJSON: serviceAccountJSON(t, server.URL, "sa@careplus-poc.iam.gserviceaccount.com")},
+			cancel:      true,
+			errContains: "context canceled",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if tt.cancel {
+				cancel()
+			}
+
+			_, err := newTokenCache().token(ctx, tt.gcp)
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errContains)
+		})
+	}
+}
+
+func TestBearerTokenWrapsCredentialFailures(t *testing.T) {
+	c := &client{
+		tokenSource: func(context.Context, *providers.GCP) (string, error) {
+			return "", fmt.Errorf("invalid_grant")
+		},
+	}
+
+	_, err := c.bearerToken(context.Background(), &providers.Config{
+		Credentials: providers.Credentials{GCP: &providers.GCP{ServiceAccountJSON: `{"type":"service_account"}`}},
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, registry.ErrCredentialAcquisition,
+		"credential failures must be terminal so the proxy does not retry or fall back")
+}
+
+func TestBearerTokenSources(t *testing.T) {
+	t.Run("service account takes precedence over api key", func(t *testing.T) {
+		c := &client{
+			tokenSource: func(context.Context, *providers.GCP) (string, error) {
+				return "minted", nil
+			},
+		}
+
+		token, err := c.bearerToken(context.Background(), &providers.Config{
+			Credentials: providers.Credentials{
+				ApiKey: "stale-manual-token",
+				GCP:    &providers.GCP{ServiceAccountJSON: `{"type":"service_account"}`},
+			},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "minted", token)
+	})
+
+	t.Run("pre-minted bearer token is used verbatim", func(t *testing.T) {
+		token, err := (&client{}).bearerToken(context.Background(), &providers.Config{
+			Credentials: providers.Credentials{ApiKey: "ya29.manual"},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "ya29.manual", token)
+	})
+
+	t.Run("no credentials at all", func(t *testing.T) {
+		_, err := (&client{}).bearerToken(context.Background(), &providers.Config{})
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, registry.ErrCredentialAcquisition)
+	})
+}


### PR DESCRIPTION
## Summary

A Vertex registry with `gcp_service_account` auth could be created, saved and validated, but no code ever turned that JSON into a token for Google. The credential mapping left the case empty, so every request failed inside TrustGate with `bearer token (api_key) is required for Vertex AI` before reaching GCP — regardless of whether the service account, project, location or IAM roles were correct.

This PR implements the missing exchange:

- `CredentialsFromTargetAuth` now carries the service account JSON to the provider client.
- The Vertex client exchanges it for a short-lived access token, caching one token source per service account so a JWT is signed only when the token expires, not on every request.
- `JWTConfigFromJSON` is used over `CredentialsFromJSON` because the latter also parses `external_account` configs, which can name a tenant-controlled local executable as their credential source. The payload here is pasted by a tenant into the registry form.
- Connection testing no longer reports GCP service accounts as unsupported: the client now exposes a probe that stops at credential acquisition, mirroring the Bedrock probe (reaching a model would need a model name and would bill tokens).

It also fixes a second, independent bug found while testing: with `location: global` the URL was built as `global-aiplatform.googleapis.com`, which does not resolve. The global endpoint is unprefixed. Locations are also normalized to lowercase, since the value reaches both the host and the URL path.

The pre-existing `api_key` path is untouched, so registries using a manually minted bearer token keep working.

## Linear

ENG-1319 — https://linear.app/neuraltrust/issue/ENG-1319/fallo-integracion-google-vertex-ai-registries

## Notes for the reviewer

- `oauth2` moves from indirect to direct; the only new module is `cloud.google.com/go/compute/metadata`.
- The token source is built on a background context on purpose: it outlives the request that created it, so binding it to a request context would break every later refresh. The exchange is bounded by the HTTP client timeout instead.
- Roughly two thirds of the diff is tests.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `golangci-lint run` (0 issues)
- [x] `go test ./... -race` green
- [x] Token minting, reuse across requests, per-service-account isolation and 20-goroutine concurrency covered against a local token endpoint with a generated RSA key
- [x] Regression test: an `external_account` config with `credential_source.executable` is rejected
- [x] URL building covered for regional, global and mixed-case locations
- [ ] Validate end to end against a real GCP service account (not possible locally)

Made with [Cursor](https://cursor.com)