### PR TITLE
fix: withhold built-in IdP from MCP consumers with a credential (RUN-1156)

### DIFF
--- a/docs/mcp/api-key-auth-and-external-credentials.md
+++ b/docs/mcp/api-key-auth-and-external-credentials.md
@@ -208,6 +208,20 @@ actually has an enabled OAuth2 auth, so an API-key-only consumer gets a plain
 `401`. Existing TTLs are unchanged: 15 minutes for the reusable ticket, 10
 minutes for the one-time OAuth state.
 
+### The built-in identity provider never covers an API-key consumer
+
+`MCP_DEFAULT_IDP_ISSUER` lets an MCP consumer that carries **no** credential of
+its own fall back to the NeuralTrust platform login, so a PoC does not have to
+register an identity provider. That fallback is added to the path's auth scope,
+and the platform issues a code to any authenticated user without checking team
+membership against the gateway.
+
+It therefore applies only while the path has no enabled credential. As soon as
+one is attached — an api key, mTLS, or the consumer's own OAuth2 IdP — the
+fallback is withheld and that credential is the only way in. Otherwise any
+platform login would reach an API-key consumer without its key, and the key
+would stop being an access control.
+
 ## 6. URLs the App must expose
 
 For an MCP consumer with an `api_key` auth, the consumer detail view should show:

--- a/pkg/api/middleware/auth_chain.go
+++ b/pkg/api/middleware/auth_chain.go
@@ -142,9 +142,13 @@ func (r *chainIdentityResolver) pathScope(c *fiber.Ctx) (authScope, error) {
 	scope := authScope{}
 	hasOAuth2 := false
 	hasEnabledOAuth2 := false
+	hasEnabledAuth := false
 	for _, m := range matches {
 		for _, a := range m.Auths {
 			scope[a.ID] = struct{}{}
+			if a.Enabled {
+				hasEnabledAuth = true
+			}
 			if a.Type == authdomain.TypeOAuth2 {
 				hasOAuth2 = true
 				if a.Enabled {
@@ -153,7 +157,11 @@ func (r *chainIdentityResolver) pathScope(c *fiber.Ctx) (authScope, error) {
 			}
 		}
 	}
-	defaultIdPUsable := r.defaultIdPEnabled && !hasOAuth2
+	// The built-in provider bootstraps consumers that carry no credential of
+	// their own. Once a path has an enabled one — an api key, mTLS, or its own
+	// oauth2 IdP — that credential is the only way in: falling back here would
+	// let any platform login reach the consumer without it.
+	defaultIdPUsable := r.defaultIdPEnabled && !hasOAuth2 && !hasEnabledAuth
 	c.Locals(OAuthChallengeAllowedLocal, hasEnabledOAuth2 || defaultIdPUsable)
 	if defaultIdPUsable {
 		scope[appauth.DefaultIdPAuthID()] = struct{}{}

--- a/pkg/api/middleware/auth_chain_test.go
+++ b/pkg/api/middleware/auth_chain_test.go
@@ -281,6 +281,8 @@ func TestChain_PathFirst_SetsChallengeEligibility(t *testing.T) {
 	disabledOAuth.Enabled = false
 	apiKey, err := authdomain.NewAPIKeyAuth(ids.New[ids.GatewayKind](), "key", true)
 	require.NoError(t, err)
+	disabledAPIKey, err := authdomain.NewAPIKeyAuth(ids.New[ids.GatewayKind](), "disabled-key", false)
+	require.NoError(t, err)
 	lookupErr := errors.New("lookup failed")
 	tests := []struct {
 		name       string
@@ -295,7 +297,7 @@ func TestChain_PathFirst_SetsChallengeEligibility(t *testing.T) {
 		},
 		{
 			name:       "usable default IdP",
-			paths:      fakePathResolver{matches: []appconsumer.PathMatch{pathMatchWith(apiKey)}},
+			paths:      fakePathResolver{matches: []appconsumer.PathMatch{pathMatchWith()}},
 			defaultIdP: true,
 			want:       true,
 		},
@@ -303,6 +305,18 @@ func TestChain_PathFirst_SetsChallengeEligibility(t *testing.T) {
 			name:  "API key only",
 			paths: fakePathResolver{matches: []appconsumer.PathMatch{pathMatchWith(apiKey)}},
 			want:  false,
+		},
+		{
+			name:       "API key blocks default IdP",
+			paths:      fakePathResolver{matches: []appconsumer.PathMatch{pathMatchWith(apiKey)}},
+			defaultIdP: true,
+			want:       false,
+		},
+		{
+			name:       "disabled API key does not block default IdP",
+			paths:      fakePathResolver{matches: []appconsumer.PathMatch{pathMatchWith(disabledAPIKey)}},
+			defaultIdP: true,
+			want:       true,
 		},
 		{
 			name:       "disabled OAuth2 blocks default IdP",

--- a/pkg/api/middleware/default_idp_chain_test.go
+++ b/pkg/api/middleware/default_idp_chain_test.go
@@ -39,12 +39,10 @@ func TestChain_DefaultIdP_SessionResolvesWithGwidClaim(t *testing.T) {
 	verifier, signer := sessionVerifier(t)
 	def := defaultIdPForTest()
 	gw := ids.New[ids.GatewayKind]()
-	apiKey, err := authdomain.NewAPIKeyAuth(gw, "api-key", true)
-	require.NoError(t, err)
 	resolver := middleware.NewChainIdentityResolver(
 		fakeAPIKeyFinder{},
 		fakeCredentialFinder{oauth2: []*authdomain.Auth{def}, defaultIdP: def},
-		fakePathResolver{matches: []appconsumer.PathMatch{pathMatchWith(apiKey)}},
+		fakePathResolver{matches: []appconsumer.PathMatch{{GatewayID: gw}}},
 		&fakeTokenValidator{err: errors.New("must not be called")}, &fakeTokenValidator{}, &fakeMTLSValidator{},
 		nil, verifier, nil, true,
 	)
@@ -62,6 +60,33 @@ func TestChain_DefaultIdP_SessionResolvesWithGwidClaim(t *testing.T) {
 	require.Equal(t, gw, id.GatewayID)
 	require.Equal(t, appauth.DefaultIdPAuthID(), id.AuthID)
 	require.Equal(t, "platform-user-1", id.Principal.Subject)
+}
+
+func TestChain_DefaultIdP_NotAddedWhenConsumerHasAPIKey(t *testing.T) {
+	verifier, signer := sessionVerifier(t)
+	def := defaultIdPForTest()
+	gw := ids.New[ids.GatewayKind]()
+	apiKey, err := authdomain.NewAPIKeyAuth(gw, "api-key", true)
+	require.NoError(t, err)
+	resolver := middleware.NewChainIdentityResolver(
+		fakeAPIKeyFinder{},
+		fakeCredentialFinder{oauth2: []*authdomain.Auth{def}, defaultIdP: def},
+		fakePathResolver{matches: []appconsumer.PathMatch{pathMatchWith(apiKey)}},
+		&fakeTokenValidator{}, &fakeTokenValidator{}, &fakeMTLSValidator{},
+		nil, verifier, nil, true,
+	)
+
+	token := mintSession(t, signer, jwt.MapClaims{
+		"sub":       "platform-user-1",
+		"aud":       def.Config.OAuth2.Audiences,
+		"authid":    appauth.DefaultIdPAuthID().String(),
+		"gwid":      gw.String(),
+		"token_use": "mcp_session",
+	})
+
+	_, err = resolveChain(t, resolver, map[string]string{"Authorization": "Bearer " + token})
+	require.ErrorIs(t, err, apiresolver.ErrUnauthenticated,
+		"a platform login must not reach a consumer that requires its api key")
 }
 
 func TestChain_DefaultIdP_NotAddedWhenConsumerHasDisabledOAuth2(t *testing.T) {


### PR DESCRIPTION
## Summary

An MCP consumer protected by an API key could be reached **without the key**. Reported from Cursor: pointing a client at `/{slug}/mcp` with no `X-AG-API-Key` triggered an authorization prompt, and completing it granted access.

`MCP_DEFAULT_IDP_ISSUER` lets an MCP consumer with no identity provider of its own fall back to the NeuralTrust platform login, so a PoC does not have to register an IdP. The guard only checked for OAuth2:

```go
defaultIdPUsable := r.defaultIdPEnabled && !hasOAuth2
```

A consumer whose only credential is an api key has `hasOAuth2 == false`, so the fallback applied: the `401` advertised OAuth discovery, and the built-in IdP was added to the path's auth scope, so the minted session was accepted. The platform authorization endpoint issues a code to any authenticated user without checking team membership against the gateway, so the api key stopped being an access control. The fallback is enabled in `dev`, `prod` and `prod-us`.

The gap predates the API-key epic, but the UI did not offer `api_key` for MCP consumers until RUN-1140, so the combination was practically unreachable.

The fix withholds the fallback as soon as the path has an **enabled** credential of any kind — api key, mTLS, or the consumer's own OAuth2 IdP. Consumers with no enabled credential keep the PoC path, and a disabled api key does not block it since it cannot authenticate.

Two existing tests asserted the vulnerable behaviour (`TestChain_DefaultIdP_SessionResolvesWithGwidClaim` resolved a default-IdP session on an api-key consumer) and now cover the legitimate no-credential case, with `TestChain_DefaultIdP_NotAddedWhenConsumerHasAPIKey` added as regression. Both were confirmed to fail when the fix is reverted.

The UI half of the report — a created api-key MCP consumer showing the OAuth note instead of the `X-AG-API-Key` snippet — ships in NeuralTrust/app.

## Test plan

- [x] `go test ./pkg/api/... ./pkg/app/...`
- [x] Mutation check: both regression tests fail with the fix reverted
- [x] `go vet`, `golangci-lint`, `make license-check`
- [ ] On dev: an api-key MCP consumer with no key returns a plain `401` and Cursor no longer offers to authorize
- [ ] On dev: a consumer with no credential still reaches the platform login

Fixes RUN-1156

Linear: https://linear.app/neuraltrust/issue/RUN-1156

Made with [Cursor](https://cursor.com)