### PR TITLE
feat(mcp): add protocol_acceptance gate and dual-era rollout docs (RUN-1109)

### DIFF
--- a/docs/mcp/dual-era-rollout.md
+++ b/docs/mcp/dual-era-rollout.md
@@ -1,0 +1,75 @@
+# Dual-era MCP rollout
+
+TrustGate accepts MCP `2026-07-28` and legacy ≤`2025-06-18` on the same
+northbound plane. The default stays **dual-era**. Legacy is not removed in
+this rollout.
+
+## Quick path
+
+1. Leave consumer `protocol_acceptance` empty (defaults to `dual_era`) and
+   registry `protocol_mode` at `auto`.
+2. Enable `OPS_METRICS_ENABLED=true` to see protocol counters.
+3. Restrict a consumer or upstream with a config write — no binary redeploy.
+
+## Controls
+
+| Knob | Where | Default | Effect |
+|------|-------|---------|--------|
+| `protocol_acceptance` | MCP consumer (`dual_era` \| `legacy_only`) | empty → `dual_era` | `legacy_only` rejects modern northbound with HTTP 400 / RPC `-32021` / `validation_class=acceptance_denied`. No composer or upstream. |
+| `protocol_mode` | Registry MCP target (`auto` \| `modern` \| `legacy`) | `auto` | Southbound: `auto` probes once then caches; `modern`/`legacy` skip the probe (`source=override`). |
+
+Config sync applies both fields without a process restart.
+
+## Dashboards
+
+Require `OPS_METRICS_ENABLED=true`. Product events carry
+`trustgate.mcp.protocol_era` / `protocol_version` on success only
+([OTLP contract](../telemetry/otlp-metadata-contract.md)).
+
+| Question | Signal |
+|----------|--------|
+| Are clients still on legacy? | Product events: `trustgate.mcp.protocol_era=legacy` vs `modern` |
+| Unknown revisions leaking? | `trustgate.mcp.protocol_version=unsupported` |
+| Protocol 400s by class | `mcp.northbound.protocol.validation_total` by `validation_class` (include `acceptance_denied`) |
+| Steady-state vs first contact | `mcp.upstream.protocol.decision_total` `source=cache` vs `source=probe` |
+| Probe cost | `mcp.upstream.protocol.probe_latency_seconds` (probe-only) |
+| Forced southbound era | `source=override` with `mode=modern` or `mode=legacy` |
+| Header/body era fights | `source=contradiction` |
+
+Do not chart origin, credentials, tokens, or tool arguments — those labels
+are not emitted.
+
+## Rollback without redeploy
+
+To stop modern northbound for a consumer, set
+`protocol_acceptance=legacy_only` on that consumer. Legacy clients keep
+working. To force a legacy upstream, set registry `protocol_mode=legacy`.
+Either change lands through config sync.
+
+To restore dual-era, set `protocol_acceptance=dual_era` (or clear it) and
+`protocol_mode=auto`.
+
+## Deprecation exit
+
+Legacy support stays until **all** of the following are true:
+
+| Criterion | Bar |
+|-----------|-----|
+| Migration window | At least 12 months after dual-era GA |
+| Residual usage | Sustained near-zero `protocol_era=legacy` and `source` decisions that still need legacy |
+| Notice | Customers notified of the planned cutover |
+| Approval | Explicit product and engineering sign-off |
+
+This document does **not** authorize removing the legacy transport.
+
+## Checklist
+
+- [ ] Cache hits dominate `decision_total` after warmup
+- [ ] `acceptance_denied` only appears on consumers set to `legacy_only`
+- [ ] A config flip to `legacy_only` / `protocol_mode=legacy` takes effect without redeploy
+- [ ] Metric cardinality stays on the enums above
+
+## Next step
+
+Exercise the plane with the [MCP testing guide](testing-guide.md).
+Instrument names live in [Operational metrics](../operational-metrics.md).

--- a/docs/mcp/testing-guide.md
+++ b/docs/mcp/testing-guide.md
@@ -31,8 +31,10 @@ flowchart LR
 2. **Registry** (`type: mcp`) — `mcp_target.url` (+ optional auth:
    `none` / `static` / `passthrough` / `exchange` / `forwarded`).
 3. **Consumer** (`type: mcp`) — binds registries; optional `toolkit`,
-   `fail_mode` (`open` \| `closed`), or `routing_mode: role_based` with
-   `mcp_policies` on roles.
+   `fail_mode` (`open` \| `closed`), `protocol_acceptance` (`dual_era` \|
+   `legacy_only`, empty → `dual_era`), or `routing_mode: role_based` with
+   `mcp_policies` on roles. Rollout, rollback, and deprecation exit:
+   [Dual-era rollout](dual-era-rollout.md).
 
 ### Auth (consumer → TrustGate)
 
@@ -331,6 +333,9 @@ X-AG-API-Key: <consumer key>
 For `tools/call` / `prompts/get` also send `Mcp-Name` matching `params.name`.
 Modern responses include `resultType`, `ttlMs`, and `cacheScope` on list/discover
 results and **must not** set `Mcp-Session-Id`.
+
+Rollout runbook (dashboards, config rollback, deprecation exit):
+[Dual-era rollout](dual-era-rollout.md).
 
 Registry field `mcp_target.protocol_mode`:
 

--- a/docs/operational-metrics.md
+++ b/docs/operational-metrics.md
@@ -17,3 +17,42 @@ Planes are `admin`, `proxy`, and `mcp`. Routes are `health`, `version`,
 
 Collector/exporter setup is deployment-owned; enabling this flag does not
 change product telemetry exporters.
+
+## Dual-era MCP protocol
+
+These instruments are no-ops unless `OPS_METRICS_ENABLED=true`. Labels are
+closed enums only: no origin URL, credentials, tokens, client metadata,
+headers, bodies, or tool arguments.
+
+### Northbound
+
+`mcp.northbound.protocol.validation_total` (`{failure}`): HTTP 400 protocol
+rejections before product MCP events. Auth and path failures still skip
+product metrics and do **not** increment this counter.
+
+| Label | Values |
+|-------|--------|
+| `validation_class` | `header_mismatch`, `unsupported_version`, `acceptance_denied`, `invalid_request`, `invalid_params`, `parse_error`, `method_not_found` |
+| `era` | `legacy`, `modern` (omitted when unknown) |
+
+`acceptance_denied` is the consumer gate (`protocol_acceptance=legacy_only`
+rejecting a modern request). It is distinct from `unsupported_version`.
+
+### Southbound
+
+`mcp.upstream.protocol.decision_total` (`{decision}`): one sample per
+negotiation outcome.
+
+| Label | Values |
+|-------|--------|
+| `source` | `cache`, `probe`, `override`, `contradiction` |
+| `mode` | `auto`, `modern`, `legacy` |
+| `era` | `legacy`, `modern` (or unknown when the decision failed before an era) |
+| `result` | `selected`, `failed` |
+| `category` | present on failures only (`contradiction`, `timeout`, `incompatible`, …) |
+
+`mcp.upstream.protocol.probe_latency_seconds`: recorded **only** when
+`source=probe`. Cache hits and `protocol_mode` overrides must not inflate
+this histogram.
+
+See [Dual-era rollout](mcp/dual-era-rollout.md) for dashboards and rollback.

--- a/docs/telemetry/otlp-metadata-contract.md
+++ b/docs/telemetry/otlp-metadata-contract.md
@@ -74,6 +74,13 @@ and — when an `otlp` exporter is declared under `exporters.raw[]` — also emi
 | `trustgate.attempts` | `attempts[]` as JSON string (when non-empty) |
 | `trustgate.attempts.count` | `len(attempts)` (when non-empty) |
 | `trustgate.mcp.*` | `mcp.*` fields (when the request is an MCP call) |
+| `trustgate.mcp.protocol_era` | `mcp.protocol_era` — `legacy` or `modern` |
+| `trustgate.mcp.protocol_version` | `mcp.protocol_version` — known revision or `unsupported` |
+
+Success MCP events stamp bounded protocol identity after request validation. Era is
+`legacy` or `modern`. Version is one of `2026-07-28`, `2025-06-18`, `2025-03-26`,
+`2024-11-05`; any other revision maps to `unsupported`. Raw client strings are never
+exported as labels.
 
 ### Latency semantics
 

--- a/openspec/changes/run-1109-dual-era-rollout-telemetry/tasks.md
+++ b/openspec/changes/run-1109-dual-era-rollout-telemetry/tasks.md
@@ -53,16 +53,16 @@ Each child PR must show only its slice; merge to `main` in order and retarget th
 
 ## Phase 3: Consumer gate (PR 3)
 
-- [ ] 3.1 RED: `toolkit_test.go` / `mcp_policy` tests — empty → `dual_era`; invalid rejected; `legacy_only`/`dual_era` accepted. Spec: Default preserves dual-era.
-- [ ] 3.2 GREEN: `ProtocolAcceptance` on `pkg/domain/consumer/mcp_policy.go`; accessor on `consumer.go`; default empty → `dual_era` in `Validate`.
-- [ ] 3.3 GREEN: API `protocol_acceptance` on `pkg/api/handler/http/consumer/request/*.go` + `response/`; thread through `pkg/app/consumer/creator.go` + `updater.go` like `fail_mode`.
-- [ ] 3.4 GREEN: goose migration `ADD COLUMN IF NOT EXISTS protocol_acceptance TEXT` (nullable, MCP-only like `fail_mode`); persist/scan in `pkg/infra/repository/consumer/repository.go` + `repository_test.go`. Snapshot/JSONB hydrate must round-trip without process restart. Spec: Config sync round-trip.
-- [ ] 3.5 GREEN: after `resolveMCPConsumer` and before dispatch in `mcp_handler.go`: `legacy_only` + modern → HTTP 400 bounded error, `validation_class=acceptance_denied`, `skipMetrics`, no composer/upstream; `legacy_only` + legacy unchanged; unset/`dual_era` keeps dual-era. Spec: Legacy-only rejects modern; Legacy-only accepts legacy; Default preserves dual-era.
-- [ ] 3.6 `clean-comments`; `/reviewer` + `/verifier`: `go test -race ./pkg/domain/consumer ./pkg/app/consumer ./pkg/api/handler/http/consumer ./pkg/api/handler/http/mcp ./pkg/infra/repository/consumer`, `go vet ./...`, `golangci-lint run`. If diff >400, add `size:exception`.
+- [x] 3.1 RED: `toolkit_test.go` / `mcp_policy` tests — empty → `dual_era`; invalid rejected; `legacy_only`/`dual_era` accepted. Spec: Default preserves dual-era.
+- [x] 3.2 GREEN: `ProtocolAcceptance` on `pkg/domain/consumer/mcp_policy.go`; accessor on `consumer.go`; default empty → `dual_era` in `Validate`.
+- [x] 3.3 GREEN: API `protocol_acceptance` on `pkg/api/handler/http/consumer/request/*.go` + `response/`; thread through `pkg/app/consumer/creator.go` + `updater.go` like `fail_mode`.
+- [x] 3.4 GREEN: goose migration `ADD COLUMN IF NOT EXISTS protocol_acceptance TEXT` (nullable, MCP-only like `fail_mode`); persist/scan in `pkg/infra/repository/consumer/repository.go` + `repository_test.go`. Snapshot/JSONB hydrate must round-trip without process restart. Spec: Config sync round-trip.
+- [x] 3.5 GREEN: after `resolveMCPConsumer` and before dispatch in `mcp_handler.go`: `legacy_only` + modern → HTTP 400 bounded error, `validation_class=acceptance_denied`, `skipMetrics`, no composer/upstream; `legacy_only` + legacy unchanged; unset/`dual_era` keeps dual-era. Spec: Legacy-only rejects modern; Legacy-only accepts legacy; Default preserves dual-era.
+- [x] 3.6 `clean-comments`; `/reviewer` + `/verifier`: `go test -race ./pkg/domain/consumer ./pkg/app/consumer ./pkg/api/handler/http/consumer ./pkg/api/handler/http/mcp ./pkg/infra/repository/consumer`, `go vet ./...`, `golangci-lint run`. If diff >400, add `size:exception`.
 
 ## Phase 4: Docs (PR 4)
 
-- [ ] 4.1 Document `trustgate.mcp.protocol_era` / `protocol_version` (bounded; unknown → `unsupported`) in `docs/telemetry/otlp-metadata-contract.md`.
-- [ ] 4.2 Document northbound `validation_total` and southbound decision/probe instruments + `OPS_METRICS_ENABLED` in `docs/operational-metrics.md`. Enum labels only; no origin/PII.
-- [ ] 4.3 Create `docs/mcp/dual-era-rollout.md`: dashboards (cache hits vs probes, validation classes including `acceptance_denied`), config rollback (`protocol_acceptance=legacy_only` and/or `protocol_mode=legacy`) without redeploy, deprecation exit (12 months, residual usage, notice, approval). MUST NOT remove legacy. Spec: Rollback without redeploy; Deprecation exit published.
-- [ ] 4.4 Link the runbook from `docs/mcp/testing-guide.md`. No e2e unless already covered.
+- [x] 4.1 Document `trustgate.mcp.protocol_era` / `protocol_version` (bounded; unknown → `unsupported`) in `docs/telemetry/otlp-metadata-contract.md`.
+- [x] 4.2 Document northbound `validation_total` and southbound decision/probe instruments + `OPS_METRICS_ENABLED` in `docs/operational-metrics.md`. Enum labels only; no origin/PII.
+- [x] 4.3 Create `docs/mcp/dual-era-rollout.md`: dashboards (cache hits vs probes, validation classes including `acceptance_denied`), config rollback (`protocol_acceptance=legacy_only` and/or `protocol_mode=legacy`) without redeploy, deprecation exit (12 months, residual usage, notice, approval). MUST NOT remove legacy. Spec: Rollback without redeploy; Deprecation exit published.
+- [x] 4.4 Link the runbook from `docs/mcp/testing-guide.md`. No e2e unless already covered.

--- a/pkg/api/handler/http/consumer/request/create_consumer_request.go
+++ b/pkg/api/handler/http/consumer/request/create_consumer_request.go
@@ -26,18 +26,19 @@ import (
 )
 
 type CreateConsumerRequest struct {
-	Name          string                   `json:"name"`
-	Type          string                   `json:"type,omitempty"`
-	RoutingMode   string                   `json:"routing_mode,omitempty"`
-	LBConfig      *LBConfigRequest         `json:"lb_config,omitempty"`
-	Headers       map[string]string        `json:"headers,omitempty"`
-	Active        *bool                    `json:"active,omitempty"`
-	Fallback      *FallbackRequest         `json:"fallback,omitempty"`
-	Registries    []RegistryBindingRequest `json:"registries,omitempty"`
-	Roles         []string                 `json:"roles,omitempty"`
-	ModelPolicies []ModelPolicyRequest     `json:"model_policies,omitempty"`
-	Toolkit       []ToolkitEntryRequest    `json:"toolkit,omitempty"`
-	FailMode      string                   `json:"fail_mode,omitempty"`
+	Name               string                   `json:"name"`
+	Type               string                   `json:"type,omitempty"`
+	RoutingMode        string                   `json:"routing_mode,omitempty"`
+	LBConfig           *LBConfigRequest         `json:"lb_config,omitempty"`
+	Headers            map[string]string        `json:"headers,omitempty"`
+	Active             *bool                    `json:"active,omitempty"`
+	Fallback           *FallbackRequest         `json:"fallback,omitempty"`
+	Registries         []RegistryBindingRequest `json:"registries,omitempty"`
+	Roles              []string                 `json:"roles,omitempty"`
+	ModelPolicies      []ModelPolicyRequest     `json:"model_policies,omitempty"`
+	Toolkit            []ToolkitEntryRequest    `json:"toolkit,omitempty"`
+	FailMode           string                   `json:"fail_mode,omitempty"`
+	ProtocolAcceptance string                   `json:"protocol_acceptance,omitempty"`
 }
 
 type RegistryBindingRequest struct {
@@ -242,12 +243,13 @@ func (r CreateConsumerRequest) ToMCPPolicy() (*domain.MCPPolicy, error) {
 	if err != nil {
 		return nil, err
 	}
-	if toolkit == nil && strings.TrimSpace(r.FailMode) == "" {
+	if toolkit == nil && strings.TrimSpace(r.FailMode) == "" && strings.TrimSpace(r.ProtocolAcceptance) == "" {
 		return nil, nil
 	}
 	return &domain.MCPPolicy{
-		Toolkit:  toolkit,
-		FailMode: domain.FailMode(strings.ToLower(strings.TrimSpace(r.FailMode))),
+		Toolkit:            toolkit,
+		FailMode:           domain.FailMode(strings.ToLower(strings.TrimSpace(r.FailMode))),
+		ProtocolAcceptance: domain.ProtocolAcceptance(strings.ToLower(strings.TrimSpace(r.ProtocolAcceptance))),
 	}, nil
 }
 

--- a/pkg/api/handler/http/consumer/request/create_consumer_request_test.go
+++ b/pkg/api/handler/http/consumer/request/create_consumer_request_test.go
@@ -120,3 +120,40 @@ func TestCreateConsumerRequest_ToRegistryBindings_RejectsWeightAboveMax(t *testi
 		t.Fatalf("err = %v, want ErrValidation", err)
 	}
 }
+
+func TestCreateConsumerRequest_ToMCPPolicy_ProtocolAcceptance(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty omitted", func(t *testing.T) {
+		t.Parallel()
+		got, err := CreateConsumerRequest{Name: "c"}.ToMCPPolicy()
+		if err != nil {
+			t.Fatalf("ToMCPPolicy error: %v", err)
+		}
+		if got != nil {
+			t.Fatalf("ToMCPPolicy = %+v, want nil", got)
+		}
+	})
+
+	t.Run("legacy_only", func(t *testing.T) {
+		t.Parallel()
+		got, err := CreateConsumerRequest{Name: "c", ProtocolAcceptance: "LEGACY_ONLY"}.ToMCPPolicy()
+		if err != nil {
+			t.Fatalf("ToMCPPolicy error: %v", err)
+		}
+		if got == nil || got.ProtocolAcceptance != domain.ProtocolAcceptanceLegacyOnly {
+			t.Fatalf("ProtocolAcceptance = %v, want legacy_only", got)
+		}
+	})
+
+	t.Run("dual_era", func(t *testing.T) {
+		t.Parallel()
+		got, err := CreateConsumerRequest{Name: "c", ProtocolAcceptance: "dual_era"}.ToMCPPolicy()
+		if err != nil {
+			t.Fatalf("ToMCPPolicy error: %v", err)
+		}
+		if got == nil || got.ProtocolAcceptance != domain.ProtocolAcceptanceDualEra {
+			t.Fatalf("ProtocolAcceptance = %v, want dual_era", got)
+		}
+	})
+}

--- a/pkg/api/handler/http/consumer/request/update_consumer_request.go
+++ b/pkg/api/handler/http/consumer/request/update_consumer_request.go
@@ -33,10 +33,11 @@ type UpdateConsumerRequest struct {
 	// Registries replaces the whole registry association set: registries absent
 	// from the list are detached. Omit the field to leave the associations as
 	// they are; send an empty list to detach every registry.
-	Registries    *[]RegistryBindingRequest `json:"registries,omitempty"`
-	ModelPolicies *[]ModelPolicyRequest     `json:"model_policies,omitempty"`
-	Toolkit       *[]ToolkitEntryRequest    `json:"toolkit,omitempty"`
-	FailMode      *string                   `json:"fail_mode,omitempty"`
+	Registries         *[]RegistryBindingRequest `json:"registries,omitempty"`
+	ModelPolicies      *[]ModelPolicyRequest     `json:"model_policies,omitempty"`
+	Toolkit            *[]ToolkitEntryRequest    `json:"toolkit,omitempty"`
+	FailMode           *string                   `json:"fail_mode,omitempty"`
+	ProtocolAcceptance *string                   `json:"protocol_acceptance,omitempty"`
 }
 
 func (r UpdateConsumerRequest) Validate() error {
@@ -130,4 +131,12 @@ func (r UpdateConsumerRequest) ToFailMode() *domain.FailMode {
 	}
 	m := domain.FailMode(*r.FailMode)
 	return &m
+}
+
+func (r UpdateConsumerRequest) ToProtocolAcceptance() *domain.ProtocolAcceptance {
+	if r.ProtocolAcceptance == nil || strings.TrimSpace(*r.ProtocolAcceptance) == "" {
+		return nil
+	}
+	a := domain.ProtocolAcceptance(*r.ProtocolAcceptance)
+	return &a
 }

--- a/pkg/api/handler/http/consumer/request/update_consumer_request_test.go
+++ b/pkg/api/handler/http/consumer/request/update_consumer_request_test.go
@@ -152,3 +152,36 @@ func TestUpdateConsumerRequest_ToRoutingMode(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateConsumerRequest_ToProtocolAcceptance(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   *string
+		want *domain.ProtocolAcceptance
+	}{
+		{"omitted", nil, nil},
+		{"empty", strPtr(""), nil},
+		{"whitespace", strPtr("   "), nil},
+		{"legacy_only", strPtr("legacy_only"), func() *domain.ProtocolAcceptance {
+			v := domain.ProtocolAcceptanceLegacyOnly
+			return &v
+		}()},
+		{"dual_era", strPtr("dual_era"), func() *domain.ProtocolAcceptance {
+			v := domain.ProtocolAcceptanceDualEra
+			return &v
+		}()},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := UpdateConsumerRequest{ProtocolAcceptance: tc.in}.ToProtocolAcceptance()
+			if (got == nil) != (tc.want == nil) {
+				t.Fatalf("ToProtocolAcceptance() nilness mismatch: got=%v want=%v", got, tc.want)
+			}
+			if got != nil && *got != *tc.want {
+				t.Fatalf("ToProtocolAcceptance() = %q, want %q", *got, *tc.want)
+			}
+		})
+	}
+}

--- a/pkg/api/handler/http/consumer/response/consumer_response.go
+++ b/pkg/api/handler/http/consumer/response/consumer_response.go
@@ -25,25 +25,26 @@ import (
 )
 
 type ConsumerResponse struct {
-	ID              ids.ConsumerID           `json:"id"`
-	GatewayID       ids.GatewayID            `json:"gateway_id"`
-	Name            string                   `json:"name"`
-	Type            string                   `json:"type"`
-	Slug            string                   `json:"slug"`
-	RoutingMode     string                   `json:"routing_mode"`
-	LBConfig        *LBConfigResponse        `json:"lb_config,omitempty"`
-	Headers         map[string]string        `json:"headers,omitempty"`
-	Active          bool                     `json:"active"`
-	RegistryIDs     []ids.RegistryID         `json:"registry_ids"`
-	RegistryWeights []RegistryWeightResponse `json:"registry_weights,omitempty"`
-	RoleIDs         []ids.RoleID             `json:"role_ids"`
-	AuthIDs         []ids.AuthID             `json:"auth_ids"`
-	Fallback        *FallbackResponse        `json:"fallback,omitempty"`
-	ModelPolicies   []ModelPolicyResponse    `json:"model_policies,omitempty"`
-	Toolkit         []ToolkitEntryResponse   `json:"toolkit,omitempty"`
-	FailMode        string                   `json:"fail_mode,omitempty"`
-	CreatedAt       time.Time                `json:"created_at"`
-	UpdatedAt       time.Time                `json:"updated_at"`
+	ID                 ids.ConsumerID           `json:"id"`
+	GatewayID          ids.GatewayID            `json:"gateway_id"`
+	Name               string                   `json:"name"`
+	Type               string                   `json:"type"`
+	Slug               string                   `json:"slug"`
+	RoutingMode        string                   `json:"routing_mode"`
+	LBConfig           *LBConfigResponse        `json:"lb_config,omitempty"`
+	Headers            map[string]string        `json:"headers,omitempty"`
+	Active             bool                     `json:"active"`
+	RegistryIDs        []ids.RegistryID         `json:"registry_ids"`
+	RegistryWeights    []RegistryWeightResponse `json:"registry_weights,omitempty"`
+	RoleIDs            []ids.RoleID             `json:"role_ids"`
+	AuthIDs            []ids.AuthID             `json:"auth_ids"`
+	Fallback           *FallbackResponse        `json:"fallback,omitempty"`
+	ModelPolicies      []ModelPolicyResponse    `json:"model_policies,omitempty"`
+	Toolkit            []ToolkitEntryResponse   `json:"toolkit,omitempty"`
+	FailMode           string                   `json:"fail_mode,omitempty"`
+	ProtocolAcceptance string                   `json:"protocol_acceptance,omitempty"`
+	CreatedAt          time.Time                `json:"created_at"`
+	UpdatedAt          time.Time                `json:"updated_at"`
 }
 
 type RegistryWeightResponse struct {
@@ -135,25 +136,26 @@ func FromConsumer(c *domain.Consumer) ConsumerResponse {
 		roleIDs = []ids.RoleID{}
 	}
 	return ConsumerResponse{
-		ID:              c.ID,
-		GatewayID:       c.GatewayID,
-		Name:            c.Name,
-		Type:            string(c.Type),
-		Slug:            c.Slug,
-		RoutingMode:     string(c.RoutingMode),
-		LBConfig:        fromLBConfig(c.LBConfig),
-		Headers:         c.Headers,
-		Active:          c.Active,
-		RegistryIDs:     registryIDs,
-		RegistryWeights: fromRegistryWeights(c.RegistryWeights),
-		RoleIDs:         roleIDs,
-		AuthIDs:         authIDs,
-		Fallback:        fromFallback(c.Fallback),
-		ModelPolicies:   fromModelPolicies(c.ModelPolicies),
-		Toolkit:         fromToolkit(c.Toolkit()),
-		FailMode:        string(c.FailMode()),
-		CreatedAt:       c.CreatedAt,
-		UpdatedAt:       c.UpdatedAt,
+		ID:                 c.ID,
+		GatewayID:          c.GatewayID,
+		Name:               c.Name,
+		Type:               string(c.Type),
+		Slug:               c.Slug,
+		RoutingMode:        string(c.RoutingMode),
+		LBConfig:           fromLBConfig(c.LBConfig),
+		Headers:            c.Headers,
+		Active:             c.Active,
+		RegistryIDs:        registryIDs,
+		RegistryWeights:    fromRegistryWeights(c.RegistryWeights),
+		RoleIDs:            roleIDs,
+		AuthIDs:            authIDs,
+		Fallback:           fromFallback(c.Fallback),
+		ModelPolicies:      fromModelPolicies(c.ModelPolicies),
+		Toolkit:            fromToolkit(c.Toolkit()),
+		FailMode:           string(c.FailMode()),
+		ProtocolAcceptance: string(c.ProtocolAcceptance()),
+		CreatedAt:          c.CreatedAt,
+		UpdatedAt:          c.UpdatedAt,
 	}
 }
 

--- a/pkg/api/handler/http/consumer/update_consumer_handler.go
+++ b/pkg/api/handler/http/consumer/update_consumer_handler.go
@@ -86,19 +86,20 @@ func (h *UpdateConsumerHandler) Handle(c *fiber.Ctx) error {
 	}
 
 	cons, err := h.updater.Update(c.UserContext(), appconsumer.UpdateInput{
-		ID:            id,
-		GatewayID:     gatewayID,
-		Name:          req.Name,
-		Type:          req.ToType(),
-		RoutingMode:   req.ToRoutingMode(),
-		LBConfig:      lbConfig,
-		Headers:       req.Headers,
-		Active:        req.Active,
-		Fallback:      fallback,
-		Registries:    registries,
-		ModelPolicies: modelPolicies,
-		Toolkit:       toolkit,
-		FailMode:      req.ToFailMode(),
+		ID:                 id,
+		GatewayID:          gatewayID,
+		Name:               req.Name,
+		Type:               req.ToType(),
+		RoutingMode:        req.ToRoutingMode(),
+		LBConfig:           lbConfig,
+		Headers:            req.Headers,
+		Active:             req.Active,
+		Fallback:           fallback,
+		Registries:         registries,
+		ModelPolicies:      modelPolicies,
+		Toolkit:            toolkit,
+		FailMode:           req.ToFailMode(),
+		ProtocolAcceptance: req.ToProtocolAcceptance(),
 	})
 	if err != nil {
 		return httpio.WriteError(c, err)

--- a/pkg/api/handler/http/mcp/mcp_handler.go
+++ b/pkg/api/handler/http/mcp/mcp_handler.go
@@ -156,6 +156,11 @@ func (h *Handler) Handle(c *fiber.Ctx) error {
 		skipMetrics(c)
 		return err
 	}
+	if protocolErr := denyModernIfLegacyOnly(rc, era); protocolErr != nil {
+		h.recordProtocolValidation(c, protocolErr.code, era)
+		skipMetrics(c)
+		return writeProtocolError(c, req.ID, protocolErr)
+	}
 	rc, err = h.scopeByRoles(c, rc)
 	if err != nil {
 		skipMetrics(c)
@@ -551,6 +556,16 @@ func resolveMCPConsumer(c *fiber.Ctx) (*appconsumer.RoutableConsumer, error) {
 		return nil, fiber.NewError(fiber.StatusForbidden, "credential not allowed for this consumer")
 	}
 	return rc, nil
+}
+
+func denyModernIfLegacyOnly(rc *appconsumer.RoutableConsumer, era protocolEra) *protocolError {
+	if era != protocolEraModern || rc == nil || rc.Consumer == nil {
+		return nil
+	}
+	if rc.Consumer.ProtocolAcceptance() != consumerdomain.ProtocolAcceptanceLegacyOnly {
+		return nil
+	}
+	return acceptanceDenied()
 }
 
 func hasAuth(rc *appconsumer.RoutableConsumer, authID ids.AuthID) bool {

--- a/pkg/api/handler/http/mcp/modern_validation.go
+++ b/pkg/api/handler/http/mcp/modern_validation.go
@@ -27,6 +27,7 @@ import (
 
 const (
 	codeHeaderMismatch             = -32020
+	codeAcceptanceDenied           = -32021
 	codeUnsupportedProtocolVersion = -32022
 	base64SentinelPrefix           = "=?base64?"
 	base64SentinelSuffix           = "?="
@@ -194,6 +195,10 @@ func newProtocolError(code int, message string) *protocolError {
 
 func headerMismatch(message string) *protocolError {
 	return newProtocolError(codeHeaderMismatch, "Header mismatch: "+message)
+}
+
+func acceptanceDenied() *protocolError {
+	return newProtocolError(codeAcceptanceDenied, "protocol acceptance denied")
 }
 
 func unsupportedProtocolVersion(requested string) *protocolError {

--- a/pkg/api/handler/http/mcp/protocol_metrics.go
+++ b/pkg/api/handler/http/mcp/protocol_metrics.go
@@ -110,6 +110,8 @@ func validationClassForCode(code int) (ValidationClass, bool) {
 	switch code {
 	case codeHeaderMismatch:
 		return ValidationClassHeaderMismatch, true
+	case codeAcceptanceDenied:
+		return ValidationClassAcceptanceDenied, true
 	case codeUnsupportedProtocolVersion:
 		return ValidationClassUnsupportedVersion, true
 	case codeInvalidRequest:

--- a/pkg/api/handler/http/mcp/protocol_validation_metrics_test.go
+++ b/pkg/api/handler/http/mcp/protocol_validation_metrics_test.go
@@ -16,6 +16,7 @@ package mcp_test
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -30,6 +31,7 @@ import (
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
 	infracontext "github.com/NeuralTrust/TrustGate/pkg/infra/context"
 	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -119,4 +121,100 @@ func newAppWithProtocolRecorder(t *testing.T, rec mcphttp.ProtocolValidationReco
 	handler := mcphttp.NewHandler(mcphttp.NewRPCGateway(mocks.NewComposer(t), noopRunner(), nil), appmcp.NewRoleScoper(approle.NewOIDCResolver()), rec)
 	app.Post(mcpPath, handler.Handle)
 	return app
+}
+
+const modernToolsListBody = `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}`
+
+func newAppWithMCPPolicy(
+	t *testing.T,
+	rec mcphttp.ProtocolValidationRecorder,
+	composer appmcp.Composer,
+	mcp *consumerdomain.MCPPolicy,
+	after func(*fiber.Ctx),
+) *fiber.App {
+	t.Helper()
+	app := fiber.New()
+	authID := ids.New[ids.AuthKind]()
+	gwID := ids.New[ids.GatewayKind]()
+	cons := &consumerdomain.Consumer{
+		ID: ids.New[ids.ConsumerKind](), GatewayID: gwID, Name: "virtual",
+		Type: consumerdomain.TypeMCP, Slug: "virtual", Active: true, AuthIDs: []ids.AuthID{authID},
+		MCP: mcp,
+	}
+	data := appconsumer.NewData(gwID, []appconsumer.RoutableConsumer{{Consumer: cons}})
+	app.Use(func(c *fiber.Ctx) error {
+		ctx := appconsumer.WithAuthID(c.UserContext(), authID)
+		ctx = appconsumer.WithData(ctx, data)
+		c.SetUserContext(ctx)
+		err := c.Next()
+		if after != nil {
+			after(c)
+		}
+		return err
+	})
+	handler := mcphttp.NewHandler(mcphttp.NewRPCGateway(composer, noopRunner(), nil), appmcp.NewRoleScoper(approle.NewOIDCResolver()), rec)
+	app.Post(mcpPath, handler.Handle)
+	return app
+}
+
+func TestHandler_LegacyOnlyRejectsModern(t *testing.T) {
+	t.Parallel()
+	rec := &recordingProtocolValidator{}
+	var skipped bool
+	composer := mocks.NewComposer(t)
+	app := newAppWithMCPPolicy(t, rec, composer, &consumerdomain.MCPPolicy{
+		ProtocolAcceptance: consumerdomain.ProtocolAcceptanceLegacyOnly,
+	}, func(c *fiber.Ctx) {
+		skipped, _ = c.Locals(string(infracontext.MCPSkipMetricsKey)).(bool)
+	})
+
+	status, body := rpcCallWithHeaders(t, app, modernToolsListBody, modernHeadersFor("tools/list"))
+	require.Equal(t, fiber.StatusBadRequest, status)
+	require.True(t, skipped)
+	require.Equal(t, []protocolValidationCall{{class: mcphttp.ValidationClassAcceptanceDenied, era: "modern"}}, rec.records)
+	rpcErr, _ := body["error"].(map[string]any)
+	require.Equal(t, float64(-32021), rpcErr["code"])
+	composer.AssertNotCalled(t, "ListTools", mock.Anything, mock.Anything)
+	composer.AssertNotCalled(t, "CallTool", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestHandler_LegacyOnlyAcceptsLegacy(t *testing.T) {
+	t.Parallel()
+	rec := &recordingProtocolValidator{}
+	composer := mocks.NewComposer(t)
+	composer.EXPECT().ListTools(mock.Anything, mock.Anything).Return([]appmcp.Tool{}, nil).Once()
+	app := newAppWithMCPPolicy(t, rec, composer, &consumerdomain.MCPPolicy{
+		ProtocolAcceptance: consumerdomain.ProtocolAcceptanceLegacyOnly,
+	}, nil)
+
+	status, _ := rpcCall(t, app, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`)
+	require.Equal(t, fiber.StatusOK, status)
+	require.Empty(t, rec.records)
+}
+
+func TestHandler_DefaultPreservesDualEra(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		mcp  *consumerdomain.MCPPolicy
+	}{
+		{"unset", nil},
+		{"empty policy", &consumerdomain.MCPPolicy{}},
+		{"dual_era", &consumerdomain.MCPPolicy{ProtocolAcceptance: consumerdomain.ProtocolAcceptanceDualEra}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rec := &recordingProtocolValidator{}
+			composer := mocks.NewComposer(t)
+			var tool appmcp.Tool
+			require.NoError(t, json.Unmarshal([]byte(`{"name":"gh_search","inputSchema":{"type":"object"}}`), &tool))
+			composer.EXPECT().ListTools(mock.Anything, mock.Anything).Return([]appmcp.Tool{tool}, nil).Once()
+			app := newAppWithMCPPolicy(t, rec, composer, tc.mcp, nil)
+
+			status, _ := rpcCallWithHeaders(t, app, modernToolsListBody, modernHeadersFor("tools/list"))
+			require.Equal(t, fiber.StatusOK, status)
+			require.Empty(t, rec.records)
+		})
+	}
 }

--- a/pkg/app/consumer/updater.go
+++ b/pkg/app/consumer/updater.go
@@ -42,10 +42,11 @@ type UpdateInput struct {
 	Fallback    *domain.Fallback
 	// Registries replaces the whole registry association set. A nil value keeps
 	// the associations the consumer already has.
-	Registries    *domain.RegistryBindings
-	ModelPolicies *domain.ModelPolicies
-	Toolkit       *domain.Toolkit
-	FailMode      *domain.FailMode
+	Registries         *domain.RegistryBindings
+	ModelPolicies      *domain.ModelPolicies
+	Toolkit            *domain.Toolkit
+	FailMode           *domain.FailMode
+	ProtocolAcceptance *domain.ProtocolAcceptance
 }
 
 //go:generate mockery --name=Updater --dir=. --output=./mocks --filename=consumer_updater_mock.go --case=underscore --with-expecter
@@ -196,7 +197,7 @@ func (u *updater) revalidateAuthsForTransition(
 }
 
 func applyMCPPolicyUpdate(existing *domain.Consumer, in UpdateInput) {
-	if in.Toolkit == nil && in.FailMode == nil {
+	if in.Toolkit == nil && in.FailMode == nil && in.ProtocolAcceptance == nil {
 		return
 	}
 	if existing.MCP == nil {
@@ -208,6 +209,9 @@ func applyMCPPolicyUpdate(existing *domain.Consumer, in UpdateInput) {
 	}
 	if in.FailMode != nil {
 		policy.FailMode = *in.FailMode
+	}
+	if in.ProtocolAcceptance != nil {
+		policy.ProtocolAcceptance = *in.ProtocolAcceptance
 	}
 }
 

--- a/pkg/app/consumer/updater_test.go
+++ b/pkg/app/consumer/updater_test.go
@@ -649,3 +649,51 @@ func TestUpdater_Update_RejectsCrossGateway(t *testing.T) {
 	}
 	publisher.AssertNotCalled(t, "Publish", mock.Anything, mock.Anything)
 }
+
+func TestUpdater_Update_ProtocolAcceptance(t *testing.T) {
+	t.Parallel()
+	gwID := ids.New[ids.GatewayKind]()
+	beID := ids.New[ids.RegistryKind]()
+	now := time.Now().UTC()
+	existing := domain.Rehydrate(domain.RehydrateParams{
+		ID:          ids.New[ids.ConsumerKind](),
+		GatewayID:   gwID,
+		Name:        "mcp",
+		Type:        domain.TypeMCP,
+		Slug:        "X84Yhsy8",
+		RoutingMode: domain.RoutingModeInline,
+		Active:      true,
+		RegistryIDs: []ids.RegistryID{beID},
+		MCP:         &domain.MCPPolicy{FailMode: domain.FailModeOpen},
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	})
+
+	repo := repomocks.NewRepository(t)
+	repo.EXPECT().FindByID(mock.Anything, existing.ID).Return(existing, nil).Once()
+	repo.EXPECT().
+		Update(mock.Anything, mock.MatchedBy(func(c *domain.Consumer) bool {
+			return c.ProtocolAcceptance() == domain.ProtocolAcceptanceLegacyOnly
+		}), mock.Anything).
+		Return(nil).
+		Once()
+
+	publisher := cachemocks.NewEventPublisher(t)
+	publisher.EXPECT().
+		Publish(mock.Anything, event.InvalidateGatewayDataEvent{GatewayID: gwID.String()}).
+		Return(nil).
+		Once()
+
+	updater := appconsumer.NewUpdater(repo, registrymocks.NewRepository(t), authmocks.NewRepository(t), newCacheManager(), publisher, newTestLogger(), nil)
+	got, err := updater.Update(context.Background(), appconsumer.UpdateInput{
+		ID:                 existing.ID,
+		GatewayID:          gwID,
+		ProtocolAcceptance: ptr(domain.ProtocolAcceptanceLegacyOnly),
+	})
+	if err != nil {
+		t.Fatalf("Update error: %v", err)
+	}
+	if got.ProtocolAcceptance() != domain.ProtocolAcceptanceLegacyOnly {
+		t.Fatalf("ProtocolAcceptance = %q, want legacy_only", got.ProtocolAcceptance())
+	}
+}

--- a/pkg/domain/consumer/consumer.go
+++ b/pkg/domain/consumer/consumer.go
@@ -126,6 +126,13 @@ func (c *Consumer) FailMode() FailMode {
 	return c.MCP.FailMode
 }
 
+func (c *Consumer) ProtocolAcceptance() ProtocolAcceptance {
+	if c.MCP == nil {
+		return ""
+	}
+	return c.MCP.ProtocolAcceptance
+}
+
 type CreateParams struct {
 	GatewayID       ids.GatewayID
 	Name            string

--- a/pkg/domain/consumer/errors.go
+++ b/pkg/domain/consumer/errors.go
@@ -36,8 +36,9 @@ var (
 	ErrInvalidFallback    = fmt.Errorf("consumer: invalid fallback: %w", commonerrors.ErrValidation)
 	ErrInvalidModelPolicy = fmt.Errorf("consumer: invalid model policy: %w", commonerrors.ErrValidation)
 
-	ErrInvalidToolkit  = fmt.Errorf("consumer: invalid toolkit: %w", commonerrors.ErrValidation)
-	ErrInvalidFailMode = fmt.Errorf("consumer: invalid fail_mode: %w", commonerrors.ErrValidation)
+	ErrInvalidToolkit            = fmt.Errorf("consumer: invalid toolkit: %w", commonerrors.ErrValidation)
+	ErrInvalidFailMode           = fmt.Errorf("consumer: invalid fail_mode: %w", commonerrors.ErrValidation)
+	ErrInvalidProtocolAcceptance = fmt.Errorf("consumer: invalid protocol_acceptance: %w", commonerrors.ErrValidation)
 
 	ErrPolicyProtocolMismatch = fmt.Errorf("consumer: policy protocol mismatch: %w", commonerrors.ErrValidation)
 )

--- a/pkg/domain/consumer/mcp_policy.go
+++ b/pkg/domain/consumer/mcp_policy.go
@@ -17,8 +17,9 @@ package consumer
 import "github.com/NeuralTrust/TrustGate/pkg/domain/ids"
 
 type MCPPolicy struct {
-	Toolkit  Toolkit  `json:"toolkit"`
-	FailMode FailMode `json:"fail_mode,omitempty"`
+	Toolkit            Toolkit            `json:"toolkit"`
+	FailMode           FailMode           `json:"fail_mode,omitempty"`
+	ProtocolAcceptance ProtocolAcceptance `json:"protocol_acceptance,omitempty"`
 }
 
 func (p *MCPPolicy) Validate(known map[ids.RegistryID]struct{}) error {
@@ -26,6 +27,12 @@ func (p *MCPPolicy) Validate(known map[ids.RegistryID]struct{}) error {
 		p.FailMode = FailModeOpen
 	}
 	if err := p.FailMode.Validate(); err != nil {
+		return err
+	}
+	if p.ProtocolAcceptance == "" {
+		p.ProtocolAcceptance = ProtocolAcceptanceDualEra
+	}
+	if err := p.ProtocolAcceptance.Validate(); err != nil {
 		return err
 	}
 	return p.Toolkit.Validate(known)

--- a/pkg/domain/consumer/toolkit.go
+++ b/pkg/domain/consumer/toolkit.go
@@ -38,6 +38,21 @@ func (m FailMode) Validate() error {
 	return fmt.Errorf("%w: %q", ErrInvalidFailMode, m)
 }
 
+type ProtocolAcceptance string
+
+const (
+	ProtocolAcceptanceDualEra    ProtocolAcceptance = "dual_era"
+	ProtocolAcceptanceLegacyOnly ProtocolAcceptance = "legacy_only"
+)
+
+func (a ProtocolAcceptance) Validate() error {
+	switch a {
+	case "", ProtocolAcceptanceDualEra, ProtocolAcceptanceLegacyOnly:
+		return nil
+	}
+	return fmt.Errorf("%w: %q", ErrInvalidProtocolAcceptance, a)
+}
+
 type ToolkitEntry struct {
 	RegistryID ids.RegistryID `json:"registry_id"`
 	Tool       string         `json:"tool,omitempty"`

--- a/pkg/domain/consumer/toolkit_test.go
+++ b/pkg/domain/consumer/toolkit_test.go
@@ -15,7 +15,9 @@
 package consumer
 
 import (
+	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	commonerrors "github.com/NeuralTrust/TrustGate/pkg/common/errors"
@@ -171,4 +173,101 @@ func TestConsumer_Validate_ToolkitAndFailMode(t *testing.T) {
 			t.Fatalf("error = %v, want ErrInvalidFailMode", err)
 		}
 	})
+}
+
+func TestConsumer_Validate_ProtocolAcceptance(t *testing.T) {
+	t.Parallel()
+	gwID := ids.New[ids.GatewayKind]()
+
+	t.Run("empty defaults to dual_era", func(t *testing.T) {
+		t.Parallel()
+		c, err := New(CreateParams{
+			GatewayID: gwID,
+			Name:      "mcp-consumer",
+			Type:      TypeMCP,
+			MCP:       &MCPPolicy{},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if c.ProtocolAcceptance() != ProtocolAcceptanceDualEra {
+			t.Fatalf("ProtocolAcceptance = %q, want %q", c.ProtocolAcceptance(), ProtocolAcceptanceDualEra)
+		}
+	})
+
+	t.Run("dual_era accepted", func(t *testing.T) {
+		t.Parallel()
+		c, err := New(CreateParams{
+			GatewayID: gwID,
+			Name:      "mcp-consumer",
+			Type:      TypeMCP,
+			MCP:       &MCPPolicy{ProtocolAcceptance: ProtocolAcceptanceDualEra},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if c.ProtocolAcceptance() != ProtocolAcceptanceDualEra {
+			t.Fatalf("ProtocolAcceptance = %q, want dual_era", c.ProtocolAcceptance())
+		}
+	})
+
+	t.Run("legacy_only accepted", func(t *testing.T) {
+		t.Parallel()
+		c, err := New(CreateParams{
+			GatewayID: gwID,
+			Name:      "mcp-consumer",
+			Type:      TypeMCP,
+			MCP:       &MCPPolicy{ProtocolAcceptance: ProtocolAcceptanceLegacyOnly},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if c.ProtocolAcceptance() != ProtocolAcceptanceLegacyOnly {
+			t.Fatalf("ProtocolAcceptance = %q, want legacy_only", c.ProtocolAcceptance())
+		}
+	})
+
+	t.Run("invalid rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := New(CreateParams{
+			GatewayID: gwID,
+			Name:      "mcp-consumer",
+			Type:      TypeMCP,
+			MCP:       &MCPPolicy{ProtocolAcceptance: "modern_only"},
+		})
+		if !errors.Is(err, ErrInvalidProtocolAcceptance) {
+			t.Fatalf("error = %v, want ErrInvalidProtocolAcceptance", err)
+		}
+	})
+}
+
+func TestMCPPolicy_JSONRoundTrip_ProtocolAcceptance(t *testing.T) {
+	t.Parallel()
+	c, err := New(CreateParams{
+		GatewayID: ids.New[ids.GatewayKind](),
+		Name:      "mcp-consumer",
+		Type:      TypeMCP,
+		MCP:       &MCPPolicy{ProtocolAcceptance: ProtocolAcceptanceLegacyOnly},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	raw, err := json.Marshal(c)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got Consumer
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.ProtocolAcceptance() != ProtocolAcceptanceLegacyOnly {
+		t.Fatalf("ProtocolAcceptance = %q, want legacy_only", got.ProtocolAcceptance())
+	}
+	toolkitRaw, err := json.Marshal(c.Toolkit())
+	if err != nil {
+		t.Fatalf("marshal toolkit: %v", err)
+	}
+	if strings.Contains(string(toolkitRaw), "protocol_acceptance") {
+		t.Fatalf("toolkit JSON must not host protocol_acceptance: %s", toolkitRaw)
+	}
 }

--- a/pkg/infra/database/migrations/20260814120000_add_consumer_protocol_acceptance.go
+++ b/pkg/infra/database/migrations/20260814120000_add_consumer_protocol_acceptance.go
@@ -1,0 +1,48 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrations
+
+import (
+	"context"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/database"
+	"github.com/jackc/pgx/v5"
+)
+
+func init() {
+	database.RegisterMigration(database.Migration{
+		ID:   "20260814120000_add_consumer_protocol_acceptance",
+		Name: "add consumer protocol_acceptance",
+		Up:   upAddConsumerProtocolAcceptance,
+		Down: downAddConsumerProtocolAcceptance,
+	})
+}
+
+func upAddConsumerProtocolAcceptance(ctx context.Context, tx pgx.Tx) error {
+	const ddl = `
+		ALTER TABLE consumers ADD COLUMN IF NOT EXISTS protocol_acceptance TEXT;
+		ALTER TABLE consumers DROP CONSTRAINT IF EXISTS consumers_protocol_acceptance_check;
+		ALTER TABLE consumers ADD CONSTRAINT consumers_protocol_acceptance_check CHECK (protocol_acceptance IN ('dual_era', 'legacy_only'));`
+	_, err := tx.Exec(ctx, ddl)
+	return err
+}
+
+func downAddConsumerProtocolAcceptance(ctx context.Context, tx pgx.Tx) error {
+	const ddl = `
+		ALTER TABLE consumers DROP CONSTRAINT IF EXISTS consumers_protocol_acceptance_check;
+		ALTER TABLE consumers DROP COLUMN IF EXISTS protocol_acceptance;`
+	_, err := tx.Exec(ctx, ddl)
+	return err
+}

--- a/pkg/infra/repository/consumer/repository.go
+++ b/pkg/infra/repository/consumer/repository.go
@@ -52,7 +52,7 @@ const (
 )
 
 const consumerSelectColumns = `
-		SELECT c.id, c.gateway_id, c.name, c.type, c.slug, c.routing_mode, c.lb_config, c.fallback, c.model_policies, c.toolkit, c.fail_mode, c.headers, c.active,
+		SELECT c.id, c.gateway_id, c.name, c.type, c.slug, c.routing_mode, c.lb_config, c.fallback, c.model_policies, c.toolkit, c.fail_mode, c.protocol_acceptance, c.headers, c.active,
 		       c.created_at, c.updated_at,
 		       COALESCE((SELECT array_agg(cb.registry_id ORDER BY cb.position NULLS FIRST, cb.registry_id)
 		                   FROM consumer_registry cb WHERE cb.consumer_id = c.id), '{}')::uuid[] AS registry_ids,
@@ -114,9 +114,9 @@ func (r *Repository) Save(ctx context.Context, c *domain.Consumer) error {
 	}
 	const insertConsumer = `
 		INSERT INTO consumers (
-			id, gateway_id, name, type, slug, routing_mode, lb_config, fallback, model_policies, toolkit, fail_mode, headers, active, created_at, updated_at
+			id, gateway_id, name, type, slug, routing_mode, lb_config, fallback, model_policies, toolkit, fail_mode, protocol_acceptance, headers, active, created_at, updated_at
 		) VALUES (
-			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15
+			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16
 		)`
 	const insertConsumerRegistry = `
 		INSERT INTO consumer_registry (consumer_id, registry_id, weight) VALUES ($1, $2, $3)
@@ -126,7 +126,7 @@ func (r *Repository) Save(ctx context.Context, c *domain.Consumer) error {
 	return r.withMarkedTx(ctx, func(tx pgx.Tx) error {
 		if _, err := tx.Exec(ctx, insertConsumer,
 			c.ID, c.GatewayID, c.Name, string(c.Type), c.Slug, string(c.RoutingMode), lbConfigBytes, fallbackBytes, modelPoliciesBytes,
-			toolkitBytes, nullableFailMode(c.FailMode()), headersBytes, c.Active, c.CreatedAt, c.UpdatedAt,
+			toolkitBytes, nullableFailMode(c.FailMode()), nullableProtocolAcceptance(c.ProtocolAcceptance()), headersBytes, c.Active, c.CreatedAt, c.UpdatedAt,
 		); err != nil {
 			return mapPgError(err)
 		}
@@ -176,12 +176,13 @@ func (r *Repository) Update(ctx context.Context, c *domain.Consumer, registries 
 		       lb_config        = $5,
 		       fallback         = $6,
 		       model_policies   = $7,
-		       toolkit          = $8,
-		       fail_mode        = $9,
-		       headers          = $10,
-		       active           = $11,
-		       updated_at       = $12
-		 WHERE id = $1 AND gateway_id = $13`
+		       toolkit             = $8,
+		       fail_mode           = $9,
+		       protocol_acceptance = $10,
+		       headers             = $11,
+		       active              = $12,
+		       updated_at          = $13
+		 WHERE id = $1 AND gateway_id = $14`
 	// The consumers row is written before the registry links because the
 	// routing-mode DB guard rejects registry rows on a role_based consumer: a
 	// role_based → inline switch has to land the new mode first.
@@ -194,7 +195,7 @@ func (r *Repository) Update(ctx context.Context, c *domain.Consumer, registries 
 		}
 		cmd, err := tx.Exec(ctx, updateConsumer,
 			c.ID, c.Name, string(c.Type), string(c.RoutingMode), lbConfigBytes, fallbackBytes, modelPoliciesBytes,
-			toolkitBytes, nullableFailMode(c.FailMode()), headersBytes, c.Active, c.UpdatedAt, c.GatewayID,
+			toolkitBytes, nullableFailMode(c.FailMode()), nullableProtocolAcceptance(c.ProtocolAcceptance()), headersBytes, c.Active, c.UpdatedAt, c.GatewayID,
 		)
 		if err != nil {
 			return mapPgError(err)
@@ -703,21 +704,22 @@ type rowScanner interface {
 func scanConsumer(s rowScanner) (*domain.Consumer, error) {
 	c := &domain.Consumer{}
 	var (
-		headersRaw       []byte
-		lbConfigRaw      []byte
-		fallbackRaw      []byte
-		modelPoliciesRaw []byte
-		toolkitRaw       []byte
-		failModeRaw      *string
-		consumerType     string
-		routingMode      string
-		registryIDs      []uuid.UUID
-		registryWeights  []byte
-		roleIDs          []uuid.UUID
-		authIDs          []uuid.UUID
+		headersRaw            []byte
+		lbConfigRaw           []byte
+		fallbackRaw           []byte
+		modelPoliciesRaw      []byte
+		toolkitRaw            []byte
+		failModeRaw           *string
+		protocolAcceptanceRaw *string
+		consumerType          string
+		routingMode           string
+		registryIDs           []uuid.UUID
+		registryWeights       []byte
+		roleIDs               []uuid.UUID
+		authIDs               []uuid.UUID
 	)
 	if err := s.Scan(
-		&c.ID, &c.GatewayID, &c.Name, &consumerType, &c.Slug, &routingMode, &lbConfigRaw, &fallbackRaw, &modelPoliciesRaw, &toolkitRaw, &failModeRaw, &headersRaw, &c.Active,
+		&c.ID, &c.GatewayID, &c.Name, &consumerType, &c.Slug, &routingMode, &lbConfigRaw, &fallbackRaw, &modelPoliciesRaw, &toolkitRaw, &failModeRaw, &protocolAcceptanceRaw, &headersRaw, &c.Active,
 		&c.CreatedAt, &c.UpdatedAt,
 		&registryIDs, &registryWeights, &roleIDs, &authIDs,
 	); err != nil {
@@ -755,17 +757,15 @@ func scanConsumer(s rowScanner) (*domain.Consumer, error) {
 	if failModeRaw != nil {
 		failMode = *failModeRaw
 	}
-	if len(toolkitRaw) > 0 || failMode != "" {
-		mcp := &domain.MCPPolicy{FailMode: domain.FailMode(failMode)}
-		if len(toolkitRaw) > 0 {
-			if err := json.Unmarshal(toolkitRaw, &mcp.Toolkit); err != nil {
-				return nil, fmt.Errorf("scan toolkit: %w", err)
-			}
-		}
-		if len(mcp.Toolkit) > 0 || mcp.FailMode != "" {
-			c.MCP = mcp
-		}
+	protocolAcceptance := ""
+	if protocolAcceptanceRaw != nil {
+		protocolAcceptance = *protocolAcceptanceRaw
 	}
+	mcp, err := mcpPolicyFromColumns(toolkitRaw, failMode, protocolAcceptance)
+	if err != nil {
+		return nil, err
+	}
+	c.MCP = mcp
 	c.RegistryIDs = ids.FromUUIDs[ids.RegistryKind](registryIDs)
 	c.RoleIDs = ids.FromUUIDs[ids.RoleKind](roleIDs)
 	c.AuthIDs = ids.FromUUIDs[ids.AuthKind](authIDs)
@@ -843,11 +843,37 @@ func marshalToolkit(t domain.Toolkit) ([]byte, error) {
 	return json.Marshal(t)
 }
 
+func mcpPolicyFromColumns(toolkitRaw []byte, failMode, protocolAcceptance string) (*domain.MCPPolicy, error) {
+	if len(toolkitRaw) == 0 && failMode == "" && protocolAcceptance == "" {
+		return nil, nil
+	}
+	mcp := &domain.MCPPolicy{
+		FailMode:           domain.FailMode(failMode),
+		ProtocolAcceptance: domain.ProtocolAcceptance(protocolAcceptance),
+	}
+	if len(toolkitRaw) > 0 {
+		if err := json.Unmarshal(toolkitRaw, &mcp.Toolkit); err != nil {
+			return nil, fmt.Errorf("scan toolkit: %w", err)
+		}
+	}
+	if len(mcp.Toolkit) == 0 && mcp.FailMode == "" && mcp.ProtocolAcceptance == "" {
+		return nil, nil
+	}
+	return mcp, nil
+}
+
 func nullableFailMode(fm domain.FailMode) any {
 	if fm == "" {
 		return nil
 	}
 	return string(fm)
+}
+
+func nullableProtocolAcceptance(a domain.ProtocolAcceptance) any {
+	if a == "" {
+		return nil
+	}
+	return string(a)
 }
 
 func nullableUUID(id uuid.UUID) any {

--- a/pkg/infra/repository/consumer/repository_test.go
+++ b/pkg/infra/repository/consumer/repository_test.go
@@ -38,3 +38,56 @@ func TestMapPgError_RoutingModeCheck(t *testing.T) {
 		t.Fatalf("err = %v, want ErrInvalidRoutingMode", err)
 	}
 }
+
+func TestNullableProtocolAcceptance(t *testing.T) {
+	t.Parallel()
+	if got := nullableProtocolAcceptance(""); got != nil {
+		t.Fatalf("empty = %v, want nil", got)
+	}
+	if got := nullableProtocolAcceptance(domain.ProtocolAcceptanceLegacyOnly); got != "legacy_only" {
+		t.Fatalf("legacy_only = %v, want legacy_only", got)
+	}
+}
+
+func TestMCPPolicyFromColumns_ProtocolAcceptance(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty columns yield nil policy", func(t *testing.T) {
+		t.Parallel()
+		got, err := mcpPolicyFromColumns(nil, "", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != nil {
+			t.Fatalf("got %+v, want nil", got)
+		}
+	})
+
+	t.Run("hydrates protocol_acceptance without toolkit JSON", func(t *testing.T) {
+		t.Parallel()
+		got, err := mcpPolicyFromColumns(nil, "open", "legacy_only")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got == nil || got.ProtocolAcceptance != domain.ProtocolAcceptanceLegacyOnly {
+			t.Fatalf("ProtocolAcceptance = %v, want legacy_only", got)
+		}
+		if got.FailMode != domain.FailModeOpen {
+			t.Fatalf("FailMode = %q, want open", got.FailMode)
+		}
+	})
+
+	t.Run("toolkit JSON does not host protocol_acceptance", func(t *testing.T) {
+		t.Parallel()
+		got, err := mcpPolicyFromColumns([]byte(`[{"registry_id":"00000000-0000-0000-0000-000000000001","tool":"*"}]`), "", "dual_era")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got == nil || got.ProtocolAcceptance != domain.ProtocolAcceptanceDualEra {
+			t.Fatalf("ProtocolAcceptance = %v, want dual_era", got)
+		}
+		if len(got.Toolkit) != 1 {
+			t.Fatalf("toolkit len = %d, want 1", len(got.Toolkit))
+		}
+	})
+}

--- a/pkg/infra/telemetry/otlp/mapping.go
+++ b/pkg/infra/telemetry/otlp/mapping.go
@@ -58,6 +58,8 @@ const (
 	attrMCPUpstreamStatus    = "trustgate.mcp.upstream_status"
 	attrMCPUpstreamLatencyMs = "trustgate.mcp.upstream_latency_ms"
 	attrMCPRPCErrorCode      = "trustgate.mcp.rpc_error_code"
+	attrMCPProtocolEra       = "trustgate.mcp.protocol_era"
+	attrMCPProtocolVersion   = "trustgate.mcp.protocol_version"
 	attrStatusOutcome        = "trustgate.status.outcome"
 	attrStatusReason         = "trustgate.status.reason"
 	attrStatusIsTimeout      = "trustgate.status.is_timeout"
@@ -166,6 +168,8 @@ func eventToRecord(evt *events.Event) otellog.Record {
 		if evt.MCP.RPCErrorCode != 0 {
 			attrs = append(attrs, otellog.Int(attrMCPRPCErrorCode, evt.MCP.RPCErrorCode))
 		}
+		appendStr(attrMCPProtocolEra, evt.MCP.ProtocolEra)
+		appendStr(attrMCPProtocolVersion, evt.MCP.ProtocolVersion)
 	}
 	appendStr(attrTraceID, evt.TraceID)
 	appendStr(attrGatewayID, evt.GatewayID)

--- a/pkg/infra/telemetry/otlp/mapping_mcp_test.go
+++ b/pkg/infra/telemetry/otlp/mapping_mcp_test.go
@@ -48,6 +48,8 @@ func TestEventToRecord_MCPAttributes(t *testing.T) {
 			Targets:           3,
 			UpstreamStatus:    http.StatusOK,
 			UpstreamLatencyMs: 120,
+			ProtocolEra:       "modern",
+			ProtocolVersion:   "2026-07-28",
 		},
 	}
 
@@ -65,6 +67,8 @@ func TestEventToRecord_MCPAttributes(t *testing.T) {
 	assert.Equal(t, int64(http.StatusOK), attrs[attrMCPUpstreamStatus].AsInt64())
 	assert.Equal(t, int64(3), attrs[attrMCPTargets].AsInt64())
 	assert.Equal(t, int64(120), attrs[attrMCPUpstreamLatencyMs].AsInt64())
+	assert.Equal(t, "modern", attrs[attrMCPProtocolEra].AsString())
+	assert.Equal(t, "2026-07-28", attrs[attrMCPProtocolVersion].AsString())
 }
 
 func TestEventToRecord_LLMKindNoMCP(t *testing.T) {


### PR DESCRIPTION
## Summary

- Persist consumer `protocol_acceptance` (`dual_era` | `legacy_only`, empty → `dual_era`) as a nullable TEXT column like `fail_mode`.
- After consumer resolve, `legacy_only` + modern returns HTTP 400 / RPC `-32021` with `validation_class=acceptance_denied` and no composer/upstream. Legacy stays unchanged.
- Document OTLP protocol attrs, ops meters, dashboards, config rollback, and deprecation exit (12 months, residual usage, notice, approval). Legacy is not removed.
- Export `trustgate.mcp.protocol_era` / `protocol_version` on the OTLP metadata mapping.

## Stack

1. [#439](https://github.com/NeuralTrust/TrustGate/pull/439) — northbound attrs + validation counters
2. [#440](https://github.com/NeuralTrust/TrustGate/pull/440) — southbound dialer meters
3. This PR — consumer gate + rollout docs (Phases 3–4)

Base: `feat/run-1103-dual-era-northbound-protocol-boundary` ([#400](https://github.com/NeuralTrust/TrustGate/pull/400)). This branch includes #439 and #440 as parents; merge those first if you want this diff to show only Phases 3–4.

## Size

Above the 400-line review budget (`size:exception`): gate + migration + API/repo threading + docs in one slice so the dual-era stack can land together.

## Linear

RUN-1109 — https://linear.app/neuraltrust/issue/RUN-1109/featmcp-roll-out-dual-era-support-with-protocol-telemetry

## Test plan

- [x] `go test -race` on consumer domain/app/API, MCP handler, consumer repo, OTLP mapping
- [x] Pre-commit hook (lint + gosec + unit) passed
- [ ] CI on this PR


Made with [Cursor](https://cursor.com)