### PR TITLE
feat: add MCP Apps policy and capability parsing (RUN-1107)

### DIFF
--- a/pkg/app/mcp/apps_capability.go
+++ b/pkg/app/mcp/apps_capability.go
@@ -1,0 +1,49 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcp
+
+// MCPAppsExtensionIdentifier is the SEP-1865 UI extension identifier.
+const MCPAppsExtensionIdentifier = "io.modelcontextprotocol/ui"
+
+// MCPAppsHTMLMIMEType is the SEP-1865 HTML resource MIME type.
+const MCPAppsHTMLMIMEType = "text/html;profile=mcp-app"
+
+// MCPAppsClientCapability is a normalized client UI declaration.
+type MCPAppsClientCapability struct {
+	MIMETypes []string
+}
+
+// ParseMCPAppsClientCapability parses a SEP-1865 UI extension settings object.
+func ParseMCPAppsClientCapability(raw any) (MCPAppsClientCapability, bool) {
+	settings, ok := raw.(map[string]any)
+	if !ok || len(settings) != 1 {
+		return MCPAppsClientCapability{}, false
+	}
+	mimeTypes, ok := settings["mimeTypes"].([]any)
+	if !ok || len(mimeTypes) == 0 {
+		return MCPAppsClientCapability{}, false
+	}
+	capability := MCPAppsClientCapability{}
+	for _, value := range mimeTypes {
+		mimeType, ok := value.(string)
+		if !ok {
+			return MCPAppsClientCapability{}, false
+		}
+		if mimeType == MCPAppsHTMLMIMEType {
+			capability.MIMETypes = []string{MCPAppsHTMLMIMEType}
+		}
+	}
+	return capability, len(capability.MIMETypes) == 1
+}

--- a/pkg/app/mcp/apps_capability_test.go
+++ b/pkg/app/mcp/apps_capability_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcp
+
+import "testing"
+
+func TestParseMCPAppsClientCapability(t *testing.T) {
+	valid, ok := ParseMCPAppsClientCapability(map[string]any{"mimeTypes": []any{MCPAppsHTMLMIMEType, MCPAppsHTMLMIMEType}})
+	if !ok || len(valid.MIMETypes) != 1 || valid.MIMETypes[0] != MCPAppsHTMLMIMEType {
+		t.Fatalf("capability = %+v, %v", valid, ok)
+	}
+	invalid := map[string]any{
+		"non-object":        "ui",
+		"missing MIME list": map[string]any{},
+		"empty MIME list":   map[string]any{"mimeTypes": []any{}},
+		"malformed MIME":    map[string]any{"mimeTypes": []any{7}},
+		"unsupported MIME":  map[string]any{"mimeTypes": []any{"text/html+skybridge"}},
+		"unknown key":       map[string]any{"mimeTypes": []any{MCPAppsHTMLMIMEType}, "features": []any{"smuggled"}},
+	}
+	for name, declaration := range invalid {
+		if got, ok := ParseMCPAppsClientCapability(declaration); ok {
+			t.Errorf("%s: capability = %+v, want rejected", name, got)
+		}
+	}
+}

--- a/pkg/app/mcp/mrtr_caps.go
+++ b/pkg/app/mcp/mrtr_caps.go
@@ -65,9 +65,6 @@ func AllowlistedClientCapabilities(raw map[string]any) map[string]any {
 	return out
 }
 
-// allowlistedExtensions keeps the tasks extension and nothing else, with its
-// value forced to an empty object so a client cannot smuggle a payload
-// southbound inside the declaration.
 func allowlistedExtensions(raw any) map[string]any {
 	declared, ok := raw.(map[string]any)
 	if !ok {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,12 +20,14 @@ import (
 	"log/slog"
 	"net"
 	"net/netip"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/NeuralTrust/TrustGate/pkg/common/errors"
+	"golang.org/x/net/publicsuffix"
 )
 
 const (
@@ -47,6 +49,14 @@ const (
 	defaultMCPTaskHandleTTL           = time.Hour
 	defaultMCPTaskPollIntervalFloorMs = 1000
 	defaultMCPTaskHandleMaxBytes      = 1024
+
+	defaultMCPAppsMaxResourceBytes       = 1024 * 1024
+	minMCPAppsMaxResourceBytes           = 64 * 1024
+	maxMCPAppsMaxResourceBytes           = 2 * 1024 * 1024
+	defaultMCPAppsCSPOriginsPerDirective = 16
+	maxMCPAppsCSPOriginsPerDirective     = 64
+	defaultMCPAppsCSPOriginsTotal        = 64
+	maxMCPAppsCSPOriginsTotal            = 64
 
 	defaultMCPSubscriptionsReauthInterval       = 30 * time.Second
 	defaultMCPSubscriptionsKeepalive            = 15 * time.Second
@@ -249,6 +259,7 @@ type ServerConfig struct {
 	MCPDefaultIdP    MCPDefaultIdPConfig
 	MCPMRTR          MCPMRTRConfig
 	MCPTasks         MCPTasksConfig
+	MCPApps          MCPAppsConfig
 	MCPSubscriptions MCPSubscriptionsConfig
 }
 
@@ -270,6 +281,16 @@ type MCPTasksConfig struct {
 	HandleTTL           time.Duration
 	PollIntervalFloorMs int
 	HandleMaxBytes      int
+}
+
+// MCPAppsConfig defines the disabled-by-default policy bounds for MCP Apps.
+type MCPAppsConfig struct {
+	Enabled                   bool
+	MaxResourceBytes          int
+	MaxCSPOriginsPerDirective int
+	MaxCSPOriginsTotal        int
+	AllowedOriginPatterns     []string
+	AllowedPermissions        []string
 }
 
 // MCPSubscriptionsConfig holds env-only settings for bounded subscriptions/listen
@@ -458,9 +479,15 @@ func LoadConfig() (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
+	mcpApps, err := getMCPAppsConfig()
+	if err != nil {
+		return nil, err
+	}
+	server := getServerConfig()
+	server.MCPApps = mcpApps
 	cfg := &Config{
 		AppEnv:              getEnv("APP_ENV", defaultAppEnv),
-		Server:              getServerConfig(),
+		Server:              server,
 		Database:            getDatabaseConfig(),
 		Redis:               getRedisConfig(),
 		Cache:               getCacheConfig(),
@@ -535,6 +562,36 @@ func getServerConfig() ServerConfig {
 		},
 		MCPSubscriptions: getMCPSubscriptionsConfig(writeTimeout),
 	}
+}
+
+func getMCPAppsConfig() (MCPAppsConfig, error) {
+	enabled, err := parseStrictBoolEnv("MCP_APPS_ENABLED", false)
+	if err != nil {
+		return MCPAppsConfig{}, err
+	}
+	limits := [...]struct {
+		key          string
+		defaultValue int
+	}{
+		{"MCP_APPS_MAX_RESOURCE_BYTES", defaultMCPAppsMaxResourceBytes},
+		{"MCP_APPS_MAX_CSP_ORIGINS_PER_DIRECTIVE", defaultMCPAppsCSPOriginsPerDirective},
+		{"MCP_APPS_MAX_CSP_ORIGINS_TOTAL", defaultMCPAppsCSPOriginsTotal},
+	}
+	values := make([]int, len(limits))
+	for i, limit := range limits {
+		values[i], err = parsePositiveIntEnv(limit.key, limit.defaultValue)
+		if err != nil {
+			return MCPAppsConfig{}, err
+		}
+	}
+	return MCPAppsConfig{
+		Enabled:                   enabled,
+		MaxResourceBytes:          values[0],
+		MaxCSPOriginsPerDirective: values[1],
+		MaxCSPOriginsTotal:        values[2],
+		AllowedOriginPatterns:     splitCSV(os.Getenv("MCP_APPS_ALLOWED_ORIGINS")),
+		AllowedPermissions:        splitCSV(os.Getenv("MCP_APPS_ALLOWED_PERMISSIONS")),
+	}, nil
 }
 
 // getMCPSubscriptionsConfig derives the lease bounds from the write timeout the
@@ -1090,6 +1147,13 @@ func (c *Config) Validate() error {
 	if err := c.Server.MCPSubscriptions.Validate(c.Server.WriteTimeout); err != nil {
 		return err
 	}
+	apps := &c.Server.MCPApps
+	if apps.Enabled || apps.MaxResourceBytes != 0 || apps.MaxCSPOriginsPerDirective != 0 ||
+		apps.MaxCSPOriginsTotal != 0 || len(apps.AllowedOriginPatterns) != 0 || len(apps.AllowedPermissions) != 0 {
+		if err := apps.Validate(); err != nil {
+			return err
+		}
+	}
 	if c.isDeployed() && c.ConfigSync.DataPlaneEnabled && c.ConfigSync.TLSInsecure {
 		return fmt.Errorf("%w: CONFIG_SYNC_TLS_INSECURE must not be true in deployed environments so the config-sync channel is not sent in cleartext", errors.ErrInvalidConfig)
 	}
@@ -1100,6 +1164,155 @@ func (c *Config) Validate() error {
 		return err
 	}
 	return nil
+}
+
+// Validate checks and normalizes MCP Apps policy settings.
+func (c *MCPAppsConfig) Validate() error {
+	bounds := [...]struct {
+		key                     string
+		value, minimum, maximum int
+	}{
+		{"MCP_APPS_MAX_RESOURCE_BYTES", c.MaxResourceBytes, minMCPAppsMaxResourceBytes, maxMCPAppsMaxResourceBytes},
+		{"MCP_APPS_MAX_CSP_ORIGINS_PER_DIRECTIVE", c.MaxCSPOriginsPerDirective, 1, maxMCPAppsCSPOriginsPerDirective},
+		{"MCP_APPS_MAX_CSP_ORIGINS_TOTAL", c.MaxCSPOriginsTotal, 1, maxMCPAppsCSPOriginsTotal},
+	}
+	for _, bound := range bounds {
+		if bound.value < bound.minimum || bound.value > bound.maximum {
+			return fmt.Errorf("%w: %s must be between %d and %d", errors.ErrInvalidConfig, bound.key, bound.minimum, bound.maximum)
+		}
+	}
+	if c.MaxCSPOriginsPerDirective > c.MaxCSPOriginsTotal {
+		return fmt.Errorf("%w: MCP_APPS_MAX_CSP_ORIGINS_PER_DIRECTIVE must not exceed MCP_APPS_MAX_CSP_ORIGINS_TOTAL", errors.ErrInvalidConfig)
+	}
+	if len(c.AllowedOriginPatterns) > c.MaxCSPOriginsTotal {
+		return fmt.Errorf("%w: MCP_APPS_ALLOWED_ORIGINS exceeds MCP_APPS_MAX_CSP_ORIGINS_TOTAL", errors.ErrInvalidConfig)
+	}
+	if len(c.AllowedPermissions) > 4 {
+		return fmt.Errorf("%w: MCP_APPS_ALLOWED_PERMISSIONS must not contain more than four entries", errors.ErrInvalidConfig)
+	}
+	origins := make([]string, 0, len(c.AllowedOriginPatterns))
+	seenOrigins := make(map[string]struct{}, len(c.AllowedOriginPatterns))
+	for index, pattern := range c.AllowedOriginPatterns {
+		origin, err := normalizeMCPAppsOrigin(pattern)
+		if err != nil {
+			return fmt.Errorf("%w: MCP_APPS_ALLOWED_ORIGINS entry %d is invalid: %v", errors.ErrInvalidConfig, index+1, err)
+		}
+		if _, exists := seenOrigins[origin]; exists {
+			return fmt.Errorf("%w: MCP_APPS_ALLOWED_ORIGINS contains a duplicate origin", errors.ErrInvalidConfig)
+		}
+		seenOrigins[origin] = struct{}{}
+		origins = append(origins, origin)
+	}
+	seenPermissions := make(map[string]struct{}, len(c.AllowedPermissions))
+	for index, permission := range c.AllowedPermissions {
+		switch permission {
+		case "camera", "microphone", "geolocation", "clipboardWrite":
+		default:
+			return fmt.Errorf("%w: MCP_APPS_ALLOWED_PERMISSIONS entry %d is unsupported", errors.ErrInvalidConfig, index+1)
+		}
+		if _, exists := seenPermissions[permission]; exists {
+			return fmt.Errorf("%w: MCP_APPS_ALLOWED_PERMISSIONS contains a duplicate entry", errors.ErrInvalidConfig)
+		}
+		seenPermissions[permission] = struct{}{}
+	}
+	c.AllowedOriginPatterns = origins
+	return nil
+}
+
+func normalizeMCPAppsOrigin(pattern string) (string, error) {
+	if strings.Contains(pattern, "*") {
+		return "", fmt.Errorf("wildcards are not allowed")
+	}
+	if !strings.HasPrefix(pattern, "https://") && !strings.HasPrefix(pattern, "wss://") {
+		return "", fmt.Errorf("must be a lowercase https or wss origin")
+	}
+	if strings.ContainsAny(pattern, "?#") {
+		return "", fmt.Errorf("query and fragment are not allowed")
+	}
+	parsed, err := url.Parse(pattern)
+	if err != nil || (parsed.Scheme != "https" && parsed.Scheme != "wss") || parsed.Host == "" {
+		return "", fmt.Errorf("must be an https or wss origin")
+	}
+	if parsed.User != nil || parsed.Path != "" || parsed.Opaque != "" {
+		return "", fmt.Errorf("credentials and paths are not allowed")
+	}
+	host := strings.ToLower(parsed.Hostname())
+	if !validMCPAppsHostname(host) || net.ParseIP(host) != nil || numericMCPAppsHost(host) {
+		return "", fmt.Errorf("host is not allowed")
+	}
+	if mcpAppsRebindingHost(host) {
+		return "", fmt.Errorf("host is not allowed")
+	}
+	_, icann := publicsuffix.PublicSuffix(host)
+	if !icann {
+		return "", fmt.Errorf("host must use an ICANN public suffix")
+	}
+	if _, err := publicsuffix.EffectiveTLDPlusOne(host); err != nil {
+		return "", fmt.Errorf("host must have a registrable domain")
+	}
+	port := parsed.Port()
+	if port == "" && strings.Contains(parsed.Host, ":") {
+		return "", fmt.Errorf("port is malformed or is the default port")
+	}
+	if port != "" {
+		number, err := strconv.Atoi(port)
+		if err != nil || number < 1 || number > 65535 || strconv.Itoa(number) != port || number == 443 {
+			return "", fmt.Errorf("port is malformed or is the default port")
+		}
+		port = ":" + port
+	}
+	return parsed.Scheme + "://" + host + port, nil
+}
+
+func mcpAppsRebindingHost(host string) bool {
+	for _, zone := range [...]string{"nip.io", "sslip.io", "xip.io", "localtest.me", "lvh.me"} {
+		if host == zone || strings.HasSuffix(host, "."+zone) {
+			return true
+		}
+	}
+	return false
+}
+
+func numericMCPAppsHost(host string) bool {
+	parts := strings.Split(host, ".")
+	if len(parts) > 4 {
+		return false
+	}
+	for _, part := range parts {
+		digits := part
+		base := byte('9')
+		if strings.HasPrefix(part, "0x") {
+			digits = part[2:]
+			base = 'f'
+		}
+		if digits == "" {
+			return false
+		}
+		for index := range digits {
+			value := digits[index]
+			if (value < '0' || value > '9') && (base != 'f' || value < 'a' || value > 'f') {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func validMCPAppsHostname(host string) bool {
+	if host == "" || len(host) > 253 || strings.HasSuffix(host, ".") {
+		return false
+	}
+	for _, label := range strings.Split(host, ".") {
+		if label == "" || len(label) > 63 || label[0] == '-' || label[len(label)-1] == '-' {
+			return false
+		}
+		for i := range label {
+			if b := label[i]; (b < 'a' || b > 'z') && (b < '0' || b > '9') && b != '-' {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 // Validate refuses to boot when a lease could outlive the server write deadline.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -79,6 +79,100 @@ func TestLoadConfig_AppliesDefaults(t *testing.T) {
 	if cfg.Telemetry.ExportersMetadata != "" || cfg.Telemetry.ExportersRaw != "" {
 		t.Errorf("Telemetry exporters env defaults = %q/%q, want empty", cfg.Telemetry.ExportersMetadata, cfg.Telemetry.ExportersRaw)
 	}
+	apps := cfg.Server.MCPApps
+	if apps.Enabled || apps.MaxResourceBytes != 1024*1024 ||
+		apps.MaxCSPOriginsPerDirective != 16 || apps.MaxCSPOriginsTotal != 64 ||
+		len(apps.AllowedOriginPatterns) != 0 || len(apps.AllowedPermissions) != 0 {
+		t.Errorf("MCP Apps defaults = %+v", apps)
+	}
+}
+
+func TestLoadConfig_MCPAppsPolicy(t *testing.T) {
+	minimumEnv(t)
+	t.Setenv("MCP_APPS_ENABLED", "true")
+	t.Setenv("MCP_APPS_MAX_RESOURCE_BYTES", "65536")
+	t.Setenv("MCP_APPS_MAX_CSP_ORIGINS_PER_DIRECTIVE", "8")
+	t.Setenv("MCP_APPS_MAX_CSP_ORIGINS_TOTAL", "32")
+	t.Setenv("MCP_APPS_ALLOWED_ORIGINS", "https://EXAMPLE.com,wss://events.example.com:8443")
+	t.Setenv("MCP_APPS_ALLOWED_PERMISSIONS", "camera,clipboardWrite")
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	apps := cfg.Server.MCPApps
+	if !apps.Enabled || apps.MaxResourceBytes != 65536 ||
+		strings.Join(apps.AllowedOriginPatterns, ",") != "https://example.com,wss://events.example.com:8443" ||
+		strings.Join(apps.AllowedPermissions, ",") != "camera,clipboardWrite" {
+		t.Fatalf("MCP Apps policy = %+v", apps)
+	}
+}
+
+func TestLoadConfig_RejectsInvalidMCPAppsPolicy(t *testing.T) {
+	settings := map[string][2]string{
+		"resource below minimum": {"MCP_APPS_MAX_RESOURCE_BYTES", "65535"},
+		"resource above maximum": {"MCP_APPS_MAX_RESOURCE_BYTES", "2097153"},
+		"CSP directive overflow": {"MCP_APPS_MAX_CSP_ORIGINS_PER_DIRECTIVE", "65"},
+		"CSP total overflow":     {"MCP_APPS_MAX_CSP_ORIGINS_TOTAL", "65"},
+		"unknown permission":     {"MCP_APPS_ALLOWED_PERMISSIONS", "clipboard-read"},
+		"duplicate permission":   {"MCP_APPS_ALLOWED_PERMISSIONS", "camera,camera"},
+	}
+	for name, env := range settings {
+		t.Run(name, func(t *testing.T) {
+			minimumEnv(t)
+			t.Setenv(env[0], env[1])
+			_, err := LoadConfig()
+			if err == nil || !stderrors.Is(err, errors.ErrInvalidConfig) || strings.Contains(err.Error(), env[1]) {
+				t.Fatalf("LoadConfig error = %v, want ErrInvalidConfig", err)
+			}
+		})
+	}
+	origins := []string{
+		"https://example.com/app", "https://example.com?x=1", "https://example.com#app",
+		"https://user@example.com", "https://192.0.2.1", "https://[::1]", "https://127.1",
+		"https://127.0.1", "https://0177.0.0.1", "https://127.000.000.001",
+		"https://2130706433", "https://0x7f000001", "HTTPS://example.com", "https://localhost",
+		"https://api.localhost", "https://service.localdomain", "https://service.internal",
+		"https://service.local", "https://service.corp", "https://app.github.io", "https://*.example.com",
+		"https://nip.io", "https://127.0.0.1.nip.io", "https://a.sslip.io", "https://xip.io",
+		"https://foo.localtest.me", "https://lvh.me",
+		"https://example.com:443", "https://example.com:", "https://EXAMPLE.com,https://example.com",
+	}
+	for _, origin := range origins {
+		minimumEnv(t)
+		t.Setenv("MCP_APPS_ALLOWED_ORIGINS", origin)
+		_, err := LoadConfig()
+		if err == nil || !stderrors.Is(err, errors.ErrInvalidConfig) || strings.Contains(err.Error(), origin) {
+			t.Errorf("origin %q rejection error = %v", origin, err)
+		}
+	}
+}
+
+func TestMCPAppsConfigValidateDirectBounds(t *testing.T) {
+	valid := func() MCPAppsConfig {
+		return MCPAppsConfig{MaxResourceBytes: 64 * 1024, MaxCSPOriginsPerDirective: 1, MaxCSPOriginsTotal: 1}
+	}
+	reject := func(name string, mutate func(*MCPAppsConfig)) {
+		t.Helper()
+		cfg := valid()
+		mutate(&cfg)
+		if err := cfg.Validate(); err == nil {
+			t.Errorf("%s: Validate succeeded", name)
+		}
+	}
+	reject("zero resource", func(c *MCPAppsConfig) { c.MaxResourceBytes = 0 })
+	reject("zero config", func(c *MCPAppsConfig) { *c = MCPAppsConfig{} })
+	reject("large resource", func(c *MCPAppsConfig) { c.MaxResourceBytes = 2*1024*1024 + 1 })
+	reject("zero per directive", func(c *MCPAppsConfig) { c.MaxCSPOriginsPerDirective = 0 })
+	reject("large per directive", func(c *MCPAppsConfig) { c.MaxCSPOriginsPerDirective = 65 })
+	reject("zero total", func(c *MCPAppsConfig) { c.MaxCSPOriginsTotal = 0 })
+	reject("large total", func(c *MCPAppsConfig) { c.MaxCSPOriginsTotal = 65 })
+	reject("per exceeds total", func(c *MCPAppsConfig) { c.MaxCSPOriginsPerDirective = 2 })
+	reject("too many origins", func(c *MCPAppsConfig) {
+		c.AllowedOriginPatterns = []string{"https://a.com", "https://b.com"}
+	})
+	reject("too many permissions", func(c *MCPAppsConfig) {
+		c.AllowedPermissions = []string{"camera", "microphone", "geolocation", "clipboardWrite", "camera"}
+	})
 }
 
 func TestLoadConfig_MCPConnectRateLimitConfigured(t *testing.T) {


### PR DESCRIPTION
## Summary
- add disabled-by-default, bounded MCP Apps policy configuration
- parse the SEP-1865 `io.modelcontextprotocol/ui` client declaration with the exact `text/html;profile=mcp-app` MIME
- enforce exact-origin and permission allowlists without activating Apps advertisement or southbound forwarding

This is RUN-1107 phase 1. It targets the unifying MCP branch and does not target `develop` or `main`. Draft PR #468 remains unmerged.

## Security
- reject wildcard origins, numeric/IP-obfuscated hosts, internal names, and known DNS-rebinding zones
- cap decoded resource and CSP-origin settings
- reject unknown capability settings, MIME types, permissions, and extension payload smuggling
- avoid echoing configured origins or permission values in validation errors

## Test plan
- [x] `make lint`
- [x] `make test`
- [x] `go vet ./...` in both Go modules
- [x] `go build ./...` in both Go modules
- [x] reviewer and security review with no remaining blockers
- [x] confirm Apps parsing has no live advertisement or forwarding call sites

Linear: https://linear.app/neuraltrust/issue/RUN-1107/featmcp-support-secure-mcp-apps-passthrough

Made with [Cursor](https://cursor.com)