### PR TITLE
feat(mcp): record southbound protocol decision and probe meters (RUN-1109)

### DIFF
--- a/openspec/changes/run-1109-dual-era-rollout-telemetry/tasks.md
+++ b/openspec/changes/run-1109-dual-era-rollout-telemetry/tasks.md
@@ -46,10 +46,10 @@ Each child PR must show only its slice; merge to `main` in order and retarget th
 
 ## Phase 2: Dialer meters (PR 2)
 
-- [ ] 2.1 RED: `negotiating_dialer_test.go` + fake meter — cache → `source=cache` and no probe histogram; probe → `source=probe` + latency; `modern`/`legacy` → `source=override` no probe; contradiction labeled; no origin/credential/tool-arg attrs. Spec: Steady-state cache; Probe without origin label; Override skips probe; Forbidden fields absent.
-- [ ] 2.2 GREEN: create `pkg/infra/mcp/client/protocol_metrics.go` (`otel.Meter("trustgate/mcp_upstream")`): `mcp.upstream.protocol.decision_total{source,mode,era,result,category?}`, `mcp.upstream.protocol.probe_latency_seconds` only when `source=probe`. Soft no-op if meter init fails or `OPS_METRICS_ENABLED` is false.
-- [ ] 2.3 GREEN: record from `logDecision`/`logSelection` in `negotiating_dialer.go`; inject recorder via ctor (nil no-op); wire in `pkg/container/modules/mcp.go`. Leave slog origin as-is. Do not change `protocol_mode` semantics.
-- [ ] 2.4 `clean-comments`; `/reviewer` + `/verifier`: `go test -race ./pkg/infra/mcp/client`, `go vet ./...`, `golangci-lint run`.
+- [x] 2.1 RED: `negotiating_dialer_test.go` + fake meter — cache → `source=cache` and no probe histogram; probe → `source=probe` + latency; `modern`/`legacy` → `source=override` no probe; contradiction labeled; no origin/credential/tool-arg attrs. Spec: Steady-state cache; Probe without origin label; Override skips probe; Forbidden fields absent.
+- [x] 2.2 GREEN: create `pkg/infra/mcp/client/protocol_metrics.go` (`otel.Meter("trustgate/mcp_upstream")`): `mcp.upstream.protocol.decision_total{source,mode,era,result,category?}`, `mcp.upstream.protocol.probe_latency_seconds` only when `source=probe`. Soft no-op if meter init fails or `OPS_METRICS_ENABLED` is false.
+- [x] 2.3 GREEN: record from `logDecision`/`logSelection` in `negotiating_dialer.go`; inject recorder via ctor (nil no-op); wire in `pkg/container/modules/mcp.go`. Leave slog origin as-is. Do not change `protocol_mode` semantics.
+- [x] 2.4 `clean-comments`; `/reviewer` + `/verifier`: `go test -race ./pkg/infra/mcp/client`, `go vet ./...`, `golangci-lint run`.
 
 ## Phase 3: Consumer gate (PR 3)
 

--- a/pkg/container/modules/mcp.go
+++ b/pkg/container/modules/mcp.go
@@ -41,8 +41,8 @@ func MCP(c *container.Container) error {
 	if err := c.Provide(mcpclient.New); err != nil {
 		return err
 	}
-	if err := c.Provide(func(client *mcpclient.Client, logger *slog.Logger) appmcp.Dialer {
-		return mcpclient.NewNegotiatingDialer(client, logger)
+	if err := c.Provide(func(client *mcpclient.Client, logger *slog.Logger, cfg *config.Config) appmcp.Dialer {
+		return mcpclient.NewNegotiatingDialer(client, logger, mcpclient.NewProtocolDecisionRecorder(cfg.Telemetry.OpsMetricsEnabled))
 	}); err != nil {
 		return err
 	}

--- a/pkg/infra/mcp/client/negotiating_dialer.go
+++ b/pkg/infra/mcp/client/negotiating_dialer.go
@@ -39,6 +39,7 @@ type negotiatingDialer struct {
 	coordinator         *eraCoordinator
 	modern              modernUpstreamFactory
 	logger              *slog.Logger
+	metrics             ProtocolDecisionRecorder
 	now                 func() time.Time
 	confirmationFlight  singleflight.Group
 	confirmationRetry   singleflight.Group
@@ -47,7 +48,7 @@ type negotiatingDialer struct {
 	reconcileConfirmed  func()
 }
 
-func NewNegotiatingDialer(client *Client, logger *slog.Logger) appmcp.Dialer {
+func NewNegotiatingDialer(client *Client, logger *slog.Logger, rec ...ProtocolDecisionRecorder) appmcp.Dialer {
 	legacy := newCachedDialer(client, logger)
 	return newNegotiatingDialer(
 		legacy,
@@ -56,6 +57,7 @@ func NewNegotiatingDialer(client *Client, logger *slog.Logger) appmcp.Dialer {
 			return newModernUpstream(target, protocolVersion)
 		},
 		logger,
+		rec...,
 	)
 }
 
@@ -64,17 +66,22 @@ func newNegotiatingDialer(
 	coordinator *eraCoordinator,
 	modern modernUpstreamFactory,
 	logger *slog.Logger,
+	rec ...ProtocolDecisionRecorder,
 ) *negotiatingDialer {
 	if logger == nil {
 		logger = slog.New(slog.DiscardHandler)
 	}
-	return &negotiatingDialer{
+	d := &negotiatingDialer{
 		legacy:      legacy,
 		coordinator: coordinator,
 		modern:      modern,
 		logger:      logger,
 		now:         time.Now,
 	}
+	if len(rec) > 0 {
+		d.metrics = rec[0]
+	}
+	return d
 }
 
 func (d *negotiatingDialer) Connect(ctx context.Context, target appmcp.Target) (appmcp.Upstream, error) {
@@ -459,6 +466,7 @@ func (d *negotiatingDialer) logDecision(
 	started time.Time,
 	err error,
 ) {
+	latency := d.now().Sub(started)
 	attrs := []slog.Attr{
 		slog.String("component", "mcp_upstream_protocol"),
 		slog.String("origin", origin),
@@ -467,12 +475,26 @@ func (d *negotiatingDialer) logDecision(
 		slog.String("source", string(source)),
 		slog.String("result", outcome),
 		slog.String("version", version),
-		slog.Int64("latency_ms", d.now().Sub(started).Milliseconds()),
+		slog.Int64("latency_ms", latency.Milliseconds()),
 	}
 	if err != nil {
 		attrs = append(attrs, slog.String("category", negotiationErrorCategory(err)))
 	}
 	d.logger.LogAttrs(ctx, slog.LevelInfo, "mcp upstream protocol selection", attrs...)
+	if d.metrics == nil {
+		return
+	}
+	decision := ProtocolDecision{
+		Source:  string(source),
+		Mode:    string(mode),
+		Era:     era.String(),
+		Result:  outcome,
+		Latency: latency,
+	}
+	if err != nil {
+		decision.Category = negotiationErrorCategory(err)
+	}
+	d.metrics.Record(ctx, decision)
 }
 
 func negotiationErrorCategory(err error) string {

--- a/pkg/infra/mcp/client/negotiating_dialer_test.go
+++ b/pkg/infra/mcp/client/negotiating_dialer_test.go
@@ -1892,3 +1892,217 @@ func TestModernRoundTripperTracksOnlyAmbiguousBadRequest(t *testing.T) {
 		})
 	}
 }
+
+type recordingProtocolDecision struct {
+	mu    sync.Mutex
+	calls []recordedProtocolDecision
+}
+
+type recordedProtocolDecision struct {
+	source         string
+	mode           string
+	era            string
+	result         string
+	category       string
+	probeHistogram bool
+	probeLatency   time.Duration
+	labels         map[string]string
+}
+
+func (r *recordingProtocolDecision) Record(_ context.Context, d ProtocolDecision) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	labels := map[string]string{
+		"source": d.Source,
+		"mode":   d.Mode,
+		"era":    d.Era,
+		"result": d.Result,
+	}
+	if d.Category != "" {
+		labels["category"] = d.Category
+	}
+	r.calls = append(r.calls, recordedProtocolDecision{
+		source:         d.Source,
+		mode:           d.Mode,
+		era:            d.Era,
+		result:         d.Result,
+		category:       d.Category,
+		probeHistogram: d.Source == string(decisionProbe),
+		probeLatency:   d.Latency,
+		labels:         labels,
+	})
+}
+
+func (r *recordingProtocolDecision) snapshot() []recordedProtocolDecision {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]recordedProtocolDecision, len(r.calls))
+	copy(out, r.calls)
+	return out
+}
+
+func metricTarget(url string, mode registrydomain.MCPProtocolMode) appmcp.Target {
+	return appmcp.Target{
+		URL:          url,
+		ProtocolMode: mode,
+		Headers:      map[string]string{"Authorization": "Bearer secret-token"},
+	}
+}
+
+func assertNoForbiddenProtocolMetricLabels(t *testing.T, calls []recordedProtocolDecision) {
+	t.Helper()
+	forbidden := []string{"origin", "credential", "token", "authorization", "header", "body", "tool", "argument", "url"}
+	for _, call := range calls {
+		for key, value := range call.labels {
+			blob := strings.ToLower(key + " " + value)
+			for _, needle := range forbidden {
+				if strings.Contains(blob, needle) {
+					t.Fatalf("forbidden metric field %q=%q", key, value)
+				}
+			}
+			if strings.Contains(value, "secret-token") || strings.Contains(strings.ToLower(value), "example.com") {
+				t.Fatalf("sensitive value leaked in %q=%q", key, value)
+			}
+		}
+	}
+}
+
+func TestNewProtocolDecisionRecorderDisabledIsNil(t *testing.T) {
+	t.Parallel()
+	if rec := NewProtocolDecisionRecorder(false); rec != nil {
+		t.Fatal("disabled recorder must be nil")
+	}
+}
+
+func TestNegotiatingDialerMetricsProbeThenCache(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingProtocolDecision{}
+	var probes atomic.Int64
+	dialer := newNegotiatingDialer(
+		legacyConnectorFunc(func(context.Context, appmcp.Target) (appmcp.Upstream, error) {
+			return nil, errors.New("legacy fallback must not run")
+		}),
+		newEraCoordinator(probeFunc(func(context.Context, appmcp.Target) (probeOutcome, error) {
+			probes.Add(1)
+			return probeOutcome{kind: probeModern, version: modernProtocolVersion}, nil
+		}), time.Second),
+		func(appmcp.Target, string) (appmcp.Upstream, error) { return &upstreamStub{}, nil },
+		slog.New(slog.DiscardHandler),
+		rec,
+	)
+	target := metricTarget("https://example.com/mcp", registrydomain.MCPProtocolModeAuto)
+	for range 2 {
+		if _, err := dialer.Connect(context.Background(), target); err != nil {
+			t.Fatalf("connect: %v", err)
+		}
+	}
+	calls := rec.snapshot()
+	if len(calls) != 2 {
+		t.Fatalf("records = %d, want 2", len(calls))
+	}
+	if calls[0].source != string(decisionProbe) || !calls[0].probeHistogram || calls[0].probeLatency < 0 {
+		t.Fatalf("probe record = %+v", calls[0])
+	}
+	if calls[1].source != string(decisionCache) || calls[1].probeHistogram {
+		t.Fatalf("cache record = %+v", calls[1])
+	}
+	if probes.Load() != 1 {
+		t.Fatalf("probes = %d, want 1", probes.Load())
+	}
+	assertNoForbiddenProtocolMetricLabels(t, calls)
+}
+
+func TestNegotiatingDialerMetricsOverrideSkipsProbe(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingProtocolDecision{}
+	var probes atomic.Int64
+	dialer := newNegotiatingDialer(
+		legacyConnectorFunc(func(context.Context, appmcp.Target) (appmcp.Upstream, error) {
+			return &upstreamStub{}, nil
+		}),
+		newEraCoordinator(probeFunc(func(context.Context, appmcp.Target) (probeOutcome, error) {
+			probes.Add(1)
+			return probeOutcome{}, errors.New("probe must not run")
+		}), time.Second),
+		func(appmcp.Target, string) (appmcp.Upstream, error) { return &upstreamStub{}, nil },
+		slog.New(slog.DiscardHandler),
+		rec,
+	)
+	if _, err := dialer.Connect(context.Background(), metricTarget("https://example.com/legacy", registrydomain.MCPProtocolModeLegacy)); err != nil {
+		t.Fatalf("legacy override: %v", err)
+	}
+	if _, err := dialer.Connect(context.Background(), metricTarget("https://example.com/modern", registrydomain.MCPProtocolModeModern)); err != nil {
+		t.Fatalf("modern override: %v", err)
+	}
+	calls := rec.snapshot()
+	if len(calls) != 2 {
+		t.Fatalf("records = %d, want 2", len(calls))
+	}
+	for _, call := range calls {
+		if call.source != string(decisionOverride) || call.probeHistogram {
+			t.Fatalf("override record = %+v", call)
+		}
+	}
+	if probes.Load() != 0 {
+		t.Fatalf("probes = %d, want 0", probes.Load())
+	}
+	assertNoForbiddenProtocolMetricLabels(t, calls)
+}
+
+func TestNegotiatingDialerMetricsContradictionLabeled(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingProtocolDecision{}
+	var probes atomic.Int64
+	modern := &upstreamStub{
+		listTools: func(context.Context) ([]appmcp.Tool, error) {
+			return nil, newEraCandidateError(eraLegacy)
+		},
+	}
+	legacy := &upstreamStub{
+		listTools: func(context.Context) ([]appmcp.Tool, error) {
+			return []appmcp.Tool{{Name: "legacy"}}, nil
+		},
+	}
+	dialer := newNegotiatingDialer(
+		legacyConnectorFunc(func(context.Context, appmcp.Target) (appmcp.Upstream, error) {
+			return legacy, nil
+		}),
+		newEraCoordinator(probeFunc(func(context.Context, appmcp.Target) (probeOutcome, error) {
+			switch probes.Add(1) {
+			case 1:
+				return probeOutcome{kind: probeModern, version: modernProtocolVersion}, nil
+			default:
+				return probeOutcome{kind: probeLegacyCandidate}, nil
+			}
+		}), time.Second),
+		func(appmcp.Target, string) (appmcp.Upstream, error) { return modern, nil },
+		slog.New(slog.DiscardHandler),
+		rec,
+	)
+	upstream, err := dialer.Connect(context.Background(), metricTarget("https://example.com/mcp", registrydomain.MCPProtocolModeAuto))
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	if _, err := upstream.ListTools(context.Background()); err != nil {
+		t.Fatalf("guarded list: %v", err)
+	}
+	var contradiction recordedProtocolDecision
+	found := false
+	for _, call := range rec.snapshot() {
+		if call.source == string(decisionContradiction) {
+			contradiction = call
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("missing contradiction record: %+v", rec.snapshot())
+	}
+	if contradiction.probeHistogram {
+		t.Fatalf("contradiction must not record probe latency: %+v", contradiction)
+	}
+	assertNoForbiddenProtocolMetricLabels(t, rec.snapshot())
+}

--- a/pkg/infra/mcp/client/protocol_metrics.go
+++ b/pkg/infra/mcp/client/protocol_metrics.go
@@ -1,0 +1,87 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// ProtocolDecision is a bounded southbound negotiation outcome.
+type ProtocolDecision struct {
+	Source   string
+	Mode     string
+	Era      string
+	Result   string
+	Category string
+	Latency  time.Duration
+}
+
+// ProtocolDecisionRecorder records bounded upstream protocol decisions.
+type ProtocolDecisionRecorder interface {
+	Record(ctx context.Context, decision ProtocolDecision)
+}
+
+type otelProtocolDecisionRecorder struct {
+	counter metric.Int64Counter
+	latency metric.Float64Histogram
+}
+
+// NewProtocolDecisionRecorder returns a no-op nil recorder unless ops metrics are enabled.
+func NewProtocolDecisionRecorder(enabled bool) ProtocolDecisionRecorder {
+	if !enabled {
+		return nil
+	}
+	meter := otel.Meter("trustgate/mcp_upstream")
+	counter, err := meter.Int64Counter(
+		"mcp.upstream.protocol.decision_total",
+		metric.WithUnit("{decision}"),
+	)
+	if err != nil {
+		return nil
+	}
+	latency, err := meter.Float64Histogram(
+		"mcp.upstream.protocol.probe_latency_seconds",
+		metric.WithUnit("s"),
+	)
+	if err != nil {
+		return &otelProtocolDecisionRecorder{counter: counter}
+	}
+	return &otelProtocolDecisionRecorder{counter: counter, latency: latency}
+}
+
+func (r *otelProtocolDecisionRecorder) Record(ctx context.Context, decision ProtocolDecision) {
+	if r == nil || r.counter == nil {
+		return
+	}
+	attrs := []attribute.KeyValue{
+		attribute.String("source", decision.Source),
+		attribute.String("mode", decision.Mode),
+		attribute.String("era", decision.Era),
+		attribute.String("result", decision.Result),
+	}
+	if decision.Category != "" {
+		attrs = append(attrs, attribute.String("category", decision.Category))
+	}
+	r.counter.Add(ctx, 1, metric.WithAttributes(attrs...))
+	if decision.Source != string(decisionProbe) || r.latency == nil {
+		return
+	}
+	r.latency.Record(ctx, decision.Latency.Seconds())
+}


### PR DESCRIPTION
## Summary

- Record bounded southbound protocol decisions as `mcp.upstream.protocol.decision_total{source,mode,era,result,category?}`.
- Record `mcp.upstream.protocol.probe_latency_seconds` only when `source=probe`.
- Cache, override, and contradiction paths skip the probe histogram. Labels stay enum-only (no origin, credentials, tokens, or tool args).
- `NewNegotiatingDialer` stays 2-arg compatible; recorder is a no-op unless `OPS_METRICS_ENABLED`.

## Stack

1. [#439](https://github.com/NeuralTrust/TrustGate/pull/439) — northbound attrs + validation counters (included as parent commit)
2. This PR — southbound dialer meters
3. Consumer `protocol_acceptance` gate (Phase 3)
4. Rollout/deprecation docs (Phase 4)

Base: `feat/run-1103-dual-era-northbound-protocol-boundary` ([#400](https://github.com/NeuralTrust/TrustGate/pull/400)). Merge #439 first if you want this diff to show Phase 2 only; otherwise this PR also contains Phase 1.

## Linear

RUN-1109 — https://linear.app/neuraltrust/issue/RUN-1109/featmcp-roll-out-dual-era-support-with-protocol-telemetry

## Test plan

- [x] `go test -race ./pkg/infra/mcp/client`
- [x] Pre-commit hook (lint + gosec + unit) passed
- [ ] CI on this PR


Made with [Cursor](https://cursor.com)