### PR TITLE
feat: resolve upstream MCP Apps capabilities (RUN-1107)

### DIFF
--- a/pkg/container/modules/cache.go
+++ b/pkg/container/modules/cache.go
@@ -67,6 +67,7 @@ func initializeMemoryCache(mgr *cache.TTLMapManager) {
 	mgr.CreateTTLMap(cache.AuthKeyTTLName, cache.AuthKeyCacheTTL)
 	mgr.CreateTTLMap(cache.CatalogModelTTLName, cache.CatalogModelCacheTTL)
 	mgr.CreateTTLMap(cache.MCPToolsTTLName, cache.MCPToolsCacheTTL)
+	mgr.CreateTTLMap(cache.MCPAppsTTLName, cache.MCPAppsCacheTTL)
 
 	lbMap := mgr.CreateTTLMap(cache.LoadBalancerTTLName, cache.LoadBalancerCacheTTL)
 	lbMap.SetOnEvict(func(value any) {

--- a/pkg/infra/cache/ttlmap_manager.go
+++ b/pkg/infra/cache/ttlmap_manager.go
@@ -38,6 +38,7 @@ const (
 	CatalogModelTTLName = "catalog_model"
 	ConsumerPathTTLName = "consumer_path"
 	MCPToolsTTLName     = "mcp_tools"
+	MCPAppsTTLName      = "mcp_apps"
 )
 
 const (
@@ -52,6 +53,7 @@ const (
 	LoadBalancerCacheTTL = 5 * time.Minute
 	CatalogModelCacheTTL = 24 * time.Hour
 	MCPToolsCacheTTL     = 5 * time.Minute
+	MCPAppsCacheTTL      = 5 * time.Minute
 )
 
 type TTLMapManager struct {

--- a/pkg/infra/mcp/client/apps_capability.go
+++ b/pkg/infra/mcp/client/apps_capability.go
@@ -1,0 +1,263 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	appmcp "github.com/NeuralTrust/TrustGate/pkg/app/mcp"
+	registrydomain "github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/cache"
+	"github.com/NeuralTrust/TrustGate/pkg/version"
+)
+
+const appCapabilityNegativeTTL = 10 * time.Second
+
+var (
+	// ErrAppCapabilityUnsupported means the upstream did not positively negotiate MCP Apps.
+	ErrAppCapabilityUnsupported = errors.New("mcp: upstream Apps capability unsupported")
+	// ErrAppCapabilityProtocol means the upstream returned malformed Apps negotiation data.
+	ErrAppCapabilityProtocol = errors.New("mcp: upstream Apps capability negotiation failed")
+)
+
+// AppCapabilityResolver resolves the MCP Apps capability of a prepared upstream target.
+type AppCapabilityResolver struct {
+	cache     *cache.TTLMap
+	transport http.RoundTripper
+	now       func() time.Time
+	mu        sync.Mutex
+	flights   map[string]*appCapabilityFlight
+	joined    func()
+}
+type appCapabilityResult struct {
+	capability appmcp.MCPAppsClientCapability
+	err        error
+	expiresAt  time.Time
+}
+type appCapabilityFlight struct {
+	ctx     context.Context
+	cancel  context.CancelFunc
+	done    chan struct{}
+	result  appCapabilityResult
+	waiters int
+}
+
+// NewAppCapabilityResolver builds a resolver backed by the MCP Apps cache namespace.
+func NewAppCapabilityResolver(capabilityCache *cache.TTLMap) *AppCapabilityResolver {
+	return &AppCapabilityResolver{cache: capabilityCache, transport: sharedHTTPTransport, now: time.Now, flights: make(map[string]*appCapabilityFlight)}
+}
+
+// Resolve discovers MCP Apps support for an already credentialed target.
+func (r *AppCapabilityResolver) Resolve(ctx context.Context, target appmcp.Target) (appmcp.MCPAppsClientCapability, error) {
+	if err := ctx.Err(); err != nil {
+		return appmcp.MCPAppsClientCapability{}, err
+	}
+	if target.ProtocolMode == registrydomain.MCPProtocolModeLegacy {
+		return appmcp.MCPAppsClientCapability{}, ErrAppCapabilityUnsupported
+	}
+	key, err := appCapabilityCacheKey(target)
+	if err != nil {
+		return appmcp.MCPAppsClientCapability{}, err
+	}
+	if cached, ok := r.lookup(key); ok {
+		return cached.capability, cached.err
+	}
+	target = cloneTarget(target)
+	for {
+		flight, leader := r.join(ctx, key)
+		if leader {
+			go r.run(key, flight, target)
+		}
+		select {
+		case <-ctx.Done():
+			if r.leave(flight) {
+				<-flight.done
+			}
+			return appmcp.MCPAppsClientCapability{}, ctx.Err()
+		case <-flight.done:
+			r.leave(flight)
+			if err := ctx.Err(); err != nil {
+				return appmcp.MCPAppsClientCapability{}, err
+			}
+			if errors.Is(flight.result.err, context.Canceled) {
+				continue
+			}
+			return flight.result.capability, flight.result.err
+		}
+	}
+}
+func (r *AppCapabilityResolver) join(ctx context.Context, key string) (*appCapabilityFlight, bool) {
+	r.mu.Lock()
+	flight := r.flights[key]
+	leader := flight == nil
+	if flight == nil {
+		workCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), responseHeaderTimeout)
+		flight = &appCapabilityFlight{ctx: workCtx, cancel: cancel, done: make(chan struct{})}
+		r.flights[key] = flight
+	}
+	flight.waiters++
+	r.mu.Unlock()
+	if r.joined != nil {
+		r.joined()
+	}
+	return flight, leader
+}
+func (r *AppCapabilityResolver) leave(flight *appCapabilityFlight) bool {
+	r.mu.Lock()
+	flight.waiters--
+	last := flight.waiters == 0
+	if last {
+		flight.cancel()
+	}
+	r.mu.Unlock()
+	return last
+}
+func (r *AppCapabilityResolver) run(key string, flight *appCapabilityFlight, target appmcp.Target) {
+	result, ok := r.lookup(key)
+	if !ok {
+		result = r.discover(flight.ctx, target)
+	}
+	if result.err == nil || errors.Is(result.err, ErrAppCapabilityUnsupported) {
+		r.cache.Set(key, result)
+	}
+	r.mu.Lock()
+	flight.result = result
+	flight.cancel()
+	delete(r.flights, key)
+	close(flight.done)
+	r.mu.Unlock()
+}
+func (r *AppCapabilityResolver) lookup(key string) (appCapabilityResult, bool) {
+	value, ok := r.cache.Get(key)
+	if !ok {
+		return appCapabilityResult{}, false
+	}
+	result, ok := value.(appCapabilityResult)
+	if !ok || !r.now().Before(result.expiresAt) {
+		r.cache.Delete(key)
+		return appCapabilityResult{}, false
+	}
+	return result, true
+}
+
+func (r *AppCapabilityResolver) discover(ctx context.Context, target appmcp.Target) appCapabilityResult {
+	client, err := newTargetHTTPClientWithTransport(target.Headers, r.transport)
+	if err != nil {
+		return r.result(appmcp.MCPAppsClientCapability{}, appmcp.ErrUnreachable)
+	}
+	probe := newStrictProbe(r.transport, []string{modernProtocolVersion}, version.Version)
+	attempt, err := probe.request(ctx, client, target.URL, modernProtocolVersion, map[string]any{"extensions": map[string]any{
+		appmcp.MCPAppsExtensionIdentifier: map[string]any{"mimeTypes": []string{appmcp.MCPAppsHTMLMIMEType}},
+	}})
+	if err != nil {
+		return r.result(appmcp.MCPAppsClientCapability{}, safeAppCapabilityError(err))
+	}
+	outcome, _, err := probe.classify(attempt, modernProtocolVersion, true)
+	if err != nil {
+		return r.result(appmcp.MCPAppsClientCapability{}, safeAppCapabilityError(err))
+	}
+	if outcome.kind != probeModern || outcome.version != modernProtocolVersion {
+		return r.result(appmcp.MCPAppsClientCapability{}, ErrAppCapabilityUnsupported)
+	}
+	capability, err := parseAppsCapability(attempt.result)
+	return r.result(capability, err)
+}
+
+func (r *AppCapabilityResolver) result(capability appmcp.MCPAppsClientCapability, err error) appCapabilityResult {
+	ttl := appCapabilityNegativeTTL
+	if err == nil {
+		ttl = cache.MCPAppsCacheTTL
+	}
+	return appCapabilityResult{capability: capability, err: err, expiresAt: r.now().Add(ttl)}
+}
+
+func safeAppCapabilityError(err error) error {
+	switch {
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		return err
+	case errors.Is(err, appmcp.ErrSubscriptionAuthentication):
+		return appmcp.ErrSubscriptionAuthentication
+	case errors.Is(err, appmcp.ErrProtocolIncompatible):
+		return ErrAppCapabilityUnsupported
+	case errors.Is(err, appmcp.ErrUnreachable):
+		return appmcp.ErrUnreachable
+	default:
+		return ErrAppCapabilityProtocol
+	}
+}
+
+func parseAppsCapability(result *discoverProbeResult) (appmcp.MCPAppsClientCapability, error) {
+	if result == nil || len(result.ExtensionsRaw) == 0 {
+		return appmcp.MCPAppsClientCapability{}, ErrAppCapabilityUnsupported
+	}
+	var extensions map[string]json.RawMessage
+	if json.Unmarshal(result.ExtensionsRaw, &extensions) != nil || extensions == nil {
+		return appmcp.MCPAppsClientCapability{}, ErrAppCapabilityProtocol
+	}
+	raw, ok := extensions[appmcp.MCPAppsExtensionIdentifier]
+	if !ok {
+		return appmcp.MCPAppsClientCapability{}, ErrAppCapabilityUnsupported
+	}
+	var settings map[string]json.RawMessage
+	if json.Unmarshal(raw, &settings) != nil || len(settings) != 1 {
+		return appmcp.MCPAppsClientCapability{}, ErrAppCapabilityProtocol
+	}
+	var mimeTypes []string
+	if rawMIMEs, ok := settings["mimeTypes"]; !ok ||
+		json.Unmarshal(rawMIMEs, &mimeTypes) != nil || len(mimeTypes) == 0 {
+		return appmcp.MCPAppsClientCapability{}, ErrAppCapabilityProtocol
+	}
+	for _, mimeType := range mimeTypes {
+		if mimeType == appmcp.MCPAppsHTMLMIMEType {
+			return appmcp.MCPAppsClientCapability{MIMETypes: []string{appmcp.MCPAppsHTMLMIMEType}}, nil
+		}
+	}
+	return appmcp.MCPAppsClientCapability{}, ErrAppCapabilityUnsupported
+}
+
+func appCapabilityCacheKey(target appmcp.Target) (string, error) {
+	origin, err := canonicalOrigin(target.URL)
+	if err != nil {
+		return "", appmcp.ErrUnreachable
+	}
+	parsed, err := url.Parse(target.URL)
+	if err != nil {
+		return "", appmcp.ErrUnreachable
+	}
+	mode := target.ProtocolMode
+	if mode == "" {
+		mode = registrydomain.MCPProtocolModeAuto
+	}
+	headers := make(map[string]string, len(target.Headers))
+	for key, value := range target.Headers {
+		headers[http.CanonicalHeaderKey(strings.TrimSpace(key))] = value
+	}
+	encoded, err := json.Marshal([]string{"mcp-apps-capability:v1", target.RegistryTargetID, origin + parsed.RequestURI(),
+		target.PinKey, string(mode), modernProtocolVersion, credentialFingerprint(headers), appmcp.MCPAppsHTMLMIMEType})
+	if err != nil {
+		return "", ErrAppCapabilityProtocol
+	}
+	sum := sha256.Sum256(encoded)
+	return hex.EncodeToString(sum[:]), nil
+}

--- a/pkg/infra/mcp/client/probe.go
+++ b/pkg/infra/mcp/client/probe.go
@@ -128,7 +128,7 @@ func (p *strictProbe) Probe(ctx context.Context, target appmcp.Target) (probeOut
 	}
 
 	requested := p.supportedVersions[0]
-	attempt, err := p.request(ctx, client, target.URL, requested)
+	attempt, err := p.request(ctx, client, target.URL, requested, nil)
 	if err != nil {
 		return probeOutcome{}, err
 	}
@@ -137,7 +137,7 @@ func (p *strictProbe) Probe(ctx context.Context, target appmcp.Target) (probeOut
 		return outcome, err
 	}
 
-	retry, err := p.request(ctx, client, target.URL, retryVersion)
+	retry, err := p.request(ctx, client, target.URL, retryVersion, nil)
 	if err != nil {
 		return probeOutcome{}, err
 	}
@@ -156,6 +156,7 @@ type probeAttempt struct {
 type discoverProbeResult struct {
 	ResultType         string
 	SupportedVersions  []string
+	ExtensionsRaw      json.RawMessage
 	Capabilities       appmcp.ListChangedCapabilities
 	SubscriptionListen bool
 }
@@ -165,12 +166,13 @@ func (p *strictProbe) request(
 	client *http.Client,
 	endpoint string,
 	protocolVersion string,
+	clientCapabilities map[string]any,
 ) (probeAttempt, error) {
 	origin, err := canonicalOrigin(endpoint)
 	if err != nil {
 		return probeAttempt{}, wrapUnreachable("", "invalid upstream origin", err)
 	}
-	body, err := p.requestBody(protocolVersion)
+	body, err := p.requestBody(protocolVersion, clientCapabilities)
 	if err != nil {
 		return probeAttempt{}, fmt.Errorf("encode server/discover probe: %w", err)
 	}
@@ -219,7 +221,10 @@ func (p *strictProbe) request(
 	return attempt, nil
 }
 
-func (p *strictProbe) requestBody(protocolVersion string) ([]byte, error) {
+func (p *strictProbe) requestBody(protocolVersion string, clientCapabilities map[string]any) ([]byte, error) {
+	if clientCapabilities == nil {
+		clientCapabilities = map[string]any{}
+	}
 	id, err := jsonrpc.MakeID(probeRequestID)
 	if err != nil {
 		return nil, err
@@ -231,7 +236,7 @@ func (p *strictProbe) requestBody(protocolVersion string) ([]byte, error) {
 				"name":    "trustgate",
 				"version": p.implementationVersion,
 			},
-			metaClientCapabilities: map[string]any{},
+			metaClientCapabilities: clientCapabilities,
 		},
 	})
 	if err != nil {
@@ -521,6 +526,7 @@ func decodeDiscoverResult(raw json.RawMessage) (*discoverProbeResult, error) {
 	if err := json.Unmarshal(fields["capabilities"], &capabilities); err != nil || capabilities == nil {
 		return nil, errors.New("server/discover capabilities must be an object")
 	}
+	result.ExtensionsRaw = capabilities["extensions"]
 	listChanged, err := decodeListChangedCapabilities(capabilities)
 	if err != nil {
 		return nil, err

--- a/pkg/infra/mcp/client/probe_test.go
+++ b/pkg/infra/mcp/client/probe_test.go
@@ -30,6 +30,8 @@ import (
 	"time"
 
 	appmcp "github.com/NeuralTrust/TrustGate/pkg/app/mcp"
+	registrydomain "github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	"github.com/NeuralTrust/TrustGate/pkg/infra/cache"
 	"github.com/NeuralTrust/TrustGate/pkg/version"
 )
 
@@ -1205,4 +1207,118 @@ func TestStrictProbePreservesCancellationAndNetworkErrors(t *testing.T) {
 			t.Fatalf("outcome = %+v", outcome)
 		}
 	})
+}
+
+const appsPositive = `{"extensions":{"io.modelcontextprotocol/ui":{"mimeTypes":["text/html;profile=mcp-app"]}}}`
+
+func appsResponse(capabilities string) *http.Response {
+	body := fmt.Sprintf(`{"jsonrpc":"2.0","id":"%s","result":{"resultType":"complete","supportedVersions":["%s"],"capabilities":%s}}`,
+		probeRequestID, modernProtocolVersion, capabilities)
+	return &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}},
+		Body: io.NopCloser(strings.NewReader(body))}
+}
+func testAppsResolver(transport http.RoundTripper) *AppCapabilityResolver {
+	resolver := NewAppCapabilityResolver(cache.NewTTLMap(cache.MCPAppsCacheTTL))
+	resolver.transport = transport
+	return resolver
+}
+func TestParseAppsCapability(t *testing.T) {
+	tests := map[string]error{
+		`{}`: ErrAppCapabilityUnsupported,
+		`{"io.modelcontextprotocol/ui":{"mimeTypes":["text/plain"]}}`: ErrAppCapabilityUnsupported,
+		`[]`:                                ErrAppCapabilityProtocol,
+		`{"io.modelcontextprotocol/ui":[]}`: ErrAppCapabilityProtocol,
+		`{"io.modelcontextprotocol/ui":{}}`: ErrAppCapabilityProtocol,
+		`{"io.modelcontextprotocol/ui":{"mimeTypes":"text/plain"}}`: ErrAppCapabilityProtocol,
+	}
+	for raw, want := range tests {
+		_, err := parseAppsCapability(&discoverProbeResult{ExtensionsRaw: json.RawMessage(raw)})
+		if !errors.Is(err, want) {
+			t.Fatalf("%s: error = %v, want %v", raw, err, want)
+		}
+	}
+}
+func TestAppCapabilityResolverSafetyAndCache(t *testing.T) {
+	now := time.Unix(100, 0)
+	resolver := testAppsResolver(roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var request map[string]any
+		_ = json.NewDecoder(req.Body).Decode(&request)
+		meta := request["params"].(map[string]any)["_meta"].(map[string]any)
+		if req.Header.Get("Authorization") != "Bearer one" ||
+			mustJSON(meta[metaClientCapabilities]) != appsPositive {
+			t.Fatal("credentialed Apps declaration missing")
+		}
+		return appsResponse(appsPositive), nil
+	}))
+	resolver.now = func() time.Time { return now }
+	target := appmcp.Target{URL: "https://upstream.example/mcp?tenant=a", RegistryTargetID: "registry",
+		PinKey: "identity", Headers: map[string]string{"authorization": "Bearer one", "X-Tenant": "a"}}
+	if _, err := resolver.Resolve(context.Background(), target); err != nil {
+		t.Fatal(err)
+	}
+	keyFor := func(headers map[string]string) string {
+		target.Headers = headers
+		key, _ := appCapabilityCacheKey(target)
+		return key
+	}
+	sameKey := keyFor(map[string]string{"X-Tenant": "a", "Authorization": "Bearer one"})
+	if keyFor(map[string]string{"authorization": "Bearer one", "X-Tenant": "a"}) != sameKey ||
+		keyFor(map[string]string{"Authorization": "Bearer two", "X-Tenant": "a"}) == sameKey {
+		t.Fatal("cache key is not canonical and credential-bound")
+	}
+	if resolver.result(appmcp.MCPAppsClientCapability{}, nil).expiresAt.Sub(now) != cache.MCPAppsCacheTTL ||
+		resolver.result(appmcp.MCPAppsClientCapability{}, ErrAppCapabilityUnsupported).expiresAt.Sub(now) != appCapabilityNegativeTTL {
+		t.Fatal("capability TTL mismatch")
+	}
+	for _, headers := range []map[string]string{{"Host": "bad"}, {"Bad Header": "bad"}, {"X-Test": "bad\nvalue"}} {
+		target.Headers = headers
+		if _, err := resolver.Resolve(context.Background(), target); !errors.Is(err, appmcp.ErrUnreachable) {
+			t.Fatalf("unsafe header error = %v", err)
+		}
+	}
+	target.ProtocolMode = registrydomain.MCPProtocolModeLegacy
+	if _, err := resolver.Resolve(context.Background(), target); !errors.Is(err, ErrAppCapabilityUnsupported) {
+		t.Fatalf("legacy error = %v", err)
+	}
+}
+
+func TestAppCapabilityResolverWaiterCancellation(t *testing.T) {
+	cancelled, release, joined := make(chan struct{}), make(chan struct{}), make(chan struct{}, 3)
+	var calls atomic.Int64
+	resolver := testAppsResolver(roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if calls.Add(1) == 1 {
+			<-req.Context().Done()
+			close(cancelled)
+			<-release
+			return nil, req.Context().Err()
+		}
+		return appsResponse(appsPositive), nil
+	}))
+	resolver.joined = func() { joined <- struct{}{} }
+	target := appmcp.Target{URL: "https://upstream.example/mcp", RegistryTargetID: "registry"}
+	result1, result2, retry := make(chan error, 1), make(chan error, 1), make(chan error, 1)
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	go func() { _, err := resolver.Resolve(ctx1, target); result1 <- err }()
+	go func() { _, err := resolver.Resolve(ctx2, target); result2 <- err }()
+	<-joined
+	<-joined
+	cancel1()
+	if err := <-result1; !errors.Is(err, context.Canceled) {
+		t.Fatalf("first error = %v", err)
+	}
+	cancel2()
+	<-cancelled
+	go func() { _, err := resolver.Resolve(context.Background(), target); retry <- err }()
+	<-joined
+	if calls.Load() != 1 {
+		t.Fatal("retry overlapped cancelled probe")
+	}
+	close(release)
+	if err := <-result2; !errors.Is(err, context.Canceled) {
+		t.Fatalf("second error = %v", err)
+	}
+	if err := <-retry; err != nil || calls.Load() != 2 || len(resolver.flights) != 0 {
+		t.Fatalf("retry error=%v calls=%d flights=%d", err, calls.Load(), len(resolver.flights))
+	}
 }


### PR DESCRIPTION
## Summary
- add authenticated `server/discover` resolution for `io.modelcontextprotocol/ui`
- bind cached capability outcomes to registry, canonical target identity, protocol, pin, credentials, and supported MIME
- coalesce concurrent probes with waiter-aware cancellation and deterministic cleanup

This is RUN-1107 phase 2. It targets the unifying MCP branch after phase 1 landed through #470. It does not target `develop` or `main`, and draft PR #468 remains unmerged.

## Security and lifecycle
- accept only a positive negotiation of `text/html;profile=mcp-app`
- distinguish unsupported capability from malformed protocol data
- map transport/header failures to safe typed errors without leaking origins or credentials
- cache only supported and explicitly unsupported outcomes
- cancel and join the probe when the last waiter leaves; immediate retries cannot overlap

## Test plan
- [x] `make lint`
- [x] `make test`
- [x] `go vet ./...` in both Go modules
- [x] `go build ./...` in both Go modules
- [x] race/stress tests for concurrent coalescing and cancellation
- [x] reviewer, security, and performance reviews with no remaining blockers
- [x] confirm resolver is not wired to live Apps advertisement yet

Linear: https://linear.app/neuraltrust/issue/RUN-1107/featmcp-support-secure-mcp-apps-passthrough

Made with [Cursor](https://cursor.com)