### PR TITLE
fix(registry): accept Vertex SA JSON object and infer project (RUN-1143)

### DIFF
--- a/pkg/api/handler/http/registry/create_registry_handler.go
+++ b/pkg/api/handler/http/registry/create_registry_handler.go
@@ -58,6 +58,7 @@ func (h *CreateRegistryHandler) Handle(c *fiber.Ctx) error {
 	if err := c.BodyParser(&req); err != nil {
 		return httpio.WriteError(c, fmt.Errorf("invalid request body: %w", commonerrors.ErrValidation))
 	}
+	req.Normalize()
 	if err := req.Validate(); err != nil {
 		return httpio.WriteError(c, err)
 	}

--- a/pkg/api/handler/http/registry/request/create_registry_request.go
+++ b/pkg/api/handler/http/registry/request/create_registry_request.go
@@ -79,7 +79,7 @@ type TargetAuthRequest struct {
 	Azure             *AzureAuthRequest         `json:"azure,omitempty"`
 	AWS               *AWSAuthRequest           `json:"aws,omitempty"`
 	OAuth             *TargetOAuthConfigRequest `json:"oauth,omitempty"`
-	GCPServiceAccount *string                   `json:"gcp_service_account,omitempty"`
+	GCPServiceAccount *GCPServiceAccountJSON    `json:"gcp_service_account,omitempty"`
 }
 
 type APIKeyAuthRequest struct {
@@ -125,6 +125,13 @@ type TargetOAuthConfigRequest struct {
 	Username     string            `json:"username,omitempty"`
 	Password     string            `json:"password,omitempty"` // #nosec G117
 	Extra        map[string]string `json:"extra,omitempty"`
+}
+
+func (r *CreateRegistryRequest) Normalize() {
+	if r == nil {
+		return
+	}
+	r.ProviderOptions = inferVertexProject(r.Provider, r.ProviderOptions, r.Auth)
 }
 
 func (r CreateRegistryRequest) Validate() error {
@@ -238,7 +245,7 @@ func (a *TargetAuthRequest) ToDomain() *domain.TargetAuth {
 	}
 	out := &domain.TargetAuth{
 		Type:              domain.AuthType(a.Type),
-		GCPServiceAccount: a.GCPServiceAccount,
+		GCPServiceAccount: a.GCPServiceAccount.stringPtr(),
 	}
 	if a.APIKey != nil {
 		out.APIKey = a.APIKey.ToDomain()

--- a/pkg/api/handler/http/registry/request/gcp_service_account.go
+++ b/pkg/api/handler/http/registry/request/gcp_service_account.go
@@ -1,0 +1,141 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package request
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	domain "github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+)
+
+// GCPServiceAccountJSON stores a service-account key as a compact JSON string.
+// UnmarshalJSON accepts either a JSON string or a JSON object so BodyParser does not 422 on nested keys.
+type GCPServiceAccountJSON string
+
+// UnmarshalJSON accepts a JSON string or object and normalizes object/pretty JSON to a compact string.
+func (s *GCPServiceAccountJSON) UnmarshalJSON(data []byte) error {
+	data = bytes.TrimSpace(data)
+	if len(data) == 0 || bytes.Equal(data, []byte("null")) {
+		*s = ""
+		return nil
+	}
+
+	switch data[0] {
+	case '"':
+		var raw string
+		if err := json.Unmarshal(data, &raw); err != nil {
+			return fmt.Errorf("gcp_service_account: %w", err)
+		}
+		*s = GCPServiceAccountJSON(compactServiceAccountJSON(raw))
+		return nil
+	case '{':
+		var obj map[string]any
+		if err := json.Unmarshal(data, &obj); err != nil {
+			return fmt.Errorf("gcp_service_account: %w", err)
+		}
+		compact, err := json.Marshal(obj)
+		if err != nil {
+			return fmt.Errorf("gcp_service_account: %w", err)
+		}
+		*s = GCPServiceAccountJSON(compact)
+		return nil
+	default:
+		return fmt.Errorf("gcp_service_account must be a JSON string or object")
+	}
+}
+
+func (s *GCPServiceAccountJSON) stringPtr() *string {
+	if s == nil {
+		return nil
+	}
+	v := string(*s)
+	return &v
+}
+
+func compactServiceAccountJSON(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return trimmed
+	}
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(trimmed), &obj); err != nil {
+		return raw
+	}
+	compact, err := json.Marshal(obj)
+	if err != nil {
+		return raw
+	}
+	return string(compact)
+}
+
+func projectIDFromServiceAccount(sa string) string {
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(sa)), &obj); err != nil {
+		return ""
+	}
+	id, _ := obj["project_id"].(string)
+	return strings.TrimSpace(id)
+}
+
+func authServiceAccountString(auth *TargetAuthRequest) string {
+	if auth == nil || auth.GCPServiceAccount == nil {
+		return ""
+	}
+	return strings.TrimSpace(string(*auth.GCPServiceAccount))
+}
+
+func providerOptionString(options map[string]any, key string) string {
+	if options == nil {
+		return ""
+	}
+	raw, ok := options[key]
+	if !ok || raw == nil {
+		return ""
+	}
+	s, ok := raw.(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(s)
+}
+
+func shouldInferVertexProject(provider string, auth *TargetAuthRequest) bool {
+	if strings.EqualFold(strings.TrimSpace(provider), providers.ProviderVertex) {
+		return true
+	}
+	return auth != nil && strings.EqualFold(strings.TrimSpace(auth.Type), string(domain.AuthTypeGCPServiceAccount))
+}
+
+func inferVertexProject(provider string, options map[string]any, auth *TargetAuthRequest) map[string]any {
+	if !shouldInferVertexProject(provider, auth) {
+		return options
+	}
+	if providerOptionString(options, "project") != "" {
+		return options
+	}
+	projectID := projectIDFromServiceAccount(authServiceAccountString(auth))
+	if projectID == "" {
+		return options
+	}
+	if options == nil {
+		options = map[string]any{}
+	}
+	options["project"] = projectID
+	return options
+}

--- a/pkg/api/handler/http/registry/request/gcp_service_account_test.go
+++ b/pkg/api/handler/http/registry/request/gcp_service_account_test.go
@@ -1,0 +1,147 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package request
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/NeuralTrust/TrustGate/pkg/infra/providers"
+	"github.com/stretchr/testify/require"
+)
+
+const sampleServiceAccount = `{
+  "type": "service_account",
+  "project_id": "cpai-sandbox",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nnot-a-real-key\n-----END PRIVATE KEY-----\n",
+  "client_email": "vertex@cpai-sandbox.iam.gserviceaccount.com"
+}`
+
+func TestGCPServiceAccountJSON_UnmarshalJSON_Object(t *testing.T) {
+	t.Parallel()
+
+	var auth TargetAuthRequest
+	err := json.Unmarshal([]byte(`{
+		"type":"gcp_service_account",
+		"gcp_service_account":{
+			"type":"service_account",
+			"project_id":"cpai-sandbox",
+			"client_email":"vertex@cpai-sandbox.iam.gserviceaccount.com",
+			"private_key":"k"
+		}
+	}`), &auth)
+	require.NoError(t, err)
+	require.NotNil(t, auth.GCPServiceAccount)
+	require.False(t, strings.Contains(string(*auth.GCPServiceAccount), "\n"))
+	require.Equal(t, "cpai-sandbox", projectIDFromServiceAccount(string(*auth.GCPServiceAccount)))
+
+	domainAuth := auth.ToDomain()
+	require.NotNil(t, domainAuth.GCPServiceAccount)
+	require.Equal(t, string(*auth.GCPServiceAccount), *domainAuth.GCPServiceAccount)
+}
+
+func TestGCPServiceAccountJSON_UnmarshalJSON_PrettyString(t *testing.T) {
+	t.Parallel()
+
+	payload, err := json.Marshal(map[string]any{
+		"type":                "gcp_service_account",
+		"gcp_service_account": sampleServiceAccount,
+	})
+	require.NoError(t, err)
+
+	var auth TargetAuthRequest
+	require.NoError(t, json.Unmarshal(payload, &auth))
+	require.NotNil(t, auth.GCPServiceAccount)
+	require.False(t, strings.Contains(string(*auth.GCPServiceAccount), "\n"))
+	require.JSONEq(t, `{"type":"service_account","project_id":"cpai-sandbox","private_key":"-----BEGIN PRIVATE KEY-----\nnot-a-real-key\n-----END PRIVATE KEY-----\n","client_email":"vertex@cpai-sandbox.iam.gserviceaccount.com"}`, string(*auth.GCPServiceAccount))
+}
+
+func TestCreateRegistryRequest_Normalize_InfersVertexProject(t *testing.T) {
+	t.Parallel()
+
+	sa := GCPServiceAccountJSON(compactServiceAccountJSON(sampleServiceAccount))
+	req := CreateRegistryRequest{
+		Name:     "vertex-reg",
+		Provider: providers.ProviderVertex,
+		ProviderOptions: map[string]any{
+			"location": "europe-west1",
+		},
+		Auth: &TargetAuthRequest{
+			Type:              "gcp_service_account",
+			GCPServiceAccount: &sa,
+		},
+	}
+	req.Normalize()
+	require.Equal(t, "cpai-sandbox", req.ProviderOptions["project"])
+	require.Equal(t, "europe-west1", req.ProviderOptions["location"])
+}
+
+func TestTestConnectionRequest_Normalize_InfersVertexProject(t *testing.T) {
+	t.Parallel()
+
+	sa := GCPServiceAccountJSON(compactServiceAccountJSON(sampleServiceAccount))
+	req := TestConnectionRequest{
+		Provider: providers.ProviderVertex,
+		ProviderOptions: map[string]any{
+			"location": "us-central1",
+		},
+		Auth: &TargetAuthRequest{
+			Type:              "gcp_service_account",
+			GCPServiceAccount: &sa,
+		},
+	}
+	req.Normalize()
+	require.Equal(t, "cpai-sandbox", req.ProviderOptions["project"])
+}
+
+func TestUpdateRegistryRequest_Normalize_InfersVertexProject(t *testing.T) {
+	t.Parallel()
+
+	sa := GCPServiceAccountJSON(compactServiceAccountJSON(sampleServiceAccount))
+	provider := providers.ProviderVertex
+	options := map[string]any{"location": "europe-west1"}
+	req := UpdateRegistryRequest{
+		Provider:        &provider,
+		ProviderOptions: &options,
+		Auth: &TargetAuthRequest{
+			Type:              "gcp_service_account",
+			GCPServiceAccount: &sa,
+		},
+	}
+	req.Normalize()
+	require.NotNil(t, req.ProviderOptions)
+	require.Equal(t, "cpai-sandbox", (*req.ProviderOptions)["project"])
+}
+
+func TestCreateRegistryRequest_Normalize_KeepsExplicitProject(t *testing.T) {
+	t.Parallel()
+
+	sa := GCPServiceAccountJSON(compactServiceAccountJSON(sampleServiceAccount))
+	req := CreateRegistryRequest{
+		Name:     "vertex-reg",
+		Provider: providers.ProviderVertex,
+		ProviderOptions: map[string]any{
+			"project":  "override-project",
+			"location": "europe-west1",
+		},
+		Auth: &TargetAuthRequest{
+			Type:              "gcp_service_account",
+			GCPServiceAccount: &sa,
+		},
+	}
+	req.Normalize()
+	require.Equal(t, "override-project", req.ProviderOptions["project"])
+}

--- a/pkg/api/handler/http/registry/request/test_connection_request.go
+++ b/pkg/api/handler/http/registry/request/test_connection_request.go
@@ -33,6 +33,13 @@ func (r TestConnectionRequest) IsByID() bool {
 	return strings.TrimSpace(r.RegistryID) != ""
 }
 
+func (r *TestConnectionRequest) Normalize() {
+	if r == nil || r.IsByID() {
+		return
+	}
+	r.ProviderOptions = inferVertexProject(r.Provider, r.ProviderOptions, r.Auth)
+}
+
 func (r TestConnectionRequest) Validate() error {
 	if r.IsByID() {
 		if r.Provider != "" || r.Auth != nil {

--- a/pkg/api/handler/http/registry/request/update_registry_request.go
+++ b/pkg/api/handler/http/registry/request/update_registry_request.go
@@ -33,6 +33,18 @@ type UpdateRegistryRequest struct {
 	MCPTarget       *MCPTargetRequest    `json:"mcp_target,omitempty"`
 }
 
+func (r *UpdateRegistryRequest) Normalize() {
+	if r == nil || r.ProviderOptions == nil {
+		return
+	}
+	provider := ""
+	if r.Provider != nil {
+		provider = *r.Provider
+	}
+	inferred := inferVertexProject(provider, *r.ProviderOptions, r.Auth)
+	r.ProviderOptions = &inferred
+}
+
 func (r UpdateRegistryRequest) Validate() error {
 	if r.Name != nil {
 		if strings.TrimSpace(*r.Name) == "" {

--- a/pkg/api/handler/http/registry/test_connection_handler.go
+++ b/pkg/api/handler/http/registry/test_connection_handler.go
@@ -59,6 +59,7 @@ func (h *TestConnectionHandler) Handle(c *fiber.Ctx) error {
 	if err := c.BodyParser(&req); err != nil {
 		return httpio.WriteError(c, fmt.Errorf("invalid request body: %w", commonerrors.ErrValidation))
 	}
+	req.Normalize()
 	if err := req.Validate(); err != nil {
 		return httpio.WriteError(c, err)
 	}

--- a/pkg/api/handler/http/registry/update_registry_handler.go
+++ b/pkg/api/handler/http/registry/update_registry_handler.go
@@ -60,6 +60,7 @@ func (h *UpdateRegistryHandler) Handle(c *fiber.Ctx) error {
 	if err := c.BodyParser(&req); err != nil {
 		return httpio.WriteError(c, fmt.Errorf("invalid request body: %w", commonerrors.ErrValidation))
 	}
+	req.Normalize()
 	if err := req.Validate(); err != nil {
 		return httpio.WriteError(c, err)
 	}

--- a/pkg/app/catalog/provider_options.go
+++ b/pkg/app/catalog/provider_options.go
@@ -76,8 +76,8 @@ var providerOptionsCatalog = map[string][]ProviderOptionField{
 			Key:         "project",
 			Label:       "Project",
 			Type:        OptionFieldTypeString,
-			Description: "GCP project ID hosting the Vertex AI models.",
-			Required:    true,
+			Description: "GCP project ID hosting the Vertex AI models. Defaults to project_id from the service account JSON when omitted.",
+			Required:    false,
 		},
 		{
 			Key:         "location",


### PR DESCRIPTION
## What
Hardens AgentGateway registry create/update/test-connection so a Vertex GCP service-account key can arrive as a JSON **object** or pretty-printed **string** without Fiber BodyParser returning `invalid request body: validation failed`. Also infers `provider_options.project` from the key’s `project_id` when omitted, and marks the catalog `project` field optional.

## How
- Add `GCPServiceAccountJSON` with custom `UnmarshalJSON` (string|object → compact string)
- Call `Normalize()` after BodyParser on create/update/test-connection
- Infer Vertex `project` from SA `project_id` when missing
- Catalog: Vertex `project` no longer required

## Testing
- [x] `make test`
- [x] `go test ./pkg/api/handler/http/registry/... ./pkg/app/registry/... ./pkg/infra/providers/...`
- [ ] Manual: POST test-connection with nested SA object + location only → parses and project filled

## Risk
Low — request-body normalization only; explicit project still wins; missing project still fails if SA has no `project_id`.

## Linear
RUN-1143 — https://linear.app/neuraltrust/issue/RUN-1143/fixregistry-vertexgcp-connect-fails-accept-service-account-json-upload

Frontend counterpart: https://github.com/NeuralTrust/app/pull/3272