### PR TITLE
fix: stop advertising OAuth for credential-protected MCP consumers (RUN-1156)

### DIFF
--- a/docs/mcp/api-key-auth-and-external-credentials.md
+++ b/docs/mcp/api-key-auth-and-external-credentials.md
@@ -222,6 +222,19 @@ fallback is withheld and that credential is the only way in. Otherwise any
 platform login would reach an API-key consumer without its key, and the key
 would stop being an access control.
 
+The rule holds in three places, because a client discovers OAuth through more
+than the challenge header:
+
+| Surface | Behaviour for a credential-protected consumer |
+|---|---|
+| Auth chain scope | The built-in provider is absent, so a brokered session is refused |
+| `/.well-known/oauth-protected-resource/{path}` | No `authorization_servers` advertised |
+| `/oauth/authorize` | `invalid_target`; no login is brokered |
+
+Fixing only the auth chain leaves a client offering an authorization prompt
+that ends in a session the gateway rejects, so all three follow the same
+condition.
+
 ## 6. URLs the App must expose
 
 For an MCP consumer with an `api_key` auth, the consumer detail view should show:

--- a/pkg/app/oauth/default_idp_selection_test.go
+++ b/pkg/app/oauth/default_idp_selection_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	appauth "github.com/NeuralTrust/TrustGate/pkg/app/auth"
+	appconsumer "github.com/NeuralTrust/TrustGate/pkg/app/consumer"
 	authdomain "github.com/NeuralTrust/TrustGate/pkg/domain/auth"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
 	"github.com/stretchr/testify/require"
@@ -67,6 +68,33 @@ func TestGatewayScopedAuth_FallsBackToDefault(t *testing.T) {
 	require.True(t, appauth.IsDefaultIdP(auth))
 	// The default is bound to the addressed gateway.
 	require.Equal(t, gw, auth.GatewayID)
+}
+
+// A consumer that authenticates with its own credential gets no identity
+// provider at all: brokering a login for it would produce a session the auth
+// chain refuses, so the flow is rejected before it starts.
+func TestAuthForResource_CredentialProtectedConsumerGetsNoIdP(t *testing.T) {
+	def := appauth.BuildDefaultIdP(appauth.DefaultIdPConfig{
+		Issuer: "https://app.neuraltrust.ai/api/mcp/oauth", ClientID: "tg",
+	})
+	gw := ids.New[ids.GatewayKind]()
+	apiKey, err := authdomain.NewAPIKeyAuth(gw, "key", true)
+	require.NoError(t, err)
+	paths := &fakePathResolver{byPath: map[string][]appconsumer.PathMatch{
+		"/api-key/mcp": {{GatewayID: gw, Auths: []*authdomain.Auth{apiKey}}},
+		"/bare/mcp":    {{GatewayID: gw}},
+	}}
+	p := &authProxy{credentials: &fakeCredentialFinder{defaultIdP: def}, paths: paths}
+
+	_, err = p.authForResource(t.Context(), "https://gw.example.com/api-key/mcp")
+	var oauthError *OAuthError
+	require.True(t, errors.As(err, &oauthError))
+	require.Equal(t, "invalid_target", oauthError.Code)
+
+	// A consumer with no credential of its own still reaches the default.
+	auth, err := p.authForResource(t.Context(), "https://gw.example.com/bare/mcp")
+	require.NoError(t, err)
+	require.True(t, appauth.IsDefaultIdP(auth))
 }
 
 func TestGatewayScopedAuth_NoDefaultKeepsError(t *testing.T) {

--- a/pkg/app/oauth/metadata.go
+++ b/pkg/app/oauth/metadata.go
@@ -110,16 +110,15 @@ func (s *metadataService) resourceAuths(ctx context.Context, resource string) ([
 		if u, err := url.Parse(resource); err == nil && u.Path != "" {
 			matches, err := s.paths.Match(ctx, u.Host, u.Path)
 			if err == nil && len(matches) > 0 {
-				var out []*authdomain.Auth
-				for _, m := range matches {
-					for _, a := range m.Auths {
-						if a.Enabled && a.Type == authdomain.TypeOAuth2 && a.Config.OAuth2 != nil {
-							out = append(out, a)
-						}
-					}
+				providers, protected := pathOAuth2Auths(matches)
+				if len(providers) > 0 {
+					return providers, nil
 				}
-				if len(out) > 0 {
-					return out, nil
+				// The resource pinned a consumer that authenticates with its own
+				// credential. Advertising the gateway's identity provider would
+				// send a client through a login the auth chain cannot honour.
+				if protected {
+					return nil, nil
 				}
 			}
 		}

--- a/pkg/app/oauth/metadata_test.go
+++ b/pkg/app/oauth/metadata_test.go
@@ -127,6 +127,41 @@ func TestProtectedResourceMetadataScopedByResource(t *testing.T) {
 	}
 }
 
+// A consumer that authenticates with its own credential must not be advertised
+// as an OAuth resource: the auth chain refuses a brokered session for it, so a
+// client following the metadata would run a login it can never use.
+func TestProtectedResourceMetadataSkipsCredentialProtectedConsumer(t *testing.T) {
+	t.Parallel()
+	idp := enabledOAuth2Auth(t, authdomain.OAuth2Config{Issuer: "https://idp.example.com", RequiredScopes: []string{"mcp:use"}})
+	gatewayID := ids.New[ids.GatewayKind]()
+	apiKey, err := authdomain.NewAPIKeyAuth(gatewayID, "key", true)
+	if err != nil {
+		t.Fatalf("build api key auth: %v", err)
+	}
+	paths := &fakePathResolver{byPath: map[string][]appconsumer.PathMatch{
+		"/api-key/mcp": {{GatewayID: gatewayID, Auths: []*authdomain.Auth{apiKey}}},
+		"/bare/mcp":    {{GatewayID: gatewayID}},
+	}}
+	svc := NewMetadataService(&fakeCredentialFinder{oauth2: []*authdomain.Auth{idp}}, paths, nil, newMemFlowStore())
+
+	meta, err := svc.ProtectedResource(context.Background(), "https://gw.example.com", "https://gw.example.com/api-key/mcp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(meta.AuthorizationServers) != 0 {
+		t.Fatalf("expected no authorization server for an api-key consumer, got %v", meta.AuthorizationServers)
+	}
+
+	// A consumer with no credential of its own still reaches the fallback.
+	meta, err = svc.ProtectedResource(context.Background(), "https://gw.example.com", "https://gw.example.com/bare/mcp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(meta.AuthorizationServers) != 1 {
+		t.Fatalf("expected the gateway as authorization server, got %v", meta.AuthorizationServers)
+	}
+}
+
 func TestProtectedResourceMetadataWithoutIdP(t *testing.T) {
 	t.Parallel()
 	svc := NewMetadataService(&fakeCredentialFinder{}, nil, nil, newMemFlowStore())

--- a/pkg/app/oauth/proxy_auth_selection.go
+++ b/pkg/app/oauth/proxy_auth_selection.go
@@ -22,21 +22,29 @@ import (
 	"net/url"
 
 	appauth "github.com/NeuralTrust/TrustGate/pkg/app/auth"
+	appconsumer "github.com/NeuralTrust/TrustGate/pkg/app/consumer"
 	appgateway "github.com/NeuralTrust/TrustGate/pkg/app/gateway"
 	authdomain "github.com/NeuralTrust/TrustGate/pkg/domain/auth"
 	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
 )
 
 func (p *authProxy) authForResource(ctx context.Context, resource string) (*authdomain.Auth, error) {
-	auth, gatewayID, matched := p.resourceAuth(ctx, resource)
-	if auth != nil {
-		return auth, nil
+	m := p.resourceAuth(ctx, resource)
+	if m.auth != nil {
+		return m.auth, nil
 	}
-	// The resource pinned a consumer but it has no OAuth2 identity provider of
-	// its own: fall back to the single IdP configured on that consumer's
-	// gateway instead of scanning every tenant on the platform.
-	if matched {
-		return p.gatewayScopedAuth(ctx, gatewayID)
+	if m.matched {
+		// The consumer authenticates with a credential of its own, so a session
+		// brokered here would be refused by the auth chain. Advertising a login
+		// would only walk the user through a flow that cannot reach it.
+		if m.protected {
+			return nil, oauthErr("invalid_target",
+				"this MCP server authenticates with its own credential; interactive login is not available")
+		}
+		// The resource pinned a consumer but it has no OAuth2 identity provider of
+		// its own: fall back to the single IdP configured on that consumer's
+		// gateway instead of scanning every tenant on the platform.
+		return p.gatewayScopedAuth(ctx, m.gatewayID)
 	}
 	// No usable resource indicator, but the request was still routed to a
 	// specific gateway (by subdomain or by the gateway-slug header). Scope the
@@ -91,35 +99,67 @@ func (p *authProxy) gatewayScopedAuth(ctx context.Context, gatewayID ids.Gateway
 	return a, err
 }
 
+// resourceMatch is the outcome of resolving an RFC 8707 resource indicator to
+// the consumer it addresses.
+type resourceMatch struct {
+	// auth is the OAuth2 provider attached to the consumer, if any.
+	auth *authdomain.Auth
+	// gatewayID owns the addressed consumer, so a fallback can be scoped to
+	// that tenant rather than the whole platform.
+	gatewayID ids.GatewayID
+	// matched reports whether the resource addressed a known consumer.
+	matched bool
+	// protected reports whether the consumer carries an enabled credential of
+	// its own, which rules out any identity-provider fallback.
+	protected bool
+}
+
 // resourceAuth resolves the RFC 8707 resource indicator to the OAuth2 auth
 // attached to the addressed consumer. When the consumer is found but exposes no
 // usable OAuth2 auth, it still reports the consumer's gateway so the caller can
 // scope the identity-provider fallback to that tenant.
-func (p *authProxy) resourceAuth(ctx context.Context, resource string) (*authdomain.Auth, ids.GatewayID, bool) {
+func (p *authProxy) resourceAuth(ctx context.Context, resource string) resourceMatch {
 	if p.paths == nil || resource == "" {
-		return nil, ids.GatewayID{}, false
+		return resourceMatch{}
 	}
 	u, err := url.Parse(resource)
 	if err != nil || u.Path == "" {
-		return nil, ids.GatewayID{}, false
+		return resourceMatch{}
 	}
 	matches, err := p.paths.Match(ctx, u.Host, u.Path)
 	if err != nil {
 		slog.Warn("oauth: resource lookup failed; falling back to single-issuer selection",
 			"resource", resource, "error", err)
-		return nil, ids.GatewayID{}, false
+		return resourceMatch{}
 	}
+	if len(matches) == 0 {
+		return resourceMatch{}
+	}
+	providers, protected := pathOAuth2Auths(matches)
+	out := resourceMatch{gatewayID: matches[0].GatewayID, matched: true, protected: protected}
+	if len(providers) > 0 {
+		out.auth = providers[0]
+	}
+	return out
+}
+
+// pathOAuth2Auths returns the usable OAuth2 providers attached to the matched
+// paths, and whether those paths carry an enabled credential of their own.
+func pathOAuth2Auths(matches []appconsumer.PathMatch) ([]*authdomain.Auth, bool) {
+	var providers []*authdomain.Auth
+	protected := false
 	for _, m := range matches {
 		for _, a := range m.Auths {
-			if a.Enabled && a.Type == authdomain.TypeOAuth2 && a.Config.OAuth2 != nil {
-				return a, m.GatewayID, true
+			if !a.Enabled {
+				continue
+			}
+			protected = true
+			if a.Type == authdomain.TypeOAuth2 && a.Config.OAuth2 != nil {
+				providers = append(providers, a)
 			}
 		}
 	}
-	if len(matches) > 0 {
-		return nil, matches[0].GatewayID, true
-	}
-	return nil, ids.GatewayID{}, false
+	return providers, protected
 }
 
 func (p *authProxy) pendingAuth(ctx context.Context, pending *PendingAuthorization) (*authdomain.Auth, error) {


### PR DESCRIPTION
## Summary

Follow-up to #456. That PR withheld the built-in identity provider from the auth chain, which closed the access bypass: an api-key MCP consumer now returns a plain `401` with no `WWW-Authenticate`, and a brokered platform session is refused.

It was not enough in practice. A client does not discover OAuth through the challenge header alone — it probes the resource metadata — and two other code paths applied the old rule:

```
GET /.well-known/oauth-protected-resource/{slug}/mcp
→ 200 {"authorization_servers":["https://<gateway>"], ...}
```

`metadataService.resourceAuths` and `authProxy.authForResource` both fell back to the gateway's identity provider whenever the addressed consumer had no oauth2 auth of its own. So an api-key consumer kept advertising OAuth, the client kept offering an authorization prompt, and `/oauth/authorize` kept brokering a login — one that ends in a session the gateway now refuses. Confusing for the user, and it still walked them onto the external-provider connect page.

Both paths now apply the same condition as the auth chain, through a shared `pathOAuth2Auths` helper: a consumer carrying an enabled credential gets no fallback, so metadata advertises no authorization server and authorize answers `invalid_target`. Consumers with no credential of their own are unaffected and still reach the platform login.

## Test plan

- [x] `go test ./pkg/app/... ./pkg/api/...`
- [x] Mutation check: both new tests fail when the `protected` flag is dropped
- [x] `go build`, `go vet`, `golangci-lint`
- [ ] On dev: `/.well-known/oauth-protected-resource/{slug}/mcp` returns no `authorization_servers` for an api-key consumer
- [ ] On dev: Cursor no longer offers to authorize that MCP server
- [ ] On dev: a consumer with no credential still reaches the platform login

Fixes RUN-1156

Linear: https://linear.app/neuraltrust/issue/RUN-1156

Made with [Cursor](https://cursor.com)