### PR TITLE
fix(security): bump Go to 1.26.6 to clear stdlib CVEs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache: true
       - name: Install addlicense
         run: go install github.com/google/addlicense@latest
@@ -33,7 +33,7 @@ jobs:
     uses: NeuralTrust/workflows/.github/workflows/tests.yml@main
     with:
       language: go
-      language_version: "1.26.5"
+      language_version: "1.26.6"
       go_private_modules: true
       lint_enabled: true
       coverage_enabled: true
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache: true
       - name: Build, vet and test pkg/metrics
         working-directory: pkg/metrics
@@ -64,7 +64,7 @@ jobs:
         with:
           version: v2.12.2
           # Released golangci-lint binaries are built with go1.25 and refuse to
-          # lint this module's go1.26.5 directive; goinstall recompiles it with
+          # lint this module's go1.26.6 directive; goinstall recompiles it with
           # the active setup-go toolchain so the versions match.
           install-mode: goinstall
           working-directory: pkg/metrics
@@ -98,7 +98,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           check-latest: true
           cache: true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM golang:1.26.5-bookworm AS builder
+FROM golang:1.26.6-bookworm AS builder
 
 WORKDIR /build
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/NeuralTrust/TrustGate
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1

--- a/pkg/metrics/go.mod
+++ b/pkg/metrics/go.mod
@@ -1,3 +1,3 @@
 module github.com/NeuralTrust/TrustGate/pkg/metrics
 
-go 1.26.5
+go 1.26.6


### PR DESCRIPTION
Trivy fails the release image scan on two HIGH stdlib findings in the vendored golang.org/x/net copies (CVE-2026-39821 idna punycode privilege escalation, CVE-2026-46600 dnsmessage DoS). Both are fixed in Go 1.26.6, so pin the builder image, both module directives, and the CI toolchain.