### PR TITLE
fix: default OTLP protocol to http/protobuf and append /v1/logs (AUT-566)

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -575,7 +575,7 @@ func getOTLPConfig() OTLPConfig {
 	return OTLPConfig{
 		Endpoint:    getEnv("OTEL_EXPORTER_OTLP_ENDPOINT", ""),
 		Headers:     parseOTLPHeaders(getEnv("OTEL_EXPORTER_OTLP_HEADERS", "")),
-		Protocol:    getEnv("OTEL_EXPORTER_OTLP_PROTOCOL", ""),
+		Protocol:    getEnv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf"),
 		Timeout:     getOTLPTimeout(),
 		Insecure:    getEnvBool("OTEL_EXPORTER_OTLP_INSECURE", false),
 		Compression: getEnv("OTEL_EXPORTER_OTLP_COMPRESSION", ""),

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -458,6 +458,9 @@ func TestLoadConfig_OTLPDefaultsAndOverrides(t *testing.T) {
 	if cfg.Telemetry.OTLP.Endpoint != "" {
 		t.Errorf("OTLP.Endpoint default = %q, want empty", cfg.Telemetry.OTLP.Endpoint)
 	}
+	if cfg.Telemetry.OTLP.Protocol != "http/protobuf" {
+		t.Errorf("OTLP.Protocol default = %q, want http/protobuf", cfg.Telemetry.OTLP.Protocol)
+	}
 	if cfg.Telemetry.OTLP.Timeout != 0 {
 		t.Errorf("OTLP.Timeout default = %v, want 0", cfg.Telemetry.OTLP.Timeout)
 	}

--- a/pkg/infra/telemetry/otlp/provider.go
+++ b/pkg/infra/telemetry/otlp/provider.go
@@ -95,9 +95,13 @@ func newGRPCExporter(ctx context.Context, s Settings) (sdklog.Exporter, error) {
 func newHTTPExporter(ctx context.Context, s Settings) (sdklog.Exporter, error) {
 	opts := []otlploghttp.Option{otlploghttp.WithTimeout(s.Timeout)}
 	if hasScheme(s.Endpoint) {
-		opts = append(opts, otlploghttp.WithEndpointURL(s.Endpoint))
+		opts = append(opts, otlploghttp.WithEndpointURL(withLogsPath(s.Endpoint)))
 	} else {
-		opts = append(opts, otlploghttp.WithEndpoint(s.Endpoint))
+		host, path := splitEndpoint(s.Endpoint)
+		opts = append(opts, otlploghttp.WithEndpoint(host))
+		if strings.Trim(path, "/") != "" {
+			opts = append(opts, otlploghttp.WithURLPath(path))
+		}
 	}
 	if len(s.Headers) > 0 {
 		opts = append(opts, otlploghttp.WithHeaders(s.Headers))

--- a/pkg/infra/telemetry/otlp/settings.go
+++ b/pkg/infra/telemetry/otlp/settings.go
@@ -47,10 +47,10 @@ const (
 	compressionGzip = "gzip"
 	compressionNone = "none"
 
-	defaultProtocol     = ProtocolGRPC
-	defaultSignal       = SignalLogs
-	defaultCompression  = compressionGzip
-	defaultTimeout      = 10 * time.Second
+	defaultProtocol    = ProtocolHTTP
+	defaultSignal      = SignalLogs
+	defaultCompression = compressionGzip
+	defaultTimeout     = 10 * time.Second
 	// Kept above events.MaxSanitizedBodyBytes on purpose: the sanitizer is the
 	// only component allowed to truncate a body, because it marks the cut. When
 	// this limit is the smaller of the two the SDK silently slices attributes
@@ -59,6 +59,8 @@ const (
 
 	otlpGRPCPort = "4317"
 	otlpHTTPPort = "4318"
+
+	logsSignalPath = "/v1/logs"
 )
 
 // TLSSettings configures mutual or server-only TLS for the OTLP transport.
@@ -172,6 +174,17 @@ func splitEndpoint(endpoint string) (host, path string) {
 		return endpoint, ""
 	}
 	return u.Host, u.Path
+}
+
+// withLogsPath appends the logs signal path to an endpoint URL that omits it.
+// WithEndpointURL takes the path verbatim and marks it as set, which suppresses
+// the SDK's own /v1/logs fallback and posts every batch to the server root.
+func withLogsPath(endpoint string) string {
+	endpoint = strings.TrimSpace(endpoint)
+	if _, path := splitEndpoint(endpoint); strings.Trim(path, "/") != "" {
+		return endpoint
+	}
+	return strings.TrimSuffix(endpoint, "/") + logsSignalPath
 }
 
 // portOf returns the port of an authority, or an empty string when it carries none.

--- a/pkg/infra/telemetry/otlp/settings_test.go
+++ b/pkg/infra/telemetry/otlp/settings_test.go
@@ -34,10 +34,10 @@ func TestParseSettings(t *testing.T) {
 	}{
 		{
 			name: "minimal valid applies defaults",
-			raw:  map[string]interface{}{"endpoint": "collector:4317"},
+			raw:  map[string]interface{}{"endpoint": "collector:4318"},
 			assert: func(t *testing.T, s Settings) {
-				assert.Equal(t, "collector:4317", s.Endpoint)
-				assert.Equal(t, ProtocolGRPC, s.Protocol)
+				assert.Equal(t, "collector:4318", s.Endpoint)
+				assert.Equal(t, ProtocolHTTP, s.Protocol)
 				assert.Equal(t, SignalLogs, s.Signal)
 				assert.Equal(t, compressionGzip, s.Compression)
 				assert.Equal(t, defaultTimeout, s.Timeout)
@@ -167,6 +167,44 @@ func TestParseSettingsResolvesProtocolFromEndpoint(t *testing.T) {
 			s, err := parseSettings(map[string]interface{}{"endpoint": tc.endpoint}, tc.env)
 			require.NoError(t, err)
 			assert.Equal(t, tc.want, s.Protocol)
+		})
+	}
+}
+
+func TestWithLogsPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		endpoint string
+		want     string
+	}{
+		{
+			name:     "endpoint without path gets the signal path",
+			endpoint: "http://collector:4318",
+			want:     "http://collector:4318/v1/logs",
+		},
+		{
+			name:     "trailing slash is not doubled",
+			endpoint: "http://collector:4318/",
+			want:     "http://collector:4318/v1/logs",
+		},
+		{
+			name:     "existing signal path is kept",
+			endpoint: "http://collector:4318/v1/logs",
+			want:     "http://collector:4318/v1/logs",
+		},
+		{
+			name:     "custom path is kept",
+			endpoint: "https://gateway.example.com/otlp/v1/logs",
+			want:     "https://gateway.example.com/otlp/v1/logs",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, withLogsPath(tc.endpoint))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

**Hotfix to `main`** — follow-up to #461. Branched off `origin/main` so nothing else from `develop` rides along.

`OTEL_EXPORTER_OTLP_PROTOCOL` had no code-level default: an unset env var stayed empty and the exporter fell back to gRPC unless the endpoint happened to look like HTTP. TrustGate overlays already set the variable, but hybrid / type-token configs that omit it would hit the same silent failure as TrustGuard.

This change:

- Defaults `OTEL_EXPORTER_OTLP_PROTOCOL` to `http/protobuf` when the env var is unset (`getEnv(..., "http/protobuf")` and `defaultProtocol = ProtocolHTTP`).
- Appends `/v1/logs` to HTTP endpoints that omit the signal path. `WithEndpointURL` marks an empty path as set and suppresses the SDK fallback, so `http://collector:4318` was POSTing to the collector root.
- Splits scheme-less endpoints (`collector:4318/v1/logs`) into host + `WithURLPath` instead of treating the whole string as a host.

gRPC still works: set `OTEL_EXPORTER_OTLP_PROTOCOL=grpc` or `settings.protocol: grpc`.

## Linear

AUT-566 — https://linear.app/neuraltrust/issue/AUT-566

Fixes AUT-566

## Test plan

- [x] `go test -mod=mod ./pkg/infra/telemetry/... ./pkg/config/` green
- [x] `go vet -mod=mod ./pkg/infra/telemetry/otlp/...` clean
- [ ] After merge: existing overlays keep exporting to ClickHouse
- [ ] HTTP endpoints without `/v1/logs` still land in the collector


Made with [Cursor](https://cursor.com)