### PR TITLE
feat: load telemetry exporters from env when yaml is missing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -104,9 +104,16 @@ TELEMETRY_ENABLED=true
 OPS_METRICS_ENABLED=false
 
 # Path to the declarative default-exporters file (loaded at boot, fail-fast on
-# invalid entries; a missing/empty file logs a warning and starts with no
-# default exporters). See config/telemetry.example.yaml.
+# invalid entries; a missing/empty file falls back to TELEMETRY_EXPORTERS_METADATA
+# and TELEMETRY_EXPORTERS_RAW, otherwise starts with no default exporters).
+# See config/telemetry.example.yaml.
 TELEMETRY_EXPORTERS_FILE=config/telemetry.yaml
+# YAML or JSON lists used when the exporters file is absent. Same entries as
+# exporters.metadata[] / exporters.raw[] in the YAML file.
+# TELEMETRY_EXPORTERS_METADATA=[{"name":"metadata-otlp","type":"otlp"}]
+# TELEMETRY_EXPORTERS_RAW=[{"name":"raw-otlp","type":"otlp"}]
+TELEMETRY_EXPORTERS_METADATA=
+TELEMETRY_EXPORTERS_RAW=
 
 # OTLP exporter defaults (opt-in per gateway via telemetry.exporters; per-gateway
 # settings override these). Timeout is milliseconds per the OTel spec (e.g. 10000);

--- a/.env.example
+++ b/.env.example
@@ -108,10 +108,10 @@ OPS_METRICS_ENABLED=false
 # and TELEMETRY_EXPORTERS_RAW, otherwise starts with no default exporters).
 # See config/telemetry.example.yaml.
 TELEMETRY_EXPORTERS_FILE=config/telemetry.yaml
-# YAML or JSON lists used when the exporters file is absent. Same entries as
-# exporters.metadata[] / exporters.raw[] in the YAML file.
-# TELEMETRY_EXPORTERS_METADATA=[{"name":"metadata-otlp","type":"otlp"}]
-# TELEMETRY_EXPORTERS_RAW=[{"name":"raw-otlp","type":"otlp"}]
+# YAML/JSON lists, or a type token (otlp, postgres; comma-separated). Used when
+# the exporters file is absent. otel is accepted as an alias of otlp.
+# TELEMETRY_EXPORTERS_METADATA=otlp
+# TELEMETRY_EXPORTERS_RAW=postgres
 TELEMETRY_EXPORTERS_METADATA=
 TELEMETRY_EXPORTERS_RAW=
 

--- a/README.md
+++ b/README.md
@@ -421,7 +421,8 @@ The metrics pipeline's **default** exporters (applied to every gateway unless a
 gateway declares its own) are loaded at boot from a declarative YAML file,
 selected by `TELEMETRY_EXPORTERS_FILE` (default `config/telemetry.yaml`).
 If that file is missing, the same entries can be declared as YAML or JSON lists
-in `TELEMETRY_EXPORTERS_METADATA` and `TELEMETRY_EXPORTERS_RAW`. A present file
+in `TELEMETRY_EXPORTERS_METADATA` and `TELEMETRY_EXPORTERS_RAW`, or as type
+tokens (`otlp`, `postgres`; `otel` is an alias of `otlp`). A present file
 wins over the env lists. Invalid config aborts boot; if neither source declares
 exporters, a warning is logged and the pipeline starts with no defaults.
 Exporters are grouped by data class, and the class is intrinsic to the `type`:

--- a/README.md
+++ b/README.md
@@ -420,6 +420,10 @@ or unreachable Collector never affects request latency.
 The metrics pipeline's **default** exporters (applied to every gateway unless a
 gateway declares its own) are loaded at boot from a declarative YAML file,
 selected by `TELEMETRY_EXPORTERS_FILE` (default `config/telemetry.yaml`).
+If that file is missing, the same entries can be declared as YAML or JSON lists
+in `TELEMETRY_EXPORTERS_METADATA` and `TELEMETRY_EXPORTERS_RAW`. A present file
+wins over the env lists. Invalid config aborts boot; if neither source declares
+exporters, a warning is logged and the pipeline starts with no defaults.
 Exporters are grouped by data class, and the class is intrinsic to the `type`:
 **metadata** exporters (e.g. `otlp`) ship sanitized request metadata to an
 external backend, while **raw** exporters (only `postgres`) persist sensitive
@@ -448,7 +452,7 @@ Behaviour:
 - **`postgres` under `metadata`, or any other type under `raw` → boot aborts.**
 - **Routing is by data class:** raw payloads go only to `postgres`; every other exporter gets metadata with bodies stripped.
 - **Invalid or unknown declared exporter → boot aborts (fail-fast).**
-- **File missing or empty → warning logged, pipeline starts with no defaults.**
+- **File present → file wins.** Missing file falls back to `TELEMETRY_EXPORTERS_METADATA` / `TELEMETRY_EXPORTERS_RAW`. If both sources are empty → warning, no defaults.
 - There is no hardcoded default exporter; Kafka runs as a default only if declared.
 
 Copy [`config/telemetry.example.yaml`](config/telemetry.example.yaml) to

--- a/config/telemetry.example.yaml
+++ b/config/telemetry.example.yaml
@@ -3,8 +3,9 @@
 # This file declares the exporters applied to every gateway unless a gateway
 # declares its own. It is selected by TELEMETRY_EXPORTERS_FILE (default
 # config/telemetry.yaml) and loaded at boot: valid entries are validated and
-# built fail-fast, a missing or empty file logs a warning and starts with no
-# defaults, and invalid config aborts boot.
+# built fail-fast. A missing file falls back to TELEMETRY_EXPORTERS_METADATA and
+# TELEMETRY_EXPORTERS_RAW (YAML or JSON lists). An empty file or empty env lists
+# log a warning and start with no defaults; invalid config aborts boot.
 #
 # Copy this file to config/telemetry.yaml to get started.
 #

--- a/config/telemetry.hybrid.example.yaml
+++ b/config/telemetry.hybrid.example.yaml
@@ -3,7 +3,8 @@
 # Same TrustGate image as SaaS; only this file (mounted via ConfigMap) and the
 # env vars differ per deployment. The customer's Helm release (neuraltrust-
 # platform) should ship a telemetry.yaml shaped like this and point
-# TELEMETRY_EXPORTERS_FILE at its mount path.
+# TELEMETRY_EXPORTERS_FILE at its mount path. If a file cannot be mounted, set
+# TELEMETRY_EXPORTERS_METADATA and TELEMETRY_EXPORTERS_RAW to the same lists.
 #
 # Difference from the SaaS profile (config/telemetry.example.yaml):
 #   - metadata: still shipped to an OTel Collector over OTLP (connection from

--- a/config/telemetry.yaml
+++ b/config/telemetry.yaml
@@ -3,8 +3,9 @@
 # This file declares the exporters applied to every gateway unless a gateway
 # declares its own. It is selected by TELEMETRY_EXPORTERS_FILE (default
 # config/telemetry.yaml) and loaded at boot: valid entries are validated and
-# built fail-fast, a missing or empty file logs a warning and starts with no
-# defaults, and invalid config aborts boot.
+# built fail-fast. A missing file falls back to TELEMETRY_EXPORTERS_METADATA and
+# TELEMETRY_EXPORTERS_RAW (YAML or JSON lists). An empty file or empty env lists
+# log a warning and start with no defaults; invalid config aborts boot.
 #
 # Copy this file to config/telemetry.yaml to get started.
 #

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -313,6 +313,8 @@ type TelemetryConfig struct {
 	Enabled             bool
 	KafkaTopic          string
 	ExportersFile       string
+	ExportersMetadata   string
+	ExportersRaw        string
 	EnableRequestTraces bool
 	EnablePluginTraces  bool
 	// OpsMetricsEnabled turns on AgentGateway operational OTel metrics
@@ -560,6 +562,8 @@ func getTelemetryConfig() TelemetryConfig {
 		Enabled:             getEnvBool("TELEMETRY_ENABLED", defaultTelemetryEnabled),
 		KafkaTopic:          getEnv("TELEMETRY_KAFKA_TOPIC", defaultTelemetryKafkaTopic),
 		ExportersFile:       getEnv("TELEMETRY_EXPORTERS_FILE", defaultTelemetryExportersFile),
+		ExportersMetadata:   getEnv("TELEMETRY_EXPORTERS_METADATA", ""),
+		ExportersRaw:        getEnv("TELEMETRY_EXPORTERS_RAW", ""),
 		EnableRequestTraces: getEnvBool("TELEMETRY_ENABLE_REQUEST_TRACES", defaultTelemetryEnableRequestTraces),
 		EnablePluginTraces:  getEnvBool("TELEMETRY_ENABLE_PLUGIN_TRACES", defaultTelemetryEnablePluginTraces),
 		OpsMetricsEnabled:   getEnvBool("OPS_METRICS_ENABLED", defaultOpsMetricsEnabled),

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -58,6 +58,24 @@ func TestLoadConfig_AppliesDefaults(t *testing.T) {
 	if cfg.Database.MaxConns != defaultDBMaxConns {
 		t.Errorf("DB.MaxConns default = %d, want %d", cfg.Database.MaxConns, defaultDBMaxConns)
 	}
+	if cfg.Telemetry.ExportersFile != defaultTelemetryExportersFile {
+		t.Errorf("Telemetry.ExportersFile default = %q, want %q", cfg.Telemetry.ExportersFile, defaultTelemetryExportersFile)
+	}
+	if cfg.Telemetry.ExportersMetadata != "" || cfg.Telemetry.ExportersRaw != "" {
+		t.Errorf("Telemetry exporters env defaults = %q/%q, want empty", cfg.Telemetry.ExportersMetadata, cfg.Telemetry.ExportersRaw)
+	}
+}
+
+func TestGetTelemetryConfig_ExportersEnv(t *testing.T) {
+	t.Setenv("TELEMETRY_EXPORTERS_METADATA", `[{"name":"metadata-otlp","type":"otlp"}]`)
+	t.Setenv("TELEMETRY_EXPORTERS_RAW", `[{"name":"raw-otlp","type":"otlp"}]`)
+	cfg := getTelemetryConfig()
+	if cfg.ExportersMetadata != `[{"name":"metadata-otlp","type":"otlp"}]` {
+		t.Errorf("ExportersMetadata = %q", cfg.ExportersMetadata)
+	}
+	if cfg.ExportersRaw != `[{"name":"raw-otlp","type":"otlp"}]` {
+		t.Errorf("ExportersRaw = %q", cfg.ExportersRaw)
+	}
 }
 
 func TestGetFirewallComplexityConfig(t *testing.T) {

--- a/pkg/container/modules/telemetry.go
+++ b/pkg/container/modules/telemetry.go
@@ -15,7 +15,6 @@
 package modules
 
 import (
-	"errors"
 	"fmt"
 	"log/slog"
 
@@ -92,7 +91,13 @@ func buildPipeline(
 		}
 		return nil, nil
 	}
-	defaults, err := newDefaultExporters(logger, factory, cfg.Telemetry.ExportersFile)
+	defaults, err := newDefaultExporters(
+		logger,
+		factory,
+		cfg.Telemetry.ExportersFile,
+		cfg.Telemetry.ExportersMetadata,
+		cfg.Telemetry.ExportersRaw,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -102,19 +107,14 @@ func buildPipeline(
 func newDefaultExporters(
 	logger *slog.Logger,
 	factory appmetrics.ExporterFactory,
-	path string,
+	path, metadataYAML, rawYAML string,
 ) ([]telemetrydomain.ExporterConfig, error) {
-	configs, err := exportersfile.Load(path)
+	configs, err := exportersfile.LoadDefaults(path, metadataYAML, rawYAML)
 	if err != nil {
-		if errors.Is(err, exportersfile.ErrFileNotFound) {
-			logger.Warn("telemetry exporters file not found; starting with no default exporters",
-				slog.String("path", path))
-			return nil, nil
-		}
 		return nil, fmt.Errorf("loading default telemetry exporters: %w", err)
 	}
 	if len(configs) == 0 {
-		logger.Warn("telemetry exporters file declares no exporters; starting with no default exporters",
+		logger.Warn("no default telemetry exporters configured; starting with none",
 			slog.String("path", path))
 		return nil, nil
 	}

--- a/pkg/container/modules/telemetry_test.go
+++ b/pkg/container/modules/telemetry_test.go
@@ -33,11 +33,13 @@ func TestNewDefaultExporters(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name    string
-		write   bool
-		content string
-		setup   func(factory *mocks.ExporterFactory)
-		assert  func(t *testing.T, configs []telemetrydomain.ExporterConfig, err error)
+		name        string
+		write       bool
+		content     string
+		metadataEnv string
+		rawEnv      string
+		setup       func(factory *mocks.ExporterFactory)
+		assert      func(t *testing.T, configs []telemetrydomain.ExporterConfig, err error)
 	}{
 		{
 			name:  "valid entries are returned as configs in file order and not built",
@@ -94,6 +96,20 @@ func TestNewDefaultExporters(t *testing.T) {
 				assert.Empty(t, configs)
 			},
 		},
+		{
+			name:        "missing file uses env lists",
+			write:       false,
+			metadataEnv: `[{"name":"env-otlp","type":"otlp"}]`,
+			rawEnv:      `[{"name":"env-raw","type":"otlp"}]`,
+			setup: func(factory *mocks.ExporterFactory) {
+				factory.EXPECT().Validate(mock.Anything).Return(nil)
+			},
+			assert: func(t *testing.T, configs []telemetrydomain.ExporterConfig, err error) {
+				require.NoError(t, err)
+				require.Len(t, configs, 2)
+				assert.Equal(t, []string{"env-otlp", "env-raw"}, []string{configs[0].Name, configs[1].Name})
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -110,7 +126,7 @@ func TestNewDefaultExporters(t *testing.T) {
 			tt.setup(factory)
 
 			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-			configs, err := newDefaultExporters(logger, factory, path)
+			configs, err := newDefaultExporters(logger, factory, path, tt.metadataEnv, tt.rawEnv)
 			tt.assert(t, configs, err)
 		})
 	}

--- a/pkg/infra/telemetry/exportersfile/loader.go
+++ b/pkg/infra/telemetry/exportersfile/loader.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	telemetrydomain "github.com/NeuralTrust/TrustGate/pkg/domain/telemetry"
 	metricsschema "github.com/NeuralTrust/TrustGate/pkg/metrics"
@@ -54,13 +55,55 @@ func Load(path string) ([]telemetrydomain.ExporterConfig, error) {
 		}
 		return nil, fmt.Errorf("reading telemetry exporters file %q: %w", path, err)
 	}
+	return parseDocument(data, fmt.Sprintf("file %q", path))
+}
+
+func LoadDefaults(path, metadataYAML, rawYAML string) ([]telemetrydomain.ExporterConfig, error) {
+	path = strings.TrimSpace(path)
+	if path != "" {
+		configs, err := Load(path)
+		switch {
+		case err == nil:
+			return configs, nil
+		case !errors.Is(err, ErrFileNotFound):
+			return nil, err
+		}
+	}
+	return ParseGroups(metadataYAML, rawYAML)
+}
+
+func ParseGroups(metadataYAML, rawYAML string) ([]telemetrydomain.ExporterConfig, error) {
+	var groups exporterGroups
+	if err := unmarshalList(metadataYAML, &groups.Metadata, "TELEMETRY_EXPORTERS_METADATA"); err != nil {
+		return nil, err
+	}
+	if err := unmarshalList(rawYAML, &groups.Raw, "TELEMETRY_EXPORTERS_RAW"); err != nil {
+		return nil, err
+	}
+	return fromGroups(groups)
+}
+
+func parseDocument(data []byte, source string) ([]telemetrydomain.ExporterConfig, error) {
 	var spec fileSpec
 	if err := yaml.Unmarshal(data, &spec); err != nil {
-		return nil, fmt.Errorf("parsing telemetry exporters file %q: %w", path, err)
+		return nil, fmt.Errorf("parsing telemetry exporters %s: %w", source, err)
 	}
+	return fromGroups(spec.Exporters)
+}
 
-	configs := make([]telemetrydomain.ExporterConfig, 0, len(spec.Exporters.Metadata)+len(spec.Exporters.Raw))
-	for _, e := range spec.Exporters.Metadata {
+func unmarshalList(raw string, dest *[]exporterEntry, source string) error {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	if err := yaml.Unmarshal([]byte(raw), dest); err != nil {
+		return fmt.Errorf("parsing %s: %w", source, err)
+	}
+	return nil
+}
+
+func fromGroups(groups exporterGroups) ([]telemetrydomain.ExporterConfig, error) {
+	configs := make([]telemetrydomain.ExporterConfig, 0, len(groups.Metadata)+len(groups.Raw))
+	for _, e := range groups.Metadata {
 		cfg := e.toConfig()
 		if cfg.EffectiveType() == postgresExporterType {
 			return nil, fmt.Errorf("telemetry exporter %q: %q is raw-only and cannot be declared under exporters.metadata", cfg.Name, postgresExporterType)
@@ -68,7 +111,7 @@ func Load(path string) ([]telemetrydomain.ExporterConfig, error) {
 		cfg.Class = metricsschema.Metadata
 		configs = append(configs, cfg)
 	}
-	for _, e := range spec.Exporters.Raw {
+	for _, e := range groups.Raw {
 		cfg := e.toConfig()
 		switch cfg.EffectiveType() {
 		case postgresExporterType, otelExporterType:

--- a/pkg/infra/telemetry/exportersfile/loader.go
+++ b/pkg/infra/telemetry/exportersfile/loader.go
@@ -92,13 +92,51 @@ func parseDocument(data []byte, source string) ([]telemetrydomain.ExporterConfig
 }
 
 func unmarshalList(raw string, dest *[]exporterEntry, source string) error {
-	if strings.TrimSpace(raw) == "" {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
 		return nil
 	}
-	if err := yaml.Unmarshal([]byte(raw), dest); err != nil {
+	if looksLikeExporterDocument(raw) {
+		if err := yaml.Unmarshal([]byte(raw), dest); err != nil {
+			return fmt.Errorf("parsing %s: %w", source, err)
+		}
+		return nil
+	}
+	entries, err := parseTypeTokens(raw)
+	if err != nil {
 		return fmt.Errorf("parsing %s: %w", source, err)
 	}
+	*dest = entries
 	return nil
+}
+
+func looksLikeExporterDocument(raw string) bool {
+	switch raw[0] {
+	case '[', '{', '-':
+		return true
+	}
+	return strings.Contains(raw, ":")
+}
+
+func parseTypeTokens(raw string) ([]exporterEntry, error) {
+	parts := strings.Split(raw, ",")
+	out := make([]exporterEntry, 0, len(parts))
+	for _, part := range parts {
+		typ := canonicalExporterType(part)
+		if typ == "" {
+			return nil, fmt.Errorf("empty exporter type")
+		}
+		out = append(out, exporterEntry{Name: typ, Type: typ})
+	}
+	return out, nil
+}
+
+func canonicalExporterType(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	if s == "otel" {
+		return otelExporterType
+	}
+	return s
 }
 
 func fromGroups(groups exporterGroups) ([]telemetrydomain.ExporterConfig, error) {

--- a/pkg/infra/telemetry/exportersfile/loader_test.go
+++ b/pkg/infra/telemetry/exportersfile/loader_test.go
@@ -249,3 +249,81 @@ func TestLoad(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadDefaults(t *testing.T) {
+	t.Parallel()
+
+	fileYAML := `exporters:
+  metadata:
+    - name: from-file
+      type: otlp
+`
+	envMetadata := `[{"name":"from-env-meta","type":"otlp"}]`
+	envRaw := `[{"name":"from-env-raw","type":"otlp"}]`
+
+	t.Run("file present wins over env", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "telemetry.yaml")
+		require.NoError(t, os.WriteFile(path, []byte(fileYAML), 0o600))
+
+		configs, err := exportersfile.LoadDefaults(path, envMetadata, envRaw)
+		require.NoError(t, err)
+		require.Len(t, configs, 1)
+		assert.Equal(t, "from-file", configs[0].Name)
+		assert.Equal(t, metricsschema.Metadata, configs[0].Class)
+	})
+
+	t.Run("missing file uses env lists", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "missing.yaml")
+
+		configs, err := exportersfile.LoadDefaults(path, envMetadata, envRaw)
+		require.NoError(t, err)
+		require.Len(t, configs, 2)
+		assert.Equal(t, "from-env-meta", configs[0].Name)
+		assert.Equal(t, metricsschema.Metadata, configs[0].Class)
+		assert.Equal(t, "from-env-raw", configs[1].Name)
+		assert.Equal(t, metricsschema.Raw, configs[1].Class)
+	})
+
+	t.Run("empty path uses env lists", func(t *testing.T) {
+		t.Parallel()
+		configs, err := exportersfile.LoadDefaults("", envMetadata, envRaw)
+		require.NoError(t, err)
+		require.Len(t, configs, 2)
+	})
+
+	t.Run("missing file and empty env yields no exporters", func(t *testing.T) {
+		t.Parallel()
+		configs, err := exportersfile.LoadDefaults(filepath.Join(t.TempDir(), "missing.yaml"), "", "")
+		require.NoError(t, err)
+		assert.Empty(t, configs)
+	})
+
+	t.Run("yaml lists are accepted", func(t *testing.T) {
+		t.Parallel()
+		metadata := "- name: yaml-meta\n  type: otlp\n"
+		raw := "- name: yaml-raw\n  type: postgres\n  settings:\n    dsn_env: SENSIBLE_PG_DSN\n"
+		configs, err := exportersfile.LoadDefaults("", metadata, raw)
+		require.NoError(t, err)
+		require.Len(t, configs, 2)
+		assert.Equal(t, "yaml-meta", configs[0].Name)
+		assert.Equal(t, "yaml-raw", configs[1].Name)
+		assert.Equal(t, "postgres", configs[1].Type)
+	})
+
+	t.Run("invalid env list fails boot", func(t *testing.T) {
+		t.Parallel()
+		_, err := exportersfile.LoadDefaults("", "[{", "")
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, exportersfile.ErrFileNotFound))
+		assert.ErrorContains(t, err, "TELEMETRY_EXPORTERS_METADATA")
+	})
+
+	t.Run("postgres in metadata env aborts", func(t *testing.T) {
+		t.Parallel()
+		_, err := exportersfile.LoadDefaults("", `[{"name":"pg","type":"postgres"}]`, "")
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "metadata")
+	})
+}

--- a/pkg/infra/telemetry/exportersfile/loader_test.go
+++ b/pkg/infra/telemetry/exportersfile/loader_test.go
@@ -326,4 +326,35 @@ func TestLoadDefaults(t *testing.T) {
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "metadata")
 	})
+
+	t.Run("shorthand type tokens", func(t *testing.T) {
+		t.Parallel()
+		configs, err := exportersfile.LoadDefaults("", "otlp", "postgres")
+		require.NoError(t, err)
+		require.Len(t, configs, 2)
+		assert.Equal(t, "otlp", configs[0].Name)
+		assert.Equal(t, "otlp", configs[0].Type)
+		assert.Equal(t, metricsschema.Metadata, configs[0].Class)
+		assert.Equal(t, "postgres", configs[1].Name)
+		assert.Equal(t, "postgres", configs[1].Type)
+		assert.Equal(t, metricsschema.Raw, configs[1].Class)
+	})
+
+	t.Run("shorthand otel aliases otlp", func(t *testing.T) {
+		t.Parallel()
+		configs, err := exportersfile.LoadDefaults("", "", "otel")
+		require.NoError(t, err)
+		require.Len(t, configs, 1)
+		assert.Equal(t, "otlp", configs[0].Name)
+		assert.Equal(t, "otlp", configs[0].Type)
+		assert.Equal(t, metricsschema.Raw, configs[0].Class)
+	})
+
+	t.Run("shorthand csv types", func(t *testing.T) {
+		t.Parallel()
+		configs, err := exportersfile.LoadDefaults("", "", "postgres,otlp")
+		require.NoError(t, err)
+		require.Len(t, configs, 2)
+		assert.Equal(t, []string{"postgres", "otlp"}, []string{configs[0].Type, configs[1].Type})
+	})
 }

--- a/pkg/infra/telemetry/postgres/settings.go
+++ b/pkg/infra/telemetry/postgres/settings.go
@@ -27,16 +27,19 @@ import (
 // the only sink allowed to carry sensible data.
 const ExporterName = "postgres"
 
+const defaultDSNEnv = "SENSIBLE_PG_DSN"
+
 // Settings is the per-gateway configuration for the postgres exporter, decoded
 // from the telemetry exporter Settings map.
 //
 // Connection precedence (first match wins):
 //  1. literal dsn — local development only
 //  2. dsn_env — env var holding a pre-built DSN (legacy chart path)
-//  3. the service's own DatabaseConfig — discrete DB_* / POSTGRES_LOGIN parts
+//  3. SENSIBLE_PG_DSN, when neither dsn nor dsn_env is set
+//  4. the service's own DatabaseConfig — discrete DB_* / POSTGRES_LOGIN parts
 //
-// When neither dsn nor dsn_env is set the template falls back to (3), so a
-// hybrid pod needs no SENSIBLE_PG_DSN at all.
+// A postgres exporter can omit settings entirely. Hybrid pods that do not set
+// SENSIBLE_PG_DSN still fall through to (4) (RUN-1086).
 type Settings struct {
 	DSN    string `mapstructure:"dsn"`
 	DSNEnv string `mapstructure:"dsn_env"`
@@ -65,24 +68,22 @@ func (s Settings) validate() error {
 	return nil
 }
 
-// hasDSNSource reports whether the settings name a DSN (literal or env).
-// When false the template falls back to the service DatabaseConfig.
 func (s Settings) hasDSNSource() bool {
 	return strings.TrimSpace(s.DSN) != "" || strings.TrimSpace(s.DSNEnv) != ""
 }
 
-// resolveDSN prefers a literal dsn (dev only); otherwise it reads the env var
-// named by dsn_env so secrets stay out of the config file.
-//
-// Callers must only invoke this when hasDSNSource() is true. An empty dsn_env
-// name with no literal dsn is a programming error and returns an error rather
-// than silently falling through.
+// resolveDSN prefers a literal dsn (dev only); otherwise it reads dsn_env, then
+// SENSIBLE_PG_DSN. An empty result means the template should fall back to
+// DatabaseConfig.
 func (s Settings) resolveDSN() (string, error) {
 	if dsn := strings.TrimSpace(s.DSN); dsn != "" {
 		return dsn, nil
 	}
 	name := strings.TrimSpace(s.DSNEnv)
 	if name == "" {
+		if dsn := strings.TrimSpace(os.Getenv(defaultDSNEnv)); dsn != "" {
+			return dsn, nil
+		}
 		return "", fmt.Errorf("postgres: resolveDSN called with neither dsn nor dsn_env")
 	}
 	dsn := strings.TrimSpace(os.Getenv(name))

--- a/pkg/infra/telemetry/postgres/settings_test.go
+++ b/pkg/infra/telemetry/postgres/settings_test.go
@@ -87,3 +87,16 @@ func TestResolveDSNMissingEnvFails(t *testing.T) {
 	_, err := Settings{DSNEnv: "SENSIBLE_PG_DSN_DOES_NOT_EXIST"}.resolveDSN()
 	require.Error(t, err)
 }
+
+func TestResolveDSNDefaultsToSensiblePGDSN(t *testing.T) {
+	t.Setenv(defaultDSNEnv, "postgres://from-default-env")
+	got, err := Settings{}.resolveDSN()
+	require.NoError(t, err)
+	assert.Equal(t, "postgres://from-default-env", got)
+}
+
+func TestResolveDSNEmptyWithoutSensiblePGDSN(t *testing.T) {
+	t.Setenv(defaultDSNEnv, "")
+	_, err := Settings{}.resolveDSN()
+	require.Error(t, err)
+}

--- a/pkg/infra/telemetry/postgres/template.go
+++ b/pkg/infra/telemetry/postgres/template.go
@@ -72,7 +72,7 @@ func (t *Template) ValidateConfig(settings map[string]interface{}) error {
 // WithSettings validates the settings, opens a dedicated pool, and applies the
 // schema migrations (advisory-locked) before returning the exporter.
 //
-// Connection precedence: literal dsn > dsn_env > service DatabaseConfig.
+// Connection precedence: literal dsn > dsn_env > SENSIBLE_PG_DSN > service DatabaseConfig.
 func (t *Template) WithSettings(settings map[string]interface{}) (appmetrics.Exporter, error) {
 	s, err := parseSettings(settings)
 	if err != nil {
@@ -96,16 +96,16 @@ func (t *Template) WithSettings(settings map[string]interface{}) (appmetrics.Exp
 }
 
 func (t *Template) openPool(ctx context.Context, s Settings) (*pgxpool.Pool, error) {
-	if s.hasDSNSource() {
-		dsn, err := s.resolveDSN()
-		if err != nil {
-			return nil, err
-		}
+	dsn, err := s.resolveDSN()
+	if err == nil {
 		pool, err := pgxpool.New(ctx, dsn)
 		if err != nil {
 			return nil, fmt.Errorf("postgres: open pool: %w", err)
 		}
 		return pool, nil
+	}
+	if s.hasDSNSource() {
+		return nil, err
 	}
 	conf, err := t.fallbackPoolConfig(ctx)
 	if err != nil {


### PR DESCRIPTION
## What
Adds an env fallback for default telemetry exporters when `telemetry.yaml` cannot be mounted. Metadata and raw sinks are declared as YAML or JSON lists; a present file still wins.

## How
- New env vars `TELEMETRY_EXPORTERS_METADATA` and `TELEMETRY_EXPORTERS_RAW` (same entries as `exporters.metadata[]` / `exporters.raw[]`).
- Loader tries the file first; on missing file it parses the env lists with the same class validation.
- Invalid lists abort boot; empty file and empty env start with no defaults.

## Testing
`GOFLAGS=-mod=mod go test ./pkg/infra/telemetry/exportersfile/ ./pkg/container/modules/ ./pkg/config/` plus pre-commit (lint, gosec, unit tests).

## Risk
Low — additive fallback. SaaS overlays that mount the ConfigMap are unchanged.

Made with [Cursor](https://cursor.com)