### PR TITLE
feat(mcp): harden OAuth RFC 9207 iss and DCR issuer bind (RUN-1106)

### DIFF
--- a/docs/mcp/google-workspace-oauth.md
+++ b/docs/mcp/google-workspace-oauth.md
@@ -44,6 +44,23 @@ Google does **not** support Dynamic Client Registration (DCR) for these MCP
 endpoints. The host cannot invent a client at connect time (unlike Granola,
 Notion-style DCR servers with `registration: "auto"`).
 
+### Authorization `iss` (RFC 9207)
+
+Google Workspace and other **manual** IdPs typically **omit** `iss` on the
+authorization redirect. That still works. TrustGate does not require `iss`
+unless the AS advertised `authorization_response_iss_parameter_supported`.
+A **wrong** `iss` is always rejected. Google’s metadata does not advertise
+the parameter, so a callback without `iss` proceeds to redeem.
+
+| Callback `iss` | Workspace / manual (param not advertised) | AS that advertised the param |
+|----------------|-------------------------------------------|------------------------------|
+| Matching | Redeem | Redeem |
+| Missing | Redeem | Reject |
+| Wrong | Reject | Reject |
+
+This is **not** CIMD. Catalog stays `registration: "manual"` / `dcr: false`.
+RFC 9207, DCR bind, and slog: [OAuth harden](oauth-harden.md).
+
 ## 2. Why Claude does not ask for client ID / secret
 
 Claude (and Antigravity) still use a Google OAuth client. Users simply never
@@ -297,6 +314,7 @@ production.
 | Forwarded MCP credentials | `pkg/app/mcp/credentials.go` |
 | Registry UI (manual client fields) | App `McpServerConfigPanel` / `mcpCatalog.ts` |
 | Local MCP plane testing | `docs/mcp/testing-guide.md` |
+| RFC 9207 `iss` / DCR bind (CIMD is future only) | [OAuth harden](oauth-harden.md) |
 | Google Calendar MCP setup | https://developers.google.com/workspace/calendar/api/guides/configure-mcp-server |
 
 ---
@@ -317,3 +335,8 @@ form fields, and complete Google verification for production users.
 
 **Can we put the client secret in `enterprise-servers.json`?**  
 No. Secrets belong in platform config / secret manager, not the public catalog.
+
+**Does RFC 9207 mix-up protection break Workspace because Google omits `iss`?**  
+No. Missing `iss` is allowed when the AS did not advertise
+`authorization_response_iss_parameter_supported`. Workspace and other
+manual IdPs keep working. See [OAuth harden](oauth-harden.md).

--- a/docs/mcp/oauth-harden.md
+++ b/docs/mcp/oauth-harden.md
@@ -1,0 +1,98 @@
+# MCP OAuth harden (RFC 9207)
+
+TrustGate emits and validates RFC 9207 `iss` on authorization responses,
+binds southbound DCR clients to the issuing AS, and logs mix-up /
+invalid-metadata without secrets. **DCR stays.** `/oauth/register` remains
+the runtime registration path. CIMD is documentation only — not implemented.
+
+## Quick path
+
+1. Treat TrustGate AS metadata `issuer` as `baseURL`. Every MCP-client
+   redirect includes `iss=baseURL`.
+2. Keep using `/oauth/register` (DCR). Do not wait for CIMD.
+3. Google Workspace and other manual IdPs that omit `iss` keep working —
+   see [Google Workspace MCP OAuth](google-workspace-oauth.md).
+4. On mix-up or bad AS metadata, look for slog `oauth.issuer_mismatch` or
+   `oauth.invalid_metadata` (issuer URLs and ids only).
+
+## RFC 9207 `iss`
+
+TrustGate is both an authorization server (northbound, MCP clients) and a
+client (IdP callback and southbound connect).
+
+| Role | Rule |
+|------|------|
+| AS (always) | Redirect query includes `iss=baseURL`. Metadata sets `authorization_response_iss_parameter_supported` true and `issuer` to `baseURL`. |
+| Client, `iss` present and matching | Redeem may proceed. |
+| Client, `iss` present and different | Reject before redeem. slog `oauth.issuer_mismatch`. |
+| Client, `iss` missing | Reject **only** when that AS advertised `authorization_response_iss_parameter_supported`. Otherwise redeem may proceed. |
+
+Issuer compare trims a trailing `/` only. No scheme rewrite.
+
+## DCR stays — CIMD is future only
+
+| Topic | Status in this change |
+|-------|------------------------|
+| Dynamic Client Registration | **Current runtime.** Not removed. |
+| `POST /oauth/register` | **Remains.** |
+| CIMD (`client_id` as URL) | **Documentation / future only.** No CIMD routes, types, or catalog flags. |
+| Enterprise Managed Auth (RUN-1112) | **Not started.** Do not begin it here. |
+
+Do not read this page as “CIMD is implemented” or “DCR is going away.”
+
+## DCR client issuer bind
+
+Southbound cached clients (`RegisteredClient`) carry `Issuer`. Cache
+identity stays `gateway` + `registry` (no Redis key rewrite). Vault user
+grants do **not** gain an issuer field.
+
+| Cached `Issuer` | Discovered AS | `EnsureClient` | `RefreshAuth` |
+|-----------------|---------------|----------------|---------------|
+| Empty (pre-1106) | A | Stamp `Issuer=A`, reuse credentials, no new consent | Stamp via `EnsureClient` |
+| A | A | Reuse | Reuse |
+| A | B | slog `oauth.issuer_mismatch`, **re-register** (no credential reuse) | slog + `ErrNoRegisteredClient` — **no DCR**; user consents again |
+
+## `application_type`
+
+| Direction | Behavior |
+|-----------|----------|
+| Southbound DCR (TrustGate → upstream AS) | Body always includes `application_type=web` (TrustGate callback is HTTPS). |
+| Northbound DCR (MCP client → TrustGate) | Accepts `web` or `native`. Omits are inferred: `https` → `web`; loopback / private-use → `native`. Other values and inconsistent pairs (e.g. `web` + `cursor://`) are rejected. |
+
+## Discovered AS metadata
+
+Fetched AS metadata `issuer` must equal the fetch identifier (RFC 8414).
+Mismatch fails closed: no DCR, no redeem, slog `oauth.invalid_metadata`.
+Invalid metadata is not cached.
+
+## slog (not an audit bus)
+
+| Event | When | Allowed attrs |
+|-------|------|----------------|
+| `oauth.issuer_mismatch` | Wrong callback `iss`, or cached DCR client bound to a different AS | `expected_issuer`, `got_issuer`, `gateway_id`, `provider` / `key` |
+| `oauth.invalid_metadata` | Discovered document `issuer` ≠ fetch identifier | `expected_issuer`, `metadata_issuer`, `gateway_id`, `provider` / `key` |
+
+Never log tokens, codes, client secrets, or raw DCR bodies. This change
+does **not** add a product MCP event or a new audit bus.
+
+## Not in this change
+
+- CIMD runtime (routes, types, catalog flags)
+- Removal of DCR or `/oauth/register`
+- RUN-1112 Enterprise Managed Auth
+- Vault `Credential` issuer field
+- Redis key migration
+- Feature-flag / observe-then-enforce mode
+
+## Checklist
+
+- [ ] AS discovery shows `authorization_response_iss_parameter_supported` and `issuer=baseURL`
+- [ ] MCP-client redirects include `iss=baseURL`
+- [ ] Google Workspace / manual omit-`iss` connect still completes
+- [ ] `/oauth/register` still registers clients
+- [ ] Mix-up and metadata-mismatch logs have issuer URLs and ids only — no secrets
+
+## Next step
+
+Workspace and other omit-`iss` IdPs: [Google Workspace MCP OAuth](google-workspace-oauth.md).
+Exercise the plane: [MCP testing guide](testing-guide.md).

--- a/openspec/changes/run-1106-oauth-harden-2026-07-28/design.md
+++ b/openspec/changes/run-1106-oauth-harden-2026-07-28/design.md
@@ -1,0 +1,101 @@
+# Design: RUN-1106 OAuth harden (MCP 2026-07-28)
+
+## Technical Approach
+
+In-place RFC 9207 harden at existing seams (`pkg/app/oauth`, `pkg/infra/oauth`, HTTP handlers). No new package, kill-switch, or Redis key rewrite. One helper (`issuersEqual`: trim trailing `/` only). Maps to locked Approach 1 / `mcp-oauth-harden`. Spec may land in parallel.
+
+## Architecture Decisions
+
+| Decision | Options | Tradeoff | Choice |
+|----------|---------|----------|--------|
+| Placement | new `oauth/security` vs in-package helpers | Extra package vs ~one function | Unexported helpers in `pkg/app/oauth/issuer.go` |
+| Missing `iss` | always-require vs advertised vs flag | Google break vs mix-up vs two behaviors | Reject mismatch always; reject missing only when AS advertised the param |
+| DCR cache bind | Redis key suffix vs `RegisteredClient.Issuer` | Strands entries vs additive JSON | Keep `gateway\|registry`; stamp empty pre-1106 on next discover; mismatch → slog + re-register |
+| Refresh vs mismatch | `EnsureClient` re-register vs `ErrNoRegisteredClient` | Background refresh mints unused DCR + kills vault grant | `RefreshAuth` does **not** re-register; returns `ErrNoRegisteredClient` so consent re-runs `EnsureClient` |
+| `application_type` | omit vs southbound `web` + northbound infer | MCP clients are native; TG callback is HTTPS | Southbound DCR sends `web`; northbound accepts `web`\|`native`, infers from URI class, rejects inconsistent pairs |
+| Audit | product events vs new bus vs slog | Scope creep | slog `oauth.issuer_mismatch` / `oauth.invalid_metadata` — never tokens/secrets/bodies |
+| CIMD | runtime vs docs | Out of scope | Docs only; `/oauth/register` stays |
+
+## Data Flow
+
+Northbound (TG is AS + IdP client):
+
+```mermaid
+sequenceDiagram
+  participant MCP
+  participant AS as TG AS
+  participant IdP
+  MCP->>AS: DCR (application_type)
+  MCP->>AS: /oauth/authorize
+  AS->>AS: park expected_issuer + advertised
+  AS->>IdP: redirect
+  IdP->>AS: callback?code&iss
+  AS->>AS: validate iss BEFORE tokenCall
+  AS->>IdP: redeem
+  AS->>MCP: redirect?code&iss=baseURL
+```
+
+Southbound (TG is client):
+
+```
+Discover AS ──RFC8414 issuer check──► EnsureClient
+  │ stamp empty Issuer │ mismatch → slog + DCR
+  ▼
+Start parks issuer+advertised on ConnectState
+  ▼
+Callback validate iss BEFORE ExchangeCode
+```
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `pkg/app/oauth/issuer.go` | Create | `issuersEqual`, `validateResponseISS`, `applicationTypeForURIs` |
+| `pkg/app/oauth/issuer_test.go` | Create | Table tests: slash, mismatch, missing+advertised, URI type pairs |
+| `pkg/app/oauth/ports.go` | Modify | `RegisteredClient.Issuer`; `UpstreamAuthServer.AuthorizationResponseIssParameterSupported` |
+| `pkg/app/oauth/proxy_types.go` | Modify | Park issuer fields on `PendingAuthorization`; `iss` on `Callback`; optional `ApplicationType` |
+| `pkg/app/oauth/proxy.go` | Modify | Park at Authorize; validate before `tokenCall`; set `iss=baseURL` on all `clientRedirect`s |
+| `pkg/app/oauth/idp_transport.go` | Modify | `idpEndpoints` carries issuer+advertised; static URLs → advertised=false |
+| `pkg/app/oauth/metadata.go` | Modify | Advertise iss param; validate fetched `issuer` before cache; northbound DCR type |
+| `pkg/app/oauth/connect_types.go` | Modify | Park issuer fields on `ConnectState`; `iss` on `ConnectService.Callback` |
+| `pkg/app/oauth/connect.go` | Modify | Park at Start; validate before `ExchangeCode` |
+| `pkg/app/oauth/connect_registration.go` | Modify | `RefreshAuth`: empty stamp via `EnsureClient`; mismatch → slog + `ErrNoRegisteredClient` |
+| `pkg/infra/oauth/dcr_registrar.go` | Modify | Validate AS `issuer` vs PRM AS URL; DCR `application_type=web`; bind/stamp/re-register |
+| `pkg/infra/oauth/connect_store.go` | Modify | Persist additive `Issuer` (no key change) |
+| `pkg/api/handler/http/oauth/callback_handler.go` | Modify | Pass `c.Query("iss")` |
+| `pkg/api/handler/http/oauth/connect_handler.go` | Modify | Pass `c.Query("iss")` |
+| `pkg/app/oauth/mocks/*` | Modify | `go generate` after interface change |
+| `docs/mcp/oauth-harden.md` | Create | RFC 9207, bind, slog; **DCR stays; CIMD future** |
+| `docs/mcp/google-workspace-oauth.md` | Modify | Manual IdPs omit `iss` |
+
+Unchanged: vault `Credential`, Redis prefixes, `events.Event.Security`, CIMD routes.
+
+## Interfaces / Contracts
+
+```go
+// validateResponseISS: mismatch always errors; missing errors iff advertised.
+// issuersEqual: strings.TrimSuffix(a,"/") == strings.TrimSuffix(b,"/")
+// applicationTypeForURIs: https→web; loopback/private-use→native; mixed URIs or web+cursor:// → invalid_client_metadata
+```
+
+Callback last arg `iss string`. Mix-up → `oauthErr("invalid_request", …)` **before** redeem. Invalid metadata → error, **do not cache**.
+
+slog attrs: `expected_issuer`, `got_issuer`/`metadata_issuer`, `gateway_id`, `provider`/`key`. Never `client_secret`, tokens, codes, raw DCR body.
+
+## Testing Strategy
+
+| Layer | What | Approach |
+|-------|------|----------|
+| Unit | `issuersEqual`, RFC 9207 matrix, URI type inference | Table-driven `issuer_test.go` |
+| Unit | AS advertises param; DCR type reject; `iss` on redirect; mix-up fails before token HTTP; Google omit-iss OK | `metadata_test.go`, `proxy_test.go`, `connect_test.go` |
+| Unit | Stamp empty Issuer; mismatch re-registers; `RefreshAuth` mismatch → `ErrNoRegisteredClient`; metadata issuer fail-closed | `dcr_registrar_test.go`, `idp_transport_test.go` |
+| Handler | Query `iss` forwarded; register `application_type`; existing Callback call-sites pass `iss ""` | `handlers_test.go`, `connect_handler_test.go` |
+| E2E | Out of scope | Existing MCP tests unchanged |
+
+## Migration / Rollout
+
+No Redis migration. Additive JSON. First `EnsureClient` stamps empty `Issuer`. Reconnect only if upstream AS changed. Revert PR to roll back. Split tests/docs if PR exceeds 400 lines.
+
+## Open Questions
+
+- None blocking. Issuer compare is slash-only (no scheme rewrite) by design.

--- a/openspec/changes/run-1106-oauth-harden-2026-07-28/exploration.md
+++ b/openspec/changes/run-1106-oauth-harden-2026-07-28/exploration.md
@@ -1,0 +1,108 @@
+# Exploration: RUN-1106 OAuth harden for MCP 2026-07-28
+
+## Current State
+
+TrustGate plays **two** OAuth roles. Neither implements RFC 9207 `iss` mix-up protection, issuer-bound DCR credentials, or `application_type`.
+
+### Northbound (TrustGate is the AS / broker)
+
+MCP clients discover `/.well-known/oauth-protected-resource` and `/.well-known/oauth-authorization-server`, register at `/oauth/register` (DCR), authorize at `/oauth/authorize`. TrustGate parks state, redirects to the configured IdP, then `/oauth/callback` redeems the IdP code and issues a gateway code back to the MCP client.
+
+- AS metadata (`AuthorizationServer`) advertises `issuer = baseURL`, endpoints, PKCE S256, `token_endpoint_auth_methods_supported: ["none"]`. **Missing:** `authorization_response_iss_parameter_supported`, `jwks_uri` (no JWT issuance), `application_type` hints.
+- Protected-resource metadata advertises the gateway as the only AS, `bearer_methods_supported: ["header"]`, path-scoped scopes. Adequate for RFC 9728 basics; no extra modern fields required for this ticket.
+- `clientRedirect` returns `code`/`error` + `state` only — **no `iss`**.
+- `CallbackHandler` / `AuthProxy.Callback` ignore the `iss` query param. `PendingAuthorization` does not store the expected IdP issuer.
+- Northbound DCR (`RegisterRequest`) accepts `redirect_uris` + `client_name` only. Redirect URI policy already distinguishes https / loopback / private-use (`IsAcceptableRedirectURI`). No `application_type`. Clients stored as `oauth:gwclient:{clientID}` with no issuer field (`RegisteredGatewayClient`).
+- IdP metadata fetch (`fetchASMetadata`) caches by configured issuer URL but **does not** check that the document's `issuer` matches.
+
+### Southbound / connect (TrustGate is the client)
+
+`registration: auto` discovers upstream PRM + AS metadata, then DCR-registers a public client (`token_endpoint_auth_method: none`). Manual providers (Google Workspace) skip DCR.
+
+- Cache key is `gatewayID|registryID` (`clientKey`). Redis key `oauth:dcr:client:{key}`.
+- `RegisteredClient` = `{client_id, client_secret, redirect_uri}` — **no issuer**.
+- `EnsureClient` reuses a cached client when `RedirectURI` matches; it does **not** compare the discovered AS issuer. An upstream that changes AS (or a poisoned discovery cache) can reuse another AS's `client_id`/`client_secret`.
+- DCR body has no `application_type`. TrustGate's callback is HTTPS → should be `web`.
+- `ConnectState` has ticket/provider/verifier only — no expected issuer. `ConnectHandler.Callback` does not read `iss`.
+- Discovery does not validate AS document `issuer` against the authorization-server URL from PRM.
+- Vault user grants (`Credential`) are keyed by `(gateway, principal, provider)` with no issuer. Ticket wording is **client** credentials (DCR), not user tokens — leave vault shape unchanged.
+
+### Audit / logging
+
+No dedicated audit package. Connect already uses structured `slog` (`oauth connect: provider grant stored` with `has_refresh_token`, never the token). Product `events.Event.Security` is request-scoped MCP telemetry, not auth-flow audit. Issuer-mismatch / invalid-metadata events do not exist.
+
+### Docs and tests
+
+- Worktree docs: `docs/mcp/google-workspace-oauth.md` (manual, no DCR), `docs/mcp/testing-guide.md`, `docs/mcp/dual-era-rollout.md`. No CIMD / RFC 9207 / `application_type` guidance.
+- `docs/mcp/api-key-auth-and-external-credentials.md` lives in the main TrustGate checkout (untracked), **not** this worktree. It covers principal vs forwarded vault ownership — complementary, not a substitute for OAuth harden docs.
+- Tests cover DCR race (`SaveClientIfAbsent`), redirect-URI replacement, northbound register/PKCE/redirect policy, connect consent + auto-registration. **No** mix-up / cross-issuer / `application_type` / `iss` cases.
+
+### Constraints (resolved from code)
+
+| Question | Answer from code |
+|---|---|
+| Where to validate `iss`? | Both callbacks: IdP→gateway (`proxy.Callback`) and upstream AS→gateway (`connect.Callback`), **before** `ExchangeCode` / `tokenCall`. Also emit `iss` on gateway→MCP-client redirects. |
+| Can cache keys bind issuer? | Yes without a Redis key migration: keep `gateway\|registry`, add `Issuer` on `RegisteredClient`, reject/re-register on mismatch. Optional key suffix is stricter but strands existing entries. |
+| Require `iss` always? | **No.** Google/GitHub-style IdPs and many manual providers do not send RFC 9207 `iss`. Requiring it would break Workspace connect. Follow RFC 9207: require when AS metadata advertises `authorization_response_iss_parameter_supported`, always reject a **present but wrong** `iss`. |
+| CIMD now? | Out of scope. No CIMD types, routes, or catalog flags exist. Preserve DCR. |
+| Audit sink? | New structured slog events (same family as connect). Do not extend product MCP events or invent a new audit bus. Never log tokens, codes, or secrets. |
+
+## Affected Areas
+
+- `pkg/app/oauth/proxy.go` + `proxy_types.go` + `tokens.go` — park expected IdP issuer; validate `iss` before redeem; emit `iss` on client redirect
+- `pkg/api/handler/http/oauth/callback_handler.go` + `connect_handler.go` — pass `iss` query into app layer
+- `pkg/app/oauth/connect.go` + `connect_types.go` + `connect_registration.go` — park expected upstream issuer; validate before exchange
+- `pkg/app/oauth/ports.go` — `RegisteredClient.Issuer`; registrar contract
+- `pkg/infra/oauth/dcr_registrar.go` — send `application_type=web`; bind/reject cached client by issuer; validate AS metadata `issuer`
+- `pkg/infra/oauth/connect_store.go` — persist new `Issuer` field (JSON-compatible; old rows lack it)
+- `pkg/app/oauth/metadata.go` — advertise `authorization_response_iss_parameter_supported`; accept/validate/echo `application_type` on DCR
+- `pkg/api/handler/http/oauth/register_handler.go` — pass through `application_type`
+- `pkg/app/oauth/idp_transport.go` — validate fetched IdP metadata `issuer`
+- Tests: `proxy_test.go`, `connect_test.go`, `metadata_test.go`, `dcr_registrar_test.go`, `handlers_test.go`, `connect_handler_test.go`
+- Docs: new OAuth harden / CIMD-prep note under `docs/mcp/`; update `google-workspace-oauth.md` (legacy IdPs omit `iss`); optionally copy/link `api-key-auth-and-external-credentials.md` into the worktree
+- Out of scope files: vault credential schema, Enterprise Managed Auth (RUN-1112), DCR removal
+
+## Approaches
+
+1. **In-place harden at existing seams (RFC 9207-compatible)** — Add issuer fields and checks on current types/handlers; emit `iss` as AS; validate as client per RFC 9207; DCR `application_type`; slog audit; docs + CIMD migration note. Legacy cached clients without `Issuer` get bound on next successful discover (stamp) or re-register if discover issuer ≠ empty-and-unbound after first stamp.
+   - Pros: Smallest diff; matches hexagonal ports already in place; keeps Google/manual providers working; no Redis key rewrite; DCR stays.
+   - Cons: Two callback signatures grow; must be careful not to log secrets; unbound legacy cache needs an explicit one-time stamp rule.
+   - Effort: Medium
+
+2. **New `oauth/security` package + always-require `iss`** — Extract validator/binder; fail closed if `iss` is missing.
+   - Pros: Cleaner unit surface; strongest mix-up story for MCP-native ASes.
+   - Cons: Extra package for ~one function; **breaks Google Workspace and other manual IdPs** that never send `iss`; larger PR vs 400-line budget.
+   - Effort: High
+
+3. **Feature-flagged observe-then-enforce** — Log mismatches first; enforce behind a gateway/env flag.
+   - Pros: Safest rollout if production IdP behavior is unknown.
+   - Cons: Mix-up stays exploitable until the flag flips; two behaviors to test; ticket QA wants mix-up **rejected**. Flag is unnecessary if RFC 9207 presence rules already protect legacy IdPs.
+   - Effort: Medium–High
+
+## Recommendation
+
+**Approach 1.** Harden the existing northbound broker and southbound DCR/connect paths. Do not add a new package or a kill-switch.
+
+Concrete policy for propose/design:
+
+1. **As AS (northbound):** always set `iss` on authorization redirects to `baseURL` (same value as metadata `issuer`); advertise `authorization_response_iss_parameter_supported: true`.
+2. **As client (IdP + upstream):** validate `iss` before code redeem. Reject mismatch always. Reject missing `iss` only when the expected AS metadata advertised the parameter (or we are the ones who discovered an MCP-modern AS that did). Google/manual static endpoints → allow missing `iss`.
+3. **Credential binding:** add `Issuer` to `RegisteredClient`. On cache hit, if stored issuer is set and ≠ discovered issuer → reject, slog audit, re-register (same as redirect-URI change). If stored issuer is empty (pre-1106) → stamp current issuer, do not force users through consent.
+4. **`application_type`:** southbound DCR sends `web`. Northbound DCR accepts `web`\|`native`, defaults by redirect URI (https → web, loopback/private-use → native), rejects inconsistent pairs (e.g. `web` + `cursor://`).
+5. **Metadata:** validate discovered/fetched AS `issuer` equals the identifier used to fetch it (RFC 8414 / OIDC). Invalid metadata → error + audit, no redeem/register.
+6. **Audit:** slog events `oauth.issuer_mismatch` and `oauth.invalid_metadata` with issuer URLs, gateway/registry/provider ids — never tokens, codes, secrets, or raw registration bodies.
+7. **CIMD:** document only — DCR remains the runtime path; CIMD is a future client_id-as-URL option when hosts and clients support it. Do not add routes or remove `/oauth/register`.
+8. **Rollout:** existing vault grants and DCR clients keep working; first discover after deploy stamps issuer. Operators reconnect only if an upstream actually changed AS.
+
+## Risks
+
+- **Legacy IdP break** if someone later tightens “missing `iss`” to always-reject (Google Workspace).
+- **Pre-1106 DCR rows** without `Issuer` are briefly unbound; stamp-on-read closes the window without consent churn. Do not treat empty issuer as mismatch.
+- **Issuer string normalization** (trailing slash, http/https, path) — must use one compare helper or false mismatches will re-register and invalidate refresh tokens.
+- **Discovery cache TTL (1h)** can delay seeing a real AS change; issuer check on cached client still fires when discovery eventually updates.
+- **PR size:** metadata + two callbacks + DCR + tests + docs can exceed 400 lines — split tests/docs if needed.
+- **CIMD confusion:** docs must say DCR is not going away in this change.
+
+## Ready for Proposal
+
+Yes. Orchestrator should run **sdd-propose** for `run-1106-oauth-harden-2026-07-28` using Approach 1. No blocking product questions remain; RFC 9207 presence rules resolve the Google/`iss` tension from the codebase.

--- a/openspec/changes/run-1106-oauth-harden-2026-07-28/proposal.md
+++ b/openspec/changes/run-1106-oauth-harden-2026-07-28/proposal.md
@@ -1,0 +1,74 @@
+# Proposal: Harden OAuth for MCP 2026-07-28 (RUN-1106)
+
+## Intent
+
+Close RFC 9207 mix-up and cross-issuer DCR reuse on TrustGate’s two OAuth roles (northbound AS, southbound client) without breaking Google/manual IdPs that omit `iss`.
+
+## Scope
+
+### In Scope
+
+- AS: always emit `iss = baseURL`; advertise `authorization_response_iss_parameter_supported`.
+- Client: reject mismatch always; reject missing `iss` only when the AS advertised the parameter.
+- Bind `RegisteredClient.Issuer`; stamp empty pre-1106 rows on next discover (no consent).
+- Southbound DCR `application_type=web`; northbound `web`|`native` from redirect URI (reject inconsistent pairs).
+- Validate discovered AS metadata `issuer` (RFC 8414).
+- slog `oauth.issuer_mismatch` / `oauth.invalid_metadata` — never tokens/secrets.
+- CIMD migration note + Workspace omit-`iss` docs.
+
+### Out of Scope
+
+- CIMD runtime; DCR removal; RUN-1112 EMA.
+- Vault `Credential` / user-token issuer binding.
+- New audit bus or product MCP events.
+- Redis key rewrite; observe-then-enforce flag; always-require `iss`.
+
+## Capabilities
+
+### New Capabilities
+
+- `mcp-oauth-harden`: RFC 9207 `iss`, issuer-bound DCR, `application_type`, metadata issuer check, slog audit, CIMD-prep docs.
+
+### Modified Capabilities
+
+- None (`mcp-dual-era-northbound` is protocol-era only).
+
+## Approach
+
+**Approach 1** (locked): in-place harden. No new package, no kill-switch. One issuer-compare helper. Keep Redis key `gateway|registry`. Mismatch → slog + re-register. Empty `Issuer` → stamp, not mismatch.
+
+## Affected Areas
+
+- `pkg/app/oauth/proxy*.go`, `tokens.go` — park IdP issuer; validate/emit `iss`
+- `pkg/app/oauth/connect*.go` — park/validate upstream issuer
+- `pkg/app/oauth/ports.go`, `pkg/infra/oauth/connect_store.go` — additive `RegisteredClient.Issuer`
+- `pkg/infra/oauth/dcr_registrar.go` — `web` DCR; issuer bind; metadata check
+- `pkg/app/oauth/metadata.go`, `idp_transport.go` — advertise iss param; infer type
+- `pkg/api/handler/http/oauth/` — pass `iss` + `application_type`
+- `docs/mcp/` — harden + CIMD-prep; Workspace omit-`iss`
+
+## Risks
+
+- Always-require `iss` later breaks Google → missing `iss` only when advertised
+- Empty pre-1106 rows treated as mismatch → stamp-on-discover; no consent
+- Issuer string drift drops refresh tokens → single compare helper
+- PR > 400 lines → split tests/docs if needed
+- CIMD docs read as DCR removal → “DCR stays; CIMD future”
+
+## Rollback Plan
+
+Revert the PR. `Issuer` is additive JSON. No Redis migration. Reconnect only if an upstream changed AS.
+
+## Dependencies
+
+- Stacked on RUN-1103 / RUN-1109 tip (`feat/run-1103-dual-era-northbound-protocol-boundary`).
+- Blocks RUN-1112 — do not start it.
+
+## Success Criteria
+
+- [ ] Mix-up rejected before redeem; missing `iss` allowed for Google/manual.
+- [ ] DCR creds not reused across issuers; empty rows stamp without consent.
+- [ ] Southbound DCR is `web`; northbound type matches redirect URI.
+- [ ] Invalid metadata `issuer` fails closed; no secrets in logs.
+- [ ] CIMD documented only; `/oauth/register` remains.
+- [ ] Ready for `sdd-spec` / `sdd-design`.

--- a/openspec/changes/run-1106-oauth-harden-2026-07-28/specs/mcp-oauth-harden/spec.md
+++ b/openspec/changes/run-1106-oauth-harden-2026-07-28/specs/mcp-oauth-harden/spec.md
@@ -1,0 +1,106 @@
+# MCP OAuth Harden Specification
+
+## Purpose
+
+RFC 9207 mix-up protection, issuer-bound DCR, and `application_type`. Omit-`iss` IdPs keep working. CIMD is docs only.
+
+## Requirements
+
+### Requirement: AS authorization `iss`
+
+As AS, every authorization redirect to an MCP client MUST include `iss` equal to metadata `issuer` (`baseURL`). AS metadata MUST set `authorization_response_iss_parameter_supported` true.
+
+#### Scenario: Redirect includes iss
+- GIVEN completed northbound authorization
+- WHEN redirecting the MCP client with a code
+- THEN query `iss` equals `baseURL`
+
+#### Scenario: Metadata advertises iss
+- GIVEN AS discovery
+- WHEN returning `/.well-known/oauth-authorization-server`
+- THEN `authorization_response_iss_parameter_supported` is true and `issuer` is `baseURL`
+
+### Requirement: Client mix-up protection
+
+As client (IdP and connect callbacks), TrustGate MUST validate `iss` before redeem. Present matching `iss` MUST be accepted; present mismatch MUST reject redeem and MUST emit slog `oauth.issuer_mismatch` (issuer URLs and ids). Missing `iss` MUST be rejected only when that AS advertised `authorization_response_iss_parameter_supported`. MUST NOT log tokens, codes, secrets, or registration bodies.
+
+#### Scenario: Mix-up rejected
+- GIVEN expected issuer A and callback `iss` B
+- WHEN processing the callback
+- THEN redeem is skipped and `oauth.issuer_mismatch` is emitted
+
+#### Scenario: Matching iss accepted
+- GIVEN expected issuer A and callback `iss` A
+- WHEN processing the callback
+- THEN redeem MAY proceed
+
+#### Scenario: Missing iss allowed when not advertised
+- GIVEN AS did not advertise `authorization_response_iss_parameter_supported`
+- WHEN callback omits `iss`
+- THEN redeem MAY proceed
+
+#### Scenario: Missing iss rejected when advertised
+- GIVEN AS advertised `authorization_response_iss_parameter_supported`
+- WHEN callback omits `iss`
+- THEN redeem is skipped
+
+### Requirement: DCR credential issuer binding
+
+Southbound cached clients MUST carry `Issuer`. Cache identity (`gateway` + `registry`) MUST stay. Non-empty `Issuer` that differs from discovered MUST re-register (no credential reuse) and MUST emit `oauth.issuer_mismatch`. Empty pre-1106 `Issuer` MUST stamp the discovered issuer without consent. Vault user grants MUST NOT gain an issuer field.
+
+#### Scenario: Cross-issuer reuse rejected
+- GIVEN cached client bound to A and discovery of B
+- WHEN ensuring the client
+- THEN credentials are not reused, registration is new, and `oauth.issuer_mismatch` is emitted
+
+#### Scenario: Pre-1106 empty issuer stamped
+- GIVEN cached client with empty `Issuer` and discovery of A
+- WHEN ensuring the client
+- THEN `Issuer` is A and credentials are reused without consent
+
+#### Scenario: Matching issuer reused
+- GIVEN cached client bound to A and discovery of A
+- WHEN ensuring the client
+- THEN existing credentials are reused
+
+### Requirement: application_type
+
+Southbound DCR MUST send `application_type=web`. Northbound MUST accept `web`|`native`, MUST reject other values, MUST infer omitted type (`web` from https, `native` from loopback/private-use), and MUST reject inconsistent pairs.
+
+#### Scenario: Southbound DCR is web
+- GIVEN auto registration toward an upstream AS
+- WHEN sending DCR
+- THEN body includes `application_type=web`
+
+#### Scenario: Northbound infers native
+- GIVEN loopback or private-use redirect URI and no `application_type`
+- WHEN processing DCR
+- THEN client is `native`
+
+#### Scenario: Inconsistent pair rejected
+- GIVEN `application_type=web` and a private-use redirect URI
+- WHEN processing DCR
+- THEN registration fails
+
+### Requirement: Discovered AS metadata issuer
+
+Fetched AS metadata `issuer` MUST equal the fetch identifier (RFC 8414). Mismatch MUST fail closed (no DCR, no redeem) and MUST emit `oauth.invalid_metadata`. MUST NOT add an audit bus or product MCP events.
+
+#### Scenario: Matching metadata proceeds
+- GIVEN metadata `issuer` equals fetch identifier
+- WHEN discovery completes
+- THEN registration or callback MAY continue
+
+#### Scenario: Mismatched metadata fails closed
+- GIVEN metadata `issuer` differs from fetch identifier
+- WHEN discovery completes
+- THEN fail closed and `oauth.invalid_metadata` is emitted
+
+### Requirement: CIMD documentation only
+
+Docs MUST cover RFC 9207 `iss`, Workspace/manual omit-`iss`, and CIMD as future client_id-as-URL with DCR remaining runtime. MUST NOT add CIMD routes or types or remove `/oauth/register`.
+
+#### Scenario: Docs keep DCR
+- GIVEN MCP OAuth harden docs
+- WHEN reading CIMD guidance
+- THEN DCR is current runtime, CIMD is future-only, and `/oauth/register` remains

--- a/openspec/changes/run-1106-oauth-harden-2026-07-28/tasks.md
+++ b/openspec/changes/run-1106-oauth-harden-2026-07-28/tasks.md
@@ -1,0 +1,66 @@
+# Tasks: RUN-1106 OAuth harden (MCP 2026-07-28)
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | 1080–1320 |
+| 400-line budget risk | High |
+| Chained PRs recommended | Yes |
+| Suggested split | PR 1 (280–360) → PR 2 (340–420) → PR 3 (360–450) → PR 4 (180–250) |
+| Delivery strategy | ask-on-risk |
+| Chain strategy | stacked onto `feat/run-1103-dual-era-northbound-protocol-boundary` (never `main`) |
+
+Decision needed before apply: No — locked to 1103 stack (same as RUN-1109)
+Chained PRs recommended: Yes
+Chain strategy: stacked onto RUN-1103 branch, then retarget `develop` after #400 lands
+400-line budget risk: High
+
+### Suggested Work Units
+
+| Unit | Goal | Likely PR | Notes |
+|------|------|-----------|-------|
+| 1 | AS emit `iss` + advertise + northbound type | PR 1 | Base RUN-1103 tip |
+| 2 | Client mix-up + DCR bind + handlers | PR 2 | Base PR 1; exception if >400 |
+| 3 | Spec scenario unit tests | PR 3 | Base PR 2 |
+| 4 | CIMD-prep + Workspace omit-`iss` docs | PR 4 | Base PR 3; docs-only |
+
+Merge into `feat/run-1103-dual-era-northbound-protocol-boundary` in order. Never target `main`.
+
+### Locks
+
+- One slash-trim `issuersEqual`. Reject mismatch always; missing `iss` only when advertised.
+- `EnsureClient` mismatch → slog + re-register. `RefreshAuth` mismatch → `ErrNoRegisteredClient` (no DCR).
+- Empty `Issuer` stamps on discover. Redis key `gateway|registry`. Southbound DCR `web`; northbound `web`/`native` from URI.
+- slog `oauth.issuer_mismatch` / `oauth.invalid_metadata` — never tokens/secrets. No CIMD runtime, DCR removal, RUN-1112, or vault issuer.
+
+## Phase 1: Foundation + AS (PR 1)
+
+- [x] 1.1 Create `pkg/app/oauth/issuer.go`: `issuersEqual`, `validateResponseISS`, `applicationTypeForURIs` (https→web; loopback/private-use→native; mixed/`cursor://` invalid).
+- [x] 1.2 `metadata.go` `AuthorizationServer`: advertise iss param; `issuer=baseURL`. Spec: Metadata advertises iss.
+- [x] 1.3 `RegisterRequest.ApplicationType`; `RegisterClient` accept `web`/`native`, infer omitted, reject other/inconsistent. Spec: infers native; inconsistent rejected.
+- [x] 1.4 `proxy.go`: every MCP `clientRedirect` includes `iss=baseURL`. Spec: Redirect includes iss.
+- [x] 1.5 `clean-comments`; `go test ./pkg/app/oauth ./pkg/api/handler/http/oauth`; `go vet ./...`.
+
+## Phase 2: Client mix-up + DCR bind (PR 2)
+
+- [x] 2.1 `ports.go`: `RegisteredClient.Issuer` + advertised flag. `connect_store.go`: additive JSON; no key change.
+- [x] 2.2 Park issuer+advertised on `PendingAuthorization`/`ConnectState`. `idp_transport.go`: carry both; static IdP → advertised=false.
+- [x] 2.3 Last-arg `iss` on `AuthProxy.Callback` and `ConnectService.Callback`. Handlers pass `c.Query("iss")`. Existing tests pass `""`. `go generate` mocks.
+- [x] 2.4 `proxy.go`/`connect.go`: `validateResponseISS` before `tokenCall`/`ExchangeCode`; mix-up → `invalid_request` + slog `oauth.issuer_mismatch` (issuers + ids only). Spec: mix-up/match/missing iss.
+- [x] 2.5 `dcr_registrar.go`: RFC 8414 issuer vs fetch; mismatch → slog `oauth.invalid_metadata`, no cache. DCR `application_type=web`. `EnsureClient`: stamp empty; mismatch re-register; match reuse. Spec: metadata; cross-issuer; stamp; reuse; southbound web.
+- [x] 2.6 `connect_registration.go` `RefreshAuth`: empty → stamp via `EnsureClient`; mismatch → `ErrNoRegisteredClient` (do not re-register). Vault unchanged.
+- [x] 2.7 Validate-before-cache on `metadata.go` `fetchASMetadata`. `clean-comments`; compile-green tests.
+
+## Phase 3: Tests (PR 3)
+
+- [x] 3.1 `issuer_test.go`: slash trim; mismatch; missing+advertised; URI type pairs.
+- [x] 3.2 `metadata_test.go`+`proxy_test.go`: advertise; `iss` on redirect; mix-up before token HTTP; Google omit-iss OK; DCR type reject.
+- [x] 3.3 `connect_test.go`+`idp_transport_test.go`: park/validate; static advertised=false.
+- [x] 3.4 `dcr_registrar_test.go`: stamp; mismatch re-register; `RefreshAuth`→`ErrNoRegisteredClient`; metadata fail-closed; southbound `web`.
+- [x] 3.5 Handler tests: `iss` forwarded; register `application_type`; slog has no secrets. `go test -race` oauth packages.
+
+## Phase 4: Docs (PR 4)
+
+- [x] 4.1 Create `docs/mcp/oauth-harden.md`: RFC 9207, DCR bind, slog; **DCR stays; CIMD future; `/oauth/register` remains**. Spec: Docs keep DCR.
+- [x] 4.2 `docs/mcp/google-workspace-oauth.md`: Workspace/manual omit-`iss` still works.

--- a/pkg/api/handler/http/oauth/callback_handler.go
+++ b/pkg/api/handler/http/oauth/callback_handler.go
@@ -37,6 +37,7 @@ func (h *CallbackHandler) Handle(c *fiber.Ctx) error {
 		c.Query("code"),
 		c.Query("error"),
 		c.Query("error_description"),
+		c.Query("iss"),
 	)
 	if err != nil {
 		return writeOAuthError(c, err)

--- a/pkg/api/handler/http/oauth/connect_handler.go
+++ b/pkg/api/handler/http/oauth/connect_handler.go
@@ -58,6 +58,7 @@ func (h *ConnectHandler) Callback(c *fiber.Ctx) error {
 	ticketID, err := h.connect.Callback(
 		c.UserContext(), c.BaseURL(), providerParam(c),
 		c.Query("state"), c.Query("code"), c.Query("error"), c.Query("error_description"),
+		c.Query("iss"),
 	)
 	if err != nil {
 		if ticketID == "" {

--- a/pkg/api/handler/http/oauth/connect_handler_test.go
+++ b/pkg/api/handler/http/oauth/connect_handler_test.go
@@ -31,6 +31,7 @@ type stubConnectService struct {
 	page        *appoauth.ConnectPage
 	err         error
 	gotProvider string
+	gotISS      string
 }
 
 func (s *stubConnectService) CreateTicket(context.Context, ids.GatewayID, string, string) (string, error) {
@@ -46,7 +47,8 @@ func (s *stubConnectService) Start(_ context.Context, _, _, provider string) (st
 	return "https://github.com/login/oauth/authorize?x=1", nil
 }
 
-func (s *stubConnectService) Callback(context.Context, string, string, string, string, string, string) (string, error) {
+func (s *stubConnectService) Callback(_ context.Context, _, _, _, _, _, _, iss string) (string, error) {
+	s.gotISS = iss
 	return "t", nil
 }
 
@@ -142,5 +144,26 @@ func TestConnectStart_ProviderWithSlash(t *testing.T) {
 	}
 	if stub.gotProvider != "app.linear/mcp" {
 		t.Fatalf("provider = %q, want app.linear/mcp", stub.gotProvider)
+	}
+}
+
+func TestConnectCallback_ForwardsISS(t *testing.T) {
+	t.Parallel()
+	stub := &stubConnectService{page: &appoauth.ConnectPage{
+		ConsumerPath: "/v1/mcp/dev",
+		Providers:    []appoauth.ProviderStatus{{Provider: "github", Registry: "github-mcp"}},
+	}}
+	h := NewConnectHandler(stub)
+	app := fiber.New()
+	app.Get(ConnectCallbackPath, h.Callback)
+	res, err := app.Test(httptest.NewRequest("GET", "/oauth/callback/github?state=s&code=secret-code&iss=https://idp.example", nil))
+	if err != nil {
+		t.Fatalf("route test: %v", err)
+	}
+	if res.StatusCode != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", res.StatusCode)
+	}
+	if stub.gotISS != "https://idp.example" {
+		t.Fatalf("forwarded iss = %q", stub.gotISS)
 	}
 }

--- a/pkg/api/handler/http/oauth/handlers_test.go
+++ b/pkg/api/handler/http/oauth/handlers_test.go
@@ -197,3 +197,114 @@ func TestRegisterHandlerUnavailable(t *testing.T) {
 		t.Fatalf("expected 400, got %d", res.StatusCode)
 	}
 }
+
+func TestAuthorizationServerHandlerAdvertisesISS(t *testing.T) {
+	t.Parallel()
+	app := newTestApp(oauth2Auth("https://idp.example.com", "mcp-public-client"))
+	res, err := app.Test(httptest.NewRequest(fiber.MethodGet, "http://gw.example.com"+WellKnownAuthorizationServerPath, nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.StatusCode != fiber.StatusOK {
+		t.Fatalf("expected 200, got %d", res.StatusCode)
+	}
+	var doc map[string]any
+	if err := json.NewDecoder(res.Body).Decode(&doc); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if doc["issuer"] != "http://gw.example.com" {
+		t.Fatalf("issuer = %v", doc["issuer"])
+	}
+	if doc["authorization_response_iss_parameter_supported"] != true {
+		t.Fatalf("authorization_response_iss_parameter_supported = %v, want true", doc["authorization_response_iss_parameter_supported"])
+	}
+}
+
+func TestRegisterHandlerApplicationType(t *testing.T) {
+	t.Parallel()
+	app := newTestApp(oauth2Auth("https://idp.example.com", "mcp-public-client"))
+	cases := []struct {
+		name       string
+		body       string
+		wantStatus int
+		wantType   string
+	}{
+		{
+			name:       "omit infers native from loopback",
+			body:       `{"redirect_uris":["http://127.0.0.1:33418/callback"]}`,
+			wantStatus: fiber.StatusCreated,
+			wantType:   "native",
+		},
+		{
+			name:       "web with private-use rejected",
+			body:       `{"redirect_uris":["cursor://anysphere.cursor-mcp/oauth/callback"],"application_type":"web"}`,
+			wantStatus: fiber.StatusBadRequest,
+		},
+		{
+			name:       "unknown type rejected",
+			body:       `{"redirect_uris":["https://app.example/cb"],"application_type":"service"}`,
+			wantStatus: fiber.StatusBadRequest,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequest(fiber.MethodPost, "http://gw.example.com"+RegisterPath, strings.NewReader(tc.body))
+			req.Header.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSON)
+			res, err := app.Test(req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if res.StatusCode != tc.wantStatus {
+				t.Fatalf("status = %d, want %d", res.StatusCode, tc.wantStatus)
+			}
+			if tc.wantType == "" {
+				return
+			}
+			var out appoauth.RegisterResponse
+			if err := json.NewDecoder(res.Body).Decode(&out); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if out.ApplicationType != tc.wantType {
+				t.Fatalf("application_type = %q, want %q", out.ApplicationType, tc.wantType)
+			}
+		})
+	}
+}
+
+type capturingProxy struct {
+	iss string
+	loc string
+}
+
+func (p *capturingProxy) Authorize(context.Context, string, appoauth.AuthorizeRequest) (string, error) {
+	return "", nil
+}
+
+func (p *capturingProxy) Callback(_ context.Context, _, _, _, _, _, iss string) (string, error) {
+	p.iss = iss
+	return p.loc, nil
+}
+
+func (p *capturingProxy) Exchange(context.Context, string, appoauth.TokenRequest) (map[string]any, error) {
+	return nil, nil
+}
+
+func TestCallbackHandlerForwardsISS(t *testing.T) {
+	t.Parallel()
+	proxy := &capturingProxy{loc: "https://client.example/cb"}
+	app := fiber.New()
+	app.Get("/oauth/callback", NewCallbackHandler(proxy).Handle)
+
+	req := httptest.NewRequest(fiber.MethodGet, "http://gw.example.com/oauth/callback?state=s&code=secret-code&iss=https://idp.example/issuer", nil)
+	res, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.StatusCode != fiber.StatusFound {
+		t.Fatalf("status = %d, want 302", res.StatusCode)
+	}
+	if proxy.iss != "https://idp.example/issuer" {
+		t.Fatalf("forwarded iss = %q", proxy.iss)
+	}
+}

--- a/pkg/app/oauth/connect.go
+++ b/pkg/app/oauth/connect.go
@@ -121,6 +121,7 @@ func (s *connectService) Start(ctx context.Context, baseURL, ticketID, provider 
 	if err != nil {
 		return "", err
 	}
+	parked := s.parkConnectIssuer(ctx, reg, cfg)
 	state, err := randomToken()
 	if err != nil {
 		return "", err
@@ -130,17 +131,35 @@ func (s *connectService) Start(ctx context.Context, baseURL, ticketID, provider 
 		return "", err
 	}
 	if err := s.store.SaveConnect(ctx, state, ConnectState{
-		Ticket:   *ticket,
-		TicketID: ticketID,
-		Provider: provider,
-		Verifier: verifier,
+		Ticket:        *ticket,
+		TicketID:      ticketID,
+		Provider:      provider,
+		Verifier:      verifier,
+		Issuer:        parked.issuer,
+		IssAdvertised: parked.advertised,
 	}); err != nil {
 		return "", err
 	}
 	return s.provider.AuthorizeURL(cfg, connectCallbackURL(baseURL, provider), state, s256(verifier)), nil
 }
 
-func (s *connectService) Callback(ctx context.Context, baseURL, provider, state, code, errCode, errDesc string) (string, error) {
+type parkedIssuer struct {
+	issuer     string
+	advertised bool
+}
+
+func (s *connectService) parkConnectIssuer(ctx context.Context, reg *registrydomain.Registry, cfg *registrydomain.MCPAuth) parkedIssuer {
+	if cfg.Registration != registrydomain.RegistrationAuto {
+		return parkedIssuer{}
+	}
+	meta, err := s.registrar.Discover(ctx, reg.MCPTarget.URL)
+	if err != nil || meta == nil {
+		return parkedIssuer{}
+	}
+	return parkedIssuer{issuer: meta.Issuer, advertised: meta.AuthorizationResponseIssParameterSupported}
+}
+
+func (s *connectService) Callback(ctx context.Context, baseURL, provider, state, code, errCode, errDesc, iss string) (string, error) {
 	st, err := s.store.TakeConnect(ctx, state)
 	if err != nil {
 		return "", err
@@ -150,6 +169,10 @@ func (s *connectService) Callback(ctx context.Context, baseURL, provider, state,
 	}
 	if errCode != "" {
 		return st.TicketID, oauthErr(errCode, errDesc)
+	}
+	if err := validateResponseISS(iss, st.Issuer, st.IssAdvertised); err != nil {
+		logIssuerMismatch(st.Issuer, iss, st.Ticket.GatewayID, provider, "")
+		return st.TicketID, err
 	}
 	gatewayID, data, rc, err := s.routable(ctx, &st.Ticket)
 	if err != nil {

--- a/pkg/app/oauth/connect_registration.go
+++ b/pkg/app/oauth/connect_registration.go
@@ -60,6 +60,16 @@ func (s *connectService) RefreshAuth(ctx context.Context, gatewayID ids.GatewayI
 	if client == nil {
 		return nil, fmt.Errorf("%w: provider %q", ErrNoRegisteredClient, cfg.Provider)
 	}
+	key := clientKey(gatewayID, reg)
+	if client.Issuer == "" {
+		client, err = s.registrar.EnsureClient(ctx, key, meta, client.RedirectURI)
+		if err != nil {
+			return nil, err
+		}
+	} else if !issuersEqual(client.Issuer, meta.Issuer) {
+		logIssuerMismatch(client.Issuer, meta.Issuer, gatewayID.String(), cfg.Provider, key)
+		return nil, fmt.Errorf("%w: provider %q", ErrNoRegisteredClient, cfg.Provider)
+	}
 	return autoAuth(cfg, meta, client), nil
 }
 

--- a/pkg/app/oauth/connect_test.go
+++ b/pkg/app/oauth/connect_test.go
@@ -15,13 +15,16 @@
 package oauth_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -33,6 +36,32 @@ import (
 	vaultdomain "github.com/NeuralTrust/TrustGate/pkg/domain/vault"
 	infraoauth "github.com/NeuralTrust/TrustGate/pkg/infra/oauth"
 )
+
+type pkgSyncBuffer struct {
+	mu sync.Mutex
+	b  bytes.Buffer
+}
+
+func (s *pkgSyncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.Write(p)
+}
+
+func (s *pkgSyncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.String()
+}
+
+func capturePkgSlog(t *testing.T) *pkgSyncBuffer {
+	t.Helper()
+	buf := &pkgSyncBuffer{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return buf
+}
 
 type memConnectStore struct {
 	tickets  map[string]oauth.ConnectTicket
@@ -140,6 +169,12 @@ func (s *stubDataFinder) FindByGateway(context.Context, ids.GatewayID) (*appcons
 
 func connectFixture(t *testing.T, providerTokenURL string) (oauth.ConnectService, *memVaultRepo, ids.GatewayID) {
 	t.Helper()
+	svc, _, vault, gw := connectFixtureWithStore(t, providerTokenURL)
+	return svc, vault, gw
+}
+
+func connectFixtureWithStore(t *testing.T, providerTokenURL string) (oauth.ConnectService, *memConnectStore, *memVaultRepo, ids.GatewayID) {
+	t.Helper()
 	gw := ids.New[ids.GatewayKind]()
 	reg, err := registrydomain.NewMCPRegistry(gw, "github-mcp", "", &registrydomain.MCPTarget{
 		URL: "https://up.example.com/mcp",
@@ -164,7 +199,7 @@ func connectFixture(t *testing.T, providerTokenURL string) (oauth.ConnectService
 	vault := &memVaultRepo{}
 	store := newMemConnectStore()
 	svc := oauth.NewConnectService(store, vault, &stubDataFinder{data: data}, infraoauth.NewProviderClient(nil), infraoauth.NewUpstreamRegistrar(store, nil))
-	return svc, vault, gw
+	return svc, store, vault, gw
 }
 
 func TestConnectService_FullConsentFlow(t *testing.T) {
@@ -212,7 +247,7 @@ func TestConnectService_FullConsentFlow(t *testing.T) {
 		t.Fatal("no state in authorize URL")
 	}
 
-	backTicket, err := svc.Callback(ctx, "https://gw.example.com", "github", state, "the-code", "", "")
+	backTicket, err := svc.Callback(ctx, "https://gw.example.com", "github", state, "the-code", "", "", "")
 	if err != nil {
 		t.Fatalf("Callback: %v", err)
 	}
@@ -246,8 +281,15 @@ func TestConnectService_FullConsentFlow(t *testing.T) {
 
 func fakeSpecUpstream(t *testing.T, registrations *int, tokenForm *url.Values) *httptest.Server {
 	t.Helper()
+	srv, _ := fakeSpecUpstreamConfigured(t, registrations, tokenForm, false)
+	return srv
+}
+
+func fakeSpecUpstreamConfigured(t *testing.T, registrations *int, tokenForm *url.Values, advertiseISS bool) (*httptest.Server, *int) {
+	t.Helper()
 	mux := http.NewServeMux()
 	var srvURL string
+	tokenHits := 0
 	mux.HandleFunc("/.well-known/oauth-protected-resource/mcp", func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"resource":              srvURL + "/mcp",
@@ -256,12 +298,16 @@ func fakeSpecUpstream(t *testing.T, registrations *int, tokenForm *url.Values) *
 		})
 	})
 	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{
+		doc := map[string]any{
 			"issuer":                 srvURL,
 			"authorization_endpoint": srvURL + "/authorize",
 			"token_endpoint":         srvURL + "/token",
 			"registration_endpoint":  srvURL + "/register",
-		})
+		}
+		if advertiseISS {
+			doc["authorization_response_iss_parameter_supported"] = true
+		}
+		_ = json.NewEncoder(w).Encode(doc)
 	})
 	mux.HandleFunc("/register", func(w http.ResponseWriter, r *http.Request) {
 		*registrations++
@@ -274,6 +320,7 @@ func fakeSpecUpstream(t *testing.T, registrations *int, tokenForm *url.Values) *
 		_ = json.NewEncoder(w).Encode(map[string]any{"client_id": "dcr-client-1"})
 	})
 	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		tokenHits++
 		_ = r.ParseForm()
 		*tokenForm = r.Form
 		_ = json.NewEncoder(w).Encode(map[string]any{
@@ -283,7 +330,7 @@ func fakeSpecUpstream(t *testing.T, registrations *int, tokenForm *url.Values) *
 	srv := httptest.NewServer(mux)
 	srvURL = srv.URL
 	t.Cleanup(srv.Close)
-	return srv
+	return srv, &tokenHits
 }
 
 func TestConnectService_AutoRegistrationFlow(t *testing.T) {
@@ -343,7 +390,7 @@ func TestConnectService_AutoRegistrationFlow(t *testing.T) {
 		t.Fatalf("scope = %q, want scopes from discovery", q.Get("scope"))
 	}
 
-	if _, err := svc.Callback(ctx, "https://gw.example.com", "linear", q.Get("state"), "the-code", "", ""); err != nil {
+	if _, err := svc.Callback(ctx, "https://gw.example.com", "linear", q.Get("state"), "the-code", "", "", ""); err != nil {
 		t.Fatalf("Callback: %v", err)
 	}
 	if tokenForm.Get("code_verifier") == "" {
@@ -423,10 +470,10 @@ func TestConnectService_StateIsSingleUse(t *testing.T) {
 	u, _ := url.Parse(location)
 	state := u.Query().Get("state")
 
-	if _, err := svc.Callback(ctx, "https://gw", "github", state, "c", "", ""); err != nil {
+	if _, err := svc.Callback(ctx, "https://gw", "github", state, "c", "", "", ""); err != nil {
 		t.Fatalf("first callback: %v", err)
 	}
-	if _, err := svc.Callback(ctx, "https://gw", "github", state, "c", "", ""); err == nil {
+	if _, err := svc.Callback(ctx, "https://gw", "github", state, "c", "", "", ""); err == nil {
 		t.Fatal("state replay succeeded, want single-use")
 	}
 }
@@ -547,7 +594,7 @@ func TestConnectService_ProviderDenialRelaysTicket(t *testing.T) {
 	u, _ := url.Parse(location)
 	state := u.Query().Get("state")
 
-	backTicket, err := svc.Callback(ctx, "https://gw", "github", state, "", "access_denied", "user said no")
+	backTicket, err := svc.Callback(ctx, "https://gw", "github", state, "", "access_denied", "user said no", "")
 	if err == nil {
 		t.Fatal("denied consent returned nil error")
 	}
@@ -557,4 +604,176 @@ func TestConnectService_ProviderDenialRelaysTicket(t *testing.T) {
 	if len(vault.creds) != 0 {
 		t.Fatal("denied consent stored a credential")
 	}
+}
+
+func autoConnectSetup(t *testing.T, advertiseISS bool) (oauth.ConnectService, *memConnectStore, ids.GatewayID, *httptest.Server, *int) {
+	t.Helper()
+	registrations := 0
+	var tokenForm url.Values
+	upstream, tokenHits := fakeSpecUpstreamConfigured(t, &registrations, &tokenForm, advertiseISS)
+
+	gw := ids.New[ids.GatewayKind]()
+	reg, err := registrydomain.NewMCPRegistry(gw, "linear-mcp", "", &registrydomain.MCPTarget{
+		URL: upstream.URL + "/mcp",
+		Auth: &registrydomain.MCPAuth{
+			Mode:         registrydomain.MCPAuthModeForwarded,
+			Provider:     "linear",
+			Registration: registrydomain.RegistrationAuto,
+		},
+	})
+	if err != nil {
+		t.Fatalf("registry: %v", err)
+	}
+	data := appconsumer.NewData(gw, []appconsumer.RoutableConsumer{{
+		Consumer: &consumerdomain.Consumer{
+			ID: ids.New[ids.ConsumerKind](), GatewayID: gw,
+			Type: consumerdomain.TypeMCP, Slug: "dev", Active: true,
+		},
+		Registries: []*registrydomain.Registry{reg},
+	}})
+	store := newMemConnectStore()
+	svc := oauth.NewConnectService(store, &memVaultRepo{}, &stubDataFinder{data: data}, infraoauth.NewProviderClient(nil), infraoauth.NewUpstreamRegistrar(store, nil))
+	return svc, store, gw, upstream, tokenHits
+}
+
+func TestConnectService_ParksIssuerAndAdvertised(t *testing.T) {
+	t.Parallel()
+	svc, store, gw, upstream, _ := autoConnectSetup(t, true)
+	ctx := context.Background()
+	ticket, err := svc.CreateTicket(ctx, gw, "alice", "/dev/mcp")
+	if err != nil {
+		t.Fatalf("CreateTicket: %v", err)
+	}
+	if _, err := svc.Start(ctx, "https://gw.example.com", ticket, "linear"); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if len(store.connects) != 1 {
+		t.Fatalf("parked states = %d, want 1", len(store.connects))
+	}
+	var parked oauth.ConnectState
+	for _, s := range store.connects {
+		parked = s
+	}
+	if parked.Issuer != upstream.URL {
+		t.Fatalf("parked issuer = %q, want %s", parked.Issuer, upstream.URL)
+	}
+	if !parked.IssAdvertised {
+		t.Fatal("expected IssAdvertised=true when AS advertised the iss parameter")
+	}
+}
+
+func TestConnectService_StaticAdvertisedFalse(t *testing.T) {
+	t.Parallel()
+	svc, store, _, gw := connectFixtureWithStore(t, "https://unused")
+	ctx := context.Background()
+	ticket, _ := svc.CreateTicket(ctx, gw, "alice", "/dev/mcp")
+	if _, err := svc.Start(ctx, "https://gw.example.com", ticket, "github"); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	var parked oauth.ConnectState
+	for _, s := range store.connects {
+		parked = s
+	}
+	if parked.IssAdvertised {
+		t.Fatal("static IdP must park advertised=false")
+	}
+	if parked.Issuer != "" {
+		t.Fatalf("static IdP parked issuer = %q, want empty", parked.Issuer)
+	}
+}
+
+func TestConnectService_MixUpRejectedBeforeTokenHTTP(t *testing.T) {
+	svc, _, gw, _, tokenHits := autoConnectSetup(t, true)
+	ctx := context.Background()
+	ticket, _ := svc.CreateTicket(ctx, gw, "alice", "/dev/mcp")
+	location, err := svc.Start(ctx, "https://gw.example.com", ticket, "linear")
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	state := mustQuery(t, location, "state")
+	logs := capturePkgSlog(t)
+
+	_, err = svc.Callback(ctx, "https://gw.example.com", "linear", state, "the-code-secret", "", "", "https://attacker.example")
+	var oe *oauth.OAuthError
+	if !errors.As(err, &oe) || oe.Code != "invalid_request" {
+		t.Fatalf("error = %v, want invalid_request", err)
+	}
+	if *tokenHits != 0 {
+		t.Fatalf("token HTTP was reached (%d hits); mix-up must fail before ExchangeCode", *tokenHits)
+	}
+	logged := logs.String()
+	if !strings.Contains(logged, "oauth.issuer_mismatch") {
+		t.Fatalf("expected oauth.issuer_mismatch, got %s", logged)
+	}
+	if strings.Contains(logged, "the-code-secret") || strings.Contains(logged, "client_secret") {
+		t.Fatalf("security log leaked secrets: %s", logged)
+	}
+}
+
+func TestConnectService_MissingISSRejectedWhenAdvertised(t *testing.T) {
+	t.Parallel()
+	svc, _, gw, _, tokenHits := autoConnectSetup(t, true)
+	ctx := context.Background()
+	ticket, _ := svc.CreateTicket(ctx, gw, "alice", "/dev/mcp")
+	location, _ := svc.Start(ctx, "https://gw.example.com", ticket, "linear")
+	state := mustQuery(t, location, "state")
+
+	_, err := svc.Callback(ctx, "https://gw.example.com", "linear", state, "the-code", "", "", "")
+	var oe *oauth.OAuthError
+	if !errors.As(err, &oe) || oe.Code != "invalid_request" {
+		t.Fatalf("error = %v, want invalid_request", err)
+	}
+	if *tokenHits != 0 {
+		t.Fatalf("token HTTP was reached (%d hits)", *tokenHits)
+	}
+}
+
+func TestConnectService_MatchingISSAccepted(t *testing.T) {
+	t.Parallel()
+	svc, _, gw, upstream, tokenHits := autoConnectSetup(t, true)
+	ctx := context.Background()
+	ticket, _ := svc.CreateTicket(ctx, gw, "alice", "/dev/mcp")
+	location, _ := svc.Start(ctx, "https://gw.example.com", ticket, "linear")
+	state := mustQuery(t, location, "state")
+
+	if _, err := svc.Callback(ctx, "https://gw.example.com", "linear", state, "the-code", "", "", upstream.URL); err != nil {
+		t.Fatalf("callback: %v", err)
+	}
+	if *tokenHits != 1 {
+		t.Fatalf("token hits = %d, want 1", *tokenHits)
+	}
+}
+
+func TestConnectService_StaticOmitISSAllowed(t *testing.T) {
+	t.Parallel()
+	tokenHits := 0
+	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tokenHits++
+		_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "gh-access", "refresh_token": "gh-refresh", "expires_in": 3600})
+	}))
+	defer provider.Close()
+	svc, _, gw := connectFixture(t, provider.URL)
+	ctx := context.Background()
+	ticket, _ := svc.CreateTicket(ctx, gw, "alice", "/dev/mcp")
+	location, _ := svc.Start(ctx, "https://gw.example.com", ticket, "github")
+	state := mustQuery(t, location, "state")
+	if _, err := svc.Callback(ctx, "https://gw.example.com", "github", state, "the-code", "", "", ""); err != nil {
+		t.Fatalf("static omit-iss: %v", err)
+	}
+	if tokenHits != 1 {
+		t.Fatalf("token hits = %d, want 1", tokenHits)
+	}
+}
+
+func mustQuery(t *testing.T, raw, key string) string {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse %q: %v", raw, err)
+	}
+	v := u.Query().Get(key)
+	if v == "" {
+		t.Fatalf("missing query %s in %s", key, raw)
+	}
+	return v
 }

--- a/pkg/app/oauth/connect_types.go
+++ b/pkg/app/oauth/connect_types.go
@@ -41,10 +41,12 @@ type ConnectTicket struct {
 }
 
 type ConnectState struct {
-	Ticket   ConnectTicket `json:"ticket"`
-	TicketID string        `json:"ticket_id"`
-	Provider string        `json:"provider"`
-	Verifier string        `json:"verifier,omitempty"`
+	Ticket        ConnectTicket `json:"ticket"`
+	TicketID      string        `json:"ticket_id"`
+	Provider      string        `json:"provider"`
+	Verifier      string        `json:"verifier,omitempty"`
+	Issuer        string        `json:"issuer,omitempty"`
+	IssAdvertised bool          `json:"iss_advertised,omitempty"`
 }
 
 type ConnectStore interface {
@@ -78,7 +80,7 @@ type ConnectService interface {
 	CreateTicket(ctx context.Context, gatewayID ids.GatewayID, principalSub, consumerPath string) (string, error)
 	Page(ctx context.Context, ticketID string) (*ConnectPage, error)
 	Start(ctx context.Context, baseURL, ticketID, provider string) (string, error)
-	Callback(ctx context.Context, baseURL, provider, state, code, errCode, errDesc string) (string, error)
+	Callback(ctx context.Context, baseURL, provider, state, code, errCode, errDesc, iss string) (string, error)
 	Disconnect(ctx context.Context, ticketID, provider string) error
 	RefreshAuth(ctx context.Context, gatewayID ids.GatewayID, reg *registrydomain.Registry) (*registrydomain.MCPAuth, error)
 	ChainURL(ctx context.Context, baseURL string, gatewayID ids.GatewayID, resource, principalSub, resumeURL string) (string, error)

--- a/pkg/app/oauth/default_idp_selection_test.go
+++ b/pkg/app/oauth/default_idp_selection_test.go
@@ -145,7 +145,7 @@ func TestCallbackDefaultIdPConsentUsesEffectiveGateway(t *testing.T) {
 		GatewayID:     gw.String(),
 	}))
 
-	loc, err := proxy.Callback(context.Background(), "http://localhost:8082", state, "the-code", "", "")
+	loc, err := proxy.Callback(context.Background(), "http://localhost:8082", state, "the-code", "", "", "")
 	require.NoError(t, err)
 	require.Equal(t, chainer.url, loc, "callback must detour to the upstream-connect page")
 	require.Equal(t, 1, chainer.calls)

--- a/pkg/app/oauth/idp_transport.go
+++ b/pkg/app/oauth/idp_transport.go
@@ -29,8 +29,10 @@ import (
 )
 
 type idpEndpoints struct {
-	authorize string
-	token     string
+	authorize  string
+	token      string
+	issuer     string
+	advertised bool
 }
 
 // idpTransport talks to the upstream identity provider: it resolves the
@@ -47,7 +49,12 @@ func newIDPTransport(client *http.Client, meta *metadataService) *idpTransport {
 
 func (t *idpTransport) endpoints(ctx context.Context, cfg *authdomain.OAuth2Config) (*idpEndpoints, error) {
 	if cfg.AuthorizeURL != "" && cfg.TokenURL != "" {
-		return &idpEndpoints{authorize: cfg.AuthorizeURL, token: cfg.TokenURL}, nil
+		return &idpEndpoints{
+			authorize:  cfg.AuthorizeURL,
+			token:      cfg.TokenURL,
+			issuer:     cfg.Issuer,
+			advertised: false,
+		}, nil
 	}
 	doc, err := t.meta.fetchASMetadata(ctx, cfg.Issuer)
 	if err != nil {
@@ -58,7 +65,12 @@ func (t *idpTransport) endpoints(ctx context.Context, cfg *authdomain.OAuth2Conf
 	if authorize == "" || token == "" {
 		return nil, fmt.Errorf("oauth: IdP metadata for %s lacks authorization/token endpoints", cfg.Issuer)
 	}
-	return &idpEndpoints{authorize: authorize, token: token}, nil
+	issuer, _ := doc["issuer"].(string)
+	if issuer == "" {
+		issuer = cfg.Issuer
+	}
+	advertised, _ := doc["authorization_response_iss_parameter_supported"].(bool)
+	return &idpEndpoints{authorize: authorize, token: token, issuer: issuer, advertised: advertised}, nil
 }
 
 func (t *idpTransport) tokenCall(ctx context.Context, endpoint string, form url.Values) (map[string]any, error) {

--- a/pkg/app/oauth/idp_transport_test.go
+++ b/pkg/app/oauth/idp_transport_test.go
@@ -16,11 +16,13 @@ package oauth
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
 
+	authdomain "github.com/NeuralTrust/TrustGate/pkg/domain/auth"
 	"github.com/stretchr/testify/require"
 )
 
@@ -74,4 +76,44 @@ func TestIDPTokenCall_FormEncodedSuccess(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, "gho_ok", doc["access_token"])
+}
+
+func TestIDPEndpoints_StaticAdvertisedFalse(t *testing.T) {
+	t.Parallel()
+	tr := &idpTransport{}
+	ep, err := tr.endpoints(context.Background(), &authdomain.OAuth2Config{
+		Issuer:       "https://accounts.google.com",
+		AuthorizeURL: "https://accounts.google.com/o/oauth2/v2/auth",
+		TokenURL:     "https://oauth2.googleapis.com/token",
+	})
+	require.NoError(t, err)
+	require.False(t, ep.advertised)
+	require.Equal(t, "https://accounts.google.com", ep.issuer)
+	require.Equal(t, "https://accounts.google.com/o/oauth2/v2/auth", ep.authorize)
+	require.Equal(t, "https://oauth2.googleapis.com/token", ep.token)
+}
+
+func TestIDPEndpoints_MetadataAdvertisedTrue(t *testing.T) {
+	t.Parallel()
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/oauth-authorization-server" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                 srv.URL,
+			"authorization_endpoint": srv.URL + "/authorize",
+			"token_endpoint":         srv.URL + "/token",
+			"authorization_response_iss_parameter_supported": true,
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	meta := &metadataService{client: srv.Client(), asCache: map[string]asCacheEntry{}}
+	tr := newIDPTransport(srv.Client(), meta)
+	ep, err := tr.endpoints(context.Background(), &authdomain.OAuth2Config{Issuer: srv.URL})
+	require.NoError(t, err)
+	require.True(t, ep.advertised)
+	require.Equal(t, srv.URL, ep.issuer)
 }

--- a/pkg/app/oauth/issuer.go
+++ b/pkg/app/oauth/issuer.go
@@ -1,0 +1,128 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oauth
+
+import (
+	"log/slog"
+	"net/url"
+	"strings"
+)
+
+// IssuersEqual reports whether a and b identify the same issuer after trimming a trailing slash.
+func IssuersEqual(a, b string) bool {
+	return issuersEqual(a, b)
+}
+
+const (
+	applicationTypeWeb    = "web"
+	applicationTypeNative = "native"
+)
+
+func issuersEqual(a, b string) bool {
+	return strings.TrimSuffix(a, "/") == strings.TrimSuffix(b, "/")
+}
+
+func validateResponseISS(got, expected string, advertised bool) error {
+	if got == "" {
+		if advertised {
+			return oauthErr("invalid_request", "missing iss")
+		}
+		return nil
+	}
+	if !issuersEqual(got, expected) {
+		return oauthErr("invalid_request", "iss mismatch")
+	}
+	return nil
+}
+
+func logIssuerMismatch(expected, got, gatewayID, provider, key string) {
+	slog.Warn("oauth.issuer_mismatch",
+		"expected_issuer", expected,
+		"got_issuer", got,
+		"gateway_id", gatewayID,
+		"provider", provider,
+		"key", key,
+	)
+}
+
+func logInvalidMetadata(expected, metadataIssuer, key string) {
+	slog.Warn("oauth.invalid_metadata",
+		"expected_issuer", expected,
+		"metadata_issuer", metadataIssuer,
+		"key", key,
+	)
+}
+
+func resolveApplicationType(requested string, uris []string) (string, error) {
+	inferred := applicationTypeForURIs(uris)
+	if inferred == "" {
+		return "", oauthErr("invalid_client_metadata", "redirect_uris mix incompatible application types")
+	}
+	appType := strings.ToLower(strings.TrimSpace(requested))
+	switch appType {
+	case "":
+		return inferred, nil
+	case applicationTypeWeb, applicationTypeNative:
+		if appType != inferred {
+			return "", oauthErr("invalid_client_metadata", "application_type is inconsistent with redirect_uris")
+		}
+		return appType, nil
+	default:
+		return "", oauthErr("invalid_client_metadata", "application_type must be web or native")
+	}
+}
+
+func applicationTypeForURIs(uris []string) string {
+	var inferred string
+	for _, uri := range uris {
+		class := redirectURIApplicationType(uri)
+		if class == "" {
+			return ""
+		}
+		if inferred == "" {
+			inferred = class
+			continue
+		}
+		if inferred != class {
+			return ""
+		}
+	}
+	return inferred
+}
+
+func redirectURIApplicationType(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.Fragment != "" {
+		return ""
+	}
+	switch u.Scheme {
+	case "https":
+		if u.Host == "" {
+			return ""
+		}
+		return applicationTypeWeb
+	case "http":
+		host := u.Hostname()
+		if host == "localhost" || host == "127.0.0.1" || host == "::1" {
+			return applicationTypeNative
+		}
+		return ""
+	default:
+		if isPrivateUseRedirectURI(u) {
+			return applicationTypeNative
+		}
+		return ""
+	}
+}

--- a/pkg/app/oauth/issuer_test.go
+++ b/pkg/app/oauth/issuer_test.go
@@ -1,0 +1,214 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oauth
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type syncBuffer struct {
+	mu sync.Mutex
+	b  bytes.Buffer
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.Write(p)
+}
+
+func (s *syncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.String()
+}
+
+func captureDefaultSlog(t *testing.T) *syncBuffer {
+	t.Helper()
+	buf := &syncBuffer{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return buf
+}
+
+func assertNoSecrets(t *testing.T, logged string) {
+	t.Helper()
+	for _, secret := range []string{
+		"idp-code-secret",
+		"gw-secret",
+		"client_secret",
+		"access_token",
+		"refresh_token",
+		"Bearer ",
+		"authorization_code",
+	} {
+		if strings.Contains(logged, secret) {
+			t.Fatalf("security log leaked %q: %s", secret, logged)
+		}
+	}
+}
+
+func TestIssuersEqual_SlashTrim(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		a, b string
+		want bool
+	}{
+		{name: "identical", a: "https://idp.example", b: "https://idp.example", want: true},
+		{name: "trailing slash on a", a: "https://idp.example/", b: "https://idp.example", want: true},
+		{name: "trailing slash on b", a: "https://idp.example", b: "https://idp.example/", want: true},
+		{name: "both slashes", a: "https://idp.example/", b: "https://idp.example/", want: true},
+		{name: "scheme differs", a: "http://idp.example", b: "https://idp.example", want: false},
+		{name: "host differs", a: "https://a.example", b: "https://b.example", want: false},
+		{name: "empty vs empty", a: "", b: "", want: true},
+		{name: "empty vs value", a: "", b: "https://idp.example", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := issuersEqual(tc.a, tc.b); got != tc.want {
+				t.Fatalf("issuersEqual(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+			if got := IssuersEqual(tc.a, tc.b); got != tc.want {
+				t.Fatalf("IssuersEqual(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateResponseISS(t *testing.T) {
+	t.Parallel()
+	const expected = "https://idp.example"
+	cases := []struct {
+		name       string
+		got        string
+		advertised bool
+		wantErr    bool
+	}{
+		{name: "matching iss", got: expected, advertised: true, wantErr: false},
+		{name: "matching iss slash trim", got: expected + "/", advertised: true, wantErr: false},
+		{name: "matching iss not advertised", got: expected, advertised: false, wantErr: false},
+		{name: "mismatch advertised", got: "https://attacker.example", advertised: true, wantErr: true},
+		{name: "mismatch not advertised", got: "https://attacker.example", advertised: false, wantErr: true},
+		{name: "missing iss advertised", got: "", advertised: true, wantErr: true},
+		{name: "missing iss not advertised", got: "", advertised: false, wantErr: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateResponseISS(tc.got, expected, tc.advertised)
+			if tc.wantErr {
+				var oe *OAuthError
+				if !errors.As(err, &oe) || oe.Code != "invalid_request" {
+					t.Fatalf("error = %v, want invalid_request", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestApplicationTypeForURIs(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		uris []string
+		want string
+	}{
+		{name: "https web", uris: []string{"https://app.example/cb"}, want: applicationTypeWeb},
+		{name: "loopback ipv4", uris: []string{"http://127.0.0.1:33418/callback"}, want: applicationTypeNative},
+		{name: "loopback localhost", uris: []string{"http://localhost:8080/cb"}, want: applicationTypeNative},
+		{name: "loopback ipv6", uris: []string{"http://[::1]/cb"}, want: applicationTypeNative},
+		{name: "private-use cursor", uris: []string{"cursor://anysphere.cursor-mcp/oauth/callback"}, want: applicationTypeNative},
+		{name: "private-use reverse dns", uris: []string{"com.example.agent:/oauth2redirect"}, want: applicationTypeNative},
+		{name: "mixed https and loopback", uris: []string{"https://app.example/cb", "http://127.0.0.1/cb"}, want: ""},
+		{name: "mixed https and cursor", uris: []string{"https://app.example/cb", "cursor://anysphere.cursor-mcp/oauth/callback"}, want: ""},
+		{name: "http non-loopback", uris: []string{"http://attacker.example/cb"}, want: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := applicationTypeForURIs(tc.uris); got != tc.want {
+				t.Fatalf("applicationTypeForURIs(%v) = %q, want %q", tc.uris, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveApplicationType(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		requested string
+		uris      []string
+		want      string
+		wantErr   bool
+	}{
+		{name: "omit infers web", requested: "", uris: []string{"https://app.example/cb"}, want: applicationTypeWeb},
+		{name: "omit infers native loopback", requested: "", uris: []string{"http://127.0.0.1:1/cb"}, want: applicationTypeNative},
+		{name: "omit infers native private-use", requested: "", uris: []string{"cursor://anysphere.cursor-mcp/oauth/callback"}, want: applicationTypeNative},
+		{name: "native matches loopback", requested: "native", uris: []string{"http://localhost/cb"}, want: applicationTypeNative},
+		{name: "web matches https", requested: "web", uris: []string{"https://app.example/cb"}, want: applicationTypeWeb},
+		{name: "web with private-use rejected", requested: "web", uris: []string{"cursor://anysphere.cursor-mcp/oauth/callback"}, wantErr: true},
+		{name: "native with https rejected", requested: "native", uris: []string{"https://app.example/cb"}, wantErr: true},
+		{name: "unknown type rejected", requested: "service", uris: []string{"https://app.example/cb"}, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := resolveApplicationType(tc.requested, tc.uris)
+			if tc.wantErr {
+				var oe *OAuthError
+				if !errors.As(err, &oe) || oe.Code != "invalid_client_metadata" {
+					t.Fatalf("error = %v, want invalid_client_metadata", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestOAuthSecurityLogsOmitSecrets(t *testing.T) {
+	buf := captureDefaultSlog(t)
+	logIssuerMismatch("https://idp-a.example", "https://idp-b.example", "gw-1", "github", "gw-1|reg-1")
+	logInvalidMetadata("https://idp-a.example", "https://attacker.example", "gw-1|reg-1")
+	logged := buf.String()
+	if !strings.Contains(logged, `"msg":"oauth.issuer_mismatch"`) {
+		t.Fatalf("missing oauth.issuer_mismatch: %s", logged)
+	}
+	if !strings.Contains(logged, `"msg":"oauth.invalid_metadata"`) {
+		t.Fatalf("missing oauth.invalid_metadata: %s", logged)
+	}
+	if !strings.Contains(logged, "https://idp-a.example") || !strings.Contains(logged, "gw-1") {
+		t.Fatalf("expected issuer URLs and ids in log: %s", logged)
+	}
+	assertNoSecrets(t, logged)
+}

--- a/pkg/app/oauth/metadata.go
+++ b/pkg/app/oauth/metadata.go
@@ -46,14 +46,16 @@ type ProtectedResourceMetadata struct {
 }
 
 type RegisterRequest struct {
-	RedirectURIs []string `json:"redirect_uris"`
-	ClientName   string   `json:"client_name,omitempty"`
+	RedirectURIs    []string `json:"redirect_uris"`
+	ClientName      string   `json:"client_name,omitempty"`
+	ApplicationType string   `json:"application_type,omitempty"`
 }
 
 type RegisterResponse struct {
 	ClientID                string   `json:"client_id"`
 	RedirectURIs            []string `json:"redirect_uris,omitempty"`
 	ClientName              string   `json:"client_name,omitempty"`
+	ApplicationType         string   `json:"application_type,omitempty"`
 	GrantTypes              []string `json:"grant_types"`
 	ResponseTypes           []string `json:"response_types"`
 	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method"`
@@ -140,14 +142,15 @@ func (s *metadataService) AuthorizationServer(ctx context.Context, baseURL strin
 		return nil, ErrNoAuthorizationServer
 	}
 	doc := map[string]any{
-		"issuer":                                baseURL,
-		"authorization_endpoint":                baseURL + "/oauth/authorize",
-		"token_endpoint":                        baseURL + "/oauth/token",
-		"registration_endpoint":                 baseURL + "/oauth/register",
-		"response_types_supported":              []string{"code"},
-		"grant_types_supported":                 []string{"authorization_code", "refresh_token"},
-		"code_challenge_methods_supported":      []string{"S256"},
-		"token_endpoint_auth_methods_supported": []string{"none"},
+		"issuer":                                         baseURL,
+		"authorization_endpoint":                         baseURL + "/oauth/authorize",
+		"token_endpoint":                                 baseURL + "/oauth/token",
+		"registration_endpoint":                          baseURL + "/oauth/register",
+		"response_types_supported":                       []string{"code"},
+		"grant_types_supported":                          []string{"authorization_code", "refresh_token"},
+		"code_challenge_methods_supported":               []string{"S256"},
+		"token_endpoint_auth_methods_supported":          []string{"none"},
+		"authorization_response_iss_parameter_supported": true,
 	}
 	if scopes := scopesOf(auths); len(scopes) > 0 {
 		doc["scopes_supported"] = scopes
@@ -172,6 +175,10 @@ func (s *metadataService) RegisterClient(ctx context.Context, req RegisterReques
 				fmt.Sprintf("%q must be an https URL, an http loopback URL, or a private-use URI without a fragment", uri))
 		}
 	}
+	appType, err := resolveApplicationType(req.ApplicationType, req.RedirectURIs)
+	if err != nil {
+		return nil, err
+	}
 	suffix, err := randomToken()
 	if err != nil {
 		return nil, err
@@ -190,6 +197,7 @@ func (s *metadataService) RegisterClient(ctx context.Context, req RegisterReques
 		ClientID:                client.ClientID,
 		RedirectURIs:            client.RedirectURIs,
 		ClientName:              client.ClientName,
+		ApplicationType:         appType,
 		GrantTypes:              []string{"authorization_code", "refresh_token"},
 		ResponseTypes:           []string{"code"},
 		TokenEndpointAuthMethod: "none",
@@ -267,6 +275,11 @@ func (s *metadataService) fetchASMetadata(ctx context.Context, issuer string) (m
 		if err != nil {
 			lastErr = err
 			continue
+		}
+		metadataIssuer, _ := doc["issuer"].(string)
+		if !issuersEqual(metadataIssuer, issuer) {
+			logInvalidMetadata(issuer, metadataIssuer, issuer)
+			return nil, fmt.Errorf("oauth: AS metadata issuer %q does not match %q", metadataIssuer, issuer)
 		}
 		s.mu.Lock()
 		s.asCache[issuer] = asCacheEntry{doc: doc, fetchedAt: time.Now()}

--- a/pkg/app/oauth/metadata_test.go
+++ b/pkg/app/oauth/metadata_test.go
@@ -16,7 +16,10 @@ package oauth
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -268,5 +271,149 @@ func TestRegisterClientUnavailable(t *testing.T) {
 	}}, nil, nil, newMemFlowStore())
 	if _, err := svc.RegisterClient(context.Background(), RegisterRequest{}); !errors.Is(err, ErrRegistrationUnavailable) {
 		t.Fatalf("expected ErrRegistrationUnavailable, got %v", err)
+	}
+}
+
+func TestAuthorizationServerMetadataAdvertisesISS(t *testing.T) {
+	t.Parallel()
+	finder := &fakeCredentialFinder{oauth2: []*authdomain.Auth{
+		oauth2Auth(t, authdomain.OAuth2Config{Issuer: "https://idp.example.com", RequiredScopes: []string{"mcp.access"}}),
+	}}
+	svc := NewMetadataService(finder, nil, nil, newMemFlowStore())
+	const baseURL = "https://gw.example.com"
+
+	doc, err := svc.AuthorizationServer(context.Background(), baseURL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc["issuer"] != baseURL {
+		t.Fatalf("issuer = %v, want %s", doc["issuer"], baseURL)
+	}
+	if doc["authorization_response_iss_parameter_supported"] != true {
+		t.Fatalf("authorization_response_iss_parameter_supported = %v, want true", doc["authorization_response_iss_parameter_supported"])
+	}
+}
+
+func TestRegisterClientApplicationType(t *testing.T) {
+	t.Parallel()
+	finder := &fakeCredentialFinder{oauth2: []*authdomain.Auth{
+		oauth2Auth(t, authdomain.OAuth2Config{Issuer: "https://idp.example.com", ClientID: "mcp-public-client"}),
+	}}
+	svc := NewMetadataService(finder, nil, nil, newMemFlowStore())
+	ctx := context.Background()
+
+	cases := []struct {
+		name     string
+		req      RegisterRequest
+		wantType string
+		wantErr  bool
+	}{
+		{
+			name:     "omit infers native from loopback",
+			req:      RegisterRequest{RedirectURIs: []string{"http://127.0.0.1:33418/callback"}},
+			wantType: applicationTypeNative,
+		},
+		{
+			name:     "omit infers native from private-use",
+			req:      RegisterRequest{RedirectURIs: []string{"cursor://anysphere.cursor-mcp/oauth/callback"}},
+			wantType: applicationTypeNative,
+		},
+		{
+			name:     "omit infers web from https",
+			req:      RegisterRequest{RedirectURIs: []string{"https://app.example/cb"}},
+			wantType: applicationTypeWeb,
+		},
+		{
+			name:     "explicit native matches loopback",
+			req:      RegisterRequest{RedirectURIs: []string{"http://localhost/cb"}, ApplicationType: "native"},
+			wantType: applicationTypeNative,
+		},
+		{
+			name:    "web with private-use rejected",
+			req:     RegisterRequest{RedirectURIs: []string{"cursor://anysphere.cursor-mcp/oauth/callback"}, ApplicationType: "web"},
+			wantErr: true,
+		},
+		{
+			name:    "unknown type rejected",
+			req:     RegisterRequest{RedirectURIs: []string{"https://app.example/cb"}, ApplicationType: "service"},
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			res, err := svc.RegisterClient(ctx, tc.req)
+			if tc.wantErr {
+				var oe *OAuthError
+				if !errors.As(err, &oe) || oe.Code != "invalid_client_metadata" {
+					t.Fatalf("error = %v, want invalid_client_metadata", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if res.ApplicationType != tc.wantType {
+				t.Fatalf("application_type = %q, want %q", res.ApplicationType, tc.wantType)
+			}
+		})
+	}
+}
+
+func TestFetchASMetadataIssuerMustMatch(t *testing.T) {
+	cases := []struct {
+		name    string
+		issuer  string
+		wantErr bool
+	}{
+		{name: "matching metadata proceeds", issuer: "", wantErr: false},
+		{name: "mismatched metadata fails closed", issuer: "https://attacker.example", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var srv *httptest.Server
+			srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/.well-known/oauth-authorization-server" {
+					http.NotFound(w, r)
+					return
+				}
+				iss := tc.issuer
+				if iss == "" {
+					iss = srv.URL
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"issuer":                 iss,
+					"authorization_endpoint": srv.URL + "/authorize",
+					"token_endpoint":         srv.URL + "/token",
+				})
+			}))
+			t.Cleanup(srv.Close)
+
+			s := &metadataService{client: srv.Client(), asCache: map[string]asCacheEntry{}}
+			var buf *syncBuffer
+			if tc.wantErr {
+				buf = captureDefaultSlog(t)
+			}
+			doc, err := s.fetchASMetadata(context.Background(), srv.URL)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected issuer mismatch to fail closed")
+				}
+				if _, ok := s.asCache[srv.URL]; ok {
+					t.Fatal("mismatched metadata must not be cached")
+				}
+				if !strings.Contains(buf.String(), "oauth.invalid_metadata") {
+					t.Fatalf("expected oauth.invalid_metadata, got %s", buf.String())
+				}
+				assertNoSecrets(t, buf.String())
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if doc["issuer"] != srv.URL {
+				t.Fatalf("issuer = %v, want %s", doc["issuer"], srv.URL)
+			}
+		})
 	}
 }

--- a/pkg/app/oauth/mocks/oauth_connect_service_mock.go
+++ b/pkg/app/oauth/mocks/oauth_connect_service_mock.go
@@ -24,9 +24,9 @@ func (_m *ConnectService) EXPECT() *ConnectService_Expecter {
 	return &ConnectService_Expecter{mock: &_m.Mock}
 }
 
-// Callback provides a mock function with given fields: ctx, baseURL, provider, state, code, errCode, errDesc
-func (_m *ConnectService) Callback(ctx context.Context, baseURL string, provider string, state string, code string, errCode string, errDesc string) (string, error) {
-	ret := _m.Called(ctx, baseURL, provider, state, code, errCode, errDesc)
+// Callback provides a mock function with given fields: ctx, baseURL, provider, state, code, errCode, errDesc, iss
+func (_m *ConnectService) Callback(ctx context.Context, baseURL string, provider string, state string, code string, errCode string, errDesc string, iss string) (string, error) {
+	ret := _m.Called(ctx, baseURL, provider, state, code, errCode, errDesc, iss)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Callback")
@@ -34,17 +34,17 @@ func (_m *ConnectService) Callback(ctx context.Context, baseURL string, provider
 
 	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, string, string) (string, error)); ok {
-		return rf(ctx, baseURL, provider, state, code, errCode, errDesc)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, string, string, string) (string, error)); ok {
+		return rf(ctx, baseURL, provider, state, code, errCode, errDesc, iss)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, string, string) string); ok {
-		r0 = rf(ctx, baseURL, provider, state, code, errCode, errDesc)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, string, string, string) string); ok {
+		r0 = rf(ctx, baseURL, provider, state, code, errCode, errDesc, iss)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, string, string, string) error); ok {
-		r1 = rf(ctx, baseURL, provider, state, code, errCode, errDesc)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, string, string, string, string) error); ok {
+		r1 = rf(ctx, baseURL, provider, state, code, errCode, errDesc, iss)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -65,13 +65,14 @@ type ConnectService_Callback_Call struct {
 //   - code string
 //   - errCode string
 //   - errDesc string
-func (_e *ConnectService_Expecter) Callback(ctx interface{}, baseURL interface{}, provider interface{}, state interface{}, code interface{}, errCode interface{}, errDesc interface{}) *ConnectService_Callback_Call {
-	return &ConnectService_Callback_Call{Call: _e.mock.On("Callback", ctx, baseURL, provider, state, code, errCode, errDesc)}
+//   - iss string
+func (_e *ConnectService_Expecter) Callback(ctx interface{}, baseURL interface{}, provider interface{}, state interface{}, code interface{}, errCode interface{}, errDesc interface{}, iss interface{}) *ConnectService_Callback_Call {
+	return &ConnectService_Callback_Call{Call: _e.mock.On("Callback", ctx, baseURL, provider, state, code, errCode, errDesc, iss)}
 }
 
-func (_c *ConnectService_Callback_Call) Run(run func(ctx context.Context, baseURL string, provider string, state string, code string, errCode string, errDesc string)) *ConnectService_Callback_Call {
+func (_c *ConnectService_Callback_Call) Run(run func(ctx context.Context, baseURL string, provider string, state string, code string, errCode string, errDesc string, iss string)) *ConnectService_Callback_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].(string), args[5].(string), args[6].(string))
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].(string), args[5].(string), args[6].(string), args[7].(string))
 	})
 	return _c
 }
@@ -81,7 +82,7 @@ func (_c *ConnectService_Callback_Call) Return(_a0 string, _a1 error) *ConnectSe
 	return _c
 }
 
-func (_c *ConnectService_Callback_Call) RunAndReturn(run func(context.Context, string, string, string, string, string, string) (string, error)) *ConnectService_Callback_Call {
+func (_c *ConnectService_Callback_Call) RunAndReturn(run func(context.Context, string, string, string, string, string, string, string) (string, error)) *ConnectService_Callback_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/app/oauth/ports.go
+++ b/pkg/app/oauth/ports.go
@@ -42,18 +42,20 @@ var ErrUpstreamNotDiscoverable = errors.New(
 var ErrInvalidGrant = errors.New("oauth provider: grant is no longer valid")
 
 type UpstreamAuthServer struct {
-	Issuer                string   `json:"issuer"`
-	AuthorizationEndpoint string   `json:"authorization_endpoint"`
-	TokenEndpoint         string   `json:"token_endpoint"`
-	RegistrationEndpoint  string   `json:"registration_endpoint"`
-	ScopesSupported       []string `json:"scopes_supported"`
-	Resource              string   `json:"resource"`
+	Issuer                                     string   `json:"issuer"`
+	AuthorizationEndpoint                      string   `json:"authorization_endpoint"`
+	TokenEndpoint                              string   `json:"token_endpoint"`
+	RegistrationEndpoint                       string   `json:"registration_endpoint"`
+	ScopesSupported                            []string `json:"scopes_supported"`
+	Resource                                   string   `json:"resource"`
+	AuthorizationResponseIssParameterSupported bool     `json:"authorization_response_iss_parameter_supported,omitempty"`
 }
 
 type RegisteredClient struct {
 	ClientID     string `json:"client_id"`
 	ClientSecret string `json:"client_secret,omitempty"`
 	RedirectURI  string `json:"redirect_uri"`
+	Issuer       string `json:"issuer,omitempty"`
 }
 
 type ClientStore interface {

--- a/pkg/app/oauth/proxy.go
+++ b/pkg/app/oauth/proxy.go
@@ -112,6 +112,8 @@ func (p *authProxy) Authorize(ctx context.Context, baseURL string, req Authorize
 		Resource:            req.Resource,
 		AuthID:              auth.ID.String(),
 		GatewayID:           auth.GatewayID.String(),
+		Issuer:              endpoints.issuer,
+		IssAdvertised:       endpoints.advertised,
 	}
 	if err := p.store.SavePending(ctx, state, pending); err != nil {
 		return "", fmt.Errorf("oauth: park authorization: %w", err)
@@ -130,7 +132,7 @@ func (p *authProxy) Authorize(ctx context.Context, baseURL string, req Authorize
 	return endpoints.authorize + "?" + q.Encode(), nil
 }
 
-func (p *authProxy) Callback(ctx context.Context, baseURL, state, code, idpErr, idpErrDesc string) (string, error) {
+func (p *authProxy) Callback(ctx context.Context, baseURL, state, code, idpErr, idpErrDesc, iss string) (string, error) {
 	pending, err := p.store.TakePending(ctx, state)
 	if err != nil {
 		return "", fmt.Errorf("oauth: load pending authorization: %w", err)
@@ -142,7 +144,12 @@ func (p *authProxy) Callback(ctx context.Context, baseURL, state, code, idpErr, 
 		return clientRedirect(pending.RedirectURI, url.Values{
 			"error":             {idpErr},
 			"error_description": {idpErrDesc},
+			"iss":               {baseURL},
 		}, pending.State), nil
+	}
+	if err := validateResponseISS(iss, pending.Issuer, pending.IssAdvertised); err != nil {
+		logIssuerMismatch(pending.Issuer, iss, pending.GatewayID, "", "")
+		return "", err
 	}
 
 	auth, err := p.pendingAuth(ctx, pending)
@@ -209,7 +216,7 @@ func (p *authProxy) Callback(ctx context.Context, baseURL, state, code, idpErr, 
 	if err := p.store.SaveCode(ctx, gwCode, grant); err != nil {
 		return "", fmt.Errorf("oauth: store code grant: %w", err)
 	}
-	resume := clientRedirect(pending.RedirectURI, url.Values{"code": {gwCode}}, pending.State)
+	resume := clientRedirect(pending.RedirectURI, url.Values{"code": {gwCode}, "iss": {baseURL}}, pending.State)
 	if detour := p.consentDetour(ctx, baseURL, effectiveGatewayID, pending.Resource, capturedSubject, token, resume); detour != "" {
 		return detour, nil
 	}

--- a/pkg/app/oauth/proxy_functional_test.go
+++ b/pkg/app/oauth/proxy_functional_test.go
@@ -119,7 +119,7 @@ func TestSessionFlowGitHubOpaqueEndToEnd(t *testing.T) {
 	ctx := context.Background()
 
 	gwState := authorizeAndGetState(t, proxy, "")
-	detour, err := proxy.Callback(ctx, "http://gw.example.com", gwState, "idp-code", "", "")
+	detour, err := proxy.Callback(ctx, "http://gw.example.com", gwState, "idp-code", "", "", "")
 	if err != nil {
 		t.Fatalf("callback: %v", err)
 	}
@@ -177,7 +177,7 @@ func TestSessionFlowDistinctSubjectsDoNotCollide(t *testing.T) {
 		idp := githubLikeIdP(t, userID)
 		proxy := githubSessionProxy(t, idp.URL, signer, &fakeChainer{url: ""})
 		gwState := authorizeAndGetState(t, proxy, "")
-		clientLoc, err := proxy.Callback(ctx, "http://gw.example.com", gwState, "idp-code", "", "")
+		clientLoc, err := proxy.Callback(ctx, "http://gw.example.com", gwState, "idp-code", "", "", "")
 		if err != nil {
 			t.Fatalf("callback: %v", err)
 		}
@@ -222,7 +222,7 @@ func TestOktaFlowNoRegressionEndToEnd(t *testing.T) {
 	ctx := context.Background()
 
 	gwState := authorizeAndGetState(t, proxy, "")
-	clientLoc, err := proxy.Callback(ctx, "http://gw.example.com", gwState, "idp-code", "", "")
+	clientLoc, err := proxy.Callback(ctx, "http://gw.example.com", gwState, "idp-code", "", "", "")
 	if err != nil {
 		t.Fatalf("callback: %v", err)
 	}
@@ -317,7 +317,7 @@ func TestSessionFlowGitHubExplicitEndpointsNoDiscovery(t *testing.T) {
 		t.Fatalf("authorize must redirect to the pinned endpoint, got %s", base)
 	}
 
-	clientLoc, err := proxy.Callback(ctx, "http://gw.example.com", loc.Query().Get("state"), "idp-code", "", "")
+	clientLoc, err := proxy.Callback(ctx, "http://gw.example.com", loc.Query().Get("state"), "idp-code", "", "", "")
 	if err != nil {
 		t.Fatalf("callback: %v", err)
 	}

--- a/pkg/app/oauth/proxy_session_test.go
+++ b/pkg/app/oauth/proxy_session_test.go
@@ -200,7 +200,7 @@ func TestCallbackSessionModeEmptySubjectDenied(t *testing.T) {
 	proxy := NewAuthProxy(finder, nil, http.DefaultClient, store, nil, newTestSigner(t), userinfo)
 
 	gwState := authorizeAndGetState(t, proxy, "")
-	_, err := proxy.Callback(context.Background(), "http://gw.example.com", gwState, "idp-code", "", "")
+	_, err := proxy.Callback(context.Background(), "http://gw.example.com", gwState, "idp-code", "", "", "")
 	var oe *OAuthError
 	if !errors.As(err, &oe) || oe.Code != "access_denied" {
 		t.Fatalf("expected access_denied for empty subject, got %v", err)
@@ -422,7 +422,7 @@ func TestCallbackSessionMintsIdPGrantedScopes(t *testing.T) {
 	ctx := context.Background()
 
 	gwState := authorizeAndGetState(t, proxy, "")
-	clientLoc, err := proxy.Callback(ctx, "http://gw.example.com", gwState, "idp-code", "", "")
+	clientLoc, err := proxy.Callback(ctx, "http://gw.example.com", gwState, "idp-code", "", "", "")
 	if err != nil {
 		t.Fatalf("callback: %v", err)
 	}

--- a/pkg/app/oauth/proxy_test.go
+++ b/pkg/app/oauth/proxy_test.go
@@ -142,17 +142,29 @@ func (s *memFlowStore) TakeCode(_ context.Context, code string) (*CodeGrant, err
 // fakeIdP serves AS metadata and a token endpoint, capturing the exchange form.
 func fakeIdP(t *testing.T) (*httptest.Server, *url.Values) {
 	t.Helper()
+	srv, captured, _ := fakeIdPConfigured(t, false)
+	return srv, captured
+}
+
+func fakeIdPConfigured(t *testing.T, advertiseISS bool) (*httptest.Server, *url.Values, *int) {
+	t.Helper()
 	captured := &url.Values{}
+	tokenHits := 0
 	var srv *httptest.Server
 	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/.well-known/oauth-authorization-server":
-			_ = json.NewEncoder(w).Encode(map[string]any{
+			doc := map[string]any{
 				"issuer":                 srv.URL,
 				"authorization_endpoint": srv.URL + "/authorize",
 				"token_endpoint":         srv.URL + "/token",
-			})
+			}
+			if advertiseISS {
+				doc["authorization_response_iss_parameter_supported"] = true
+			}
+			_ = json.NewEncoder(w).Encode(doc)
 		case "/token":
+			tokenHits++
 			if err := r.ParseForm(); err != nil {
 				http.Error(w, "bad form", http.StatusBadRequest)
 				return
@@ -169,7 +181,7 @@ func fakeIdP(t *testing.T) (*httptest.Server, *url.Values) {
 		}
 	}))
 	t.Cleanup(srv.Close)
-	return srv, captured
+	return srv, captured, &tokenHits
 }
 
 func newProxyUnderTest(t *testing.T, idpURL string, store FlowStore) AuthProxy {
@@ -224,7 +236,7 @@ func TestBrokeredFlowEndToEnd(t *testing.T) {
 	gwState := q.Get("state")
 
 	// Leg 2: IdP callback -> gateway exchanges code, mints its own.
-	clientLoc, err := proxy.Callback(ctx, "http://gw.example.com", gwState, "idp-code", "", "")
+	clientLoc, err := proxy.Callback(ctx, "http://gw.example.com", gwState, "idp-code", "", "", "")
 	if err != nil {
 		t.Fatalf("callback: %v", err)
 	}
@@ -417,7 +429,7 @@ func TestCallbackRelaysIdPDenial(t *testing.T) {
 		State:       "client-state",
 	})
 
-	loc, err := proxy.Callback(ctx, "http://gw.example.com", "gw-state", "", "access_denied", "user cancelled")
+	loc, err := proxy.Callback(ctx, "http://gw.example.com", "gw-state", "", "access_denied", "user cancelled", "")
 	if err != nil {
 		t.Fatalf("callback: %v", err)
 	}
@@ -508,7 +520,7 @@ func TestResourceScopedFacadeSelectsIdPPerTenant(t *testing.T) {
 	}
 
 	// Callback must exchange the code at the same IdP (pinned via AuthID).
-	if _, err := proxy.Callback(ctx, "http://gw.example.com", loc.Query().Get("state"), "idp-code", "", ""); err != nil {
+	if _, err := proxy.Callback(ctx, "http://gw.example.com", loc.Query().Get("state"), "idp-code", "", "", ""); err != nil {
 		t.Fatalf("callback: %v", err)
 	}
 	if len(*capturedA) != 0 {
@@ -858,7 +870,7 @@ func TestCallbackChainsDownstreamConsent(t *testing.T) {
 	proxy := chainProxyUnderTest(t, idp.URL, store, chainer)
 
 	gwState := authorizeAndGetState(t, proxy, "http://gw.example.com/v1/mcp/linear")
-	loc, err := proxy.Callback(context.Background(), "http://gw.example.com", gwState, "idp-code", "", "")
+	loc, err := proxy.Callback(context.Background(), "http://gw.example.com", gwState, "idp-code", "", "", "")
 	if err != nil {
 		t.Fatalf("callback: %v", err)
 	}
@@ -887,7 +899,7 @@ func TestCallbackSkipsChainWhenNothingToLink(t *testing.T) {
 	proxy := chainProxyUnderTest(t, idp.URL, store, chainer)
 
 	gwState := authorizeAndGetState(t, proxy, "http://gw.example.com/v1/mcp/linear")
-	loc, err := proxy.Callback(context.Background(), "http://gw.example.com", gwState, "idp-code", "", "")
+	loc, err := proxy.Callback(context.Background(), "http://gw.example.com", gwState, "idp-code", "", "", "")
 	if err != nil {
 		t.Fatalf("callback: %v", err)
 	}
@@ -909,7 +921,7 @@ func TestCallbackChainsWithoutResource(t *testing.T) {
 	proxy := chainProxyUnderTest(t, idp.URL, store, chainer)
 
 	gwState := authorizeAndGetState(t, proxy, "")
-	loc, err := proxy.Callback(context.Background(), "http://gw.example.com", gwState, "idp-code", "", "")
+	loc, err := proxy.Callback(context.Background(), "http://gw.example.com", gwState, "idp-code", "", "", "")
 	if err != nil {
 		t.Fatalf("callback: %v", err)
 	}
@@ -931,7 +943,7 @@ func TestCallbackOpaqueTokenSkipsChain(t *testing.T) {
 	proxy := chainProxyUnderTest(t, idp.URL, store, chainer)
 
 	gwState := authorizeAndGetState(t, proxy, "http://gw.example.com/v1/mcp/linear")
-	loc, err := proxy.Callback(context.Background(), "http://gw.example.com", gwState, "idp-code", "", "")
+	loc, err := proxy.Callback(context.Background(), "http://gw.example.com", gwState, "idp-code", "", "", "")
 	if err != nil {
 		t.Fatalf("callback: %v", err)
 	}
@@ -940,5 +952,143 @@ func TestCallbackOpaqueTokenSkipsChain(t *testing.T) {
 	}
 	if chainer.calls != 0 {
 		t.Fatalf("chainer must not run without a subject, calls=%d", chainer.calls)
+	}
+}
+
+func TestCallbackRedirectIncludesISS(t *testing.T) {
+	t.Parallel()
+	idp, _ := fakeIdP(t)
+	store := newMemFlowStore()
+	proxy := newProxyUnderTest(t, idp.URL, store)
+	const baseURL = "http://gw.example.com"
+
+	gwState := authorizeAndGetState(t, proxy, "")
+	loc, err := proxy.Callback(context.Background(), baseURL, gwState, "idp-code", "", "", "")
+	if err != nil {
+		t.Fatalf("callback: %v", err)
+	}
+	cu, err := url.Parse(loc)
+	if err != nil {
+		t.Fatalf("parse client redirect: %v", err)
+	}
+	if cu.Query().Get("iss") != baseURL {
+		t.Fatalf("iss = %q, want %s", cu.Query().Get("iss"), baseURL)
+	}
+	if cu.Query().Get("code") == "" {
+		t.Fatal("expected gateway-minted code on redirect")
+	}
+}
+
+func TestCallbackMixUpRejectedBeforeTokenHTTP(t *testing.T) {
+	idp, _, tokenHits := fakeIdPConfigured(t, true)
+	store := newMemFlowStore()
+	proxy := newProxyUnderTest(t, idp.URL, store)
+	buf := captureDefaultSlog(t)
+
+	gwState := authorizeAndGetState(t, proxy, "")
+	_, err := proxy.Callback(context.Background(), "http://gw.example.com", gwState, "idp-code-secret", "", "", "https://attacker.example")
+	var oe *OAuthError
+	if !errors.As(err, &oe) || oe.Code != "invalid_request" {
+		t.Fatalf("error = %v, want invalid_request", err)
+	}
+	if *tokenHits != 0 {
+		t.Fatalf("token HTTP was reached (%d hits); mix-up must fail before redeem", *tokenHits)
+	}
+	logged := buf.String()
+	if !strings.Contains(logged, "oauth.issuer_mismatch") {
+		t.Fatalf("expected oauth.issuer_mismatch, got %s", logged)
+	}
+	assertNoSecrets(t, logged)
+}
+
+func TestCallbackMatchingISSAccepted(t *testing.T) {
+	t.Parallel()
+	idp, _, tokenHits := fakeIdPConfigured(t, true)
+	store := newMemFlowStore()
+	proxy := newProxyUnderTest(t, idp.URL, store)
+
+	gwState := authorizeAndGetState(t, proxy, "")
+	loc, err := proxy.Callback(context.Background(), "http://gw.example.com", gwState, "idp-code", "", "", idp.URL)
+	if err != nil {
+		t.Fatalf("callback: %v", err)
+	}
+	if *tokenHits != 1 {
+		t.Fatalf("token hits = %d, want 1 after matching iss", *tokenHits)
+	}
+	cu, _ := url.Parse(loc)
+	if cu.Query().Get("iss") != "http://gw.example.com" {
+		t.Fatalf("client redirect iss = %q", cu.Query().Get("iss"))
+	}
+}
+
+func TestCallbackMissingISSRejectedWhenAdvertised(t *testing.T) {
+	t.Parallel()
+	idp, _, tokenHits := fakeIdPConfigured(t, true)
+	store := newMemFlowStore()
+	proxy := newProxyUnderTest(t, idp.URL, store)
+
+	gwState := authorizeAndGetState(t, proxy, "")
+	_, err := proxy.Callback(context.Background(), "http://gw.example.com", gwState, "idp-code-secret", "", "", "")
+	var oe *OAuthError
+	if !errors.As(err, &oe) || oe.Code != "invalid_request" {
+		t.Fatalf("error = %v, want invalid_request", err)
+	}
+	if *tokenHits != 0 {
+		t.Fatalf("token HTTP was reached (%d hits); missing iss must skip redeem", *tokenHits)
+	}
+}
+
+func TestCallbackGoogleOmitISSAllowedWhenNotAdvertised(t *testing.T) {
+	t.Parallel()
+	idp, captured, tokenHits := fakeIdPConfigured(t, false)
+	store := newMemFlowStore()
+	proxy := newProxyUnderTest(t, idp.URL, store)
+
+	gwState := authorizeAndGetState(t, proxy, "")
+	loc, err := proxy.Callback(context.Background(), "http://gw.example.com", gwState, "idp-code", "", "", "")
+	if err != nil {
+		t.Fatalf("omit-iss callback: %v", err)
+	}
+	if *tokenHits != 1 {
+		t.Fatalf("token hits = %d, want 1 when advertised=false and iss omitted", *tokenHits)
+	}
+	if captured.Get("code") != "idp-code" {
+		t.Fatalf("IdP exchange form = %v", *captured)
+	}
+	cu, _ := url.Parse(loc)
+	if cu.Query().Get("iss") != "http://gw.example.com" {
+		t.Fatalf("northbound redirect must still include iss, got %q", cu.Query().Get("iss"))
+	}
+}
+
+func TestCallbackStaticIdPOmitISSAllowed(t *testing.T) {
+	t.Parallel()
+	tokenHits := 0
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tokenHits++
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "g-access", "token_type": "Bearer", "expires_in": 3600,
+		})
+	}))
+	t.Cleanup(tokenSrv.Close)
+
+	store := newMemFlowStore()
+	finder := &fakeCredentialFinder{oauth2: []*authdomain.Auth{
+		oauth2Auth(t, authdomain.OAuth2Config{
+			Issuer:       "https://accounts.google.com",
+			AuthorizeURL: "https://accounts.google.com/o/oauth2/v2/auth",
+			TokenURL:     tokenSrv.URL,
+			ClientID:     "gw-client-id",
+			ClientSecret: "gw-secret",
+		}),
+	}}
+	proxy := NewAuthProxy(finder, nil, http.DefaultClient, store, nil, nil, nil)
+
+	gwState := authorizeAndGetState(t, proxy, "")
+	if _, err := proxy.Callback(context.Background(), "http://gw.example.com", gwState, "idp-code", "", "", ""); err != nil {
+		t.Fatalf("google omit-iss: %v", err)
+	}
+	if tokenHits != 1 {
+		t.Fatalf("token hits = %d, want 1", tokenHits)
 	}
 }

--- a/pkg/app/oauth/proxy_types.go
+++ b/pkg/app/oauth/proxy_types.go
@@ -51,7 +51,9 @@ type PendingAuthorization struct {
 	// captured at authorize time so the built-in default identity provider —
 	// which has no owning gateway of its own — can still bind the minted
 	// session to the right gateway at callback time.
-	GatewayID string `json:"gateway_id,omitempty"`
+	GatewayID     string `json:"gateway_id,omitempty"`
+	Issuer        string `json:"issuer,omitempty"`
+	IssAdvertised bool   `json:"iss_advertised,omitempty"`
 }
 
 type CodeGrant struct {
@@ -126,6 +128,6 @@ type ConsentChainer interface {
 
 type AuthProxy interface {
 	Authorize(ctx context.Context, baseURL string, req AuthorizeRequest) (string, error)
-	Callback(ctx context.Context, baseURL, state, code, idpErr, idpErrDesc string) (string, error)
+	Callback(ctx context.Context, baseURL, state, code, idpErr, idpErrDesc, iss string) (string, error)
 	Exchange(ctx context.Context, baseURL string, req TokenRequest) (map[string]any, error)
 }

--- a/pkg/infra/oauth/dcr_registrar.go
+++ b/pkg/infra/oauth/dcr_registrar.go
@@ -132,6 +132,14 @@ func (r *upstreamRegistrar) discover(ctx context.Context, upstreamURL string) (*
 	if !ok {
 		return nil, fmt.Errorf("oauth dcr: no authorization-server metadata at %s", as)
 	}
+	if !appoauth.IssuersEqual(doc.Issuer, as) {
+		slog.Warn("oauth.invalid_metadata",
+			"expected_issuer", as,
+			"metadata_issuer", doc.Issuer,
+			"key", as,
+		)
+		return nil, fmt.Errorf("oauth dcr: authorization server metadata issuer %q does not match %q", doc.Issuer, as)
+	}
 	if len(doc.ScopesSupported) == 0 {
 		doc.ScopesSupported = prm.ScopesSupported
 	}
@@ -145,13 +153,30 @@ func (r *upstreamRegistrar) discover(ctx context.Context, upstreamURL string) (*
 func (r *upstreamRegistrar) EnsureClient(ctx context.Context, key string, meta *appoauth.UpstreamAuthServer, redirectURI string) (*appoauth.RegisteredClient, error) {
 	cached, cacheErr := r.clients.GetClient(ctx, key)
 	if cacheErr == nil && cached != nil && cached.RedirectURI == redirectURI {
-		return cached, nil
+		if cached.Issuer == "" {
+			if meta != nil && meta.Issuer != "" {
+				cached.Issuer = meta.Issuer
+				if err := r.clients.SaveClient(ctx, key, *cached); err != nil {
+					return nil, err
+				}
+			}
+			return cached, nil
+		}
+		if meta != nil && appoauth.IssuersEqual(cached.Issuer, meta.Issuer) {
+			return cached, nil
+		}
+		got := ""
+		if meta != nil {
+			got = meta.Issuer
+		}
+		slog.Warn("oauth.issuer_mismatch",
+			"expected_issuer", cached.Issuer,
+			"got_issuer", got,
+			"key", key,
+		)
 	}
-	// A client is already registered but for a different redirect URI. Replacing
-	// it is deliberate, and it invalidates every refresh token the old client
-	// holds, so say so rather than losing those grants silently.
 	replacing := cacheErr == nil && cached != nil
-	if replacing {
+	if replacing && cached.RedirectURI != redirectURI {
 		slog.Warn("oauth dcr: re-registering upstream client because the redirect URI changed; grants held by the previous client can no longer be refreshed",
 			"key", key, "old_redirect_uri", cached.RedirectURI, "new_redirect_uri", redirectURI)
 	}
@@ -164,6 +189,7 @@ func (r *upstreamRegistrar) EnsureClient(ctx context.Context, key string, meta *
 		"grant_types":                []string{"authorization_code", "refresh_token"},
 		"response_types":             []string{"code"},
 		"token_endpoint_auth_method": "none",
+		"application_type":           "web",
 	})
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, meta.RegistrationEndpoint, bytes.NewReader(body))
 	if err != nil {
@@ -189,7 +215,12 @@ func (r *upstreamRegistrar) EnsureClient(ctx context.Context, key string, meta *
 	if err := json.Unmarshal(raw, &doc); err != nil || doc.ClientID == "" {
 		return nil, fmt.Errorf("oauth dcr: registration response has no client_id")
 	}
-	client := &appoauth.RegisteredClient{ClientID: doc.ClientID, ClientSecret: doc.ClientSecret, RedirectURI: redirectURI}
+	client := &appoauth.RegisteredClient{
+		ClientID:     doc.ClientID,
+		ClientSecret: doc.ClientSecret,
+		RedirectURI:  redirectURI,
+		Issuer:       meta.Issuer,
+	}
 	if replacing {
 		if err := r.clients.SaveClient(ctx, key, *client); err != nil {
 			return nil, err

--- a/pkg/infra/oauth/dcr_registrar_test.go
+++ b/pkg/infra/oauth/dcr_registrar_test.go
@@ -15,9 +15,11 @@
 package oauth_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -25,6 +27,8 @@ import (
 	"testing"
 
 	appoauth "github.com/NeuralTrust/TrustGate/pkg/app/oauth"
+	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
+	registrydomain "github.com/NeuralTrust/TrustGate/pkg/domain/registry"
 	infraoauth "github.com/NeuralTrust/TrustGate/pkg/infra/oauth"
 	"github.com/stretchr/testify/require"
 )
@@ -151,4 +155,260 @@ func TestEnsureClient_RedirectURIChangeReplacesClient(t *testing.T) {
 	stored, err := store.GetClient(ctx, "gw|reg")
 	require.NoError(t, err)
 	require.Equal(t, moved.ClientID, stored.ClientID)
+}
+
+func TestEnsureClient_StampsEmptyIssuerWithoutReregister(t *testing.T) {
+	t.Parallel()
+	var issued atomic.Int64
+	idp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := issued.Add(1)
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"client_id": fmt.Sprintf("client-%d", n)})
+	}))
+	defer idp.Close()
+
+	store := newClaimStore()
+	const key = "gw|reg"
+	const redirect = "https://gw.example.com/oauth/callback/p"
+	require.NoError(t, store.SaveClient(context.Background(), key, appoauth.RegisteredClient{
+		ClientID:     "pre-1106",
+		ClientSecret: "old-secret",
+		RedirectURI:  redirect,
+	}))
+	meta := &appoauth.UpstreamAuthServer{
+		Issuer:               "https://as.example",
+		RegistrationEndpoint: idp.URL,
+	}
+	r := infraoauth.NewUpstreamRegistrar(store, idp.Client())
+	got, err := r.EnsureClient(context.Background(), key, meta, redirect)
+	require.NoError(t, err)
+	require.Equal(t, "pre-1106", got.ClientID)
+	require.Equal(t, "old-secret", got.ClientSecret)
+	require.Equal(t, "https://as.example", got.Issuer)
+	require.Equal(t, int64(0), issued.Load())
+	stored, err := store.GetClient(context.Background(), key)
+	require.NoError(t, err)
+	require.Equal(t, "https://as.example", stored.Issuer)
+}
+
+func TestEnsureClient_MatchingIssuerReuses(t *testing.T) {
+	t.Parallel()
+	var issued atomic.Int64
+	idp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		issued.Add(1)
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"client_id": "fresh"})
+	}))
+	defer idp.Close()
+
+	store := newClaimStore()
+	const key = "gw|reg"
+	const redirect = "https://gw.example.com/oauth/callback/p"
+	require.NoError(t, store.SaveClient(context.Background(), key, appoauth.RegisteredClient{
+		ClientID:    "bound-a",
+		RedirectURI: redirect,
+		Issuer:      "https://as.example",
+	}))
+	r := infraoauth.NewUpstreamRegistrar(store, idp.Client())
+	got, err := r.EnsureClient(context.Background(), key, &appoauth.UpstreamAuthServer{
+		Issuer:               "https://as.example/",
+		RegistrationEndpoint: idp.URL,
+	}, redirect)
+	require.NoError(t, err)
+	require.Equal(t, "bound-a", got.ClientID)
+	require.Equal(t, int64(0), issued.Load())
+}
+
+func TestEnsureClient_MismatchReregisters(t *testing.T) {
+	var issued atomic.Int64
+	idp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := issued.Add(1)
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"client_id": fmt.Sprintf("client-%d", n)})
+	}))
+	defer idp.Close()
+
+	store := newClaimStore()
+	const key = "gw|reg"
+	const redirect = "https://gw.example.com/oauth/callback/p"
+	require.NoError(t, store.SaveClient(context.Background(), key, appoauth.RegisteredClient{
+		ClientID:     "bound-a",
+		ClientSecret: "secret-a",
+		RedirectURI:  redirect,
+		Issuer:       "https://as-a.example",
+	}))
+	logs := captureDCRSlog(t)
+	r := infraoauth.NewUpstreamRegistrar(store, idp.Client())
+	got, err := r.EnsureClient(context.Background(), key, &appoauth.UpstreamAuthServer{
+		Issuer:               "https://as-b.example",
+		RegistrationEndpoint: idp.URL,
+	}, redirect)
+	require.NoError(t, err)
+	require.NotEqual(t, "bound-a", got.ClientID)
+	require.Equal(t, "https://as-b.example", got.Issuer)
+	require.Equal(t, int64(1), issued.Load())
+	logged := logs.String()
+	require.Contains(t, logged, "oauth.issuer_mismatch")
+	require.NotContains(t, logged, "secret-a")
+	require.NotContains(t, logged, "client_secret")
+}
+
+func TestEnsureClient_SouthboundDCRIsWeb(t *testing.T) {
+	t.Parallel()
+	var body map[string]any
+	idp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"client_id": "web-client"})
+	}))
+	defer idp.Close()
+
+	r := infraoauth.NewUpstreamRegistrar(newClaimStore(), idp.Client())
+	got, err := r.EnsureClient(context.Background(), "gw|reg", &appoauth.UpstreamAuthServer{
+		Issuer:               "https://as.example",
+		RegistrationEndpoint: idp.URL,
+	}, "https://gw.example.com/oauth/callback/p")
+	require.NoError(t, err)
+	require.Equal(t, "web-client", got.ClientID)
+	require.Equal(t, "web", body["application_type"])
+}
+
+func TestDiscover_MetadataIssuerFailClosed(t *testing.T) {
+	cases := []struct {
+		name    string
+		issuer  string
+		wantErr bool
+	}{
+		{name: "matching metadata proceeds", issuer: "", wantErr: false},
+		{name: "mismatched metadata fails closed", issuer: "https://attacker.example", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			registerHits := 0
+			var srvURL string
+			mux := http.NewServeMux()
+			mux.HandleFunc("/.well-known/oauth-protected-resource/mcp", func(w http.ResponseWriter, _ *http.Request) {
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"resource":              srvURL + "/mcp",
+					"authorization_servers": []string{srvURL},
+				})
+			})
+			mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, _ *http.Request) {
+				iss := tc.issuer
+				if iss == "" {
+					iss = srvURL
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"issuer":                 iss,
+					"authorization_endpoint": srvURL + "/authorize",
+					"token_endpoint":         srvURL + "/token",
+					"registration_endpoint":  srvURL + "/register",
+				})
+			})
+			mux.HandleFunc("/register", func(w http.ResponseWriter, _ *http.Request) {
+				registerHits++
+			})
+			srv := httptest.NewServer(mux)
+			srvURL = srv.URL
+			t.Cleanup(srv.Close)
+
+			var logs *dcrSyncBuffer
+			if tc.wantErr {
+				logs = captureDCRSlog(t)
+			}
+			r := infraoauth.NewUpstreamRegistrar(newClaimStore(), srv.Client())
+			meta, err := r.Discover(context.Background(), srv.URL+"/mcp")
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Equal(t, 0, registerHits)
+				require.Contains(t, logs.String(), "oauth.invalid_metadata")
+				require.NotContains(t, logs.String(), "client_secret")
+				return
+			}
+			require.NoError(t, err)
+			require.True(t, appoauth.IssuersEqual(meta.Issuer, srv.URL))
+		})
+	}
+}
+
+func TestRefreshAuth_MismatchReturnsErrNoRegisteredClient(t *testing.T) {
+	registerHits := 0
+	var srvURL string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/oauth-protected-resource/mcp", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"resource":              srvURL + "/mcp",
+			"authorization_servers": []string{srvURL},
+		})
+	})
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                 srvURL,
+			"authorization_endpoint": srvURL + "/authorize",
+			"token_endpoint":         srvURL + "/token",
+			"registration_endpoint":  srvURL + "/register",
+		})
+	})
+	mux.HandleFunc("/register", func(w http.ResponseWriter, _ *http.Request) {
+		registerHits++
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"client_id": "should-not-issue"})
+	})
+	srv := httptest.NewServer(mux)
+	srvURL = srv.URL
+	defer srv.Close()
+
+	gw := ids.New[ids.GatewayKind]()
+	reg, err := registrydomain.NewMCPRegistry(gw, "linear-mcp", "", &registrydomain.MCPTarget{
+		URL: srv.URL + "/mcp",
+		Auth: &registrydomain.MCPAuth{
+			Mode:         registrydomain.MCPAuthModeForwarded,
+			Provider:     "linear",
+			Registration: registrydomain.RegistrationAuto,
+		},
+	})
+	require.NoError(t, err)
+
+	store := newClaimStore()
+	key := gw.String() + "|" + reg.ID.String()
+	require.NoError(t, store.SaveClient(context.Background(), key, appoauth.RegisteredClient{
+		ClientID:    "bound-a",
+		RedirectURI: "https://gw.example.com/oauth/callback/linear",
+		Issuer:      "https://as-a.example",
+	}))
+
+	logs := captureDCRSlog(t)
+	registrar := infraoauth.NewUpstreamRegistrar(store, srv.Client())
+	svc := appoauth.NewConnectService(nil, nil, nil, nil, registrar)
+
+	_, err = svc.RefreshAuth(context.Background(), gw, reg)
+	require.ErrorIs(t, err, appoauth.ErrNoRegisteredClient)
+	require.Equal(t, 0, registerHits)
+	require.Contains(t, logs.String(), "oauth.issuer_mismatch")
+}
+
+type dcrSyncBuffer struct {
+	mu sync.Mutex
+	b  bytes.Buffer
+}
+
+func (s *dcrSyncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.Write(p)
+}
+
+func (s *dcrSyncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.String()
+}
+
+func captureDCRSlog(t *testing.T) *dcrSyncBuffer {
+	t.Helper()
+	buf := &dcrSyncBuffer{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return buf
 }


### PR DESCRIPTION
## Summary

- As AS, always emit `iss=baseURL` on MCP client redirects and advertise `authorization_response_iss_parameter_supported`.
- As client, reject issuer mismatch before redeem; reject missing `iss` only when the AS advertised the parameter (Google Workspace / manual IdPs keep working).
- Bind DCR credentials to the issuing AS (`RegisteredClient.Issuer`): stamp empty pre-1106 rows on next discover; `EnsureClient` mismatch re-registers; `RefreshAuth` mismatch returns `ErrNoRegisteredClient` without minting a new client.
- Southbound DCR sends `application_type=web`; northbound accepts `web`|`native` inferred from redirect URI. slog `oauth.issuer_mismatch` / `oauth.invalid_metadata` never log tokens or secrets. CIMD is docs-only; `/oauth/register` stays.

## Size

Above the 400-line review budget (`size:exception`): AS emit, client mix-up, DCR bind, spec tests, and CIMD-prep docs in one PR per request.

## Linear

RUN-1106 — https://linear.app/neuraltrust/issue/RUN-1106/featmcp-auth-harden-oauth-for-mcp-2026-07-28

Base: `feat/run-1103-dual-era-northbound-protocol-boundary` ([#400](https://github.com/NeuralTrust/TrustGate/pull/400)). Retarget `develop` after #400 lands.

## Test plan

- [x] `go test -race` on `pkg/app/oauth`, `pkg/infra/oauth`, `pkg/api/handler/http/oauth`
- [x] Pre-commit hook (lint + gosec + unit) passed (retried once: known flake `TestNegotiatingDialerConcurrentPinnedLegacyFallbackSharesColdSession`)
- [ ] CI on this PR


Made with [Cursor](https://cursor.com)