### PR TITLE
feat(mcp): add enterprise-managed authorization ID-JAG exchange (RUN-1112)

### DIFF
--- a/docs/mcp/enterprise-managed-authorization.md
+++ b/docs/mcp/enterprise-managed-authorization.md
@@ -1,0 +1,51 @@
+# Enterprise-Managed Authorization (EMA)
+
+TrustGate accepts an IdP-issued **ID-JAG** at `/oauth/token` (`urn:ietf:params:oauth:grant-type:jwt-bearer`) and always mints a TrustGate session JWT. The ID-JAG is never returned to the client.
+
+This is MCP **enterprise-managed authorization** (ID-JAG draft-04) on the existing `oauth2` identity provider. There is no separate auth type.
+
+## IdP registers TrustGate as the MCP resource
+
+The identity provider issues the ID-JAG **for TrustGate**, not for the upstream LLM.
+
+| Claim | Value |
+|-------|--------|
+| `typ` | `oauth-id-jag+jwt` |
+| `iss` | The configured OAuth2 issuer (trailing `/` ignored; same as RUN-1106 `IssuersEqual`) |
+| `aud` | TrustGate `baseURL` (the northbound AS), **not** `oauth2.audiences` |
+| `resource` | The RFC 8707 MCP resource URL the client is calling |
+| `client_id` | A client registered at TrustGate (`POST /oauth/register`) |
+| `sub` | End-user subject (`subject_claim` if set; never a silent Entra `oid`) |
+| `jti` / `exp` / `iat` | Required; `jti` is consumed until `exp` (replay → `invalid_grant`) |
+
+Configure a **https** `jwks_url` (or a https issuer so JWKS can be discovered from **that** issuer). JWKS is never taken from the assertion host.
+
+## `northbound_mode`
+
+On `oauth2`:
+
+| Mode | Default | Authorize (OIDC) | jwt-bearer | Refresh |
+|------|---------|------------------|------------|---------|
+| `oidc` (empty) | yes | yes | `unsupported_grant_type` | yes |
+| `ema` | | `access_denied` | yes | yes |
+| `both` | | yes | yes | yes |
+
+AS metadata advertises `grant_types_supported` jwt-bearer and `io.modelcontextprotocol/enterprise-managed-authorization` **only when any oauth2 IdP is `ema` or `both`**.
+
+A failed jwt-bearer is `invalid_grant`. There is **no** silent fall-through to the OIDC code flow.
+
+## Session mint
+
+On success TrustGate always mints `token_use=mcp_session` (plus `authid`, `gwid`, session `aud` from config) and a `gwrt_` refresh token. Email on the ID-JAG is a linking claim only; identity is `iss`+`sub` (or explicit `subject_claim`). `act` is dropped (delegation / `Principal.Actor` is RUN-1117).
+
+Logs: `oauth.ema.accept` / `oauth.ema.deny` with `auth_id`, `gateway_id`, `jti` or `reason`. No grants, tokens, secrets, or identity claims.
+
+## Client matrix
+
+| Client | Status |
+|--------|--------|
+| MCP clients that can present an IdP ID-JAG at `/oauth/token` | Supported when the IdP is configured for EMA |
+| Cursor | **Unconfirmed** — Cursor's ID-JAG / enterprise-managed-auth support is not verified here |
+| OIDC-only clients (`authorization_code` + PKCE) | Use `oidc` or `both` |
+
+Google omit-`iss` / Workspace southbound connect is unchanged: [Google Workspace MCP OAuth](google-workspace-oauth.md). RFC 9207 harden: [MCP OAuth harden](oauth-harden.md).

--- a/docs/mcp/oauth-harden.md
+++ b/docs/mcp/oauth-harden.md
@@ -36,7 +36,7 @@ Issuer compare trims a trailing `/` only. No scheme rewrite.
 | Dynamic Client Registration | **Current runtime.** Not removed. |
 | `POST /oauth/register` | **Remains.** |
 | CIMD (`client_id` as URL) | **Documentation / future only.** No CIMD routes, types, or catalog flags. |
-| Enterprise Managed Auth (RUN-1112) | **Not started.** Do not begin it here. |
+| Enterprise Managed Auth (RUN-1112) | **This change.** See [Enterprise-Managed Authorization](enterprise-managed-authorization.md). |
 
 Do not read this page as “CIMD is implemented” or “DCR is going away.”
 
@@ -79,7 +79,6 @@ does **not** add a product MCP event or a new audit bus.
 
 - CIMD runtime (routes, types, catalog flags)
 - Removal of DCR or `/oauth/register`
-- RUN-1112 Enterprise Managed Auth
 - Vault `Credential` issuer field
 - Redis key migration
 - Feature-flag / observe-then-enforce mode
@@ -95,4 +94,5 @@ does **not** add a product MCP event or a new audit bus.
 ## Next step
 
 Workspace and other omit-`iss` IdPs: [Google Workspace MCP OAuth](google-workspace-oauth.md).
+Enterprise-managed authorization (jwt-bearer / ID-JAG): [Enterprise-Managed Authorization](enterprise-managed-authorization.md).
 Exercise the plane: [MCP testing guide](testing-guide.md).

--- a/openspec/changes/run-1112-enterprise-managed-authorization/design.md
+++ b/openspec/changes/run-1112-enterprise-managed-authorization/design.md
@@ -1,0 +1,99 @@
+# Design: Enterprise-Managed Authorization (RUN-1112)
+
+## Technical Approach
+
+In-place jwt-bearer on existing `oauth2` Auth. No `TypeEMA`, no new package. ID-JAG (draft-04) vs **configured** issuer/JWKS; always `mintSession`. Approach 1 / `mcp-enterprise-managed-authorization`. Reuse RUN-1106 `IssuersEqual` + slog. Do not touch `Callback` / `validateResponseISS`. Spec may land in parallel.
+
+## Architecture Decisions
+
+| Decision | Options | Tradeoff | Choice |
+|----------|---------|----------|--------|
+| Placement | `TypeEMA` / `oauth/ema` / in-package | Fork vs one grant | Unexported `idjag.go` |
+| Mode | global vs per-`OAuth2Config` | Blast vs per-IdP | `northbound_mode` empty/`oidc` (default), `ema`, `both` |
+| Failed jwt-bearer | silent OIDC vs `invalid_grant` | Mix-up vs hard fail | `invalid_grant`; no fall-through |
+| `ema` authorize | keep vs reject | Compat vs fail-closed | Reject authorize; keep refresh + in-flight codes |
+| ID-JAG `aud` | `oauth2.audiences` vs `baseURL` | Session mix-up | `aud=baseURL`; session `aud` stays config |
+| Verify path | `OAuth2TokenValidator` vs dedicated | Wrong aud + silent `oid` | Dedicated; `Verify` with `Audiences:[baseURL]` |
+| Issuer | verifier exact vs `IssuersEqual` | Slash vs inbound change | Peek + `IssuersEqual`; Verify token `iss`; JWKS from **cfg** |
+| Subject | `subjectOf`(`oid`) vs `iss`+`sub` | Vault key vs spec | `subject_claim` or `sub`; never silent `oid`; `authid` binds iss |
+| Email | Subject vs claim vs ignore | Takeover vs no store | Session claim only; JIT `iss`+`sub`; never log |
+| RoleScoper | sparse vs copy claims | Miss roles vs leak | Copy claims except `act`/`jti`/`client_id`; no `Actor` |
+| Replay | none vs jti TTL | Replay vs Redis | `ConsumeJTI` `SET NX` `oauth:jti:{jti}` TTL=`exp`; fail closed |
+| JWKS | assertion `iss` vs configured | SSRF vs pin | Configured https JWKS or discover **cfg.Issuer** |
+| Advertise | always vs `ema`\|`both` | Cursor gap | jwt-bearer + EMA extension iff any resolved oauth2 is `ema`\|`both` |
+| Audit | events vs slog | Scope | `oauth.ema.accept`/`deny` — ids only |
+
+## Data Flow
+
+```mermaid
+sequenceDiagram
+  participant C as MCP client
+  participant AS as TG /oauth/token
+  participant V as idjag validator
+  participant J as JWKS (configured)
+  participant R as Redis jti
+  participant S as mintSession
+  C->>AS: grant_type=jwt-bearer assertion resource client_id
+  AS->>AS: mode oidc → unsupported_grant_type
+  AS->>AS: authForResource + mode ema/both
+  AS->>V: typ, Peek iss, IssuersEqual
+  V->>J: Verify aud=baseURL (no assertion host)
+  V->>AS: client_id bind, resource, scopes, iat, no act map
+  AS->>R: ConsumeJTI NX TTL=exp
+  R-->>AS: replay or store down → invalid_grant
+  AS->>S: always mint mcp_session + gwrt_ refresh
+  S-->>C: access_token (never ID-JAG)
+```
+
+`both` OIDC path unchanged. Failed assertion never becomes it.
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `pkg/domain/auth/config.go` | Modify | `NorthboundMode`; validate `oidc`\|`ema`\|`both`; ema\|both require https JWKS or https issuer |
+| `pkg/domain/auth/config_test.go` | Modify | Mode + https table tests |
+| `pkg/app/oauth/idjag.go` | Create | typ, Peek+`IssuersEqual`, Verify(aud=baseURL), resource/scope/`client_id`/`iat`, slog |
+| `pkg/app/oauth/idjag_test.go` | Create | typ/iss/aud/resource/scope/jti/alg/`oid`/act tables |
+| `pkg/app/oauth/proxy_types.go` | Modify | `TokenRequest.Assertion`; `FlowStore.ConsumeJTI`; `CodeGrant.Claims` |
+| `pkg/app/oauth/proxy.go` | Modify | jwt-bearer branch; `ema` Authorize reject; always mint; inject `OIDCVerifier` |
+| `pkg/app/oauth/metadata.go` | Modify | grant + EMA extension when any auth is `ema`\|`both`; DCR grant_types |
+| `pkg/api/handler/http/oauth/token_handler.go` | Modify | Read `assertion` |
+| `pkg/infra/oauth/store.go` | Modify | `ConsumeJTI` `SET NX`; prefix `oauth:jti:` (additive) |
+| `pkg/container/modules/api.go` | Modify | Pass existing `OIDCVerifier` into `NewAuthProxy` |
+| `docs/mcp/enterprise-managed-authorization.md` | Create | IdP registers TG resource; client matrix (Cursor unconfirmed) |
+| `docs/mcp/oauth-harden.md` | Modify | Point EMA at this change |
+
+Unchanged: Google omit-iss, `Principal`, `auth_rules`, southbound, vault, inbound `subjectOf`.
+
+## Interfaces / Contracts
+
+```go
+const (
+    grantJWTBearer = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+    idJAGTyp       = "oauth-id-jag+jwt" // draft-04
+    emaExtension   = "io.modelcontextprotocol/enterprise-managed-authorization"
+)
+// ConsumeJTI: SET NX; exists → invalid_grant; Redis err → invalid_grant
+// Verify OIDCConfig{Issuer: tokenIss, Audiences: []string{baseURL}, JWKSURL: configured|discover(cfg.Issuer)}
+```
+
+Errors: `oidc` + jwt-bearer → `unsupported_grant_type`. Assertion fail → `invalid_grant`. Unknown form `client_id` → `invalid_client`. `ema` authorize → `access_denied`.
+
+## Testing Strategy
+
+| Layer | What | Approach |
+|-------|------|----------|
+| Unit | mode validate; typ/iss/aud/resource/scope/exp/nbf/iat/jti/HMAC/`oid`/act | `config_test.go`, `idjag_test.go` |
+| Unit | `oidc` unsupported; `both` no downgrade; `ema` authorize reject + refresh OK; mint `token_use=mcp_session` | `proxy_test.go`, `metadata_test.go` |
+| Infra | jti NX replay + Redis error deny | `store` tests |
+| Handler | form `assertion` forwarded | `handlers_test.go` |
+| E2E | Out of scope | Existing MCP tests; docs note Cursor unconfirmed |
+
+## Migration / Rollout
+
+No Redis rewrite. Default `oidc`. Rollout `oidc` → `both` → `ema`. Chain: (1) config+metadata (2) validator+jti+grant+mint (3) tests+docs+slog. Rollback: set `northbound_mode=oidc`; revert slices reverse-order.
+
+## Open Questions
+
+- None blocking. Email = claim + JIT (no account store). Mixed modes: advertise if **any** oauth2 is `ema`\|`both`; grant checks the **selected** auth.

--- a/openspec/changes/run-1112-enterprise-managed-authorization/exploration.md
+++ b/openspec/changes/run-1112-enterprise-managed-authorization/exploration.md
@@ -1,0 +1,113 @@
+# Exploration: RUN-1112 Enterprise-Managed Authorization
+
+## Current State
+
+TrustGate is already the MCP Authorization Server. An MCP client discovers `/.well-known/oauth-protected-resource` and `/.well-known/oauth-authorization-server`, registers at `/oauth/register` (public DCR, `token_endpoint_auth_method: none`), authorizes at `/oauth/authorize` (PKCE S256 → configured IdP), and redeems at `/oauth/token` (`authorization_code` | `refresh_token` only).
+
+When `session_mode` is on, `/oauth/token` mints a TrustGate session JWT (`sub`, `scope`, `authid`, `gwid`, `aud`, `token_use=mcp_session`, 1h) plus a `gwrt_` refresh token. `MCPAuthMiddleware` → `chainIdentityResolver` verifies that session (`token_use` must be `mcp_session`) and attaches `AuthID` + `identity.Principal`. `RoleScoper` then evaluates `principal.Claims` via `OIDCResolver`. Consumer, toolkit, plugins, and composer stay downstream of that principal.
+
+There is **no** ID-JAG / RFC 7523 path. `TokenRequest` has no `assertion`. AS metadata advertises only `authorization_code` and `refresh_token`. Auth types remain `api_key | oauth2 | oidc | mtls`. MCP consumers **cannot** attach `TypeOIDC` — interactive MCP requires `oauth2` so the gateway can broker login (`auth_rules.go`).
+
+JWT validation already exists and is reusable: `pkg/infra/auth/oidc` (JWKS cache 5m, HMAC/`none` rejected, `iss`/`aud`/`exp`/`nbf`/scopes). RUN-1106 just added `IssuersEqual`, RFC 9207 `iss` (Google/manual IdPs may omit), DCR issuer bind, and slog `oauth.issuer_mismatch` / `oauth.invalid_metadata`. Invalid AS metadata is not cached.
+
+ID-JAG (IETF `draft-ietf-oauth-identity-assertion-authz-grant-04`, pinned by MCP EMA): client obtains the grant at the **enterprise IdP** (RFC 8693 — out of TG scope), then POSTs to TG `/oauth/token`:
+
+```
+grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer
+assertion=<ID-JAG JWT>
+```
+
+Required JWT: `typ=oauth-id-jag+jwt`, `iss`, `sub`, `aud` = **Resource AS issuer** (TG `baseURL`), `client_id`, `jti`, `exp`, `iat`. Optional: `resource`, `scope`, `email`, `nbf`, `act`. Email is linking only. `act` is dual-identity (RUN-1117) — do not implement.
+
+Cursor does not publicly document EMA/ID-JAG as of 2026-08. Mode must stay optional; default remains interactive OIDC.
+
+### Constraints from code
+
+| Question | Answer |
+|---|---|
+| New Auth type? | **No.** MCP already forbids `TypeOIDC`. Add a mode on `OAuth2Config`. |
+| What token to mint? | Always the existing session JWT via `mintSession`. Never return the ID-JAG; never propagate it southbound. |
+| ID-JAG `aud` vs `oauth2.audiences`? | Different. ID-JAG `aud` = TG AS issuer (`baseURL`). `oauth2.audiences` stay the inbound/session `aud` minted onto the TG token. |
+| Public DCR clients? | TG advertises `token_endpoint_auth_methods_supported: ["none"]`. Bind `client_id` claim to form `client_id`; do **not** require a client secret. |
+| `both` fallback? | Interactive OIDC stays. A **failed** jwt-bearer must return `invalid_grant`, never fall through to code/OIDC. |
+| `ema` and `/oauth/authorize`? | Reject new interactive starts. Keep `refresh_token` for already-minted sessions. |
+| Replay? | `jti` is required. No jti store exists — add a TTL store (`exp`). Fail closed if the store is down. |
+| Audit sink? | slog, same family as RUN-1106. No product MCP event bus. Never log grants/tokens/secrets/claims/email. |
+| RUN-1106 Google omit-`iss`? | Do not touch `Callback` / `validateResponseISS`. EMA is a different hop. |
+| RUN-1117? | Note the seam only. Do not add `Principal.Actor` or map ID-JAG `act`. |
+
+## Affected Areas
+
+- `pkg/domain/auth/config.go` + `config_test.go` — `northbound_mode` (`oidc` default / `ema` / `both`) and optional EMA fields on `OAuth2Config` (expected resources, claim map). No new `Type`.
+- `pkg/app/oauth/metadata.go` — advertise `urn:ietf:params:oauth:grant-type:jwt-bearer` and `io.modelcontextprotocol/enterprise-managed-authorization` **only** when mode is `ema` or `both`.
+- `pkg/app/oauth/proxy.go` + `proxy_types.go` — `TokenRequest.Assertion`; `Exchange` jwt-bearer branch; `Authorize` reject when mode is `ema`.
+- `pkg/api/handler/http/oauth/token_handler.go` — read `assertion`.
+- New `pkg/app/oauth` ID-JAG validator (keep in oauth; do not invent a parallel Auth stack) — typ, sig via existing OIDC verifier/JWKS, trusted issuer, aud=`baseURL`, resource, scopes, exp/nbf, `client_id`, jti replay. Reuse `IssuersEqual`.
+- `pkg/app/oauth/ports.go` / FlowStore (or sibling) — jti consume-once with TTL=`exp`.
+- `pkg/infra/auth/oidc/{verifier,jwks_cache,discovery}.go` — reuse; pin JWKS to **configured** issuer/JWKS URL only (no assertion-driven discovery). Fail closed on refresh errors.
+- Identity mapping into existing `identity.Principal` + `mintSession` (`authid`, `gwid`, `aud`, `token_use=mcp_session`). Primary id = `iss`+`sub` (or configured `subject_claim`). Email = optional link only.
+- Unchanged after mint: `MCPAuthMiddleware`, `auth_chain.go` session path, `RoleScoper`, consumer AuthID, toolkit, plugins, composer.
+- Tests: `proxy_test.go`, `metadata_test.go`, `handlers_test.go`, `config_test.go`, new ID-JAG table tests, functional MCP auth.
+- Docs: `docs/mcp/enterprise-managed-authorization.md` (IdP registers TG as approved MCP resource; client support matrix — Cursor unconfirmed). Update `oauth-harden.md` (EMA is this change, not 1106).
+- Out of scope files: southbound connect/DCR, vault schema, `Principal.Actor`, TypeOIDC, upstream MCP servers.
+
+## Approaches
+
+1. **In-place jwt-bearer on existing `oauth2` Auth (mode field)** — Add `northbound_mode` to `OAuth2Config`. Extend `/oauth/token` and AS metadata. Validate ID-JAG with existing OIDC verifier + RUN-1106 issuer helpers. Always `mintSession`. slog audit + jti store.
+   - Pros: No Auth-model fork; MCP consumers already use `oauth2`; session/middleware/RoleScoper reused; OIDC path untouched when mode is `oidc`; `both` is a grant-type switch, not a second IdP.
+   - Cons: `OAuth2Config` grows; ID-JAG `aud` (AS issuer) must not be confused with `oauth2.audiences`; public-client `client_id` bind needs care; jti store is new infra.
+   - Effort: Medium (implementation) / High if tests+docs stay in one PR (400-line risk).
+
+2. **New `TypeEMA` Auth** — Second identity-provider type beside `oauth2`/`oidc`.
+   - Pros: Clean config isolation.
+   - Cons: Duplicates the Auth model (ticket forbids); MCP attach rules and RoleScoper would need a third IdP type; operators would split OIDC vs EMA across two auths.
+   - Effort: High
+
+3. **New `oauth/ema` package + observe-then-enforce flag** — Extract validator; advertise extension behind a kill-switch; log mismatches first.
+   - Pros: Smaller blast radius if IdP JWT shapes are unknown.
+   - Cons: Extra package for one grant; observe mode leaves mix-up/replay open; ticket QA wants fail-closed. Optional **mode** already covers rollout (`oidc` → `both` → `ema`).
+   - Effort: Medium–High
+
+## Recommendation
+
+**Approach 1.** Keep one `oauth2` Auth. Default `northbound_mode=oidc` (empty = oidc). EMA is an additional token grant, not a new identity system.
+
+Concrete policy for propose/design:
+
+1. **Mode**
+   - `oidc`: current behavior. jwt-bearer → `unsupported_grant_type`. No EMA advertisement.
+   - `both`: advertise EMA; accept jwt-bearer **and** interactive OIDC. Failed jwt-bearer is `invalid_grant` (no silent OIDC downgrade). Optional slog `oauth.ema.fallback` only when the client **chose** authorize/code, never after a failed assertion.
+   - `ema`: advertise EMA; reject `/oauth/authorize`; accept jwt-bearer; keep `refresh_token` for minted sessions.
+
+2. **Validation (fail closed)** — configured issuer + JWKS only; `typ=oauth-id-jag+jwt`; reject `none`/HMAC/alg confusion (reuse `validateAlgorithm`); `iss` via `IssuersEqual`; `aud` is exactly TG `baseURL` (single string or one-element array per draft-04); `resource` must match the requested TG MCP resource (RFC 8707); scopes ⊆ configured allowed; `exp`/`nbf`/`iat`; `client_id` matches form `client_id` of a registered gateway client; consume `jti` until `exp`. Metadata/JWKS refresh errors deny the grant and are not cached as success.
+
+3. **Mint** — always `mintSession` with IdP `sub` (stable `iss`+`sub`, or `subject_claim`; Entra `oid` only if explicitly configured — do not silently prefer `oid` over `sub` for EMA). Copy approved claims into session claims so `RoleScoper` still works. Bind `authid` + `gwid` + session `aud` from the accepting oauth2 Auth. Short expiry stays 1h.
+
+4. **Email** — never `Principal.Subject`. Optional controlled link to a pre-EMA account; if link fails, still accept on `iss`+`sub` (JIT). Do not log email.
+
+5. **RUN-1117 seam** — EMA fills the **end-user** `Principal.Subject`. `AuthID` remains the consumer-attached oauth2 auth. Leave `act` unmapped. Do not add `Principal.Actor`.
+
+6. **RUN-1106** — reuse issuer compare + slog shape. Do not change Google omit-`iss` on the interactive callback.
+
+7. **SSRF** — JWKS/discovery only from configured https issuer/JWKS URL. Do not follow `iss` from the assertion to a new host.
+
+8. **Docs** — IdP-side: register TG AS issuer + MCP resource URI; group/policy at the IdP. Client matrix: no confirmed Cursor EMA support as of 2026-08; treat as optional.
+
+9. **Delivery** — expect >400 lines. Default split: (1) config+metadata, (2) validator+jti+token grant+mint, (3) tests+docs+slog. Stack on `feat/run-1112-enterprise-managed-authorization` (base 1103; retarget develop after #400).
+
+## Risks
+
+- **Client support gap** — Cursor/other MCP clients may not send ID-JAG yet. Default `oidc` and `both` are mandatory; do not require EMA globally.
+- **ID-JAG `aud` vs session `aud` confusion** — mixing them accepts foreign grants or mints wrong-audience sessions.
+- **Public-client `client_id` spoofing** — DCR is `none`; bind assertion `client_id` to the registered gateway client and to the requested resource/consumer.
+- **jti store availability** — fail closed (deny) if Redis/store is down; do not accept without replay protection.
+- **JWKS SSRF / cross-issuer reuse** — assertion-driven discovery would fetch attacker URLs; pin to configured issuer/JWKS.
+- **Entra `oid` vs `sub`** — existing `subjectOf` prefers `oid` for vault keys. Silent reuse on EMA would diverge from the spec’s `iss`+`sub` primary id. Make it an explicit `subject_claim`.
+- **`both` misuse** — operators may think `both` means “try EMA then OIDC on the same request.” It does not.
+- **RUN-1117 collision** — mapping `act` or growing `Principal` here would pre-empt the dual-identity spike.
+- **PR size** — validator + tests + docs will exceed the 400-line review budget unless chained.
+- **IETF draft churn** — ID-JAG is draft-04 (expires 2026-11). Pin draft-04 + MCP extension name; do not chase later drafts in this change.
+
+## Ready for Proposal
+
+Yes. Orchestrator should run **sdd-propose** for `run-1112-enterprise-managed-authorization` using Approach 1. No blocking product questions remain: mode lives on `OAuth2Config`, EMA always mints the existing session token, OIDC stays default, RUN-1117 is a documented seam only.

--- a/openspec/changes/run-1112-enterprise-managed-authorization/proposal.md
+++ b/openspec/changes/run-1112-enterprise-managed-authorization/proposal.md
@@ -1,0 +1,75 @@
+# Proposal: Enterprise-Managed Authorization (RUN-1112)
+
+## Intent
+
+Enterprise MCP clients exchange an IdP ID-JAG at `/oauth/token` for the existing TG session JWT. OIDC stays default. No Auth-model fork. RoleScoper, AuthID, toolkit, plugins stay.
+
+## Scope
+
+### In Scope
+- `northbound_mode` on `OAuth2Config`: `oidc` (default) | `ema` | `both`
+- jwt-bearer + ID-JAG (draft-04) vs configured issuer/JWKS; `jti` until `exp`
+- Always `mintSession`
+- Advertise `jwt-bearer` + `io.modelcontextprotocol/enterprise-managed-authorization` only when `ema`|`both`
+- slog accept/deny — never grants/tokens/secrets/claims
+- Docs: IdP registers TG as MCP resource; client matrix (Cursor unconfirmed)
+
+### Out of Scope
+- `TypeEMA`; `Principal.Actor` / `act` (RUN-1117)
+- Google omit-`iss` (RUN-1106); global EMA; Cursor allowlists
+- Southbound EMA; ID-JAG propagation; assertion-driven JWKS
+
+## Capabilities
+
+### New Capabilities
+- `mcp-enterprise-managed-authorization`: mode, jwt-bearer/ID-JAG, mint, metadata, jti, slog, fail-closed JWKS.
+
+### Modified Capabilities
+- None (`mcp-dual-era-northbound` era-only; `mcp-oauth-harden` reused, unchanged).
+
+## Approach
+
+**Approach 1** (locked): in-place jwt-bearer on existing `oauth2` Auth.
+
+- `oidc`: jwt-bearer → `unsupported_grant_type`; no EMA ad
+- `both`: advertise EMA; jwt-bearer **and** OIDC; failed assertion → `invalid_grant` (no silent downgrade)
+- `ema`: advertise EMA; reject `/oauth/authorize`; keep `refresh_token`
+- Validate: `typ=oauth-id-jag+jwt`; configured issuer/JWKS; `IssuersEqual`; `aud=baseURL`; resource; scopes ⊆ allowed; exp/nbf/iat; bind `client_id`; consume `jti`; reject `none`/HMAC
+- Mint: session JWT; id `iss`+`sub` (or explicit `subject_claim`); email linking only
+- Pin draft-04. Chain: (1) config+metadata (2) validator+jti+grant+mint (3) tests+docs+slog
+
+## Affected Areas
+
+- `pkg/domain/auth/config.go` — `northbound_mode` + EMA fields; no new Type
+- `pkg/app/oauth/metadata.go` — jwt-bearer + EMA extension when `ema`|`both`
+- `pkg/app/oauth/proxy.go`, `proxy_types.go`, `token_handler.go` — `Assertion`; jwt-bearer Exchange; ema Authorize reject
+- `pkg/app/oauth` validator + jti port — new ID-JAG validate; jti TTL store
+- `pkg/infra/auth/oidc/*` — reuse; configured JWKS only; fail closed
+- `docs/mcp/enterprise-managed-authorization.md` — IdP + client matrix
+
+## Risks
+
+- Clients lack EMA (High) — default `oidc`; `both` optional
+- `aud` mix-up / `client_id` spoof (Med) — `aud=baseURL`; bind registered client + resource
+- jti down / JWKS SSRF (Med) — fail closed; configured https JWKS only
+- Entra `oid` vs `sub` (Med) — explicit `subject_claim`
+- RUN-1117 / PR size / draft (Med) — no `act`; 3 slices; pin draft-04
+
+## Rollback Plan
+
+Set `northbound_mode=oidc`. Revert slices reverse-order. jti additive; no Redis rewrite.
+
+## Dependencies
+
+- RUN-1106 (blocks; reuse `IssuersEqual`, slog)
+- Stacked on RUN-1103 tip; retarget `develop` after #400
+- RUN-1117 seam only
+
+## Success Criteria
+
+- [ ] Valid ID-JAG → TG session JWT; invalid typ/sig/iss/aud/resource/scope/exp/nbf/jti → `invalid_grant`
+- [ ] `oidc` unchanged; `both` no silent downgrade; `ema` rejects authorize, keeps refresh
+- [ ] EMA advertised only when `ema`|`both`
+- [ ] Principal is `iss`+`sub`; email linking only; RoleScoper works
+- [ ] No grants/tokens/secrets/claims in logs; JWKS from configured URLs only
+- [ ] Docs list confirmed clients (Cursor unconfirmed)

--- a/openspec/changes/run-1112-enterprise-managed-authorization/specs/mcp-enterprise-managed-authorization/spec.md
+++ b/openspec/changes/run-1112-enterprise-managed-authorization/specs/mcp-enterprise-managed-authorization/spec.md
@@ -1,0 +1,106 @@
+# MCP Enterprise-Managed Authorization Specification
+
+## Purpose
+
+Clients exchange an IdP ID-JAG at `/oauth/token` for the TG session JWT. EMA is a jwt-bearer grant on `oauth2` Auth (draft-04).
+
+## Requirements
+
+### Requirement: Northbound mode
+
+`OAuth2Config` MUST accept `northbound_mode` `oidc` (default if empty), `ema`, or `both`. MUST NOT add `TypeEMA`. `oidc` MUST reject jwt-bearer with `unsupported_grant_type`. `ema` MUST reject `/oauth/authorize` and MUST keep `refresh_token`. `both` MUST accept jwt-bearer and OIDC.
+
+#### Scenario: Default oidc rejects jwt-bearer
+- GIVEN empty or omitted `northbound_mode`
+- WHEN a client POSTs jwt-bearer
+- THEN the response is `unsupported_grant_type`
+
+#### Scenario: ema rejects authorize keeps refresh
+- GIVEN `northbound_mode=ema` and a minted session
+- WHEN a client starts `/oauth/authorize`
+- THEN authorize is rejected and `refresh_token` still succeeds
+
+#### Scenario: both accepts either grant
+- GIVEN `northbound_mode=both`
+- WHEN the client uses `authorization_code` or valid jwt-bearer
+- THEN the chosen grant proceeds
+
+### Requirement: EMA metadata advertisement
+
+AS metadata MUST advertise jwt-bearer and `io.modelcontextprotocol/enterprise-managed-authorization` iff mode is `ema` or `both`.
+
+#### Scenario: oidc hides EMA
+- GIVEN `northbound_mode=oidc`
+- WHEN fetching AS metadata
+- THEN jwt-bearer and the EMA extension are absent
+
+#### Scenario: ema and both advertise
+- GIVEN mode `ema` or `both`
+- WHEN fetching AS metadata
+- THEN jwt-bearer and the EMA extension are present
+
+### Requirement: ID-JAG validation
+
+In `ema`|`both`, `/oauth/token` MUST accept jwt-bearer `assertion`. Draft-04 MUST hold: `typ=oauth-id-jag+jwt`; `iss` via `IssuersEqual`; `aud`=`baseURL` (not session audiences); matching `resource`; scopes ⊆ allowed; valid `exp`/`nbf`/`iat`; registered `client_id` (no secret). MUST reject `none`/HMAC. MUST use only configured https JWKS. JWKS refresh errors MUST deny, not cache as success. Failure MUST be `invalid_grant` with no OIDC fallback.
+
+#### Scenario: Valid ID-JAG accepted
+- GIVEN `ema` or `both` and a passing draft-04 ID-JAG
+- WHEN the client POSTs jwt-bearer
+- THEN the grant succeeds
+
+#### Scenario: Invalid claim rejected
+- GIVEN `both` and wrong typ, iss, aud, resource, scope, time, client_id, or alg
+- WHEN the client POSTs jwt-bearer
+- THEN the response is `invalid_grant` and no OIDC fallback starts
+
+#### Scenario: JWKS refresh failure denies
+- GIVEN JWKS refresh fails
+- WHEN the client POSTs jwt-bearer
+- THEN the grant is denied and not cached as success
+
+### Requirement: jti replay protection
+
+Accepted ID-JAG MUST include `jti`, consumed until `exp`. Reuse or store-down MUST deny (`invalid_grant` on reuse).
+
+#### Scenario: Replay rejected
+- GIVEN a consumed `jti` still before `exp`
+- WHEN it is replayed
+- THEN the response is `invalid_grant`
+
+#### Scenario: Store down denies
+- GIVEN the jti store is unavailable
+- WHEN a client POSTs jwt-bearer
+- THEN the grant is denied
+
+### Requirement: Session mint and identity
+
+A valid jwt-bearer MUST `mintSession` (`token_use=mcp_session`, `authid`, `gwid`, session `aud`) and MUST NOT return or propagate the ID-JAG. Primary id MUST be `iss`+`sub` or explicit `subject_claim` (no silent Entra `oid`). Email MAY link; failed link MUST still accept. MUST NOT set `Principal.Subject` from email, map `act`, or add `Principal.Actor`. RoleScoper MUST still evaluate session claims.
+
+#### Scenario: Session minted
+- GIVEN a valid ID-JAG
+- WHEN jwt-bearer succeeds
+- THEN a session JWT (`token_use=mcp_session`) is returned, not the ID-JAG
+
+#### Scenario: Email is linking only
+- GIVEN a valid ID-JAG with unmatched email
+- WHEN jwt-bearer succeeds
+- THEN id is `iss`+`sub` (or `subject_claim`), not email
+
+#### Scenario: act ignored
+- GIVEN a valid ID-JAG that includes `act`
+- WHEN jwt-bearer succeeds
+- THEN `Principal.Actor` is absent and `act` is not mapped
+
+### Requirement: Audit and docs
+
+Accept and deny MUST emit slog without grants, tokens, secrets, claims, or email. Docs MUST cover IdP registration of TG as MCP resource and a Cursor-unconfirmed client matrix.
+
+#### Scenario: Logs omit secrets
+- GIVEN accept or deny of jwt-bearer
+- WHEN slog is emitted
+- THEN no grant, token, secret, claim, or email values appear
+
+#### Scenario: Docs mark Cursor unconfirmed
+- GIVEN the EMA docs
+- WHEN reading the client matrix
+- THEN Cursor is unconfirmed

--- a/openspec/changes/run-1112-enterprise-managed-authorization/tasks.md
+++ b/openspec/changes/run-1112-enterprise-managed-authorization/tasks.md
@@ -1,0 +1,65 @@
+# Tasks: Enterprise-Managed Authorization (RUN-1112)
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | 860–1150 |
+| 400-line budget risk | High |
+| Chained PRs recommended | Yes |
+| Suggested split | PR 1 (200–280) → PR 2 (340–450) → PR 3 (320–420) |
+| Delivery strategy | ask-on-risk |
+| Chain strategy | pending |
+
+Decision needed before apply: No — single PR `size:exception` onto RUN-1103 (same as RUN-1106)
+Chained PRs recommended: Yes
+Chain strategy: pending
+400-line budget risk: High
+
+May prefer one PR (`size:exception`). Else **feature-branch-chain** onto RUN-1103 tip until #400, then `develop`. Never `main`. Split PR 2 if >400.
+
+### Suggested Work Units
+
+| Unit | Goal | Likely PR | Notes |
+|------|------|-----------|-------|
+| 1 | `northbound_mode` + EMA metadata | PR 1 | Base 1103 tip |
+| 2 | ID-JAG + jti + jwt-bearer mint | PR 2 | Base PR 1; impl; overflow risk |
+| 3 | Spec tests + docs + slog | PR 3 | Base PR 2 |
+
+### Locks
+- Approach 1; no `TypeEMA`; configured JWKS only; jti/JWKS fail-closed.
+- Failed jwt-bearer → `invalid_grant`; no OIDC downgrade.
+- Email linking only; id `iss`+`sub`; no `act`/`Principal.Actor`.
+- Advertise iff any oauth2 is `ema`|`both`.
+- Leave `Callback`, omit-iss, vault, southbound untouched.
+
+## Phase 1: Config + metadata (PR 1)
+
+- [x] 1.1 `pkg/domain/auth/config.go`: `NorthboundMode`; empty=`oidc`; validate `oidc`|`ema`|`both`; `ema`|`both` need https JWKS or issuer. No `TypeEMA`.
+- [x] 1.2 `pkg/domain/auth/config_test.go`: mode + https tables.
+- [x] 1.3 `pkg/app/oauth/metadata.go`: jwt-bearer + EMA extension iff any oauth2 is `ema`|`both`. DCR `grant_types` in `pkg/infra/oauth/dcr_registrar.go` when advertising.
+- [x] 1.4 `pkg/app/oauth/metadata_test.go`: oidc hides EMA; ema/both advertise.
+- [x] 1.5 `clean-comments`; `go test ./pkg/domain/auth ./pkg/app/oauth`.
+
+## Phase 2: Validator + jti + grant + mint (PR 2)
+
+- [x] 2.1 Create `pkg/app/oauth/idjag.go`: typ `oauth-id-jag+jwt`; Peek+`IssuersEqual`; `Verify` aud=`baseURL`; configured JWKS; resource/scope/`client_id`/`iat`; reject none/HMAC; slog accept/deny ids only.
+- [x] 2.2 `pkg/app/oauth/proxy_types.go`: `TokenRequest.Assertion`; `FlowStore.ConsumeJTI`; `CodeGrant.Claims`.
+- [x] 2.3 `pkg/infra/oauth/store.go`: `ConsumeJTI` `SET NX` `oauth:jti:{jti}` TTL=exp; exists or Redis err → deny.
+- [x] 2.4 Inject existing `OIDCVerifier` via `NewAuthProxy` + `pkg/container/modules/api.go`. Add `ConsumeJTI` to both `memFlowStore` fakes.
+- [x] 2.5 `pkg/api/handler/http/oauth/token_handler.go`: read form `assertion`.
+- [x] 2.6 `pkg/app/oauth/proxy.go`: `oidc` jwt-bearer → `unsupported_grant_type`; `ema`|`both` validate → `ConsumeJTI` → always `mintSession`; never return ID-JAG; fail → `invalid_grant` (no OIDC fallback). `ema` Authorize → `access_denied`; keep refresh. Subject `subject_claim` or `sub` (never `oid`); email claim only; drop `act`; no `Actor`.
+- [x] 2.7 Compile-green: `go test` oauth + auth + handler packages.
+
+## Phase 3: Spec tests (PR 3)
+
+- [x] 3.1 `pkg/app/oauth/idjag_test.go`: typ/iss/aud/resource/scope/exp/nbf/iat/jti/HMAC/`oid`/act; JWKS refresh deny.
+- [x] 3.2 `pkg/app/oauth/proxy_test.go`: oidc unsupported; both no downgrade; ema reject authorize + refresh OK; mint `mcp_session`; email linking only; `act` ignored.
+- [x] 3.3 `pkg/infra/oauth/store_test.go`: jti NX replay + Redis error deny.
+- [x] 3.4 `pkg/api/handler/http/oauth/handlers_test.go`: form `assertion` forwarded; slog omits secrets.
+
+## Phase 4: Docs + polish (PR 3)
+
+- [x] 4.1 Create `docs/mcp/enterprise-managed-authorization.md`: IdP registers TG resource; Cursor unconfirmed.
+- [x] 4.2 `docs/mcp/oauth-harden.md`: point EMA at this change (replace “not started”).
+- [x] 4.3 `clean-comments`; `go test -race` oauth packages; `go vet ./...`.

--- a/pkg/api/handler/http/oauth/handlers_test.go
+++ b/pkg/api/handler/http/oauth/handlers_test.go
@@ -99,6 +99,8 @@ func (s *memFlowStore) GetSession(context.Context, string) (*appoauth.SessionRec
 
 func (s *memFlowStore) RetireSession(context.Context, string, time.Duration) error { return nil }
 
+func (s *memFlowStore) ConsumeJTI(context.Context, string, time.Time) error { return nil }
+
 func newTestApp(auths ...*authdomain.Auth) *fiber.App {
 	svc := appoauth.NewMetadataService(&fakeCredentialFinder{oauth2: auths}, nil, nil, newMemFlowStore())
 	app := fiber.New()
@@ -284,6 +286,7 @@ func TestRegisterHandlerApplicationType(t *testing.T) {
 type capturingProxy struct {
 	iss string
 	loc string
+	got appoauth.TokenRequest
 }
 
 func (p *capturingProxy) Authorize(context.Context, string, appoauth.AuthorizeRequest) (string, error) {
@@ -295,8 +298,40 @@ func (p *capturingProxy) Callback(_ context.Context, _, _, _, _, _, iss string) 
 	return p.loc, nil
 }
 
-func (p *capturingProxy) Exchange(context.Context, string, appoauth.TokenRequest) (map[string]any, error) {
-	return nil, nil
+func (p *capturingProxy) Exchange(_ context.Context, _ string, req appoauth.TokenRequest) (map[string]any, error) {
+	p.got = req
+	return map[string]any{"token_type": "Bearer"}, nil
+}
+
+func TestTokenHandlerForwardsAssertion(t *testing.T) {
+	t.Parallel()
+	proxy := &capturingProxy{}
+	app := fiber.New()
+	app.Post("/oauth/token", NewTokenHandler(proxy, nil).Handle)
+
+	body := strings.NewReader("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=id-jag.jwt&client_id=agw-1&resource=https%3A%2F%2Fgw.example.com%2Fv1%2Fmcp%2Fdev")
+	req := httptest.NewRequest(fiber.MethodPost, "/oauth/token", body)
+	req.Host = "gw.example.com"
+	req.Header.Set(fiber.HeaderContentType, fiber.MIMEApplicationForm)
+	res, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.StatusCode != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", res.StatusCode)
+	}
+	if proxy.got.GrantType != "urn:ietf:params:oauth:grant-type:jwt-bearer" {
+		t.Fatalf("grant_type = %q", proxy.got.GrantType)
+	}
+	if proxy.got.Assertion != "id-jag.jwt" {
+		t.Fatalf("assertion = %q", proxy.got.Assertion)
+	}
+	if proxy.got.ClientID != "agw-1" {
+		t.Fatalf("client_id = %q", proxy.got.ClientID)
+	}
+	if proxy.got.Resource != "https://gw.example.com/v1/mcp/dev" {
+		t.Fatalf("resource = %q", proxy.got.Resource)
+	}
 }
 
 func TestCallbackHandlerForwardsISS(t *testing.T) {

--- a/pkg/api/handler/http/oauth/token_handler.go
+++ b/pkg/api/handler/http/oauth/token_handler.go
@@ -43,6 +43,7 @@ func (h *TokenHandler) Handle(c *fiber.Ctx) error {
 		CodeVerifier: c.FormValue("code_verifier"),
 		RefreshToken: c.FormValue("refresh_token"),
 		Resource:     c.FormValue("resource"),
+		Assertion:    c.FormValue("assertion"),
 	}
 	ctx := resolver.WithResolvedGateway(c, h.gateways)
 	token, err := h.proxy.Exchange(ctx, c.BaseURL(), req)

--- a/pkg/app/oauth/default_idp_selection_test.go
+++ b/pkg/app/oauth/default_idp_selection_test.go
@@ -130,7 +130,7 @@ func TestCallbackDefaultIdPConsentUsesEffectiveGateway(t *testing.T) {
 	store := newMemFlowStore()
 	chainer := &fakeChainer{url: "http://localhost:8082/oMTXK0qG/mcp/connect?ticket=tk"}
 	finder := &fakeCredentialFinder{oauth2: []*authdomain.Auth{def}, defaultIdP: def}
-	proxy := NewAuthProxy(finder, nil, http.DefaultClient, store, chainer, nil, nil)
+	proxy := NewAuthProxy(finder, nil, http.DefaultClient, store, chainer, nil, nil, nil)
 
 	gw := ids.New[ids.GatewayKind]()
 	state := "state-1"

--- a/pkg/app/oauth/idjag.go
+++ b/pkg/app/oauth/idjag.go
@@ -1,0 +1,239 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oauth
+
+import (
+	"context"
+	"log/slog"
+	"net/url"
+	"strings"
+	"time"
+
+	authdomain "github.com/NeuralTrust/TrustGate/pkg/domain/auth"
+	"github.com/NeuralTrust/TrustGate/pkg/domain/identity"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+const (
+	grantJWTBearer = "urn:ietf:params:oauth:grant-type:jwt-bearer" // #nosec G101 -- OAuth grant type URN, not a credential
+	idJAGTyp       = "oauth-id-jag+jwt"
+	emaExtension   = "io.modelcontextprotocol/enterprise-managed-authorization"
+)
+
+type idjagResult struct {
+	subject string
+	scopes  []string
+	claims  map[string]any
+	jti     string
+	exp     time.Time
+}
+
+func (p *authProxy) validateIDJAG(ctx context.Context, baseURL string, auth *authdomain.Auth, req TokenRequest) (*idjagResult, error) {
+	cfg := auth.Config.OAuth2
+	deny := func(reason string) (*idjagResult, error) {
+		logEMADeny(auth.ID.String(), auth.GatewayID.String(), reason)
+		return nil, oauthErr("invalid_grant", "invalid assertion")
+	}
+
+	typ, alg := jwtHeader(req.Assertion)
+	if !strings.EqualFold(typ, idJAGTyp) {
+		return deny("typ")
+	}
+	if algNoneOrHMAC(alg) {
+		return deny("alg")
+	}
+	if p.verifier == nil {
+		return deny("verifier")
+	}
+
+	hints, err := p.verifier.Peek(req.Assertion)
+	if err != nil {
+		return deny("peek")
+	}
+	if algNoneOrHMAC(hints.Algorithm) {
+		return deny("alg")
+	}
+	if !IssuersEqual(hints.Issuer, cfg.Issuer) {
+		return deny("iss")
+	}
+
+	jwksURL, err := p.configuredJWKSURL(ctx, cfg)
+	if err != nil {
+		return deny("jwks")
+	}
+
+	verified, err := p.verifier.Verify(ctx, req.Assertion, authdomain.OIDCConfig{
+		Issuer:            hints.Issuer,
+		Audiences:         []string{baseURL},
+		JWKSURL:           jwksURL,
+		AllowedAlgorithms: cfg.Algorithms,
+		SubjectClaim:      strings.TrimSpace(cfg.SubjectClaim),
+	})
+	if err != nil {
+		return deny("verify")
+	}
+
+	if !resourceMatches(verified.Claims["resource"], req.Resource) {
+		return deny("resource")
+	}
+	scopes := verified.Scopes
+	if !scopesSubset(scopes, cfg.RequiredScopes) {
+		return deny("scope")
+	}
+	if _, ok := verified.Claims["iat"]; !ok {
+		return deny("iat")
+	}
+	clientClaim := coerceClaim(verified.Claims["client_id"])
+	if clientClaim == "" || clientClaim != req.ClientID {
+		return deny("client_id")
+	}
+	jti := coerceClaim(verified.Claims["jti"])
+	if jti == "" {
+		return deny("jti")
+	}
+	exp, err := jwt.MapClaims(verified.Claims).GetExpirationTime()
+	if err != nil || exp == nil || !exp.After(time.Now()) {
+		return deny("exp")
+	}
+	if nbf, nbfErr := jwt.MapClaims(verified.Claims).GetNotBefore(); nbfErr == nil && nbf != nil && nbf.After(time.Now()) {
+		return deny("nbf")
+	}
+
+	sub := emaSubject(cfg, verified.Claims)
+	if sub == "" {
+		return deny("sub")
+	}
+
+	logEMAAccept(auth.ID.String(), auth.GatewayID.String(), jti)
+	return &idjagResult{
+		subject: sub,
+		scopes:  scopes,
+		claims:  verified.Claims,
+		jti:     jti,
+		exp:     exp.Time,
+	}, nil
+}
+
+func emaSubject(cfg *authdomain.OAuth2Config, claims map[string]any) string {
+	if cfg != nil {
+		if claim := strings.TrimSpace(cfg.SubjectClaim); claim != "" {
+			return coerceClaim(claims[claim])
+		}
+	}
+	return coerceClaim(claims["sub"])
+}
+
+func (p *authProxy) configuredJWKSURL(ctx context.Context, cfg *authdomain.OAuth2Config) (string, error) {
+	if u := strings.TrimSpace(cfg.JWKSURL); u != "" {
+		if !isHTTPSURL(u) {
+			return "", errNotHTTPSJWKS
+		}
+		return u, nil
+	}
+	if p.idp == nil || p.idp.meta == nil {
+		return "", errNotHTTPSJWKS
+	}
+	doc, err := p.idp.meta.fetchASMetadata(ctx, cfg.Issuer)
+	if err != nil {
+		return "", err
+	}
+	jwks, _ := doc["jwks_uri"].(string)
+	if !isHTTPSURL(jwks) {
+		return "", errNotHTTPSJWKS
+	}
+	return jwks, nil
+}
+
+var errNotHTTPSJWKS = oauthErr("invalid_grant", "jwks is not https")
+
+func jwtHeader(raw string) (typ, alg string) {
+	parsed, _, err := jwt.NewParser().ParseUnverified(raw, jwt.MapClaims{})
+	if err != nil || parsed == nil {
+		return "", ""
+	}
+	typ, _ = parsed.Header["typ"].(string)
+	if parsed.Method != nil {
+		alg = parsed.Method.Alg()
+	}
+	return typ, alg
+}
+
+func algNoneOrHMAC(alg string) bool {
+	upper := strings.ToUpper(strings.TrimSpace(alg))
+	return upper == "NONE" || strings.HasPrefix(upper, "HS")
+}
+
+func resourceMatches(claim any, want string) bool {
+	if want == "" {
+		return false
+	}
+	switch v := claim.(type) {
+	case string:
+		return v == want
+	case []string:
+		for _, r := range v {
+			if r == want {
+				return true
+			}
+		}
+	case []any:
+		for _, item := range v {
+			if s, ok := item.(string); ok && s == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func scopesSubset(got, allowed []string) bool {
+	if len(allowed) == 0 {
+		return true
+	}
+	allow := make(map[string]struct{}, len(allowed))
+	for _, s := range allowed {
+		allow[s] = struct{}{}
+	}
+	for _, s := range got {
+		if identity.IsProtocolScope(s) {
+			continue
+		}
+		if _, ok := allow[s]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func isHTTPSURL(raw string) bool {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	return err == nil && u.Scheme == "https" && u.Host != ""
+}
+
+func logEMAAccept(authID, gatewayID, jti string) {
+	slog.Info("oauth.ema.accept",
+		"auth_id", authID,
+		"gateway_id", gatewayID,
+		"jti", jti,
+	)
+}
+
+func logEMADeny(authID, gatewayID, reason string) {
+	slog.Warn("oauth.ema.deny",
+		"auth_id", authID,
+		"gateway_id", gatewayID,
+		"reason", reason,
+	)
+}

--- a/pkg/app/oauth/idjag_test.go
+++ b/pkg/app/oauth/idjag_test.go
@@ -1,0 +1,395 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oauth
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	appauth "github.com/NeuralTrust/TrustGate/pkg/app/auth"
+	authdomain "github.com/NeuralTrust/TrustGate/pkg/domain/auth"
+	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
+)
+
+type stubOIDCVerifier struct {
+	hints       appauth.TokenHints
+	peekErr     error
+	verified    *appauth.VerifiedClaims
+	verifyErr   error
+	lastCfg     authdomain.OIDCConfig
+	verifyCalls int
+}
+
+func (s *stubOIDCVerifier) Peek(string) (appauth.TokenHints, error) {
+	if s.peekErr != nil {
+		return appauth.TokenHints{}, s.peekErr
+	}
+	return s.hints, nil
+}
+
+func (s *stubOIDCVerifier) Verify(_ context.Context, _ string, cfg authdomain.OIDCConfig) (*appauth.VerifiedClaims, error) {
+	s.verifyCalls++
+	s.lastCfg = cfg
+	if s.verifyErr != nil {
+		return nil, s.verifyErr
+	}
+	return s.verified, nil
+}
+
+func jagJWT(typ, alg string) string {
+	header, _ := json.Marshal(map[string]string{"typ": typ, "alg": alg})
+	payload, _ := json.Marshal(map[string]any{"sub": "x"})
+	enc := func(b []byte) string { return base64.RawURLEncoding.EncodeToString(b) }
+	return enc(header) + "." + enc(payload) + ".sig"
+}
+
+func validJAGClaims(now time.Time, extra map[string]any) map[string]any {
+	c := map[string]any{
+		"sub":       "user-1",
+		"iss":       "https://idp.example.com",
+		"aud":       "https://gw.example.com",
+		"resource":  "https://gw.example.com/v1/mcp/dev",
+		"client_id": "agw-client",
+		"jti":       "jti-1",
+		"iat":       float64(now.Unix()),
+		"exp":       float64(now.Add(time.Hour).Unix()),
+		"email":     "nobody@example.com",
+	}
+	for k, v := range extra {
+		if v == nil {
+			delete(c, k)
+			continue
+		}
+		c[k] = v
+	}
+	return c
+}
+
+func emaAuth(t *testing.T, cfg authdomain.OAuth2Config) *authdomain.Auth {
+	t.Helper()
+	if cfg.Issuer == "" {
+		cfg.Issuer = "https://idp.example.com"
+	}
+	if cfg.JWKSURL == "" {
+		cfg.JWKSURL = "https://idp.example.com/jwks"
+	}
+	if cfg.RequiredScopes == nil {
+		cfg.RequiredScopes = []string{"mcp.access"}
+	}
+	return &authdomain.Auth{
+		ID:        ids.New[ids.AuthKind](),
+		GatewayID: ids.New[ids.GatewayKind](),
+		Type:      authdomain.TypeOAuth2,
+		Enabled:   true,
+		Config:    authdomain.Config{OAuth2: &cfg},
+	}
+}
+
+func TestValidateIDJAG(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	baseURL := "https://gw.example.com"
+	resource := "https://gw.example.com/v1/mcp/dev"
+	goodClaims := validJAGClaims(now, nil)
+	goodHints := appauth.TokenHints{Issuer: "https://idp.example.com", Algorithm: "RS256"}
+
+	tests := []struct {
+		name      string
+		typ       string
+		alg       string
+		hints     appauth.TokenHints
+		peekErr   error
+		claims    map[string]any
+		scopes    []string
+		verifyErr error
+		jwks      string
+		subject   string
+		req       TokenRequest
+		wantCode  string
+		wantAud   string
+	}{
+		{
+			name:    "valid",
+			typ:     idJAGTyp,
+			alg:     "RS256",
+			hints:   goodHints,
+			claims:  goodClaims,
+			scopes:  []string{"mcp.access", "openid"},
+			req:     TokenRequest{ClientID: "agw-client", Resource: resource},
+			wantAud: baseURL,
+		},
+		{
+			name:     "wrong typ",
+			typ:      "JWT",
+			alg:      "RS256",
+			hints:    goodHints,
+			claims:   goodClaims,
+			scopes:   []string{"mcp.access"},
+			req:      TokenRequest{ClientID: "agw-client", Resource: resource},
+			wantCode: "invalid_grant",
+		},
+		{
+			name:     "hmac",
+			typ:      idJAGTyp,
+			alg:      "HS256",
+			hints:    goodHints,
+			claims:   goodClaims,
+			scopes:   []string{"mcp.access"},
+			req:      TokenRequest{ClientID: "agw-client", Resource: resource},
+			wantCode: "invalid_grant",
+		},
+		{
+			name:     "none alg",
+			typ:      idJAGTyp,
+			alg:      "none",
+			hints:    goodHints,
+			claims:   goodClaims,
+			scopes:   []string{"mcp.access"},
+			req:      TokenRequest{ClientID: "agw-client", Resource: resource},
+			wantCode: "invalid_grant",
+		},
+		{
+			name:     "iss mismatch",
+			typ:      idJAGTyp,
+			alg:      "RS256",
+			hints:    appauth.TokenHints{Issuer: "https://other.example.com", Algorithm: "RS256"},
+			claims:   goodClaims,
+			scopes:   []string{"mcp.access"},
+			req:      TokenRequest{ClientID: "agw-client", Resource: resource},
+			wantCode: "invalid_grant",
+		},
+		{
+			name:      "aud rejected by verifier",
+			typ:       idJAGTyp,
+			alg:       "RS256",
+			hints:     goodHints,
+			claims:    goodClaims,
+			scopes:    []string{"mcp.access"},
+			verifyErr: errors.New("audience"),
+			req:       TokenRequest{ClientID: "agw-client", Resource: resource},
+			wantCode:  "invalid_grant",
+			wantAud:   baseURL,
+		},
+		{
+			name:     "resource mismatch",
+			typ:      idJAGTyp,
+			alg:      "RS256",
+			hints:    goodHints,
+			claims:   validJAGClaims(now, map[string]any{"resource": "https://other.example.com/mcp"}),
+			scopes:   []string{"mcp.access"},
+			req:      TokenRequest{ClientID: "agw-client", Resource: resource},
+			wantCode: "invalid_grant",
+		},
+		{
+			name:     "scope extra",
+			typ:      idJAGTyp,
+			alg:      "RS256",
+			hints:    goodHints,
+			claims:   goodClaims,
+			scopes:   []string{"mcp.access", "admin"},
+			req:      TokenRequest{ClientID: "agw-client", Resource: resource},
+			wantCode: "invalid_grant",
+		},
+		{
+			name:     "missing iat",
+			typ:      idJAGTyp,
+			alg:      "RS256",
+			hints:    goodHints,
+			claims:   validJAGClaims(now, map[string]any{"iat": nil}),
+			scopes:   []string{"mcp.access"},
+			req:      TokenRequest{ClientID: "agw-client", Resource: resource},
+			wantCode: "invalid_grant",
+		},
+		{
+			name:     "expired",
+			typ:      idJAGTyp,
+			alg:      "RS256",
+			hints:    goodHints,
+			claims:   validJAGClaims(now, map[string]any{"exp": float64(now.Add(-time.Minute).Unix())}),
+			scopes:   []string{"mcp.access"},
+			req:      TokenRequest{ClientID: "agw-client", Resource: resource},
+			wantCode: "invalid_grant",
+		},
+		{
+			name:     "future nbf",
+			typ:      idJAGTyp,
+			alg:      "RS256",
+			hints:    goodHints,
+			claims:   validJAGClaims(now, map[string]any{"nbf": float64(now.Add(time.Hour).Unix())}),
+			scopes:   []string{"mcp.access"},
+			req:      TokenRequest{ClientID: "agw-client", Resource: resource},
+			wantCode: "invalid_grant",
+		},
+		{
+			name:     "missing jti",
+			typ:      idJAGTyp,
+			alg:      "RS256",
+			hints:    goodHints,
+			claims:   validJAGClaims(now, map[string]any{"jti": nil}),
+			scopes:   []string{"mcp.access"},
+			req:      TokenRequest{ClientID: "agw-client", Resource: resource},
+			wantCode: "invalid_grant",
+		},
+		{
+			name:     "oid is not silent subject",
+			typ:      idJAGTyp,
+			alg:      "RS256",
+			hints:    goodHints,
+			claims:   validJAGClaims(now, map[string]any{"sub": nil, "oid": "entra-oid"}),
+			scopes:   []string{"mcp.access"},
+			req:      TokenRequest{ClientID: "agw-client", Resource: resource},
+			wantCode: "invalid_grant",
+		},
+		{
+			name:    "act ignored on accept",
+			typ:     idJAGTyp,
+			alg:     "RS256",
+			hints:   goodHints,
+			claims:  validJAGClaims(now, map[string]any{"act": map[string]any{"sub": "actor"}}),
+			scopes:  []string{"mcp.access"},
+			req:     TokenRequest{ClientID: "agw-client", Resource: resource},
+			wantAud: baseURL,
+		},
+		{
+			name:      "jwks refresh deny",
+			typ:       idJAGTyp,
+			alg:       "RS256",
+			hints:     goodHints,
+			claims:    goodClaims,
+			scopes:    []string{"mcp.access"},
+			verifyErr: errors.New("jwks refresh failed"),
+			req:       TokenRequest{ClientID: "agw-client", Resource: resource},
+			wantCode:  "invalid_grant",
+		},
+		{
+			name:     "http jwks denied",
+			typ:      idJAGTyp,
+			alg:      "RS256",
+			hints:    goodHints,
+			claims:   goodClaims,
+			scopes:   []string{"mcp.access"},
+			jwks:     "http://idp.example.com/jwks",
+			req:      TokenRequest{ClientID: "agw-client", Resource: resource},
+			wantCode: "invalid_grant",
+		},
+		{
+			name:     "client_id mismatch",
+			typ:      idJAGTyp,
+			alg:      "RS256",
+			hints:    goodHints,
+			claims:   goodClaims,
+			scopes:   []string{"mcp.access"},
+			req:      TokenRequest{ClientID: "other-client", Resource: resource},
+			wantCode: "invalid_grant",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			stub := &stubOIDCVerifier{
+				hints:     tc.hints,
+				peekErr:   tc.peekErr,
+				verifyErr: tc.verifyErr,
+			}
+			if tc.claims != nil {
+				stub.verified = &appauth.VerifiedClaims{Subject: "user-1", Claims: tc.claims, Scopes: tc.scopes}
+			}
+			cfg := authdomain.OAuth2Config{}
+			if tc.jwks != "" {
+				cfg.JWKSURL = tc.jwks
+			}
+			auth := emaAuth(t, cfg)
+			p := &authProxy{verifier: stub}
+			req := tc.req
+			req.Assertion = jagJWT(tc.typ, tc.alg)
+			got, err := p.validateIDJAG(context.Background(), baseURL, auth, req)
+			if tc.wantCode != "" {
+				var oe *OAuthError
+				if !errors.As(err, &oe) || oe.Code != tc.wantCode {
+					t.Fatalf("error = %v, want %s", err, tc.wantCode)
+				}
+				if got != nil {
+					t.Fatal("expected no result on deny")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.subject != "user-1" {
+				t.Fatalf("subject = %q", got.subject)
+			}
+			if tc.wantAud != "" {
+				if len(stub.lastCfg.Audiences) != 1 || stub.lastCfg.Audiences[0] != tc.wantAud {
+					t.Fatalf("verify aud = %v, want [%s]", stub.lastCfg.Audiences, tc.wantAud)
+				}
+				if stub.lastCfg.JWKSURL != auth.Config.OAuth2.JWKSURL {
+					t.Fatalf("verify jwks = %q, want configured %q", stub.lastCfg.JWKSURL, auth.Config.OAuth2.JWKSURL)
+				}
+			}
+		})
+	}
+}
+
+func TestEMALogsOmitSecrets(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	now := time.Now()
+	claims := validJAGClaims(now, map[string]any{"email": "secret.user@example.com"})
+	stub := &stubOIDCVerifier{
+		hints:    appauth.TokenHints{Issuer: "https://idp.example.com", Algorithm: "RS256"},
+		verified: &appauth.VerifiedClaims{Subject: "user-1", Claims: claims, Scopes: []string{"mcp.access"}},
+	}
+	auth := emaAuth(t, authdomain.OAuth2Config{})
+	p := &authProxy{verifier: stub}
+	req := TokenRequest{
+		Assertion: jagJWT(idJAGTyp, "RS256"),
+		ClientID:  "agw-client",
+		Resource:  "https://gw.example.com/v1/mcp/dev",
+		GrantType: grantJWTBearer,
+	}
+	if _, err := p.validateIDJAG(context.Background(), "https://gw.example.com", auth, req); err != nil {
+		t.Fatalf("accept: %v", err)
+	}
+	req.Assertion = jagJWT("JWT", "RS256")
+	if _, err := p.validateIDJAG(context.Background(), "https://gw.example.com", auth, req); err == nil {
+		t.Fatal("expected deny")
+	}
+	logs := buf.String()
+	forbidden := []string{
+		grantJWTBearer,
+		"secret.user@example.com",
+		"nobody@example.com",
+	}
+	for _, s := range forbidden {
+		if s != "" && strings.Contains(logs, s) {
+			t.Fatalf("log leaked %q: %s", s, logs)
+		}
+	}
+	if !strings.Contains(logs, "oauth.ema.accept") || !strings.Contains(logs, "oauth.ema.deny") {
+		t.Fatalf("expected accept and deny events, got %s", logs)
+	}
+}

--- a/pkg/app/oauth/metadata.go
+++ b/pkg/app/oauth/metadata.go
@@ -147,10 +147,13 @@ func (s *metadataService) AuthorizationServer(ctx context.Context, baseURL strin
 		"token_endpoint":                                 baseURL + "/oauth/token",
 		"registration_endpoint":                          baseURL + "/oauth/register",
 		"response_types_supported":                       []string{"code"},
-		"grant_types_supported":                          []string{"authorization_code", "refresh_token"},
+		"grant_types_supported":                          grantTypesSupported(auths),
 		"code_challenge_methods_supported":               []string{"S256"},
 		"token_endpoint_auth_methods_supported":          []string{"none"},
 		"authorization_response_iss_parameter_supported": true,
+	}
+	if advertisesEMA(auths) {
+		doc[emaExtension] = true
 	}
 	if scopes := scopesOf(auths); len(scopes) > 0 {
 		doc["scopes_supported"] = scopes
@@ -198,7 +201,7 @@ func (s *metadataService) RegisterClient(ctx context.Context, req RegisterReques
 		RedirectURIs:            client.RedirectURIs,
 		ClientName:              client.ClientName,
 		ApplicationType:         appType,
-		GrantTypes:              []string{"authorization_code", "refresh_token"},
+		GrantTypes:              grantTypesSupported(auths),
 		ResponseTypes:           []string{"code"},
 		TokenEndpointAuthMethod: "none",
 	}, nil
@@ -343,4 +346,24 @@ func scopesOf(auths []*authdomain.Auth) []string {
 		}
 	}
 	return out
+}
+
+func advertisesEMA(auths []*authdomain.Auth) bool {
+	for _, a := range auths {
+		if a == nil || a.Config.OAuth2 == nil {
+			continue
+		}
+		if a.Config.OAuth2.AdvertisesEMA() {
+			return true
+		}
+	}
+	return false
+}
+
+func grantTypesSupported(auths []*authdomain.Auth) []string {
+	grants := []string{"authorization_code", "refresh_token"}
+	if advertisesEMA(auths) {
+		grants = append(grants, grantJWTBearer)
+	}
+	return grants
 }

--- a/pkg/app/oauth/metadata_test.go
+++ b/pkg/app/oauth/metadata_test.go
@@ -225,6 +225,69 @@ func TestRegisterClient(t *testing.T) {
 	}
 }
 
+func TestAuthorizationServerMetadataEMAAdvertisement(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		mode      string
+		wantEMA   bool
+		wantGrant bool
+	}{
+		{name: "empty oidc hides", mode: "", wantEMA: false, wantGrant: false},
+		{name: "oidc hides", mode: authdomain.NorthboundModeOIDC, wantEMA: false, wantGrant: false},
+		{name: "ema advertises", mode: authdomain.NorthboundModeEMA, wantEMA: true, wantGrant: true},
+		{name: "both advertises", mode: authdomain.NorthboundModeBoth, wantEMA: true, wantGrant: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			finder := &fakeCredentialFinder{oauth2: []*authdomain.Auth{
+				oauth2Auth(t, authdomain.OAuth2Config{
+					Issuer:         "https://idp.example.com",
+					ClientID:       "mcp-public-client",
+					NorthboundMode: tc.mode,
+				}),
+			}}
+			svc := NewMetadataService(finder, nil, nil, newMemFlowStore())
+			doc, err := svc.AuthorizationServer(context.Background(), "https://gw.example.com")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			_, hasExt := doc[emaExtension]
+			if hasExt != tc.wantEMA {
+				t.Fatalf("extension present = %v, want %v", hasExt, tc.wantEMA)
+			}
+			grants, _ := doc["grant_types_supported"].([]string)
+			hasJWT := false
+			for _, g := range grants {
+				if g == grantJWTBearer {
+					hasJWT = true
+					break
+				}
+			}
+			if hasJWT != tc.wantGrant {
+				t.Fatalf("jwt-bearer present = %v, want %v (grants=%v)", hasJWT, tc.wantGrant, grants)
+			}
+			reg, err := svc.RegisterClient(context.Background(), RegisterRequest{
+				RedirectURIs: []string{"cursor://anysphere.cursor-mcp/oauth/callback"},
+			})
+			if err != nil {
+				t.Fatalf("register: %v", err)
+			}
+			regHas := false
+			for _, g := range reg.GrantTypes {
+				if g == grantJWTBearer {
+					regHas = true
+					break
+				}
+			}
+			if regHas != tc.wantGrant {
+				t.Fatalf("DCR grant_types jwt-bearer = %v, want %v (%v)", regHas, tc.wantGrant, reg.GrantTypes)
+			}
+		})
+	}
+}
+
 func TestRegisterClientAcceptsPrivateUseRedirects(t *testing.T) {
 	t.Parallel()
 	finder := &fakeCredentialFinder{oauth2: []*authdomain.Auth{

--- a/pkg/app/oauth/proxy.go
+++ b/pkg/app/oauth/proxy.go
@@ -44,6 +44,7 @@ type authProxy struct {
 	chainer     ConsentChainer
 	signer      appsts.TokenSigner
 	userinfo    UserInfoClient
+	verifier    appauth.OIDCVerifier
 }
 
 func NewAuthProxy(
@@ -54,6 +55,7 @@ func NewAuthProxy(
 	chainer ConsentChainer,
 	signer appsts.TokenSigner,
 	userinfo UserInfoClient,
+	verifier appauth.OIDCVerifier,
 ) AuthProxy {
 	if client == nil {
 		client = &http.Client{Timeout: 15 * time.Second}
@@ -67,6 +69,7 @@ func NewAuthProxy(
 		chainer:     chainer,
 		signer:      signer,
 		userinfo:    userinfo,
+		verifier:    verifier,
 	}
 }
 
@@ -85,6 +88,9 @@ func (p *authProxy) Authorize(ctx context.Context, baseURL string, req Authorize
 		return "", err
 	}
 	cfg := auth.Config.OAuth2
+	if cfg != nil && cfg.EffectiveNorthboundMode() == authdomain.NorthboundModeEMA {
+		return "", oauthErr("access_denied", "authorization code flow is disabled for this identity provider")
+	}
 	if err := p.validateClientRedirect(ctx, req.ClientID, req.RedirectURI); err != nil {
 		return "", err
 	}
@@ -338,9 +344,78 @@ func (p *authProxy) Exchange(ctx context.Context, baseURL string, req TokenReque
 		return p.exchangeCode(ctx, req)
 	case "refresh_token":
 		return p.refresh(ctx, req)
+	case grantJWTBearer:
+		return p.exchangeJWTBearer(ctx, baseURL, req)
 	default:
 		return nil, oauthErr("unsupported_grant_type", "supported: authorization_code, refresh_token")
 	}
+}
+
+func (p *authProxy) exchangeJWTBearer(ctx context.Context, baseURL string, req TokenRequest) (map[string]any, error) {
+	if strings.TrimSpace(req.Assertion) == "" {
+		return nil, oauthErr("invalid_request", "assertion is required")
+	}
+	auth, err := p.authForResource(ctx, req.Resource)
+	if err != nil {
+		return nil, err
+	}
+	cfg := auth.Config.OAuth2
+	if cfg == nil || cfg.EffectiveNorthboundMode() == authdomain.NorthboundModeOIDC {
+		return nil, oauthErr("unsupported_grant_type", "supported: authorization_code, refresh_token")
+	}
+	if req.ClientID == "" {
+		return nil, oauthErr("invalid_client", "client_id is required")
+	}
+	if p.store == nil {
+		logEMADeny(auth.ID.String(), auth.GatewayID.String(), "store")
+		return nil, oauthErr("invalid_grant", "invalid assertion")
+	}
+	client, err := p.store.GetGatewayClient(ctx, req.ClientID)
+	if err != nil {
+		return nil, fmt.Errorf("oauth: load client registration: %w", err)
+	}
+	if client == nil {
+		return nil, oauthErr("invalid_client", "unknown client_id; register via /oauth/register")
+	}
+	jag, err := p.validateIDJAG(ctx, baseURL, auth, req)
+	if err != nil {
+		return nil, err
+	}
+	if err := p.store.ConsumeJTI(ctx, jag.jti, jag.exp); err != nil {
+		logEMADeny(auth.ID.String(), auth.GatewayID.String(), "jti")
+		return nil, oauthErr("invalid_grant", "invalid assertion")
+	}
+	grant := CodeGrant{
+		ClientID:    req.ClientID,
+		Subject:     jag.subject,
+		AuthID:      auth.ID.String(),
+		GatewayID:   auth.GatewayID.String(),
+		Audiences:   cfg.Audiences,
+		Scopes:      jag.scopes,
+		SessionMode: true,
+		Claims:      jag.claims,
+	}
+	resp, err := p.mintSession(grant)
+	if err != nil {
+		return nil, err
+	}
+	token, err := randomToken()
+	if err != nil {
+		return nil, err
+	}
+	refresh := gatewayRefreshPrefix + token
+	rec := SessionRecord{
+		Subject:   grant.Subject,
+		Scopes:    grant.Scopes,
+		GatewayID: grant.GatewayID,
+		AuthID:    grant.AuthID,
+		Audiences: grant.Audiences,
+	}
+	if err := p.store.SaveSession(ctx, refresh, rec); err != nil {
+		return nil, fmt.Errorf("oauth: persist session: %w", err)
+	}
+	resp["refresh_token"] = refresh
+	return resp, nil
 }
 
 func (p *authProxy) exchangeCode(ctx context.Context, req TokenRequest) (map[string]any, error) {
@@ -390,12 +465,19 @@ func (p *authProxy) exchangeCode(ctx context.Context, req TokenRequest) (map[str
 }
 
 func (p *authProxy) mintSession(grant CodeGrant) (map[string]any, error) {
-	claims := jwt.MapClaims{
-		"sub":       grant.Subject,
-		"scope":     strings.Join(grant.Scopes, " "),
-		"authid":    grant.AuthID,
-		"token_use": "mcp_session",
+	claims := jwt.MapClaims{}
+	for k, v := range grant.Claims {
+		switch k {
+		case "act", "jti", "client_id":
+			continue
+		default:
+			claims[k] = v
+		}
 	}
+	claims["sub"] = grant.Subject
+	claims["scope"] = strings.Join(grant.Scopes, " ")
+	claims["authid"] = grant.AuthID
+	claims["token_use"] = "mcp_session"
 	// gwid binds the session to the gateway the login was brokered for. It is
 	// authoritative for the built-in default identity provider, whose synthetic
 	// auth record carries no gateway of its own.

--- a/pkg/app/oauth/proxy_ema_test.go
+++ b/pkg/app/oauth/proxy_ema_test.go
@@ -1,0 +1,255 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oauth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	appauth "github.com/NeuralTrust/TrustGate/pkg/app/auth"
+	authdomain "github.com/NeuralTrust/TrustGate/pkg/domain/auth"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func setupEMAProxy(t *testing.T, mode string, stub appauth.OIDCVerifier, store *memFlowStore) (AuthProxy, *memFlowStore, *authdomain.Auth) {
+	t.Helper()
+	auth := enabledOAuth2Auth(t, authdomain.OAuth2Config{
+		Issuer:         "https://idp.example.com",
+		JWKSURL:        "https://idp.example.com/jwks",
+		NorthboundMode: mode,
+		Audiences:      []string{"api://gw"},
+		RequiredScopes: []string{"mcp.access"},
+		ClientID:       "gw-client-id",
+	})
+	if store == nil {
+		store = newMemFlowStore()
+	}
+	if err := store.SaveGatewayClient(context.Background(), RegisteredGatewayClient{ClientID: "agw-client"}); err != nil {
+		t.Fatalf("save client: %v", err)
+	}
+	finder := &fakeCredentialFinder{oauth2: []*authdomain.Auth{auth}}
+	proxy := NewAuthProxy(finder, nil, http.DefaultClient, store, nil, newTestSigner(t), nil, stub)
+	return proxy, store, auth
+}
+
+func validBearerReq(t *testing.T, stub *stubOIDCVerifier) TokenRequest {
+	t.Helper()
+	now := time.Now()
+	claims := validJAGClaims(now, nil)
+	stub.hints = appauth.TokenHints{Issuer: "https://idp.example.com", Algorithm: "RS256"}
+	stub.verified = &appauth.VerifiedClaims{Subject: "user-1", Claims: claims, Scopes: []string{"mcp.access"}}
+	return TokenRequest{
+		GrantType: grantJWTBearer,
+		Assertion: jagJWT(idJAGTyp, "RS256"),
+		ClientID:  "agw-client",
+		Resource:  "https://gw.example.com/v1/mcp/dev",
+	}
+}
+
+func parseSessionClaims(t *testing.T, accessToken string) jwt.MapClaims {
+	t.Helper()
+	parsed, _, err := jwt.NewParser().ParseUnverified(accessToken, jwt.MapClaims{})
+	if err != nil {
+		t.Fatalf("parse session: %v", err)
+	}
+	claims, ok := parsed.Claims.(jwt.MapClaims)
+	if !ok {
+		t.Fatal("expected map claims")
+	}
+	return claims
+}
+
+func TestOIDCRejectsJWTBearer(t *testing.T) {
+	t.Parallel()
+	for _, mode := range []string{"", authdomain.NorthboundModeOIDC} {
+		t.Run("mode_"+mode, func(t *testing.T) {
+			t.Parallel()
+			proxy, _, _ := setupEMAProxy(t, mode, &stubOIDCVerifier{}, nil)
+			_, err := proxy.Exchange(context.Background(), "https://gw.example.com", TokenRequest{
+				GrantType: grantJWTBearer,
+				Assertion: jagJWT(idJAGTyp, "RS256"),
+				ClientID:  "agw-client",
+				Resource:  "https://gw.example.com/v1/mcp/dev",
+			})
+			var oe *OAuthError
+			if !errors.As(err, &oe) || oe.Code != "unsupported_grant_type" {
+				t.Fatalf("got %v, want unsupported_grant_type", err)
+			}
+		})
+	}
+}
+
+func TestBothJWTBearerNoOIDCDowngrade(t *testing.T) {
+	t.Parallel()
+	stub := &stubOIDCVerifier{
+		hints: appauth.TokenHints{Issuer: "https://idp.example.com", Algorithm: "RS256"},
+	}
+	proxy, _, _ := setupEMAProxy(t, authdomain.NorthboundModeBoth, stub, nil)
+	_, err := proxy.Exchange(context.Background(), "https://gw.example.com", TokenRequest{
+		GrantType: grantJWTBearer,
+		Assertion: jagJWT("JWT", "RS256"),
+		ClientID:  "agw-client",
+		Resource:  "https://gw.example.com/v1/mcp/dev",
+	})
+	var oe *OAuthError
+	if !errors.As(err, &oe) || oe.Code != "invalid_grant" {
+		t.Fatalf("got %v, want invalid_grant with no OIDC fallback", err)
+	}
+}
+
+func TestEMARejectsAuthorizeKeepsRefresh(t *testing.T) {
+	t.Parallel()
+	store := newMemFlowStore()
+	proxy, _, auth := setupEMAProxy(t, authdomain.NorthboundModeEMA, &stubOIDCVerifier{}, store)
+	_, err := proxy.Authorize(context.Background(), "https://gw.example.com", AuthorizeRequest{
+		ResponseType:        "code",
+		ClientID:            "agw-client",
+		RedirectURI:         "https://127.0.0.1/cb",
+		CodeChallenge:       s256("verifier"),
+		CodeChallengeMethod: "S256",
+	})
+	var oe *OAuthError
+	if !errors.As(err, &oe) || oe.Code != "access_denied" {
+		t.Fatalf("authorize = %v, want access_denied", err)
+	}
+
+	refresh := gatewayRefreshPrefix + "keep"
+	if err := store.SaveSession(context.Background(), refresh, SessionRecord{
+		Subject:   "user-1",
+		Scopes:    []string{"mcp.access"},
+		GatewayID: auth.GatewayID.String(),
+		AuthID:    auth.ID.String(),
+		Audiences: []string{"api://gw"},
+	}); err != nil {
+		t.Fatalf("save session: %v", err)
+	}
+	resp, err := proxy.Exchange(context.Background(), "https://gw.example.com", TokenRequest{
+		GrantType:    "refresh_token",
+		RefreshToken: refresh,
+	})
+	if err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+	if resp["access_token"] == nil {
+		t.Fatal("expected a minted session on refresh")
+	}
+}
+
+func TestJWTBearerMintsSessionNotIDJAG(t *testing.T) {
+	t.Parallel()
+	stub := &stubOIDCVerifier{}
+	proxy, store, auth := setupEMAProxy(t, authdomain.NorthboundModeBoth, stub, nil)
+	req := validBearerReq(t, stub)
+	req.Assertion = jagJWT(idJAGTyp, "RS256")
+	resp, err := proxy.Exchange(context.Background(), "https://gw.example.com", req)
+	if err != nil {
+		t.Fatalf("exchange: %v", err)
+	}
+	access, _ := resp["access_token"].(string)
+	if access == "" || access == req.Assertion {
+		t.Fatal("must mint a session JWT, not return the ID-JAG")
+	}
+	claims := parseSessionClaims(t, access)
+	if claims["token_use"] != "mcp_session" {
+		t.Fatalf("token_use = %v", claims["token_use"])
+	}
+	if claims["sub"] != "user-1" {
+		t.Fatalf("sub = %v, want iss+sub identity not email", claims["sub"])
+	}
+	if claims["sub"] == "nobody@example.com" {
+		t.Fatal("email must not become the subject")
+	}
+	if claims["authid"] != auth.ID.String() {
+		t.Fatalf("authid = %v", claims["authid"])
+	}
+	if claims["gwid"] != auth.GatewayID.String() {
+		t.Fatalf("gwid = %v", claims["gwid"])
+	}
+	refresh, _ := resp["refresh_token"].(string)
+	if !strings.HasPrefix(refresh, gatewayRefreshPrefix) {
+		t.Fatalf("refresh = %q", refresh)
+	}
+	if rec := store.peekSession(refresh); rec == nil {
+		t.Fatal("expected persisted session")
+	}
+}
+
+func TestJWTBearerEmailLinkingOnlyAndActDropped(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	claims := validJAGClaims(now, map[string]any{
+		"email": "unmatched@example.com",
+		"act":   map[string]any{"sub": "delegate"},
+	})
+	stub := &stubOIDCVerifier{
+		hints:    appauth.TokenHints{Issuer: "https://idp.example.com", Algorithm: "RS256"},
+		verified: &appauth.VerifiedClaims{Subject: "user-1", Claims: claims, Scopes: []string{"mcp.access"}},
+	}
+	proxy, _, _ := setupEMAProxy(t, authdomain.NorthboundModeEMA, stub, nil)
+	resp, err := proxy.Exchange(context.Background(), "https://gw.example.com", TokenRequest{
+		GrantType: grantJWTBearer,
+		Assertion: jagJWT(idJAGTyp, "RS256"),
+		ClientID:  "agw-client",
+		Resource:  "https://gw.example.com/v1/mcp/dev",
+	})
+	if err != nil {
+		t.Fatalf("exchange: %v", err)
+	}
+	session := parseSessionClaims(t, resp["access_token"].(string))
+	if session["sub"] != "user-1" {
+		t.Fatalf("sub = %v", session["sub"])
+	}
+	if session["sub"] == "unmatched@example.com" {
+		t.Fatal("email must not replace subject")
+	}
+	if _, ok := session["act"]; ok {
+		t.Fatal("act must not be copied into the session")
+	}
+	if session["jti"] == "jti-1" {
+		t.Fatal("assertion jti must not be copied into the session")
+	}
+}
+
+func TestJWTBearerJTIReplayAndStoreDown(t *testing.T) {
+	t.Parallel()
+	stub := &stubOIDCVerifier{}
+	store := newMemFlowStore()
+	proxy, _, _ := setupEMAProxy(t, authdomain.NorthboundModeBoth, stub, store)
+	req := validBearerReq(t, stub)
+	if _, err := proxy.Exchange(context.Background(), "https://gw.example.com", req); err != nil {
+		t.Fatalf("first exchange: %v", err)
+	}
+	_, err := proxy.Exchange(context.Background(), "https://gw.example.com", req)
+	var oe *OAuthError
+	if !errors.As(err, &oe) || oe.Code != "invalid_grant" {
+		t.Fatalf("replay = %v, want invalid_grant", err)
+	}
+
+	store.jtis = map[string]struct{}{}
+	store.jtiErr = errors.New("redis down")
+	_, err = proxy.Exchange(context.Background(), "https://gw.example.com", TokenRequest{
+		GrantType: grantJWTBearer,
+		Assertion: jagJWT(idJAGTyp, "RS256"),
+		ClientID:  "agw-client",
+		Resource:  "https://gw.example.com/v1/mcp/dev",
+	})
+	if !errors.As(err, &oe) || oe.Code != "invalid_grant" {
+		t.Fatalf("store down = %v, want invalid_grant", err)
+	}
+}

--- a/pkg/app/oauth/proxy_functional_test.go
+++ b/pkg/app/oauth/proxy_functional_test.go
@@ -90,7 +90,7 @@ func githubSessionProxy(t *testing.T, idpURL string, signer *infrasts.Signer, ch
 			RequiredScopes: []string{"mcp.access"},
 		}),
 	}}
-	return NewAuthProxy(finder, nil, http.DefaultClient, newMemFlowStore(), chainer, signer, httpUserInfo{http.DefaultClient})
+	return NewAuthProxy(finder, nil, http.DefaultClient, newMemFlowStore(), chainer, signer, httpUserInfo{http.DefaultClient}, nil)
 }
 
 func exchangeCodeFrom(t *testing.T, resumeURL string) string {
@@ -295,7 +295,7 @@ func TestSessionFlowGitHubExplicitEndpointsNoDiscovery(t *testing.T) {
 			TokenURL:       idp.URL + "/login/oauth/access_token",
 		}),
 	}}
-	proxy := NewAuthProxy(finder, nil, http.DefaultClient, newMemFlowStore(), &fakeChainer{url: ""}, signer, httpUserInfo{http.DefaultClient})
+	proxy := NewAuthProxy(finder, nil, http.DefaultClient, newMemFlowStore(), &fakeChainer{url: ""}, signer, httpUserInfo{http.DefaultClient}, nil)
 	ctx := context.Background()
 
 	location, err := proxy.Authorize(ctx, "http://gw.example.com", AuthorizeRequest{

--- a/pkg/app/oauth/proxy_session_test.go
+++ b/pkg/app/oauth/proxy_session_test.go
@@ -197,7 +197,7 @@ func TestCallbackSessionModeEmptySubjectDenied(t *testing.T) {
 	store := newMemFlowStore()
 	userinfo := &fakeUserInfo{info: map[string]any{"login": "octocat"}}
 	finder := &fakeCredentialFinder{oauth2: []*authdomain.Auth{sessionAuth(t, idp.URL)}}
-	proxy := NewAuthProxy(finder, nil, http.DefaultClient, store, nil, newTestSigner(t), userinfo)
+	proxy := NewAuthProxy(finder, nil, http.DefaultClient, store, nil, newTestSigner(t), userinfo, nil)
 
 	gwState := authorizeAndGetState(t, proxy, "")
 	_, err := proxy.Callback(context.Background(), "http://gw.example.com", gwState, "idp-code", "", "", "")
@@ -214,7 +214,7 @@ func TestExchangeCodeSessionModeMintsSessionToken(t *testing.T) {
 	t.Parallel()
 	store := newMemFlowStore()
 	signer := newTestSigner(t)
-	proxy := NewAuthProxy(&fakeCredentialFinder{}, nil, http.DefaultClient, store, nil, signer, nil)
+	proxy := NewAuthProxy(&fakeCredentialFinder{}, nil, http.DefaultClient, store, nil, signer, nil, nil)
 	ctx := context.Background()
 
 	if err := store.SaveCode(ctx, "gw-code", CodeGrant{
@@ -287,7 +287,7 @@ func TestRefreshSessionReMintsAndRotates(t *testing.T) {
 	store := newMemFlowStore()
 	signer := newTestSigner(t)
 	noIdP := &http.Client{Transport: failingTransport{t}}
-	proxy := NewAuthProxy(&fakeCredentialFinder{}, nil, noIdP, store, nil, signer, nil)
+	proxy := NewAuthProxy(&fakeCredentialFinder{}, nil, noIdP, store, nil, signer, nil, nil)
 	ctx := context.Background()
 
 	const oldRefresh = "gwrt_old-refresh"
@@ -393,7 +393,7 @@ func TestRefreshUnknownTokenFallsBackToIdP(t *testing.T) {
 func TestRefreshUnknownGatewayTokenRejected(t *testing.T) {
 	t.Parallel()
 	noIdP := &http.Client{Transport: failingTransport{t}}
-	proxy := NewAuthProxy(&fakeCredentialFinder{}, nil, noIdP, newMemFlowStore(), nil, newTestSigner(t), nil)
+	proxy := NewAuthProxy(&fakeCredentialFinder{}, nil, noIdP, newMemFlowStore(), nil, newTestSigner(t), nil, nil)
 
 	_, err := proxy.Exchange(context.Background(), "http://gw.example.com", TokenRequest{
 		GrantType:    "refresh_token",
@@ -418,7 +418,7 @@ func TestCallbackSessionMintsIdPGrantedScopes(t *testing.T) {
 			RequiredScopes: []string{"api://gw-client-id/mcp.access"},
 		}),
 	}}
-	proxy := NewAuthProxy(finder, nil, http.DefaultClient, store, nil, signer, nil)
+	proxy := NewAuthProxy(finder, nil, http.DefaultClient, store, nil, signer, nil, nil)
 	ctx := context.Background()
 
 	gwState := authorizeAndGetState(t, proxy, "")
@@ -488,7 +488,7 @@ func fakeIdPWithScopedToken(t *testing.T, scope, idToken string) *httptest.Serve
 func TestExchangeCodeOffModeReturnsTokenVerbatim(t *testing.T) {
 	t.Parallel()
 	store := newMemFlowStore()
-	proxy := NewAuthProxy(&fakeCredentialFinder{}, nil, http.DefaultClient, store, nil, newTestSigner(t), nil)
+	proxy := NewAuthProxy(&fakeCredentialFinder{}, nil, http.DefaultClient, store, nil, newTestSigner(t), nil, nil)
 	ctx := context.Background()
 
 	idpToken := map[string]any{"access_token": "idp-access-token", "token_type": "Bearer", "expires_in": 3600}

--- a/pkg/app/oauth/proxy_test.go
+++ b/pkg/app/oauth/proxy_test.go
@@ -41,6 +41,8 @@ type memFlowStore struct {
 	clients  map[string]RegisteredGatewayClient
 	sessions map[string]SessionRecord
 	retired  []string
+	jtis     map[string]struct{}
+	jtiErr   error
 }
 
 func newMemFlowStore() *memFlowStore {
@@ -73,6 +75,25 @@ func (s *memFlowStore) RetireSession(_ context.Context, refreshToken string, _ t
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.retired = append(s.retired, refreshToken)
+	return nil
+}
+
+func (s *memFlowStore) ConsumeJTI(_ context.Context, jti string, exp time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.jtiErr != nil {
+		return s.jtiErr
+	}
+	if !exp.After(time.Now()) {
+		return errors.New("jti expired")
+	}
+	if s.jtis == nil {
+		s.jtis = map[string]struct{}{}
+	}
+	if _, ok := s.jtis[jti]; ok {
+		return ErrJTIReplay
+	}
+	s.jtis[jti] = struct{}{}
 	return nil
 }
 
@@ -194,7 +215,7 @@ func newProxyUnderTest(t *testing.T, idpURL string, store FlowStore) AuthProxy {
 			RequiredScopes: []string{"api://gw-client-id/mcp.access"},
 		}),
 	}}
-	return NewAuthProxy(finder, nil, http.DefaultClient, store, nil, nil, nil)
+	return NewAuthProxy(finder, nil, http.DefaultClient, store, nil, nil, nil, nil)
 }
 
 func TestBrokeredFlowEndToEnd(t *testing.T) {
@@ -493,7 +514,7 @@ func TestResourceScopedFacadeSelectsIdPPerTenant(t *testing.T) {
 		"/v1/mcp/tenant-b": {{GatewayID: authB.GatewayID, Auths: []*authdomain.Auth{authB}}},
 	}}
 	store := newMemFlowStore()
-	proxy := NewAuthProxy(finder, paths, http.DefaultClient, store, nil, nil, nil)
+	proxy := NewAuthProxy(finder, paths, http.DefaultClient, store, nil, nil, nil, nil)
 	ctx := context.Background()
 
 	location, err := proxy.Authorize(ctx, "http://gw.example.com", AuthorizeRequest{
@@ -548,7 +569,7 @@ func TestAuthorizeResourceFallsBackToGatewayScopedIdP(t *testing.T) {
 	paths := &fakePathResolver{byPath: map[string][]appconsumer.PathMatch{
 		"/cons/mcp": {{GatewayID: gatewayID, Auths: nil}},
 	}}
-	proxy := NewAuthProxy(finder, paths, http.DefaultClient, newMemFlowStore(), nil, nil, nil)
+	proxy := NewAuthProxy(finder, paths, http.DefaultClient, newMemFlowStore(), nil, nil, nil, nil)
 
 	location, err := proxy.Authorize(context.Background(), "http://gw.example.com", AuthorizeRequest{
 		ResponseType:        "code",
@@ -588,7 +609,7 @@ func TestAuthorizeResourceAmbiguousWithinGateway(t *testing.T) {
 	paths := &fakePathResolver{byPath: map[string][]appconsumer.PathMatch{
 		"/cons/mcp": {{GatewayID: gatewayID, Auths: nil}},
 	}}
-	proxy := NewAuthProxy(finder, paths, http.DefaultClient, newMemFlowStore(), nil, nil, nil)
+	proxy := NewAuthProxy(finder, paths, http.DefaultClient, newMemFlowStore(), nil, nil, nil, nil)
 
 	_, err := proxy.Authorize(context.Background(), "http://gw.example.com", AuthorizeRequest{
 		ResponseType:        "code",
@@ -611,7 +632,7 @@ func TestAuthorizeResourceNoOAuth2GivesClearError(t *testing.T) {
 	paths := &fakePathResolver{byPath: map[string][]appconsumer.PathMatch{
 		"/cons/mcp": {{GatewayID: gatewayID, Auths: nil}},
 	}}
-	proxy := NewAuthProxy(finder, paths, http.DefaultClient, newMemFlowStore(), nil, nil, nil)
+	proxy := NewAuthProxy(finder, paths, http.DefaultClient, newMemFlowStore(), nil, nil, nil, nil)
 
 	_, err := proxy.Authorize(context.Background(), "http://gw.example.com", AuthorizeRequest{
 		ResponseType:        "code",
@@ -635,7 +656,7 @@ func TestAuthorizeMultiIssuerRequiresResource(t *testing.T) {
 		enabledOAuth2Auth(t, authdomain.OAuth2Config{Issuer: "https://idp-a.example.com", ClientID: "client-a"}),
 		enabledOAuth2Auth(t, authdomain.OAuth2Config{Issuer: "https://idp-b.example.com", ClientID: "client-b"}),
 	}}
-	proxy := NewAuthProxy(finder, &fakePathResolver{}, http.DefaultClient, newMemFlowStore(), nil, nil, nil)
+	proxy := NewAuthProxy(finder, &fakePathResolver{}, http.DefaultClient, newMemFlowStore(), nil, nil, nil, nil)
 
 	_, err := proxy.Authorize(context.Background(), "http://gw.example.com", AuthorizeRequest{
 		ResponseType:        "code",
@@ -664,7 +685,7 @@ func TestAuthorizeFallsBackToContextGatewayWithoutResource(t *testing.T) {
 	otherAuth := enabledOAuth2Auth(t, authdomain.OAuth2Config{Issuer: idpOther.URL, ClientID: "client-other"})
 
 	finder := &fakeCredentialFinder{oauth2: []*authdomain.Auth{gatewayAuth, otherAuth}}
-	proxy := NewAuthProxy(finder, &fakePathResolver{}, http.DefaultClient, newMemFlowStore(), nil, nil, nil)
+	proxy := NewAuthProxy(finder, &fakePathResolver{}, http.DefaultClient, newMemFlowStore(), nil, nil, nil, nil)
 
 	ctx := appgateway.WithGateway(context.Background(), &gatewaydomain.Gateway{ID: gatewayID, Slug: "acme"})
 	location, err := proxy.Authorize(ctx, "https://acme.mcp.example.com", AuthorizeRequest{
@@ -701,7 +722,7 @@ func TestRefreshUsesResourceIndicator(t *testing.T) {
 	paths := &fakePathResolver{byPath: map[string][]appconsumer.PathMatch{
 		"/v1/mcp/tenant-b": {{GatewayID: authB.GatewayID, Auths: []*authdomain.Auth{authB}}},
 	}}
-	proxy := NewAuthProxy(finder, paths, http.DefaultClient, newMemFlowStore(), nil, nil, nil)
+	proxy := NewAuthProxy(finder, paths, http.DefaultClient, newMemFlowStore(), nil, nil, nil, nil)
 
 	if _, err := proxy.Exchange(context.Background(), "http://gw.example.com", TokenRequest{
 		GrantType:    "refresh_token",
@@ -836,7 +857,7 @@ func chainProxyUnderTest(t *testing.T, idpURL string, store FlowStore, chainer C
 			ClientID: "gw-client-id",
 		}),
 	}}
-	return NewAuthProxy(finder, nil, http.DefaultClient, store, chainer, nil, nil)
+	return NewAuthProxy(finder, nil, http.DefaultClient, store, chainer, nil, nil, nil)
 }
 
 func authorizeAndGetState(t *testing.T, proxy AuthProxy, resource string) string {
@@ -1082,7 +1103,7 @@ func TestCallbackStaticIdPOmitISSAllowed(t *testing.T) {
 			ClientSecret: "gw-secret",
 		}),
 	}}
-	proxy := NewAuthProxy(finder, nil, http.DefaultClient, store, nil, nil, nil)
+	proxy := NewAuthProxy(finder, nil, http.DefaultClient, store, nil, nil, nil, nil)
 
 	gwState := authorizeAndGetState(t, proxy, "")
 	if _, err := proxy.Callback(context.Background(), "http://gw.example.com", gwState, "idp-code", "", "", ""); err != nil {

--- a/pkg/app/oauth/proxy_types.go
+++ b/pkg/app/oauth/proxy_types.go
@@ -16,10 +16,14 @@ package oauth
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
 )
+
+// ErrJTIReplay is returned when ConsumeJTI is called with a jti that is already stored.
+var ErrJTIReplay = errors.New("oauth: jti already consumed")
 
 const CallbackPath = "/oauth/callback"
 
@@ -67,6 +71,7 @@ type CodeGrant struct {
 	Audiences     []string       `json:"audiences,omitempty"`
 	Scopes        []string       `json:"scopes,omitempty"`
 	SessionMode   bool           `json:"session_mode,omitempty"`
+	Claims        map[string]any `json:"claims,omitempty"`
 }
 
 type SessionRecord struct {
@@ -99,6 +104,7 @@ type FlowStore interface {
 	// either into invalid_grant — killing the whole session. It must only ever
 	// shorten the TTL, so replaying an old token cannot keep it alive.
 	RetireSession(ctx context.Context, refreshToken string, grace time.Duration) error
+	ConsumeJTI(ctx context.Context, jti string, exp time.Time) error
 }
 
 type AuthorizeRequest struct {
@@ -120,6 +126,7 @@ type TokenRequest struct {
 	CodeVerifier string
 	RefreshToken string
 	Resource     string
+	Assertion    string
 }
 
 type ConsentChainer interface {

--- a/pkg/container/modules/api.go
+++ b/pkg/container/modules/api.go
@@ -181,8 +181,9 @@ func API(c *container.Container) error {
 		connect appoauth.ConnectService,
 		signer sts.TokenSigner,
 		userinfo appoauth.UserInfoClient,
+		verifier appauth.OIDCVerifier,
 	) appoauth.AuthProxy {
-		return appoauth.NewAuthProxy(credentials, paths, nil, store, connect, signer, userinfo)
+		return appoauth.NewAuthProxy(credentials, paths, nil, store, connect, signer, userinfo, verifier)
 	}); err != nil {
 		return err
 	}

--- a/pkg/domain/auth/config.go
+++ b/pkg/domain/auth/config.go
@@ -31,6 +31,12 @@ type Config struct {
 	MTLS   *MTLSConfig   `json:"mtls,omitempty"`
 }
 
+const (
+	NorthboundModeOIDC = "oidc"
+	NorthboundModeEMA  = "ema"
+	NorthboundModeBoth = "both"
+)
+
 type OAuth2Config struct {
 	Issuer           string   `json:"issuer"`
 	Audiences        []string `json:"audiences,omitempty"`
@@ -45,6 +51,26 @@ type OAuth2Config struct {
 	SubjectClaim     string   `json:"subject_claim,omitempty"`
 	AuthorizeURL     string   `json:"authorize_url,omitempty"`
 	TokenURL         string   `json:"token_url,omitempty"`
+	NorthboundMode   string   `json:"northbound_mode,omitempty"`
+}
+
+// EffectiveNorthboundMode returns oidc when NorthboundMode is empty.
+func (c OAuth2Config) EffectiveNorthboundMode() string {
+	mode := strings.ToLower(strings.TrimSpace(c.NorthboundMode))
+	if mode == "" {
+		return NorthboundModeOIDC
+	}
+	return mode
+}
+
+// AdvertisesEMA reports whether this config should advertise jwt-bearer and the EMA extension.
+func (c OAuth2Config) AdvertisesEMA() bool {
+	switch c.EffectiveNorthboundMode() {
+	case NorthboundModeEMA, NorthboundModeBoth:
+		return true
+	default:
+		return false
+	}
 }
 
 type OIDCConfig struct {
@@ -152,7 +178,34 @@ func (c *OAuth2Config) validate() error {
 			return fmt.Errorf("%w: oauth2 requires jwks_url or introspection_url, or an http(s) issuer for OIDC discovery", ErrInvalidConfig)
 		}
 	}
-	return nil
+	return c.validateNorthboundMode()
+}
+
+func (c *OAuth2Config) validateNorthboundMode() error {
+	mode := strings.ToLower(strings.TrimSpace(c.NorthboundMode))
+	switch mode {
+	case "", NorthboundModeOIDC:
+		return nil
+	case NorthboundModeEMA, NorthboundModeBoth:
+		jwks := strings.TrimSpace(c.JWKSURL)
+		if jwks != "" {
+			if !isHTTPSURL(jwks) {
+				return fmt.Errorf("%w: oauth2.jwks_url must be https when northbound_mode is %q", ErrInvalidConfig, mode)
+			}
+			return nil
+		}
+		if !isHTTPSURL(c.Issuer) {
+			return fmt.Errorf("%w: oauth2 requires an https jwks_url or https issuer when northbound_mode is %q", ErrInvalidConfig, mode)
+		}
+		return nil
+	default:
+		return fmt.Errorf("%w: oauth2.northbound_mode must be oidc, ema, or both", ErrInvalidConfig)
+	}
+}
+
+func isHTTPSURL(raw string) bool {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	return err == nil && u.Scheme == "https" && u.Host != ""
 }
 
 // validateAuthorizationEndpoints enforces the manual brokering endpoints used

--- a/pkg/domain/auth/config_test.go
+++ b/pkg/domain/auth/config_test.go
@@ -177,3 +177,106 @@ func TestOAuth2Config_Validate_ManualAuthorizationEndpoints(t *testing.T) {
 		})
 	}
 }
+
+func TestOAuth2Config_Validate_NorthboundMode(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		config    OAuth2Config
+		wantErr   bool
+		want      string
+		advertise bool
+	}{
+		{
+			name: "empty defaults to oidc",
+			config: OAuth2Config{
+				Issuer:    "https://idp.example.com",
+				Audiences: []string{"gateway"},
+				JWKSURL:   "https://idp.example.com/jwks",
+			},
+			want: NorthboundModeOIDC,
+		},
+		{
+			name: "oidc explicit",
+			config: OAuth2Config{
+				Issuer:         "https://idp.example.com",
+				Audiences:      []string{"gateway"},
+				JWKSURL:        "https://idp.example.com/jwks",
+				NorthboundMode: NorthboundModeOIDC,
+			},
+			want: NorthboundModeOIDC,
+		},
+		{
+			name: "ema with https jwks",
+			config: OAuth2Config{
+				Issuer:         "https://idp.example.com",
+				Audiences:      []string{"gateway"},
+				JWKSURL:        "https://idp.example.com/jwks",
+				NorthboundMode: NorthboundModeEMA,
+			},
+			want:      NorthboundModeEMA,
+			advertise: true,
+		},
+		{
+			name: "both with https issuer and no jwks",
+			config: OAuth2Config{
+				Issuer:         "https://idp.example.com",
+				Audiences:      []string{"gateway"},
+				NorthboundMode: NorthboundModeBoth,
+			},
+			want:      NorthboundModeBoth,
+			advertise: true,
+		},
+		{
+			name: "ema with http jwks",
+			config: OAuth2Config{
+				Issuer:         "https://idp.example.com",
+				Audiences:      []string{"gateway"},
+				JWKSURL:        "http://idp.example.com/jwks",
+				NorthboundMode: NorthboundModeEMA,
+			},
+			wantErr: true,
+		},
+		{
+			name: "both with http issuer and no jwks",
+			config: OAuth2Config{
+				Issuer:         "http://idp.example.com",
+				Audiences:      []string{"gateway"},
+				NorthboundMode: NorthboundModeBoth,
+			},
+			wantErr: true,
+		},
+		{
+			name: "unknown mode",
+			config: OAuth2Config{
+				Issuer:         "https://idp.example.com",
+				Audiences:      []string{"gateway"},
+				JWKSURL:        "https://idp.example.com/jwks",
+				NorthboundMode: "saml",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := tt.config
+			err := cfg.validate()
+			if tt.wantErr {
+				if !errors.Is(err, ErrInvalidConfig) {
+					t.Fatalf("validate() error = %v, want ErrInvalidConfig", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("validate() error = %v, want nil", err)
+			}
+			if got := cfg.EffectiveNorthboundMode(); got != tt.want {
+				t.Fatalf("EffectiveNorthboundMode() = %q, want %q", got, tt.want)
+			}
+			if cfg.AdvertisesEMA() != tt.advertise {
+				t.Fatalf("AdvertisesEMA() = %v, want %v", cfg.AdvertisesEMA(), tt.advertise)
+			}
+		})
+	}
+}

--- a/pkg/infra/oauth/store.go
+++ b/pkg/infra/oauth/store.go
@@ -30,6 +30,7 @@ const (
 	codePrefix          = "oauth:code:"
 	gatewayClientPrefix = "oauth:gwclient:"
 	sessionPrefix       = "oauth:session:"
+	jtiPrefix           = "oauth:jti:"
 	pendingTTL          = 10 * time.Minute
 	codeTTL             = 5 * time.Minute
 	gatewayClientTTL    = 30 * 24 * time.Hour
@@ -116,6 +117,21 @@ func (s *Store) RetireSession(ctx context.Context, refreshToken string, grace ti
 	// retired token cannot push its expiry out again.
 	if err := s.rdb.ExpireLT(ctx, sessionPrefix+refreshToken, grace).Err(); err != nil {
 		return fmt.Errorf("oauth flow store: retire session: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) ConsumeJTI(ctx context.Context, jti string, exp time.Time) error {
+	ttl := time.Until(exp)
+	if ttl <= 0 {
+		return fmt.Errorf("oauth flow store: jti already expired")
+	}
+	ok, err := s.rdb.SetNX(ctx, jtiPrefix+jti, "1", ttl).Result()
+	if err != nil {
+		return fmt.Errorf("oauth flow store: consume jti: %w", err)
+	}
+	if !ok {
+		return appoauth.ErrJTIReplay
 	}
 	return nil
 }

--- a/pkg/infra/oauth/store_test.go
+++ b/pkg/infra/oauth/store_test.go
@@ -16,6 +16,7 @@ package oauth_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -145,5 +146,26 @@ func TestStoreSessionRotation(t *testing.T) {
 	}
 	if fresh.Subject != "user-42" {
 		t.Fatalf("preserved record mismatch: %+v", fresh)
+	}
+}
+
+func TestStoreConsumeJTIReplayAndError(t *testing.T) {
+	store, mr := newSessionStore(t)
+	ctx := context.Background()
+	exp := time.Now().Add(time.Minute)
+
+	if err := store.ConsumeJTI(ctx, "jti-1", exp); err != nil {
+		t.Fatalf("first consume: %v", err)
+	}
+	if err := store.ConsumeJTI(ctx, "jti-1", exp); !errors.Is(err, appoauth.ErrJTIReplay) {
+		t.Fatalf("replay = %v, want ErrJTIReplay", err)
+	}
+	if err := store.ConsumeJTI(ctx, "expired", time.Now().Add(-time.Second)); err == nil {
+		t.Fatal("expired jti must be denied")
+	}
+
+	mr.Close()
+	if err := store.ConsumeJTI(ctx, "jti-2", exp); err == nil {
+		t.Fatal("redis error must deny")
 	}
 }


### PR DESCRIPTION
## Summary

- Add optional `northbound_mode` (`oidc` default | `ema` | `both`) on existing `oauth2` Auth. No new Auth type.
- `/oauth/token` accepts RFC 7523 `jwt-bearer` ID-JAG grants (`typ=oauth-id-jag+jwt`), validates configured issuer/JWKS, `aud=baseURL`, resource, scopes, and `jti` (fail-closed). Always mints the existing TrustGate session JWT.
- Failed jwt-bearer returns `invalid_grant` with no silent OIDC downgrade. Advertise `io.modelcontextprotocol/enterprise-managed-authorization` only when mode is `ema` or `both`. Email is linking only; primary id is `iss`+`sub`. Does not map `act` (RUN-1117).

## Size

Above the 400-line review budget (`size:exception`): config, validator, grant path, tests, and docs in one PR.

## Linear

RUN-1112 — https://linear.app/neuraltrust/issue/RUN-1112/featmcp-auth-support-enterprise-managed-authorization

Base: `feat/run-1103-dual-era-northbound-protocol-boundary` (unifying dual-era branch).

## Test plan

- [x] `go test -race` on `pkg/app/oauth`, `pkg/domain/auth`, `pkg/infra/oauth`, `pkg/api/handler/http/oauth`
- [x] Pre-commit hook (lint + gosec + unit) passed
- [ ] CI on this PR


Made with [Cursor](https://cursor.com)