### PR TITLE
feat: support OAuth client_credentials and add Sectigo, n8n and Halo MCP servers (ENG-1348)

### DIFF
--- a/pkg/api/handler/http/registry/request/create_registry_request.go
+++ b/pkg/api/handler/http/registry/request/create_registry_request.go
@@ -54,14 +54,15 @@ type MCPAuthRequest struct {
 	Scope    string `json:"scope,omitempty"`
 	Actor    string `json:"actor,omitempty"`
 
-	Provider     string   `json:"provider,omitempty"`
-	Registration string   `json:"registration,omitempty"`
-	ClientID     string   `json:"client_id,omitempty"`
-	ClientSecret string   `json:"client_secret,omitempty"` // #nosec G117
-	AuthorizeURL string   `json:"authorize_url,omitempty"`
-	TokenURL     string   `json:"token_url,omitempty"`
-	Scopes       []string `json:"scopes,omitempty"`
-	Resource     string   `json:"resource,omitempty"`
+	Provider                string   `json:"provider,omitempty"`
+	Registration            string   `json:"registration,omitempty"`
+	ClientID                string   `json:"client_id,omitempty"`
+	ClientSecret            string   `json:"client_secret,omitempty"` // #nosec G117
+	AuthorizeURL            string   `json:"authorize_url,omitempty"`
+	TokenURL                string   `json:"token_url,omitempty"`
+	Scopes                  []string `json:"scopes,omitempty"`
+	Resource                string   `json:"resource,omitempty"`
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method,omitempty"`
 }
 
 type HealthChecksRequest struct {
@@ -193,22 +194,23 @@ func (t *MCPTargetRequest) ToDomain() *domain.MCPTarget {
 	}
 	if t.Auth != nil {
 		out.Auth = &domain.MCPAuth{
-			Mode:             domain.MCPAuthMode(t.Auth.Mode),
-			Header:           t.Auth.Header,
-			Value:            t.Auth.Value,
-			ExpectedAudience: t.Auth.ExpectedAudience,
-			Pattern:          domain.MCPExchangePattern(t.Auth.Pattern),
-			Audience:         t.Auth.Audience,
-			Scope:            t.Auth.Scope,
-			Actor:            t.Auth.Actor,
-			Provider:         t.Auth.Provider,
-			Registration:     domain.MCPClientRegistration(t.Auth.Registration),
-			ClientID:         t.Auth.ClientID,
-			ClientSecret:     t.Auth.ClientSecret,
-			AuthorizeURL:     t.Auth.AuthorizeURL,
-			TokenURL:         t.Auth.TokenURL,
-			Scopes:           t.Auth.Scopes,
-			Resource:         t.Auth.Resource,
+			Mode:                    domain.MCPAuthMode(t.Auth.Mode),
+			Header:                  t.Auth.Header,
+			Value:                   t.Auth.Value,
+			ExpectedAudience:        t.Auth.ExpectedAudience,
+			Pattern:                 domain.MCPExchangePattern(t.Auth.Pattern),
+			Audience:                t.Auth.Audience,
+			Scope:                   t.Auth.Scope,
+			Actor:                   t.Auth.Actor,
+			Provider:                t.Auth.Provider,
+			Registration:            domain.MCPClientRegistration(t.Auth.Registration),
+			ClientID:                t.Auth.ClientID,
+			ClientSecret:            t.Auth.ClientSecret,
+			AuthorizeURL:            t.Auth.AuthorizeURL,
+			TokenURL:                t.Auth.TokenURL,
+			Scopes:                  t.Auth.Scopes,
+			Resource:                t.Auth.Resource,
+			TokenEndpointAuthMethod: t.Auth.TokenEndpointAuthMethod,
 		}
 	}
 	return out

--- a/pkg/api/handler/http/registry/response/registry_response.go
+++ b/pkg/api/handler/http/registry/response/registry_response.go
@@ -58,14 +58,15 @@ type MCPAuthResponse struct {
 	Scope    string `json:"scope,omitempty"`
 	Actor    string `json:"actor,omitempty"`
 
-	Provider     string   `json:"provider,omitempty"`
-	Registration string   `json:"registration,omitempty"`
-	ClientID     string   `json:"client_id,omitempty"`
-	ClientSecret string   `json:"client_secret,omitempty"` // #nosec G117 -- masked before serialization
-	AuthorizeURL string   `json:"authorize_url,omitempty"`
-	TokenURL     string   `json:"token_url,omitempty"`
-	Scopes       []string `json:"scopes,omitempty"`
-	Resource     string   `json:"resource,omitempty"`
+	Provider                string   `json:"provider,omitempty"`
+	Registration            string   `json:"registration,omitempty"`
+	ClientID                string   `json:"client_id,omitempty"`
+	ClientSecret            string   `json:"client_secret,omitempty"` // #nosec G117 -- masked before serialization
+	AuthorizeURL            string   `json:"authorize_url,omitempty"`
+	TokenURL                string   `json:"token_url,omitempty"`
+	Scopes                  []string `json:"scopes,omitempty"`
+	Resource                string   `json:"resource,omitempty"`
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method,omitempty"`
 }
 
 type HealthChecksResponse struct {
@@ -169,22 +170,23 @@ func fromMCPTarget(t *domain.MCPTarget) *MCPTargetResponse {
 	}
 	if t.Auth != nil {
 		out.Auth = &MCPAuthResponse{
-			Mode:             string(t.Auth.Mode),
-			Header:           t.Auth.Header,
-			Value:            secret.Mask(t.Auth.Value),
-			ExpectedAudience: t.Auth.ExpectedAudience,
-			Pattern:          string(t.Auth.Pattern),
-			Audience:         t.Auth.Audience,
-			Scope:            t.Auth.Scope,
-			Actor:            t.Auth.Actor,
-			Provider:         t.Auth.Provider,
-			Registration:     string(t.Auth.Registration),
-			ClientID:         t.Auth.ClientID,
-			ClientSecret:     secret.Mask(t.Auth.ClientSecret),
-			AuthorizeURL:     t.Auth.AuthorizeURL,
-			TokenURL:         t.Auth.TokenURL,
-			Scopes:           t.Auth.Scopes,
-			Resource:         t.Auth.Resource,
+			Mode:                    string(t.Auth.Mode),
+			Header:                  t.Auth.Header,
+			Value:                   secret.Mask(t.Auth.Value),
+			ExpectedAudience:        t.Auth.ExpectedAudience,
+			Pattern:                 string(t.Auth.Pattern),
+			Audience:                t.Auth.Audience,
+			Scope:                   t.Auth.Scope,
+			Actor:                   t.Auth.Actor,
+			Provider:                t.Auth.Provider,
+			Registration:            string(t.Auth.Registration),
+			ClientID:                t.Auth.ClientID,
+			ClientSecret:            secret.Mask(t.Auth.ClientSecret),
+			AuthorizeURL:            t.Auth.AuthorizeURL,
+			TokenURL:                t.Auth.TokenURL,
+			Scopes:                  t.Auth.Scopes,
+			Resource:                t.Auth.Resource,
+			TokenEndpointAuthMethod: t.Auth.TokenEndpointAuthMethod,
 		}
 	}
 	return out

--- a/pkg/app/catalog/mcp_servers.go
+++ b/pkg/app/catalog/mcp_servers.go
@@ -25,12 +25,15 @@ import (
 
 type MCPServerCatalog interface {
 	ListMCPServers() []domain.MCPServer
+	// GetByCode returns the curated entry for code, or false when unknown.
+	GetByCode(code string) (domain.MCPServer, bool)
 }
 
 var _ MCPServerCatalog = (*mcpServerCatalog)(nil)
 
 type mcpServerCatalog struct {
 	servers []domain.MCPServer
+	byCode  map[string]domain.MCPServer
 }
 
 // NewMCPServerCatalog loads the curated catalog of remote MCP servers embedded
@@ -41,13 +44,22 @@ func NewMCPServerCatalog() (MCPServerCatalog, error) {
 	if err != nil {
 		return nil, fmt.Errorf("loading curated mcp catalog: %w", err)
 	}
-	return &mcpServerCatalog{servers: servers}, nil
+	byCode := make(map[string]domain.MCPServer, len(servers))
+	for _, s := range servers {
+		byCode[s.Code] = s
+	}
+	return &mcpServerCatalog{servers: servers, byCode: byCode}, nil
 }
 
 func (c *mcpServerCatalog) ListMCPServers() []domain.MCPServer {
 	out := make([]domain.MCPServer, len(c.servers))
 	copy(out, c.servers)
 	return out
+}
+
+func (c *mcpServerCatalog) GetByCode(code string) (domain.MCPServer, bool) {
+	s, ok := c.byCode[code]
+	return s, ok
 }
 
 const curatedSource = "curated"
@@ -63,6 +75,9 @@ const (
 // registrationAuto marks OAuth servers whose client self-registers (DCR), so no
 // operator configuration is needed before connecting.
 const registrationAuto = "auto"
+
+// grantTypeClientCredentials marks machine-to-machine OAuth in the catalog.
+const grantTypeClientCredentials = "client_credentials"
 
 // rawCatalog mirrors the schema of seed/mcp-catalog/enterprise-servers.json.
 type rawCatalog struct {
@@ -175,6 +190,9 @@ func requiresConfig(s rawServer) bool {
 	case authHintStatic:
 		return true
 	case authHintOAuth:
+		if s.OAuth != nil && s.OAuth.GrantType == grantTypeClientCredentials {
+			return true
+		}
 		return s.OAuth.Registration != registrationAuto
 	default:
 		return true

--- a/pkg/app/catalog/mcp_servers_test.go
+++ b/pkg/app/catalog/mcp_servers_test.go
@@ -119,62 +119,6 @@ func TestParseCuratedMCPServers_OmitsHidden(t *testing.T) {
 	require.NotContains(t, codes, "com.hidden/mcp")
 }
 
-func TestRequiresConfig_Classification(t *testing.T) {
-	t.Parallel()
-
-	boolPtr := func(b bool) *bool { return &b }
-
-	tests := []struct {
-		name string
-		in   rawServer
-		want bool
-	}{
-		{
-			name: "public, no url vars => connect by default",
-			in:   rawServer{RequiresAuth: false},
-			want: false,
-		},
-		{
-			name: "oauth auto, no url vars => connect by default",
-			in:   rawServer{OAuth: &domain.MCPOAuth{Required: true, Registration: "auto", DCR: boolPtr(true)}},
-			want: false,
-		},
-		{
-			name: "oauth manual => needs config",
-			in:   rawServer{OAuth: &domain.MCPOAuth{Required: true, Registration: "manual", DCR: boolPtr(false)}},
-			want: true,
-		},
-		{
-			name: "oauth unknown registration (tenant) => needs config",
-			in:   rawServer{OAuth: &domain.MCPOAuth{Required: true}},
-			want: true,
-		},
-		{
-			name: "static secret => needs config",
-			in: rawServer{
-				RequiresAuth: true,
-				AuthHeaders:  []domain.MCPAuthHeader{{Name: "Authorization", Required: true, Secret: true}},
-			},
-			want: true,
-		},
-		{
-			name: "oauth auto but required url var (tenant host) => needs config",
-			in: rawServer{
-				OAuth:        &domain.MCPOAuth{Required: true, Registration: "auto", DCR: boolPtr(true)},
-				URLVariables: []domain.MCPURLVariable{{Name: "domain", Required: true}},
-			},
-			want: true,
-		},
-	}
-	for _, tc := range tests {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			require.Equal(t, tc.want, requiresConfig(tc.in))
-		})
-	}
-}
-
 func TestAuthHint_Classification(t *testing.T) {
 	t.Parallel()
 
@@ -214,4 +158,98 @@ func TestAuthHint_Classification(t *testing.T) {
 			require.Equal(t, tc.want, authHint(tc.in))
 		})
 	}
+}
+
+func TestRequiresConfig_Classification(t *testing.T) {
+	t.Parallel()
+
+	boolPtr := func(b bool) *bool { return &b }
+
+	tests := []struct {
+		name string
+		in   rawServer
+		want bool
+	}{
+		{
+			name: "public, no url vars => connect by default",
+			in:   rawServer{RequiresAuth: false},
+			want: false,
+		},
+		{
+			name: "oauth auto, no url vars => connect by default",
+			in:   rawServer{OAuth: &domain.MCPOAuth{Required: true, Registration: "auto", DCR: boolPtr(true)}},
+			want: false,
+		},
+		{
+			name: "oauth manual => needs config",
+			in:   rawServer{OAuth: &domain.MCPOAuth{Required: true, Registration: "manual", DCR: boolPtr(false)}},
+			want: true,
+		},
+		{
+			name: "oauth unknown registration (tenant) => needs config",
+			in:   rawServer{OAuth: &domain.MCPOAuth{Required: true}},
+			want: true,
+		},
+		{
+			name: "static secret => needs config",
+			in: rawServer{
+				RequiresAuth: true,
+				AuthHeaders:  []domain.MCPAuthHeader{{Name: "Authorization", Required: true, Secret: true}},
+			},
+			want: true,
+		},
+		{
+			name: "oauth client_credentials => needs config",
+			in: rawServer{OAuth: &domain.MCPOAuth{
+				Required:  true,
+				GrantType: "client_credentials",
+				TokenURL:  "https://idp.example/token",
+			}},
+			want: true,
+		},
+		{
+			name: "oauth auto but required url var (tenant host) => needs config",
+			in: rawServer{
+				OAuth:        &domain.MCPOAuth{Required: true, Registration: "auto", DCR: boolPtr(true)},
+				URLVariables: []domain.MCPURLVariable{{Name: "domain", Required: true}},
+			},
+			want: true,
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, requiresConfig(tc.in))
+		})
+	}
+}
+
+func TestNewMCPServerCatalog_IncludesSectigoN8nHalo(t *testing.T) {
+	t.Parallel()
+	cat, err := NewMCPServerCatalog()
+	require.NoError(t, err)
+
+	sectigo, ok := cat.GetByCode("com.sectigo/mcp")
+	require.True(t, ok)
+	require.Equal(t, "https://mcp.{instance}.sectigo.com/mcp", sectigo.URL)
+	require.Equal(t, authHintOAuth, sectigo.AuthHint)
+	require.True(t, sectigo.RequiresConfig)
+	require.NotNil(t, sectigo.OAuth)
+	require.Equal(t, "client_credentials", sectigo.OAuth.GrantType)
+	require.Contains(t, sectigo.OAuth.TokenURL, "auth.sso.sectigo.com")
+
+	n8n, ok := cat.GetByCode("io.n8n/mcp")
+	require.True(t, ok)
+	require.Equal(t, "https://{domain}/mcp-server/http", n8n.URL)
+	require.Equal(t, authHintOAuth, n8n.AuthHint)
+	require.True(t, n8n.RequiresConfig)
+	require.Equal(t, "auto", n8n.OAuth.Registration)
+
+	halo, ok := cat.GetByCode("com.haloitsm/mcp")
+	require.True(t, ok)
+	require.Equal(t, "https://{instance}/api/mcp", halo.URL)
+	require.Equal(t, authHintStatic, halo.AuthHint)
+	require.True(t, halo.RequiresConfig)
+	require.NotEmpty(t, halo.AuthHeaders)
 }

--- a/pkg/app/mcp/credentials.go
+++ b/pkg/app/mcp/credentials.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	appconsumer "github.com/NeuralTrust/TrustGate/pkg/app/consumer"
@@ -59,6 +60,16 @@ type credentialResolver struct {
 	provider  appoauth.ProviderClient
 	logger    *slog.Logger
 	refresh   singleflight.Group
+	ccFlight  singleflight.Group
+	ccCache   sync.Map // key → *ccCacheEntry
+}
+
+type ccCacheEntry struct {
+	token     string
+	expiresAt time.Time
+	// fingerprint pins the entry to the registry revision it was minted for, so
+	// editing the credential invalidates it without leaving a stale key behind.
+	fingerprint string
 }
 
 func NewCredentialResolver(
@@ -96,6 +107,8 @@ func (r *credentialResolver) Apply(ctx context.Context, rc *appconsumer.Routable
 		return r.exchange(ctx, rc, reg, cfg, target)
 	case registrydomain.MCPAuthModeForwarded:
 		return r.forwarded(ctx, rc, reg, target)
+	case registrydomain.MCPAuthModeClientCredentials:
+		return r.clientCredentials(ctx, reg, cfg, target)
 	default:
 		return fmt.Errorf("mcp: unknown downstream auth mode %q", cfg.Mode)
 	}
@@ -259,6 +272,74 @@ func (r *credentialResolver) consentRequired(ctx context.Context, rc *appconsume
 		return err
 	}
 	return &ConsentRequiredError{Provider: provider, Ticket: ticket, Path: consumerPath}
+}
+
+func (r *credentialResolver) clientCredentials(
+	ctx context.Context,
+	reg *registrydomain.Registry,
+	cfg *registrydomain.MCPAuth,
+	target *Target,
+) error {
+	if r.provider == nil {
+		return errors.New("mcp: client_credentials requires an OAuth provider client")
+	}
+	// Keyed by registry id alone so the map stays bounded by the number of MCP
+	// registries; a credential edit overwrites its entry instead of adding one.
+	key := reg.ID.String()
+	fingerprint := ccFingerprint(reg)
+	if cached, ok := r.cachedCCToken(key, fingerprint); ok {
+		setAuthorization(target, "Bearer "+cached.token)
+		return nil
+	}
+	v, err, _ := r.ccFlight.Do(key+"|"+fingerprint, func() (any, error) {
+		if cached, ok := r.cachedCCToken(key, fingerprint); ok {
+			return cached, nil
+		}
+		tok, err := r.provider.ClientCredentials(ctx, cfg)
+		if err != nil {
+			return nil, err
+		}
+		if tok.AccessToken == "" {
+			return nil, errors.New("mcp: client_credentials returned empty access token")
+		}
+		expiresAt := tok.ExpiresAt
+		if expiresAt.IsZero() {
+			expiresAt = time.Now().Add(defaultCCTokenTTL)
+		}
+		cached := &ccCacheEntry{token: tok.AccessToken, expiresAt: expiresAt, fingerprint: fingerprint}
+		r.ccCache.Store(key, cached)
+		return cached, nil
+	})
+	if err != nil {
+		return err
+	}
+	cached, ok := v.(*ccCacheEntry)
+	if !ok {
+		return errors.New("mcp credentials: unexpected singleflight result type")
+	}
+	setAuthorization(target, "Bearer "+cached.token)
+	return nil
+}
+
+const defaultCCTokenTTL = time.Hour
+
+func (r *credentialResolver) cachedCCToken(key, fingerprint string) (*ccCacheEntry, bool) {
+	v, ok := r.ccCache.Load(key)
+	if !ok {
+		return nil, false
+	}
+	cached, ok := v.(*ccCacheEntry)
+	if !ok || cached.fingerprint != fingerprint {
+		return nil, false
+	}
+	if !time.Now().Before(cached.expiresAt.Add(-vaultRefreshSkew)) {
+		return nil, false
+	}
+	return cached, true
+}
+
+func ccFingerprint(reg *registrydomain.Registry) string {
+	return reg.UpdatedAt.UTC().Format(time.RFC3339Nano)
 }
 
 func setAuthorization(target *Target, value string) {

--- a/pkg/app/mcp/credentials_test.go
+++ b/pkg/app/mcp/credentials_test.go
@@ -420,6 +420,135 @@ func TestCredentialResolver_NoneAndStaticAreNoops(t *testing.T) {
 	}
 }
 
+type stubProviderClient struct {
+	token   *appoauth.ProviderToken
+	err     error
+	calls   int
+	lastCfg *registrydomain.MCPAuth
+	block   chan struct{}
+	started chan struct{}
+}
+
+func (s *stubProviderClient) AuthorizeURL(*registrydomain.MCPAuth, string, string, string) string {
+	return ""
+}
+
+func (s *stubProviderClient) ExchangeCode(context.Context, *registrydomain.MCPAuth, string, string, string) (*appoauth.ProviderToken, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *stubProviderClient) Refresh(context.Context, *registrydomain.MCPAuth, string) (*appoauth.ProviderToken, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *stubProviderClient) ClientCredentials(_ context.Context, cfg *registrydomain.MCPAuth) (*appoauth.ProviderToken, error) {
+	s.calls++
+	s.lastCfg = cfg
+	if s.started != nil {
+		close(s.started)
+		s.started = nil
+	}
+	if s.block != nil {
+		<-s.block
+	}
+	return s.token, s.err
+}
+
+func TestCredentialResolver_ClientCredentials(t *testing.T) {
+	t.Parallel()
+	gw := ids.New[ids.GatewayKind]()
+	auth := &registrydomain.MCPAuth{
+		Mode:     registrydomain.MCPAuthModeClientCredentials,
+		ClientID: "cid", ClientSecret: "csec",
+		TokenURL:                "https://idp.example/token",
+		TokenEndpointAuthMethod: registrydomain.TokenEndpointAuthClientSecretBasic,
+		Resource:                "https://mcp.example.com/mcp",
+	}
+	reg := regWithAuth(gw, auth)
+
+	t.Run("injects bearer token and caches", func(t *testing.T) {
+		t.Parallel()
+		prov := &stubProviderClient{token: &appoauth.ProviderToken{
+			AccessToken: "m2m-tok", ExpiresAt: time.Now().Add(time.Hour),
+		}}
+		r := NewCredentialResolver(nil, nil, nil, prov, discardLogger())
+		target := Target{}
+		if err := r.Apply(context.Background(), mcpConsumer(gw), reg, &target); err != nil {
+			t.Fatalf("Apply: %v", err)
+		}
+		if target.Headers["Authorization"] != "Bearer m2m-tok" {
+			t.Fatalf("Authorization = %q", target.Headers["Authorization"])
+		}
+		target2 := Target{}
+		if err := r.Apply(context.Background(), mcpConsumer(gw), reg, &target2); err != nil {
+			t.Fatalf("Apply cached: %v", err)
+		}
+		if prov.calls != 1 {
+			t.Fatalf("provider calls = %d, want 1 (cached)", prov.calls)
+		}
+		if target2.Headers["Authorization"] != "Bearer m2m-tok" {
+			t.Fatalf("cached Authorization = %q", target2.Headers["Authorization"])
+		}
+	})
+
+	t.Run("does not require a principal", func(t *testing.T) {
+		t.Parallel()
+		prov := &stubProviderClient{token: &appoauth.ProviderToken{
+			AccessToken: "anon-ok", ExpiresAt: time.Now().Add(time.Hour),
+		}}
+		r := NewCredentialResolver(nil, nil, nil, prov, discardLogger())
+		target := Target{}
+		if err := r.Apply(context.Background(), mcpConsumer(gw), reg, &target); err != nil {
+			t.Fatalf("Apply without principal: %v", err)
+		}
+	})
+
+	t.Run("re-mints and reuses one cache slot when the registry changes", func(t *testing.T) {
+		t.Parallel()
+		prov := &stubProviderClient{token: &appoauth.ProviderToken{
+			AccessToken: "first", ExpiresAt: time.Now().Add(time.Hour),
+		}}
+		r := NewCredentialResolver(nil, nil, nil, prov, discardLogger())
+		resolver, ok := r.(*credentialResolver)
+		if !ok {
+			t.Fatalf("unexpected resolver type %T", r)
+		}
+		edited := regWithAuth(gw, auth)
+		target := Target{}
+		if err := r.Apply(context.Background(), mcpConsumer(gw), edited, &target); err != nil {
+			t.Fatalf("Apply: %v", err)
+		}
+
+		prov.token = &appoauth.ProviderToken{AccessToken: "second", ExpiresAt: time.Now().Add(time.Hour)}
+		edited.UpdatedAt = edited.UpdatedAt.Add(time.Minute)
+		target2 := Target{}
+		if err := r.Apply(context.Background(), mcpConsumer(gw), edited, &target2); err != nil {
+			t.Fatalf("Apply after edit: %v", err)
+		}
+		if target2.Headers["Authorization"] != "Bearer second" {
+			t.Fatalf("Authorization = %q, want the re-minted token", target2.Headers["Authorization"])
+		}
+		entries := 0
+		resolver.ccCache.Range(func(any, any) bool {
+			entries++
+			return true
+		})
+		if entries != 1 {
+			t.Fatalf("cache entries = %d, want 1 per registry", entries)
+		}
+	})
+
+	t.Run("surfaces provider errors", func(t *testing.T) {
+		t.Parallel()
+		prov := &stubProviderClient{err: errors.New("idp down")}
+		r := NewCredentialResolver(nil, nil, nil, prov, discardLogger())
+		target := Target{}
+		if err := r.Apply(context.Background(), mcpConsumer(gw), reg, &target); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+}
+
 // undecryptableVault holds a credential the current key cannot read, the way
 // the real vault reports it after SERVER_SECRET_KEY changes.
 type undecryptableVault struct{}

--- a/pkg/app/oauth/mocks/oauth_provider_client_mock.go
+++ b/pkg/app/oauth/mocks/oauth_provider_client_mock.go
@@ -194,6 +194,65 @@ func (_c *ProviderClient_Refresh_Call) RunAndReturn(run func(context.Context, *r
 	return _c
 }
 
+// ClientCredentials provides a mock function with given fields: ctx, cfg
+func (_m *ProviderClient) ClientCredentials(ctx context.Context, cfg *registry.MCPAuth) (*oauth.ProviderToken, error) {
+	ret := _m.Called(ctx, cfg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ClientCredentials")
+	}
+
+	var r0 *oauth.ProviderToken
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *registry.MCPAuth) (*oauth.ProviderToken, error)); ok {
+		return rf(ctx, cfg)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *registry.MCPAuth) *oauth.ProviderToken); ok {
+		r0 = rf(ctx, cfg)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*oauth.ProviderToken)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *registry.MCPAuth) error); ok {
+		r1 = rf(ctx, cfg)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ProviderClient_ClientCredentials_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ClientCredentials'
+type ProviderClient_ClientCredentials_Call struct {
+	*mock.Call
+}
+
+// ClientCredentials is a helper method to define mock.On call
+//   - ctx context.Context
+//   - cfg *registry.MCPAuth
+func (_e *ProviderClient_Expecter) ClientCredentials(ctx interface{}, cfg interface{}) *ProviderClient_ClientCredentials_Call {
+	return &ProviderClient_ClientCredentials_Call{Call: _e.mock.On("ClientCredentials", ctx, cfg)}
+}
+
+func (_c *ProviderClient_ClientCredentials_Call) Run(run func(ctx context.Context, cfg *registry.MCPAuth)) *ProviderClient_ClientCredentials_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*registry.MCPAuth))
+	})
+	return _c
+}
+
+func (_c *ProviderClient_ClientCredentials_Call) Return(_a0 *oauth.ProviderToken, _a1 error) *ProviderClient_ClientCredentials_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *ProviderClient_ClientCredentials_Call) RunAndReturn(run func(context.Context, *registry.MCPAuth) (*oauth.ProviderToken, error)) *ProviderClient_ClientCredentials_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewProviderClient creates a new instance of ProviderClient. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewProviderClient(t interface {

--- a/pkg/app/oauth/ports.go
+++ b/pkg/app/oauth/ports.go
@@ -34,6 +34,7 @@ type ProviderClient interface {
 	AuthorizeURL(cfg *registrydomain.MCPAuth, redirectURI, state, challenge string) string
 	ExchangeCode(ctx context.Context, cfg *registrydomain.MCPAuth, code, redirectURI, verifier string) (*ProviderToken, error)
 	Refresh(ctx context.Context, cfg *registrydomain.MCPAuth, refreshToken string) (*ProviderToken, error)
+	ClientCredentials(ctx context.Context, cfg *registrydomain.MCPAuth) (*ProviderToken, error)
 }
 
 var ErrUpstreamNotDiscoverable = errors.New(

--- a/pkg/app/registry/creator.go
+++ b/pkg/app/registry/creator.go
@@ -48,14 +48,22 @@ type creator struct {
 	memoryCache *cache.TTLMap
 	logger      *slog.Logger
 	signaler    configsyncport.SnapshotSignaler
+	catalog     MCPAuthCatalog
 }
 
-func NewCreator(repo domain.Repository, manager *cache.TTLMapManager, logger *slog.Logger, signaler configsyncport.SnapshotSignaler) Creator {
+func NewCreator(
+	repo domain.Repository,
+	manager *cache.TTLMapManager,
+	logger *slog.Logger,
+	signaler configsyncport.SnapshotSignaler,
+	catalog MCPAuthCatalog,
+) Creator {
 	return &creator{
 		repo:        repo,
 		memoryCache: manager.GetTTLMap(cache.RegistryTTLName),
 		logger:      logger,
 		signaler:    signaler,
+		catalog:     catalog,
 	}
 }
 
@@ -63,6 +71,9 @@ func (c *creator) Create(ctx context.Context, in CreateInput) (*domain.Registry,
 	var b *domain.Registry
 	var err error
 	if in.Type == domain.TypeMCP {
+		if err := CanonicalizeMCPAuthFromCatalog(in.MCPTarget, c.catalog); err != nil {
+			return nil, err
+		}
 		b, err = domain.NewMCPRegistry(
 			in.GatewayID,
 			in.Name,

--- a/pkg/app/registry/creator_test.go
+++ b/pkg/app/registry/creator_test.go
@@ -62,7 +62,7 @@ func TestCreator_Create_Success(t *testing.T) {
 		Once()
 
 	mgr := newCacheManager()
-	creator := appregistry.NewCreator(repo, mgr, newTestLogger(), nil)
+	creator := appregistry.NewCreator(repo, mgr, newTestLogger(), nil, nil)
 
 	b, err := creator.Create(context.Background(), validCreateInput(gwID, "backend-1"))
 	if err != nil {
@@ -82,7 +82,7 @@ func TestCreator_Create_RejectsInvalidProviderOptions(t *testing.T) {
 	repo := repomocks.NewRepository(t)
 	gwID := ids.New[ids.GatewayKind]()
 
-	creator := appregistry.NewCreator(repo, newCacheManager(), newTestLogger(), nil)
+	creator := appregistry.NewCreator(repo, newCacheManager(), newTestLogger(), nil, nil)
 
 	_, err := creator.Create(context.Background(), appregistry.CreateInput{
 		GatewayID: gwID,
@@ -124,7 +124,7 @@ func TestCreator_Create_EnabledFlag(t *testing.T) {
 				Return(nil).
 				Once()
 
-			creator := appregistry.NewCreator(repo, newCacheManager(), newTestLogger(), nil)
+			creator := appregistry.NewCreator(repo, newCacheManager(), newTestLogger(), nil, nil)
 			in := validCreateInput(gwID, "backend-"+tt.name)
 			in.Enabled = ptr(tt.enabled)
 			got, err := creator.Create(context.Background(), in)
@@ -149,7 +149,7 @@ func TestCreator_Create_EnabledDefaultsTrueWhenNil(t *testing.T) {
 		Return(nil).
 		Once()
 
-	creator := appregistry.NewCreator(repo, newCacheManager(), newTestLogger(), nil)
+	creator := appregistry.NewCreator(repo, newCacheManager(), newTestLogger(), nil, nil)
 	in := validCreateInput(gwID, "backend-default")
 	if in.Enabled != nil {
 		t.Fatal("precondition: Enabled should be unset in validCreateInput")
@@ -235,7 +235,7 @@ func TestCreator_Create_AzureModes(t *testing.T) {
 				Return(nil).
 				Once()
 
-			creator := appregistry.NewCreator(repo, newCacheManager(), newTestLogger(), nil)
+			creator := appregistry.NewCreator(repo, newCacheManager(), newTestLogger(), nil, nil)
 			got, err := creator.Create(context.Background(), appregistry.CreateInput{
 				GatewayID: gwID,
 				Name:      "azure-" + tt.name,
@@ -255,7 +255,7 @@ func TestCreator_Create_AzureModes(t *testing.T) {
 func TestCreator_Create_RejectsInvalid(t *testing.T) {
 	t.Parallel()
 	repo := repomocks.NewRepository(t)
-	creator := appregistry.NewCreator(repo, newCacheManager(), newTestLogger(), nil)
+	creator := appregistry.NewCreator(repo, newCacheManager(), newTestLogger(), nil, nil)
 
 	in := validCreateInput(ids.New[ids.GatewayKind](), "x")
 	in.LLMTarget.Provider = ""
@@ -269,7 +269,7 @@ func TestCreator_Create_PropagatesRepoError(t *testing.T) {
 	t.Parallel()
 	repo := repomocks.NewRepository(t)
 	repo.EXPECT().Save(mock.Anything, mock.Anything).Return(domain.ErrAlreadyExists).Once()
-	creator := appregistry.NewCreator(repo, newCacheManager(), newTestLogger(), nil)
+	creator := appregistry.NewCreator(repo, newCacheManager(), newTestLogger(), nil, nil)
 
 	_, err := creator.Create(context.Background(), validCreateInput(ids.New[ids.GatewayKind](), "dupe"))
 	if !errors.Is(err, domain.ErrAlreadyExists) {

--- a/pkg/app/registry/mcp_catalog_auth.go
+++ b/pkg/app/registry/mcp_catalog_auth.go
@@ -1,0 +1,93 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"fmt"
+	"strings"
+
+	commonerrors "github.com/NeuralTrust/TrustGate/pkg/common/errors"
+	catalogdomain "github.com/NeuralTrust/TrustGate/pkg/domain/catalog"
+	domain "github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+)
+
+const grantTypeClientCredentials = "client_credentials"
+
+// MCPAuthCatalog looks up curated MCP server metadata used to canonicalize
+// client_credentials auth. Defined here (instead of importing app/catalog) to
+// avoid an import cycle with catalog → registry.
+type MCPAuthCatalog interface {
+	GetByCode(code string) (catalogdomain.MCPServer, bool)
+}
+
+// CanonicalizeMCPAuthFromCatalog overwrites client-supplied token endpoint
+// metadata from the curated catalog when the registry was created from a
+// catalog code. This prevents an operator from redirecting a client secret to
+// an attacker-controlled token URL.
+func CanonicalizeMCPAuthFromCatalog(target *domain.MCPTarget, catalog MCPAuthCatalog) error {
+	if target == nil {
+		return nil
+	}
+	code := strings.TrimSpace(target.Code)
+	if code == "" {
+		return nil
+	}
+	// Fail closed: without the catalog a client-supplied token_url could not be
+	// checked against the curated entry it claims to be.
+	if catalog == nil {
+		return fmt.Errorf("%w: mcp catalog unavailable; cannot verify catalog entry %q",
+			commonerrors.ErrValidation, code)
+	}
+	entry, ok := catalog.GetByCode(code)
+	if !ok || entry.OAuth == nil || !entry.OAuth.Required {
+		return nil
+	}
+	if entry.OAuth.GrantType != grantTypeClientCredentials {
+		return nil
+	}
+	if target.Auth == nil {
+		target.Auth = &domain.MCPAuth{}
+	}
+	if mode := strings.TrimSpace(string(target.Auth.Mode)); mode != "" && mode != string(domain.MCPAuthModeClientCredentials) {
+		return fmt.Errorf("%w: catalog entry %q requires auth mode client_credentials", commonerrors.ErrValidation, code)
+	}
+	if strings.TrimSpace(entry.OAuth.TokenURL) == "" {
+		return fmt.Errorf("%w: catalog entry %q is missing oauth.token_url", commonerrors.ErrValidation, code)
+	}
+	target.Auth.Mode = domain.MCPAuthModeClientCredentials
+	target.Auth.TokenURL = entry.OAuth.TokenURL
+	target.Auth.Scopes = append([]string(nil), entry.OAuth.Scopes...)
+	target.Auth.TokenEndpointAuthMethod = entry.OAuth.TokenEndpointAuthMethod
+	if target.Auth.TokenEndpointAuthMethod == "" {
+		target.Auth.TokenEndpointAuthMethod = domain.TokenEndpointAuthClientSecretBasic
+	}
+	switch resource := strings.TrimSpace(entry.OAuth.Resource); {
+	case resource != "":
+		target.Auth.Resource = resource
+	case entry.OAuth.ResourceMetadata:
+		target.Auth.Resource = target.URL
+	default:
+		// The audience is part of what the catalog vouches for; never keep a
+		// client-supplied resource indicator.
+		target.Auth.Resource = ""
+	}
+	// Drop authorization-code fields that do not apply to M2M.
+	target.Auth.Provider = ""
+	target.Auth.Registration = ""
+	target.Auth.AuthorizeURL = ""
+	target.Auth.Header = ""
+	target.Auth.Value = ""
+	return nil
+}

--- a/pkg/app/registry/mcp_catalog_auth_test.go
+++ b/pkg/app/registry/mcp_catalog_auth_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"testing"
+
+	catalogdomain "github.com/NeuralTrust/TrustGate/pkg/domain/catalog"
+	domain "github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	"github.com/stretchr/testify/require"
+)
+
+type stubCatalog struct {
+	entries map[string]catalogdomain.MCPServer
+}
+
+func (s stubCatalog) GetByCode(code string) (catalogdomain.MCPServer, bool) {
+	e, ok := s.entries[code]
+	return e, ok
+}
+
+func TestCanonicalizeMCPAuthFromCatalog_ClientCredentials(t *testing.T) {
+	t.Parallel()
+	cat := stubCatalog{entries: map[string]catalogdomain.MCPServer{
+		"com.sectigo/mcp": {
+			Code: "com.sectigo/mcp",
+			URL:  "https://mcp.{instance}.sectigo.com/mcp",
+			OAuth: &catalogdomain.MCPOAuth{
+				Required:                true,
+				ResourceMetadata:        true,
+				GrantType:               "client_credentials",
+				TokenURL:                "https://auth.sso.sectigo.com/token",
+				TokenEndpointAuthMethod: domain.TokenEndpointAuthClientSecretBasic,
+			},
+		},
+	}}
+	target := &domain.MCPTarget{
+		Code: "com.sectigo/mcp",
+		URL:  "https://mcp.enterprise.sectigo.com/mcp",
+		Auth: &domain.MCPAuth{
+			Mode:         domain.MCPAuthModeClientCredentials,
+			ClientID:     "cid",
+			ClientSecret: "csecret",
+			TokenURL:     "https://evil.example/token",
+		},
+	}
+	require.NoError(t, CanonicalizeMCPAuthFromCatalog(target, cat))
+	require.Equal(t, "https://auth.sso.sectigo.com/token", target.Auth.TokenURL)
+	require.Equal(t, domain.TokenEndpointAuthClientSecretBasic, target.Auth.TokenEndpointAuthMethod)
+	require.Equal(t, "https://mcp.enterprise.sectigo.com/mcp", target.Auth.Resource)
+	require.Equal(t, "cid", target.Auth.ClientID)
+	require.Equal(t, "csecret", target.Auth.ClientSecret)
+}
+
+func TestCanonicalizeMCPAuthFromCatalog_RejectsWrongMode(t *testing.T) {
+	t.Parallel()
+	cat := stubCatalog{entries: map[string]catalogdomain.MCPServer{
+		"com.sectigo/mcp": {
+			Code: "com.sectigo/mcp",
+			OAuth: &catalogdomain.MCPOAuth{
+				Required:  true,
+				GrantType: "client_credentials",
+				TokenURL:  "https://auth.sso.sectigo.com/token",
+			},
+		},
+	}}
+	target := &domain.MCPTarget{
+		Code: "com.sectigo/mcp",
+		URL:  "https://mcp.enterprise.sectigo.com/mcp",
+		Auth: &domain.MCPAuth{Mode: domain.MCPAuthModeStatic, Header: "Authorization", Value: "Bearer x"},
+	}
+	require.Error(t, CanonicalizeMCPAuthFromCatalog(target, cat))
+}
+
+func TestCanonicalizeMCPAuthFromCatalog_DropsClientResourceWithoutCatalogAudience(t *testing.T) {
+	t.Parallel()
+	cat := stubCatalog{entries: map[string]catalogdomain.MCPServer{
+		"com.acme/mcp": {
+			Code: "com.acme/mcp",
+			OAuth: &catalogdomain.MCPOAuth{
+				Required:  true,
+				GrantType: "client_credentials",
+				TokenURL:  "https://idp.acme/token",
+			},
+		},
+	}}
+	target := &domain.MCPTarget{
+		Code: "com.acme/mcp",
+		URL:  "https://mcp.acme/mcp",
+		Auth: &domain.MCPAuth{
+			Mode:     domain.MCPAuthModeClientCredentials,
+			ClientID: "cid", ClientSecret: "csecret",
+			Resource: "https://attacker.example/audience",
+		},
+	}
+	require.NoError(t, CanonicalizeMCPAuthFromCatalog(target, cat))
+	require.Empty(t, target.Auth.Resource)
+}
+
+func TestCanonicalizeMCPAuthFromCatalog_FailsClosedWithoutCatalog(t *testing.T) {
+	t.Parallel()
+	target := &domain.MCPTarget{
+		Code: "com.sectigo/mcp",
+		URL:  "https://mcp.enterprise.sectigo.com/mcp",
+		Auth: &domain.MCPAuth{
+			Mode:     domain.MCPAuthModeClientCredentials,
+			ClientID: "cid", ClientSecret: "csecret",
+			TokenURL: "https://evil.example/token",
+		},
+	}
+	require.Error(t, CanonicalizeMCPAuthFromCatalog(target, nil))
+}
+
+func TestCanonicalizeMCPAuthFromCatalog_SkipsNonCatalog(t *testing.T) {
+	t.Parallel()
+	target := &domain.MCPTarget{
+		URL:  "https://custom.example/mcp",
+		Auth: &domain.MCPAuth{Mode: domain.MCPAuthModeNone},
+	}
+	require.NoError(t, CanonicalizeMCPAuthFromCatalog(target, stubCatalog{}))
+}

--- a/pkg/app/registry/signal_test.go
+++ b/pkg/app/registry/signal_test.go
@@ -33,7 +33,7 @@ func TestCreator_Create_SignalsOnSuccess(t *testing.T) {
 	repo.EXPECT().Save(mock.Anything, mock.Anything).Return(nil).Once()
 
 	signaler := &configsynctest.FakeSignaler{}
-	creator := appregistry.NewCreator(repo, newCacheManager(), newTestLogger(), signaler)
+	creator := appregistry.NewCreator(repo, newCacheManager(), newTestLogger(), signaler, nil)
 
 	if _, err := creator.Create(context.Background(), validCreateInput(gwID, "backend-1")); err != nil {
 		t.Fatalf("Create error: %v", err)
@@ -50,7 +50,7 @@ func TestCreator_Create_DoesNotSignalOnFailure(t *testing.T) {
 	repo.EXPECT().Save(mock.Anything, mock.Anything).Return(errors.New("boom")).Once()
 
 	signaler := &configsynctest.FakeSignaler{}
-	creator := appregistry.NewCreator(repo, newCacheManager(), newTestLogger(), signaler)
+	creator := appregistry.NewCreator(repo, newCacheManager(), newTestLogger(), signaler, nil)
 
 	if _, err := creator.Create(context.Background(), validCreateInput(gwID, "backend-1")); err == nil {
 		t.Fatal("expected error, got nil")
@@ -66,7 +66,7 @@ func TestCreator_Create_NilSignalerIsSafe(t *testing.T) {
 	gwID := ids.New[ids.GatewayKind]()
 	repo.EXPECT().Save(mock.Anything, mock.Anything).Return(nil).Once()
 
-	creator := appregistry.NewCreator(repo, newCacheManager(), newTestLogger(), nil)
+	creator := appregistry.NewCreator(repo, newCacheManager(), newTestLogger(), nil, nil)
 
 	if _, err := creator.Create(context.Background(), validCreateInput(gwID, "backend-1")); err != nil {
 		t.Fatalf("Create error: %v", err)

--- a/pkg/app/registry/updater.go
+++ b/pkg/app/registry/updater.go
@@ -53,6 +53,7 @@ type updater struct {
 	publisher   cache.EventPublisher
 	logger      *slog.Logger
 	signaler    configsyncport.SnapshotSignaler
+	catalog     MCPAuthCatalog
 }
 
 func NewUpdater(
@@ -61,6 +62,7 @@ func NewUpdater(
 	publisher cache.EventPublisher,
 	logger *slog.Logger,
 	signaler configsyncport.SnapshotSignaler,
+	catalog MCPAuthCatalog,
 ) Updater {
 	return &updater{
 		repo:        repo,
@@ -68,6 +70,7 @@ func NewUpdater(
 		publisher:   publisher,
 		logger:      logger,
 		signaler:    signaler,
+		catalog:     catalog,
 	}
 }
 
@@ -89,7 +92,9 @@ func (u *updater) Update(ctx context.Context, in UpdateInput) (*domain.Registry,
 		existing.Enabled = *in.Enabled
 	}
 	applyLLMTargetUpdate(existing, in)
-	applyMCPTargetUpdate(existing, in)
+	if err := applyMCPTargetUpdate(existing, in, u.catalog); err != nil {
+		return nil, err
+	}
 	existing.UpdatedAt = time.Now().UTC()
 	if !existing.IsMCP() {
 		if verr := validateProviderOptions(existing.LLMTarget); verr != nil {
@@ -110,9 +115,9 @@ func (u *updater) Update(ctx context.Context, in UpdateInput) (*domain.Registry,
 	return existing, nil
 }
 
-func applyMCPTargetUpdate(existing *domain.Registry, in UpdateInput) {
+func applyMCPTargetUpdate(existing *domain.Registry, in UpdateInput, catalog MCPAuthCatalog) error {
 	if in.MCPTarget == nil {
-		return
+		return nil
 	}
 	incoming := in.MCPTarget
 	if prev := existing.MCPTarget; prev != nil {
@@ -128,10 +133,17 @@ func applyMCPTargetUpdate(existing *domain.Registry, in UpdateInput) {
 		if incoming.Auth == nil {
 			incoming.Auth = prev.Auth
 		}
+		if strings.TrimSpace(incoming.Code) == "" {
+			incoming.Code = prev.Code
+		}
 	}
 	incoming.Normalize()
 	incoming.ResolveSecretsFrom(existing.MCPTarget)
+	if err := CanonicalizeMCPAuthFromCatalog(incoming, catalog); err != nil {
+		return err
+	}
 	existing.MCPTarget = incoming
+	return nil
 }
 
 func applyLLMTargetUpdate(existing *domain.Registry, in UpdateInput) {

--- a/pkg/app/registry/updater_test.go
+++ b/pkg/app/registry/updater_test.go
@@ -45,7 +45,7 @@ func TestUpdater_Update_Success(t *testing.T) {
 		Return(nil).
 		Once()
 
-	updater := appregistry.NewUpdater(repo, newCacheManager(), publisher, newTestLogger(), nil)
+	updater := appregistry.NewUpdater(repo, newCacheManager(), publisher, newTestLogger(), nil, nil)
 	got, err := updater.Update(context.Background(), appregistry.UpdateInput{
 		ID:       existing.ID,
 		Name:     ptr("new"),
@@ -78,7 +78,7 @@ func TestUpdater_Update_TogglesEnabled(t *testing.T) {
 		Return(nil).
 		Once()
 
-	updater := appregistry.NewUpdater(repo, newCacheManager(), publisher, newTestLogger(), nil)
+	updater := appregistry.NewUpdater(repo, newCacheManager(), publisher, newTestLogger(), nil, nil)
 	got, err := updater.Update(context.Background(), appregistry.UpdateInput{
 		ID:      existing.ID,
 		Enabled: ptr(false),
@@ -106,7 +106,7 @@ func TestUpdater_Update_EnabledUnchangedWhenNil(t *testing.T) {
 		Return(nil).
 		Once()
 
-	updater := appregistry.NewUpdater(repo, newCacheManager(), publisher, newTestLogger(), nil)
+	updater := appregistry.NewUpdater(repo, newCacheManager(), publisher, newTestLogger(), nil, nil)
 	got, err := updater.Update(context.Background(), appregistry.UpdateInput{
 		ID:   existing.ID,
 		Name: ptr("renamed"),
@@ -139,7 +139,7 @@ func TestUpdater_Update_Partial_PreservesProviderOptionsAndHealthChecks(t *testi
 		Return(nil).
 		Once()
 
-	updater := appregistry.NewUpdater(repo, newCacheManager(), publisher, newTestLogger(), nil)
+	updater := appregistry.NewUpdater(repo, newCacheManager(), publisher, newTestLogger(), nil, nil)
 	got, err := updater.Update(context.Background(), appregistry.UpdateInput{
 		ID:   existing.ID,
 		Name: ptr("renamed"),
@@ -182,7 +182,7 @@ func TestUpdater_Update_PartialMCPTargetPreservesAuthAndHeaders(t *testing.T) {
 		Return(nil).
 		Once()
 
-	updater := appregistry.NewUpdater(repo, newCacheManager(), publisher, newTestLogger(), nil)
+	updater := appregistry.NewUpdater(repo, newCacheManager(), publisher, newTestLogger(), nil, nil)
 	got, err := updater.Update(context.Background(), appregistry.UpdateInput{
 		ID:        existing.ID,
 		MCPTarget: &domain.MCPTarget{URL: "https://new.example.com/mcp"},
@@ -220,7 +220,7 @@ func TestUpdater_Update_MCPTargetAuthClearedExplicitly(t *testing.T) {
 		Return(nil).
 		Once()
 
-	updater := appregistry.NewUpdater(repo, newCacheManager(), publisher, newTestLogger(), nil)
+	updater := appregistry.NewUpdater(repo, newCacheManager(), publisher, newTestLogger(), nil, nil)
 	got, err := updater.Update(context.Background(), appregistry.UpdateInput{
 		ID:        existing.ID,
 		MCPTarget: &domain.MCPTarget{Auth: &domain.MCPAuth{Mode: domain.MCPAuthModeNone}},
@@ -251,7 +251,7 @@ func TestUpdater_Update_PreservesRedactedSecret(t *testing.T) {
 		Return(nil).
 		Once()
 
-	updater := appregistry.NewUpdater(repo, newCacheManager(), publisher, newTestLogger(), nil)
+	updater := appregistry.NewUpdater(repo, newCacheManager(), publisher, newTestLogger(), nil, nil)
 	got, err := updater.Update(context.Background(), appregistry.UpdateInput{
 		ID:       existing.ID,
 		Name:     ptr("old"),
@@ -281,7 +281,7 @@ func TestUpdater_Update_PreservesSecretWhenAuthOmitted(t *testing.T) {
 		Return(nil).
 		Once()
 
-	updater := appregistry.NewUpdater(repo, newCacheManager(), publisher, newTestLogger(), nil)
+	updater := appregistry.NewUpdater(repo, newCacheManager(), publisher, newTestLogger(), nil, nil)
 	got, err := updater.Update(context.Background(), appregistry.UpdateInput{
 		ID:       existing.ID,
 		Name:     ptr("renamed"),
@@ -322,7 +322,7 @@ func TestUpdater_Update_AzurePreservesAPIKeyForSameMode(t *testing.T) {
 		Return(nil).
 		Once()
 
-	updater := appregistry.NewUpdater(repo, newCacheManager(), publisher, newTestLogger(), nil)
+	updater := appregistry.NewUpdater(repo, newCacheManager(), publisher, newTestLogger(), nil, nil)
 	got, err := updater.Update(context.Background(), appregistry.UpdateInput{
 		ID: existing.ID,
 		Auth: &domain.TargetAuth{
@@ -372,7 +372,7 @@ func TestUpdater_Update_AzurePreservesClientSecretForSameServicePrincipal(t *tes
 		Return(nil).
 		Once()
 
-	updater := appregistry.NewUpdater(repo, newCacheManager(), publisher, newTestLogger(), nil)
+	updater := appregistry.NewUpdater(repo, newCacheManager(), publisher, newTestLogger(), nil, nil)
 	got, err := updater.Update(context.Background(), appregistry.UpdateInput{
 		ID: existing.ID,
 		Auth: &domain.TargetAuth{
@@ -424,7 +424,7 @@ func TestUpdater_Update_AzureClearsIncompatibleSecretsOnModeChange(t *testing.T)
 		Return(nil).
 		Once()
 
-	updater := appregistry.NewUpdater(repo, newCacheManager(), publisher, newTestLogger(), nil)
+	updater := appregistry.NewUpdater(repo, newCacheManager(), publisher, newTestLogger(), nil, nil)
 	got, err := updater.Update(context.Background(), appregistry.UpdateInput{
 		ID: existing.ID,
 		Auth: &domain.TargetAuth{
@@ -462,7 +462,7 @@ func TestUpdater_Update_AzureRejectsServicePrincipalSecretForDifferentPrincipal(
 
 	publisher := cachemocks.NewEventPublisher(t)
 
-	updater := appregistry.NewUpdater(repo, newCacheManager(), publisher, newTestLogger(), nil)
+	updater := appregistry.NewUpdater(repo, newCacheManager(), publisher, newTestLogger(), nil, nil)
 	_, err := updater.Update(context.Background(), appregistry.UpdateInput{
 		ID: existing.ID,
 		Auth: &domain.TargetAuth{
@@ -489,7 +489,7 @@ func TestUpdater_Update_RejectsGatewayIDChange(t *testing.T) {
 
 	publisher := cachemocks.NewEventPublisher(t)
 
-	updater := appregistry.NewUpdater(repo, newCacheManager(), publisher, newTestLogger(), nil)
+	updater := appregistry.NewUpdater(repo, newCacheManager(), publisher, newTestLogger(), nil, nil)
 	_, err := updater.Update(context.Background(), appregistry.UpdateInput{
 		ID:        existing.ID,
 		GatewayID: ids.New[ids.GatewayKind](),
@@ -511,7 +511,7 @@ func TestUpdater_Update_NotFound(t *testing.T) {
 
 	publisher := cachemocks.NewEventPublisher(t)
 
-	updater := appregistry.NewUpdater(repo, newCacheManager(), publisher, newTestLogger(), nil)
+	updater := appregistry.NewUpdater(repo, newCacheManager(), publisher, newTestLogger(), nil, nil)
 	_, err := updater.Update(context.Background(), appregistry.UpdateInput{
 		ID:       id,
 		Name:     ptr("x"),

--- a/pkg/container/modules/registry.go
+++ b/pkg/container/modules/registry.go
@@ -18,6 +18,7 @@ import (
 	"log/slog"
 
 	registryhttp "github.com/NeuralTrust/TrustGate/pkg/api/handler/http/registry"
+	appcatalog "github.com/NeuralTrust/TrustGate/pkg/app/catalog"
 	appregistry "github.com/NeuralTrust/TrustGate/pkg/app/registry"
 	"github.com/NeuralTrust/TrustGate/pkg/container"
 	domain "github.com/NeuralTrust/TrustGate/pkg/domain/registry"
@@ -42,13 +43,13 @@ func provideRegistryRepository(c *container.Container) error {
 }
 
 func provideRegistryServices(c *container.Container) error {
-	if err := c.Provide(func(repo domain.Repository, manager *cache.TTLMapManager, logger *slog.Logger, sig snapshotSignalParams) appregistry.Creator {
-		return appregistry.NewCreator(repo, manager, logger, sig.Signaler)
+	if err := c.Provide(func(repo domain.Repository, manager *cache.TTLMapManager, logger *slog.Logger, sig snapshotSignalParams, catalog appcatalog.MCPServerCatalog) appregistry.Creator {
+		return appregistry.NewCreator(repo, manager, logger, sig.Signaler, catalog)
 	}); err != nil {
 		return err
 	}
-	if err := c.Provide(func(repo domain.Repository, manager *cache.TTLMapManager, publisher cache.EventPublisher, logger *slog.Logger, sig snapshotSignalParams) appregistry.Updater {
-		return appregistry.NewUpdater(repo, manager, publisher, logger, sig.Signaler)
+	if err := c.Provide(func(repo domain.Repository, manager *cache.TTLMapManager, publisher cache.EventPublisher, logger *slog.Logger, sig snapshotSignalParams, catalog appcatalog.MCPServerCatalog) appregistry.Updater {
+		return appregistry.NewUpdater(repo, manager, publisher, logger, sig.Signaler, catalog)
 	}); err != nil {
 		return err
 	}

--- a/pkg/domain/catalog/mcp_server.go
+++ b/pkg/domain/catalog/mcp_server.go
@@ -87,7 +87,8 @@ type MCPAuthHeader struct {
 // These fields tell the gateway how to drive the "forwarded" auth mode: when
 // DCR is supported it can self-register (registration: auto); otherwise the
 // operator must pre-register a client and the gateway needs AuthorizeURL/
-// TokenURL/Scopes to complete the flow.
+// TokenURL/Scopes to complete the flow. When GrantType is "client_credentials",
+// the gateway instead uses machine-to-machine auth (no per-user consent).
 type MCPOAuth struct {
 	Required         bool `json:"required"`
 	ResourceMetadata bool `json:"resource_metadata"`
@@ -107,10 +108,17 @@ type MCPOAuth struct {
 	// AuthorizeURL / TokenURL are required for manual registration
 	// (Registration == "manual"), where the operator supplies a pre-registered
 	// client_id/secret; they also serve as a discovery fallback otherwise.
+	// TokenURL is also required for GrantType "client_credentials".
 	AuthorizeURL string `json:"authorize_url,omitempty"`
 	TokenURL     string `json:"token_url,omitempty"`
 	// Scopes are the default/required OAuth scopes for the server.
 	Scopes []string `json:"scopes,omitempty"`
 	// Resource is the RFC 8707 resource indicator / expected token audience.
 	Resource string `json:"resource,omitempty"`
+	// GrantType selects the OAuth grant. Empty / omitted means authorization
+	// code (forwarded). "client_credentials" is machine-to-machine.
+	GrantType string `json:"grant_type,omitempty"`
+	// TokenEndpointAuthMethod is used with client_credentials:
+	// client_secret_basic (default) or client_secret_post.
+	TokenEndpointAuthMethod string `json:"token_endpoint_auth_method,omitempty"`
 }

--- a/pkg/domain/registry/mcp_target.go
+++ b/pkg/domain/registry/mcp_target.go
@@ -36,11 +36,18 @@ const MCPTransportStreamableHTTP MCPTransport = "streamable-http"
 type MCPAuthMode string
 
 const (
-	MCPAuthModeNone        MCPAuthMode = "none"
-	MCPAuthModeStatic      MCPAuthMode = "static"
-	MCPAuthModePassthrough MCPAuthMode = "passthrough"
-	MCPAuthModeExchange    MCPAuthMode = "exchange"
-	MCPAuthModeForwarded   MCPAuthMode = "forwarded"
+	MCPAuthModeNone              MCPAuthMode = "none"
+	MCPAuthModeStatic            MCPAuthMode = "static"
+	MCPAuthModePassthrough       MCPAuthMode = "passthrough"
+	MCPAuthModeExchange          MCPAuthMode = "exchange"
+	MCPAuthModeForwarded         MCPAuthMode = "forwarded"
+	MCPAuthModeClientCredentials MCPAuthMode = "client_credentials"
+)
+
+// Token endpoint auth methods for MCPAuthModeClientCredentials (RFC 6749).
+const (
+	TokenEndpointAuthClientSecretBasic = "client_secret_basic"
+	TokenEndpointAuthClientSecretPost  = "client_secret_post"
 )
 
 type MCPClientRegistration string
@@ -78,6 +85,10 @@ type MCPAuth struct {
 	TokenURL     string                `json:"token_url,omitempty"`
 	Scopes       []string              `json:"scopes,omitempty"`
 	Resource     string                `json:"resource,omitempty"`
+	// TokenEndpointAuthMethod selects how client_id/secret are presented to the
+	// token endpoint for client_credentials: client_secret_basic (default) or
+	// client_secret_post.
+	TokenEndpointAuthMethod string `json:"token_endpoint_auth_method,omitempty"`
 }
 
 type MCPTarget struct {
@@ -192,6 +203,22 @@ func (a *MCPAuth) Validate() error {
 		default:
 			return fmt.Errorf("%w: unknown registration mode %q", ErrInvalidMCPTarget, a.Registration)
 		}
+	case MCPAuthModeClientCredentials:
+		if strings.TrimSpace(a.ClientID) == "" || strings.TrimSpace(a.ClientSecret) == "" {
+			return fmt.Errorf("%w: client_credentials requires client_id and client_secret", ErrInvalidMCPTarget)
+		}
+		if strings.TrimSpace(a.TokenURL) == "" || !isHTTPURL(a.TokenURL) {
+			return fmt.Errorf("%w: client_credentials requires a valid http(s) token_url", ErrInvalidMCPTarget)
+		}
+		if secret.IsMasked(a.ClientSecret) {
+			return fmt.Errorf("%w: secret cannot be a masked value; omit the field to keep the stored value",
+				ErrInvalidMCPTarget)
+		}
+		switch a.TokenEndpointAuthMethod {
+		case "", TokenEndpointAuthClientSecretBasic, TokenEndpointAuthClientSecretPost:
+		default:
+			return fmt.Errorf("%w: unknown token_endpoint_auth_method %q", ErrInvalidMCPTarget, a.TokenEndpointAuthMethod)
+		}
 	default:
 		return fmt.Errorf("%w: unknown auth mode %q", ErrInvalidMCPTarget, a.Mode)
 	}
@@ -213,7 +240,7 @@ func (t *MCPTarget) ResolveSecretsFrom(prev *MCPTarget) {
 	switch t.Auth.Mode {
 	case MCPAuthModeStatic:
 		t.Auth.Value = secret.Resolve(t.Auth.Value, prev.Auth.Value)
-	case MCPAuthModeForwarded:
+	case MCPAuthModeForwarded, MCPAuthModeClientCredentials:
 		t.Auth.ClientSecret = secret.Resolve(t.Auth.ClientSecret, prev.Auth.ClientSecret)
 	}
 }

--- a/pkg/domain/registry/mcp_target_test.go
+++ b/pkg/domain/registry/mcp_target_test.go
@@ -106,6 +106,21 @@ func TestNewMCPRegistry_Rejects(t *testing.T) {
 			m.Auth = &MCPAuth{Mode: MCPAuthModeForwarded, Provider: "linear", Registration: "magic"}
 			return m
 		}},
+		{"client_credentials without client_id", func(m *MCPTarget) *MCPTarget {
+			m.Auth = &MCPAuth{Mode: MCPAuthModeClientCredentials, ClientSecret: "s", TokenURL: "https://idp/token"}
+			return m
+		}},
+		{"client_credentials without token_url", func(m *MCPTarget) *MCPTarget {
+			m.Auth = &MCPAuth{Mode: MCPAuthModeClientCredentials, ClientID: "id", ClientSecret: "s"}
+			return m
+		}},
+		{"client_credentials with bad auth method", func(m *MCPTarget) *MCPTarget {
+			m.Auth = &MCPAuth{
+				Mode: MCPAuthModeClientCredentials, ClientID: "id", ClientSecret: "s",
+				TokenURL: "https://idp/token", TokenEndpointAuthMethod: "private_key_jwt",
+			}
+			return m
+		}},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -191,6 +206,10 @@ func TestMCPAuth_Validate_NewModes(t *testing.T) {
 		{Mode: MCPAuthModeExchange, Pattern: ExchangeTokenExchange, Audience: "https://up.example.com"},
 		{Mode: MCPAuthModeForwarded, Provider: "github", ClientID: "id",
 			AuthorizeURL: "https://github.com/login/oauth/authorize", TokenURL: "https://github.com/login/oauth/access_token"},
+		{Mode: MCPAuthModeClientCredentials, ClientID: "id", ClientSecret: "s",
+			TokenURL: "https://auth.example.com/token", TokenEndpointAuthMethod: TokenEndpointAuthClientSecretBasic},
+		{Mode: MCPAuthModeClientCredentials, ClientID: "id", ClientSecret: "s",
+			TokenURL: "https://auth.example.com/token", TokenEndpointAuthMethod: TokenEndpointAuthClientSecretPost},
 	}
 	for _, a := range valid {
 		if err := a.Validate(); err != nil {
@@ -213,6 +232,28 @@ func TestMCPTarget_ResolveSecretsFrom_ForwardedClientSecret(t *testing.T) {
 	prev := forwarded()
 	next := forwarded()
 	next.Auth.ClientSecret = ""
+	next.ResolveSecretsFrom(prev)
+	if next.Auth.ClientSecret != "s3cret" {
+		t.Fatalf("ClientSecret = %q, want previous secret kept", next.Auth.ClientSecret)
+	}
+}
+
+func TestMCPTarget_ResolveSecretsFrom_ClientCredentialsSecret(t *testing.T) {
+	t.Parallel()
+	prev := &MCPTarget{
+		URL: "https://mcp.example.com/mcp",
+		Auth: &MCPAuth{
+			Mode: MCPAuthModeClientCredentials, ClientID: "id", ClientSecret: "s3cret",
+			TokenURL: "https://idp/token",
+		},
+	}
+	next := &MCPTarget{
+		URL: "https://mcp.example.com/mcp",
+		Auth: &MCPAuth{
+			Mode: MCPAuthModeClientCredentials, ClientID: "id", ClientSecret: "",
+			TokenURL: "https://idp/token",
+		},
+	}
 	next.ResolveSecretsFrom(prev)
 	if next.Auth.ClientSecret != "s3cret" {
 		t.Fatalf("ClientSecret = %q, want previous secret kept", next.Auth.ClientSecret)

--- a/pkg/infra/oauth/provider_client.go
+++ b/pkg/infra/oauth/provider_client.go
@@ -81,7 +81,7 @@ func (p *providerClient) ExchangeCode(ctx context.Context, cfg *registrydomain.M
 	if cfg.Resource != "" {
 		form.Set("resource", cfg.Resource)
 	}
-	return p.tokenCall(ctx, cfg.TokenURL, form)
+	return p.tokenCall(ctx, cfg.TokenURL, form, "", "")
 }
 
 func (p *providerClient) Refresh(ctx context.Context, cfg *registrydomain.MCPAuth, refreshToken string) (*appoauth.ProviderToken, error) {
@@ -95,16 +95,45 @@ func (p *providerClient) Refresh(ctx context.Context, cfg *registrydomain.MCPAut
 	if cfg.Resource != "" {
 		form.Set("resource", cfg.Resource)
 	}
-	return p.tokenCall(ctx, cfg.TokenURL, form)
+	return p.tokenCall(ctx, cfg.TokenURL, form, "", "")
 }
 
-func (p *providerClient) tokenCall(ctx context.Context, endpoint string, form url.Values) (*appoauth.ProviderToken, error) {
+func (p *providerClient) ClientCredentials(ctx context.Context, cfg *registrydomain.MCPAuth) (*appoauth.ProviderToken, error) {
+	form := url.Values{}
+	form.Set("grant_type", "client_credentials")
+	if len(cfg.Scopes) > 0 {
+		form.Set("scope", strings.Join(cfg.Scopes, " "))
+	}
+	if cfg.Resource != "" {
+		form.Set("resource", cfg.Resource)
+	}
+	method := cfg.TokenEndpointAuthMethod
+	if method == "" {
+		method = registrydomain.TokenEndpointAuthClientSecretBasic
+	}
+	var basicUser, basicPass string
+	switch method {
+	case registrydomain.TokenEndpointAuthClientSecretBasic:
+		basicUser, basicPass = cfg.ClientID, cfg.ClientSecret
+	case registrydomain.TokenEndpointAuthClientSecretPost:
+		form.Set("client_id", cfg.ClientID)
+		form.Set("client_secret", cfg.ClientSecret)
+	default:
+		return nil, fmt.Errorf("oauth provider: unsupported token_endpoint_auth_method %q", method)
+	}
+	return p.tokenCall(ctx, cfg.TokenURL, form, basicUser, basicPass)
+}
+
+func (p *providerClient) tokenCall(ctx context.Context, endpoint string, form url.Values, basicUser, basicPass string) (*appoauth.ProviderToken, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
+	if basicUser != "" {
+		req.SetBasicAuth(basicUser, basicPass)
+	}
 	res, err := p.client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("oauth provider: token call: %w", err)
@@ -117,6 +146,7 @@ func (p *providerClient) tokenCall(ctx context.Context, endpoint string, form ur
 	var doc struct {
 		AccessToken  string `json:"access_token"`
 		RefreshToken string `json:"refresh_token"`
+		TokenType    string `json:"token_type"`
 		ExpiresIn    int    `json:"expires_in"`
 		Scope        string `json:"scope"`
 		Error        string `json:"error"`
@@ -131,11 +161,16 @@ func (p *providerClient) tokenCall(ctx context.Context, endpoint string, form ur
 		}
 		return nil, fmt.Errorf("oauth provider: token exchange failed (%s): %s", doc.Error, doc.ErrorDesc)
 	}
+	if doc.TokenType != "" && !strings.EqualFold(doc.TokenType, "Bearer") {
+		return nil, fmt.Errorf("oauth provider: unsupported token_type %q", doc.TokenType)
+	}
 	out := &appoauth.ProviderToken{AccessToken: doc.AccessToken, RefreshToken: doc.RefreshToken}
 	switch {
 	case doc.ExpiresIn > 0:
 		out.ExpiresAt = time.Now().Add(time.Duration(doc.ExpiresIn) * time.Second)
 	case doc.RefreshToken != "":
+		out.ExpiresAt = time.Now().Add(defaultProviderTokenTTL)
+	default:
 		out.ExpiresAt = time.Now().Add(defaultProviderTokenTTL)
 	}
 	if doc.Scope != "" {

--- a/pkg/infra/oauth/provider_client_cc_test.go
+++ b/pkg/infra/oauth/provider_client_cc_test.go
@@ -1,0 +1,115 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oauth
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	registrydomain "github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+)
+
+func TestProviderClient_ClientCredentials_Basic(t *testing.T) {
+	t.Parallel()
+	var gotAuth, gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "tok-basic",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	p := NewProviderClient(srv.Client())
+	tok, err := p.ClientCredentials(context.Background(), &registrydomain.MCPAuth{
+		ClientID: "cid", ClientSecret: "csec",
+		TokenURL:                srv.URL,
+		TokenEndpointAuthMethod: registrydomain.TokenEndpointAuthClientSecretBasic,
+		Resource:                "https://mcp.example/mcp",
+		Scopes:                  []string{"mcp"},
+	})
+	if err != nil {
+		t.Fatalf("ClientCredentials: %v", err)
+	}
+	if tok.AccessToken != "tok-basic" {
+		t.Fatalf("token = %q", tok.AccessToken)
+	}
+	want := "Basic " + base64.StdEncoding.EncodeToString([]byte("cid:csec"))
+	if gotAuth != want {
+		t.Fatalf("Authorization = %q, want %q", gotAuth, want)
+	}
+	form, err := url.ParseQuery(gotBody)
+	if err != nil {
+		t.Fatalf("parse body: %v", err)
+	}
+	if form.Get("grant_type") != "client_credentials" {
+		t.Fatalf("grant_type = %q", form.Get("grant_type"))
+	}
+	if form.Get("client_id") != "" || form.Get("client_secret") != "" {
+		t.Fatalf("basic must not put credentials in body: %v", form)
+	}
+	if form.Get("resource") != "https://mcp.example/mcp" {
+		t.Fatalf("resource = %q", form.Get("resource"))
+	}
+	if form.Get("scope") != "mcp" {
+		t.Fatalf("scope = %q", form.Get("scope"))
+	}
+}
+
+func TestProviderClient_ClientCredentials_Post(t *testing.T) {
+	t.Parallel()
+	var gotAuth, gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "tok-post",
+			"token_type":   "Bearer",
+			"expires_in":   60,
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	p := NewProviderClient(srv.Client())
+	tok, err := p.ClientCredentials(context.Background(), &registrydomain.MCPAuth{
+		ClientID: "cid", ClientSecret: "csec",
+		TokenURL:                srv.URL,
+		TokenEndpointAuthMethod: registrydomain.TokenEndpointAuthClientSecretPost,
+	})
+	if err != nil {
+		t.Fatalf("ClientCredentials: %v", err)
+	}
+	if tok.AccessToken != "tok-post" {
+		t.Fatalf("token = %q", tok.AccessToken)
+	}
+	if gotAuth != "" {
+		t.Fatalf("Authorization = %q, want empty for post", gotAuth)
+	}
+	if !strings.Contains(gotBody, "client_id=cid") || !strings.Contains(gotBody, "client_secret=csec") {
+		t.Fatalf("body missing credentials: %q", gotBody)
+	}
+}

--- a/seed/mcp-catalog/enterprise-servers.json
+++ b/seed/mcp-catalog/enterprise-servers.json
@@ -7188,6 +7188,32 @@
       ]
     },
     {
+      "name": "com.haloitsm/mcp",
+      "vendor": "Halo",
+      "category": "ITSM",
+      "description": "Per-instance Halo ITSM/PSA MCP endpoint (enable in Configuration > AI). Tickets, knowledge base, assets, and runbooks.",
+      "transport": "streamable-http",
+      "server_url": "https://{instance}/api/mcp",
+      "url_variables": [
+        {
+          "name": "instance",
+          "description": "Your Halo host without scheme, e.g. acme.halopsa.com or acme.haloitsm.com.",
+          "required": true
+        }
+      ],
+      "requires_auth": true,
+      "auth_headers": [
+        {
+          "name": "Authorization",
+          "description": "Bearer <token from a Halo API Application>.",
+          "required": true,
+          "secret": true,
+          "scheme": "Bearer"
+        }
+      ],
+      "relevance": 70
+    },
+    {
       "name": "co.huggingface/mcp",
       "vendor": "Hugging Face",
       "category": "AI & ML",
@@ -10496,6 +10522,30 @@
       ]
     },
     {
+      "name": "io.n8n/mcp",
+      "vendor": "n8n",
+      "category": "Automation",
+      "description": "Instance-level n8n MCP: search, run, and build workflows exposed to MCP clients (Settings > Instance-level MCP).",
+      "transport": "streamable-http",
+      "server_url": "https://{domain}/mcp-server/http",
+      "url_variables": [
+        {
+          "name": "domain",
+          "description": "Your n8n host without path, e.g. your-instance.app.n8n.cloud or n8n.example.com.",
+          "required": true
+        }
+      ],
+      "requires_auth": true,
+      "oauth": {
+        "required": true,
+        "resource_metadata": true,
+        "registration": "auto",
+        "dcr": true,
+        "pkce": true
+      },
+      "relevance": 75
+    },
+    {
       "name": "com.paddle/mcp",
       "vendor": "Paddle",
       "category": "Billing & Payments",
@@ -12323,6 +12373,30 @@
           "description": "Run a report"
         }
       ]
+    },
+    {
+      "name": "com.sectigo/mcp",
+      "vendor": "Sectigo",
+      "category": "Security & Identity",
+      "description": "Sectigo Certificate Manager (SCM) hosted MCP: issue, renew, revoke, search and report on certificates.",
+      "transport": "streamable-http",
+      "server_url": "https://mcp.{instance}.sectigo.com/mcp",
+      "url_variables": [
+        {
+          "name": "instance",
+          "description": "Your SCM environment from onboarding, e.g. enterprise, eu, or hard.",
+          "required": true
+        }
+      ],
+      "requires_auth": true,
+      "oauth": {
+        "required": true,
+        "resource_metadata": true,
+        "grant_type": "client_credentials",
+        "token_url": "https://auth.sso.sectigo.com/auth/realms/apiclients/protocol/openid-connect/token",
+        "token_endpoint_auth_method": "client_secret_basic"
+      },
+      "relevance": 72
     },
     {
       "name": "dev.sentry/mcp",


### PR DESCRIPTION
## Summary

Adds three enterprise MCP servers to the curated catalog and the runtime support Sectigo needs.

- **OAuth `client_credentials` for MCP targets** — new auth mode on `MCPTarget` with `token_endpoint_auth_method` (`client_secret_basic` / `client_secret_post`), a `ClientCredentials` call on the OAuth provider client, and token minting in the MCP credential resolver.
- **Token cache** — singleflight around minting, bounded, and keyed by a fingerprint derived from the registry so a credentials update re-mints instead of serving a stale token.
- **Catalog canonicalization** — `token_url` and `resource` are always taken from the curated catalog entry on create and update; a client-supplied token endpoint is never trusted, and the request fails closed when the catalog is unavailable.
- **Seed entries** — Sectigo (client_credentials), n8n (remote authorization code + DCR) and Halo (static Bearer).

## Linear

ENG-1348 — https://linear.app/neuraltrust/issue/ENG-1348/featmcp-add-sectigo-n8n-and-halo-to-the-mcp-catalog

Fixes ENG-1348

## Review budget

~1.1k changed lines, above the 400-line budget. Roughly half is tests and mock regeneration, and the two commits split cleanly: `1eb9bf3f` is the runtime/contract change, `b1d58f02` is the catalog seed. Reviewing commit by commit is the easiest path; happy to split into stacked PRs if preferred.

## Test plan

- [x] `go test ./...` green
- [x] `golangci-lint` and gosec clean (pre-commit hook)
- [ ] Connect Sectigo from Registry → MCP with client id + secret only
- [ ] Connect n8n through the remote OAuth handshake
- [ ] Connect Halo with a static Bearer token
- [ ] Update the registry credentials and confirm the next call mints a fresh token

Made with [Cursor](https://cursor.com)