### PR TITLE
fix: return OAuth authorize refusals to the MCP client (RUN-1136)

### DIFF
--- a/docs/mcp/api-key-auth-and-external-credentials.md
+++ b/docs/mcp/api-key-auth-and-external-credentials.md
@@ -235,6 +235,15 @@ Fixing only the auth chain leaves a client offering an authorization prompt
 that ends in a session the gateway rejects, so all three follow the same
 condition.
 
+The `invalid_target` refusal travels back on the client's `redirect_uri` as
+RFC 6749 §4.1.2.1 prescribes, carrying `state` and a description that names the
+`X-AG-API-Key` header. Rendering it on the gateway instead would strand an MCP
+client that is parked on its callback: the access is denied either way, but the
+client only learns of it through the redirect. The `redirect_uri` is therefore
+validated against the client before the resource is resolved — a request whose
+redirect cannot be trusted is still refused on the gateway, since following it
+would be an open redirect.
+
 ## 6. URLs the App must expose
 
 For an MCP consumer with an `api_key` auth, the consumer detail view should show:

--- a/pkg/app/oauth/proxy.go
+++ b/pkg/app/oauth/proxy.go
@@ -17,6 +17,7 @@ package oauth
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math"
@@ -80,14 +81,18 @@ func (p *authProxy) Authorize(ctx context.Context, baseURL string, req Authorize
 	if req.CodeChallenge == "" || (req.CodeChallengeMethod != "" && req.CodeChallengeMethod != "S256") {
 		return "", oauthErr("invalid_request", "PKCE with code_challenge_method=S256 is required")
 	}
-	auth, err := p.authForResource(ctx, req.Resource)
-	if err != nil {
-		return "", err
-	}
-	cfg := auth.Config.OAuth2
+	// The redirect_uri is only trustworthy once it has been checked against the
+	// client, so that check comes before anything else that can fail: from here
+	// on a protocol error can be reported to the client instead of rendered
+	// here, where an agent waiting on its callback would never read it.
 	if err := p.validateClientRedirect(ctx, req.ClientID, req.RedirectURI); err != nil {
 		return "", err
 	}
+	auth, err := p.authForResource(ctx, req.Resource)
+	if err != nil {
+		return authorizeFailure(req, err)
+	}
+	cfg := auth.Config.OAuth2
 	endpoints, err := p.idp.endpoints(ctx, cfg)
 	if err != nil {
 		return "", err
@@ -128,6 +133,21 @@ func (p *authProxy) Authorize(ctx context.Context, baseURL string, req Authorize
 		q.Set("scope", scope)
 	}
 	return endpoints.authorize + "?" + q.Encode(), nil
+}
+
+// authorizeFailure turns a rejected authorization into a redirect back to the
+// client, as RFC 6749 §4.1.2.1 requires once the redirect_uri is validated.
+// Anything that is not a protocol error is a fault on this side and is left to
+// the caller to render.
+func authorizeFailure(req AuthorizeRequest, err error) (string, error) {
+	var oe *OAuthError
+	if !errors.As(err, &oe) {
+		return "", err
+	}
+	return clientRedirect(req.RedirectURI, url.Values{
+		"error":             {oe.Code},
+		"error_description": {oe.Description},
+	}, req.State), nil
 }
 
 func (p *authProxy) Callback(ctx context.Context, baseURL, state, code, idpErr, idpErrDesc string) (string, error) {

--- a/pkg/app/oauth/proxy_auth_selection.go
+++ b/pkg/app/oauth/proxy_auth_selection.go
@@ -39,7 +39,8 @@ func (p *authProxy) authForResource(ctx context.Context, resource string) (*auth
 		// would only walk the user through a flow that cannot reach it.
 		if m.protected {
 			return nil, oauthErr("invalid_target",
-				"this MCP server authenticates with its own credential; interactive login is not available")
+				"this MCP server authenticates with a credential of its own: send it on every request "+
+					"(an api key travels in the X-AG-API-Key header) instead of signing in here")
 		}
 		// The resource pinned a consumer but it has no OAuth2 identity provider of
 		// its own: fall back to the single IdP configured on that consumer's

--- a/pkg/app/oauth/proxy_test.go
+++ b/pkg/app/oauth/proxy_test.go
@@ -561,6 +561,88 @@ func TestAuthorizeResourceFallsBackToGatewayScopedIdP(t *testing.T) {
 	}
 }
 
+// assertClientToldOfError checks that a refused authorization travelled back to
+// the client instead of being rendered by the gateway. An agent that opened the
+// authorize URL is parked on its callback: an error it never receives leaves it
+// waiting forever.
+func assertClientToldOfError(t *testing.T, location, redirectURI, code string) {
+	t.Helper()
+	if !strings.HasPrefix(location, redirectURI) {
+		t.Fatalf("refusal must land on the client's redirect_uri, got %q", location)
+	}
+	u, err := url.Parse(location)
+	if err != nil {
+		t.Fatalf("parse refusal redirect: %v", err)
+	}
+	if got := u.Query().Get("error"); got != code {
+		t.Fatalf("expected error=%s, got %q", code, got)
+	}
+	if u.Query().Get("error_description") == "" {
+		t.Fatal("a refusal without a description leaves the user with nothing to act on")
+	}
+}
+
+// A consumer that authenticates with its own credential cannot be reached
+// through an interactive login, and the client has to hear that: an MCP client
+// that opened this URL is blocked on its callback until the refusal arrives.
+func TestAuthorizeCredentialProtectedConsumerRefusesToClient(t *testing.T) {
+	t.Parallel()
+	gatewayID := ids.New[ids.GatewayKind]()
+	apiKey, err := authdomain.NewAPIKeyAuth(gatewayID, "key", true)
+	if err != nil {
+		t.Fatalf("build api key auth: %v", err)
+	}
+	paths := &fakePathResolver{byPath: map[string][]appconsumer.PathMatch{
+		"/cons/mcp": {{GatewayID: gatewayID, Auths: []*authdomain.Auth{apiKey}}},
+	}}
+	proxy := NewAuthProxy(&fakeCredentialFinder{}, paths, http.DefaultClient, newMemFlowStore(), nil, nil, nil)
+
+	location, err := proxy.Authorize(context.Background(), "http://gw.example.com", AuthorizeRequest{
+		ResponseType:        "code",
+		ClientID:            "cli",
+		RedirectURI:         "https://client.example.com/cb",
+		State:               "client-state",
+		CodeChallenge:       s256("v"),
+		CodeChallengeMethod: "S256",
+		Resource:            "http://gw.example.com/cons/mcp",
+	})
+	if err != nil {
+		t.Fatalf("the client, not the gateway, owns this refusal: %v", err)
+	}
+	assertClientToldOfError(t, location, "https://client.example.com/cb", "invalid_target")
+	u, _ := url.Parse(location)
+	if got := u.Query().Get("state"); got != "client-state" {
+		t.Fatalf("state must survive the refusal, got %q", got)
+	}
+	if desc := u.Query().Get("error_description"); !strings.Contains(desc, "X-AG-API-Key") {
+		t.Fatalf("the refusal should name the credential the client is missing, got %q", desc)
+	}
+}
+
+// An unregistered private-use redirect_uri is rejected before the request is
+// acted on, and cannot be redirected to: the gateway renders that one itself.
+func TestAuthorizeUnregisteredPrivateUseRedirectIsNotFollowed(t *testing.T) {
+	t.Parallel()
+	gatewayID := ids.New[ids.GatewayKind]()
+	paths := &fakePathResolver{byPath: map[string][]appconsumer.PathMatch{
+		"/cons/mcp": {{GatewayID: gatewayID, Auths: nil}},
+	}}
+	proxy := NewAuthProxy(&fakeCredentialFinder{}, paths, http.DefaultClient, newMemFlowStore(), nil, nil, nil)
+
+	_, err := proxy.Authorize(context.Background(), "http://gw.example.com", AuthorizeRequest{
+		ResponseType:        "code",
+		ClientID:            "cli",
+		RedirectURI:         "cursor://cb",
+		CodeChallenge:       s256("v"),
+		CodeChallengeMethod: "S256",
+		Resource:            "http://gw.example.com/cons/mcp",
+	})
+	var oe *OAuthError
+	if !errors.As(err, &oe) || oe.Code != "invalid_request" {
+		t.Fatalf("expected invalid_request for an unregistered private-use redirect, got %v", err)
+	}
+}
+
 // A consumer without its own OAuth2 auth on a gateway that hosts several IdPs
 // is genuinely ambiguous: the client gets invalid_target, not a cross-tenant
 // leak.
@@ -578,18 +660,18 @@ func TestAuthorizeResourceAmbiguousWithinGateway(t *testing.T) {
 	}}
 	proxy := NewAuthProxy(finder, paths, http.DefaultClient, newMemFlowStore(), nil, nil, nil)
 
-	_, err := proxy.Authorize(context.Background(), "http://gw.example.com", AuthorizeRequest{
+	location, err := proxy.Authorize(context.Background(), "http://gw.example.com", AuthorizeRequest{
 		ResponseType:        "code",
 		ClientID:            "client-a",
-		RedirectURI:         "cursor://cb",
+		RedirectURI:         "https://client.example.com/cb",
 		CodeChallenge:       s256("v"),
 		CodeChallengeMethod: "S256",
 		Resource:            "http://gw.example.com/cons/mcp",
 	})
-	var oe *OAuthError
-	if !errors.As(err, &oe) || oe.Code != "invalid_target" {
-		t.Fatalf("expected invalid_target within an ambiguous gateway, got %v", err)
+	if err != nil {
+		t.Fatalf("an ambiguous target is the client's to hear about: %v", err)
 	}
+	assertClientToldOfError(t, location, "https://client.example.com/cb", "invalid_target")
 }
 
 func TestAuthorizeResourceNoOAuth2GivesClearError(t *testing.T) {
@@ -601,18 +683,18 @@ func TestAuthorizeResourceNoOAuth2GivesClearError(t *testing.T) {
 	}}
 	proxy := NewAuthProxy(finder, paths, http.DefaultClient, newMemFlowStore(), nil, nil, nil)
 
-	_, err := proxy.Authorize(context.Background(), "http://gw.example.com", AuthorizeRequest{
+	location, err := proxy.Authorize(context.Background(), "http://gw.example.com", AuthorizeRequest{
 		ResponseType:        "code",
 		ClientID:            "cli",
-		RedirectURI:         "cursor://cb",
+		RedirectURI:         "https://client.example.com/cb",
 		CodeChallenge:       s256("v"),
 		CodeChallengeMethod: "S256",
 		Resource:            "http://gw.example.com/cons/mcp",
 	})
-	var oe *OAuthError
-	if !errors.As(err, &oe) || oe.Code != "invalid_request" {
-		t.Fatalf("expected invalid_request for a consumer without oauth2, got %v", err)
+	if err != nil {
+		t.Fatalf("a consumer without oauth2 is the client's to hear about: %v", err)
 	}
+	assertClientToldOfError(t, location, "https://client.example.com/cb", "invalid_request")
 }
 
 // Multiple IdPs without a resource indicator cannot be disambiguated: the
@@ -625,16 +707,16 @@ func TestAuthorizeMultiIssuerRequiresResource(t *testing.T) {
 	}}
 	proxy := NewAuthProxy(finder, &fakePathResolver{}, http.DefaultClient, newMemFlowStore(), nil, nil, nil)
 
-	_, err := proxy.Authorize(context.Background(), "http://gw.example.com", AuthorizeRequest{
+	location, err := proxy.Authorize(context.Background(), "http://gw.example.com", AuthorizeRequest{
 		ResponseType:        "code",
-		RedirectURI:         "cursor://cb",
+		RedirectURI:         "https://client.example.com/cb",
 		CodeChallenge:       s256("v"),
 		CodeChallengeMethod: "S256",
 	})
-	var oe *OAuthError
-	if !errors.As(err, &oe) || oe.Code != "invalid_target" {
-		t.Fatalf("expected invalid_target, got %v", err)
+	if err != nil {
+		t.Fatalf("an ambiguous issuer set is the client's to hear about: %v", err)
 	}
+	assertClientToldOfError(t, location, "https://client.example.com/cb", "invalid_target")
 }
 
 // Without a resource indicator, the gateway addressed by the request (resolved

--- a/tests/functional/mcp_oauth_shared_host_test.go
+++ b/tests/functional/mcp_oauth_shared_host_test.go
@@ -221,8 +221,15 @@ func TestMCPOAuth_SharedHostScopesChallengeAndResolvesConsumerIdP(t *testing.T) 
 	t.Run("authorize without a resource is ambiguous", func(t *testing.T) {
 		resp := mcpRequestWithHost(t, http.MethodGet, "/oauth/authorize", sharedHost,
 			authorizeQuery(clientA, ""), nil)
-		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
-		require.Equal(t, "invalid_target", decodeBody(t, resp)["error"])
+		defer func() { _ = resp.Body.Close() }()
+		// The refusal rides back on the client's redirect_uri: a client parked on
+		// its callback would otherwise wait out an error it never reads.
+		require.Equal(t, http.StatusFound, resp.StatusCode)
+		loc, err := resp.Location()
+		require.NoError(t, err)
+		require.Equal(t, "https://client.example/oauth/callback", loc.Scheme+"://"+loc.Host+loc.Path)
+		require.Equal(t, "invalid_target", loc.Query().Get("error"))
+		require.NotEmpty(t, loc.Query().Get("state"))
 	})
 
 	t.Run("authorize with the path-scoped resource redirects to the consumer IdP", func(t *testing.T) {


### PR DESCRIPTION
## Summary

An MCP client that opens `/oauth/authorize` is parked on its callback. When the gateway refused the request it rendered the error itself, so the client never read it and hung — in Cursor this shows up as an endless *Waiting for callback…* after trying to sign in to a consumer that authenticates with an API key.

The refusal was correct; only its delivery was wrong.

- `validateClientRedirect` now runs **before** the resource is resolved, so the `redirect_uri` is trustworthy by the time anything else can fail.
- Protocol errors after that point travel back on the client's `redirect_uri` with `state` preserved, as RFC 6749 §4.1.2.1 prescribes.
- A `redirect_uri` that cannot be trusted (private-use, unregistered) is still refused by the gateway — following it would be an open redirect.
- The `invalid_target` description now names the `X-AG-API-Key` header, so the user learns what to send instead of just being told no.

No change to who gets in: access for credential-protected consumers stays closed, exactly as #456 and #457 left it.

## Test plan

- [x] New: refusal for an API-key consumer redirects with `invalid_target`, keeps `state`, and names the header
- [x] New: unregistered private-use `redirect_uri` is refused on the gateway, not followed
- [x] Updated three authorize tests that relied on the old ordering, plus the shared-host functional test that expected a 400 JSON body
- [x] `go build ./...`, `go vet ./...` (incl. `-tags functional`), `gofmt`, `golangci-lint` — 0 issues
- [x] Green: `pkg/app/oauth`, `pkg/api/handler/http/oauth`, `pkg/api/middleware`, `pkg/server/router`
- [ ] Verify in dev with Cursor: adding the MCP without an API key fails fast instead of hanging

Linear: https://linear.app/neuraltrust/issue/RUN-1136

Made with [Cursor](https://cursor.com)