### PR TITLE
fix: backport the OTLP protocol inference to develop (AUT-566)

### DIFF
--- a/pkg/infra/telemetry/otlp/settings.go
+++ b/pkg/infra/telemetry/otlp/settings.go
@@ -17,6 +17,8 @@ package otlp
 import (
 	"errors"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -54,6 +56,9 @@ const (
 	// this limit is the smaller of the two the SDK silently slices attributes
 	// mid-JSON, which drops the trailing usage chunk of streamed responses.
 	defaultMaxBodyBytes = 2 * 1024 * 1024
+
+	otlpGRPCPort = "4317"
+	otlpHTTPPort = "4318"
 )
 
 // TLSSettings configures mutual or server-only TLS for the OTLP transport.
@@ -116,7 +121,7 @@ func parseSettings(raw map[string]interface{}, env config.OTLPConfig) (Settings,
 	}
 
 	if s.Protocol == "" {
-		s.Protocol = defaultProtocol
+		s.Protocol = resolveProtocol(s.Endpoint)
 	}
 	if s.Signal == "" {
 		s.Signal = defaultSignal
@@ -133,6 +138,51 @@ func parseSettings(raw map[string]interface{}, env config.OTLPConfig) (Settings,
 	return s, nil
 }
 
+// resolveProtocol picks the wire protocol for exporters that declare none, either
+// in their settings or through OTEL_EXPORTER_OTLP_PROTOCOL: a gRPC client aimed at
+// an OTLP/HTTP collector fails on every export rather than at boot. A path
+// (/v1/logs) or port 4318 only exist on the HTTP form; gRPC endpoints are
+// host:4317.
+func resolveProtocol(endpoint string) Protocol {
+	host, path := splitEndpoint(endpoint)
+	if strings.Trim(path, "/") != "" {
+		return ProtocolHTTP
+	}
+	switch portOf(host) {
+	case otlpHTTPPort:
+		return ProtocolHTTP
+	case otlpGRPCPort:
+		return ProtocolGRPC
+	}
+	return defaultProtocol
+}
+
+// splitEndpoint separates the authority from the path of an OTLP endpoint, which
+// may be a full URL or a bare host:port.
+func splitEndpoint(endpoint string) (host, path string) {
+	endpoint = strings.TrimSpace(endpoint)
+	if endpoint == "" {
+		return "", ""
+	}
+	if !hasScheme(endpoint) {
+		endpoint = "//" + endpoint
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return endpoint, ""
+	}
+	return u.Host, u.Path
+}
+
+// portOf returns the port of an authority, or an empty string when it carries none.
+func portOf(host string) string {
+	_, port, err := net.SplitHostPort(host)
+	if err != nil {
+		return ""
+	}
+	return port
+}
+
 // validate performs structural validation only; it never performs network I/O.
 func (s Settings) validate() error {
 	if strings.TrimSpace(s.Endpoint) == "" {
@@ -142,6 +192,14 @@ func (s Settings) validate() error {
 	case ProtocolGRPC, ProtocolHTTP:
 	default:
 		return fmt.Errorf("otlp: invalid protocol %q (want %q or %q)", s.Protocol, ProtocolGRPC, ProtocolHTTP)
+	}
+	if s.Protocol == ProtocolGRPC {
+		if _, path := splitEndpoint(s.Endpoint); strings.Trim(path, "/") != "" {
+			return fmt.Errorf(
+				"otlp: grpc endpoint %q must not carry a path; drop it or set protocol %q",
+				s.Endpoint, ProtocolHTTP,
+			)
+		}
 	}
 	switch s.Signal {
 	case SignalLogs:

--- a/pkg/infra/telemetry/otlp/settings_test.go
+++ b/pkg/infra/telemetry/otlp/settings_test.go
@@ -119,6 +119,58 @@ func TestParseSettings(t *testing.T) {
 	}
 }
 
+func TestParseSettingsResolvesProtocolFromEndpoint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		endpoint string
+		env      config.OTLPConfig
+		want     Protocol
+	}{
+		{
+			name:     "collector url with signal path is http",
+			endpoint: "http://collector:4318/v1/logs",
+			want:     ProtocolHTTP,
+		},
+		{
+			name:     "scheme-less endpoint with path is http",
+			endpoint: "collector:4318/v1/logs",
+			want:     ProtocolHTTP,
+		},
+		{
+			name:     "otlp http port without path is http",
+			endpoint: "http://collector:4318",
+			want:     ProtocolHTTP,
+		},
+		{
+			name:     "otlp grpc port is grpc",
+			endpoint: "collector:4317",
+			want:     ProtocolGRPC,
+		},
+		{
+			name:     "unknown port falls back to the default",
+			endpoint: "collector:9999",
+			want:     defaultProtocol,
+		},
+		{
+			name:     "env protocol wins over the endpoint",
+			endpoint: "http://collector:4318/v1/logs",
+			env:      config.OTLPConfig{Protocol: string(ProtocolGRPC)},
+			want:     ProtocolGRPC,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s, err := parseSettings(map[string]interface{}{"endpoint": tc.endpoint}, tc.env)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, s.Protocol)
+		})
+	}
+}
+
 func TestSettingsValidate(t *testing.T) {
 	t.Parallel()
 
@@ -152,6 +204,14 @@ func TestSettingsValidate(t *testing.T) {
 			name:    "non-positive timeout",
 			raw:     map[string]interface{}{"endpoint": "collector:4317", "timeout": "-1s"},
 			wantErr: "timeout",
+		},
+		{
+			name: "grpc endpoint carrying a path",
+			raw: map[string]interface{}{
+				"endpoint": "http://collector:4317/v1/logs",
+				"protocol": string(ProtocolGRPC),
+			},
+			wantErr: "must not carry a path",
 		},
 		{
 			name:    "invalid compression",


### PR DESCRIPTION
## Summary

Hardening ported from TrustGuard, where this exact configuration shape took prod telemetry down this morning ([TrustGuard#500](https://github.com/NeuralTrust/TrustGuard/pull/500)).

An `otlp` exporter declared as a type token (`TELEMETRY_EXPORTERS_METADATA=otlp`) or as `type: otlp` with no `settings` — which is what `config/telemetry.hybrid.example.yaml` ships — takes its whole connection from the `OTEL_EXPORTER_OTLP_*` env vars. When `OTEL_EXPORTER_OTLP_PROTOCOL` is unset the protocol falls back to `defaultProtocol = ProtocolGRPC`, so a collector URL such as `http://host:4318/v1/logs` builds an insecure gRPC client against an OTLP/HTTP receiver. Every export then dies on the HTTP/2 preface:

```
error reading server preface: http2: failed reading the frame payload:
http2: frame too large, note that the frame header looked like an HTTP/1.1 header
```

TrustGate's own overlays are **not** affected — `dev`, `prod` and `prod-us` already set `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` on both `main` and `develop`, so no config change is needed here. This closes the latent trap for anyone (notably hybrid customers) whose values omit that variable.

Changes:

- `resolveProtocol` picks the protocol when neither the settings nor the env declare one: a path (`/v1/logs`) or port 4318 means `http/protobuf`, port 4317 means `grpc`, anything else keeps the previous `grpc` default.
- `Settings.validate` rejects a `grpc` endpoint carrying a path, turning a permanent runtime failure into a boot error.

## Linear

AUT-566 — https://linear.app/neuraltrust/issue/AUT-566

## Test plan

- [x] `go test -race ./pkg/infra/telemetry/...`
- [x] `golangci-lint run ./pkg/infra/telemetry/otlp/...` clean
- [x] New table tests cover URL with path, scheme-less endpoint with path, ports 4317/4318, unknown port, and env precedence

Made with [Cursor](https://cursor.com)