### PR TITLE
feat: mediate MCP Apps advertisement end to end (RUN-1107)

### DIFF
--- a/pkg/api/handler/http/mcp/mcp_handler.go
+++ b/pkg/api/handler/http/mcp/mcp_handler.go
@@ -83,6 +83,7 @@ type Handler struct {
 	mrtr       MRTRSupport
 	tasks      TasksSupport
 	subs       SubscriptionsSupport
+	apps       appmcp.AppsMediator
 }
 
 func NewHandler(gateway *RPCGateway, roleScoper appmcp.RoleScoper, rec ...ProtocolValidationRecorder) *Handler {
@@ -121,7 +122,20 @@ func NewHandlerWithSubscriptions(
 	subs SubscriptionsSupport,
 	rec ...ProtocolValidationRecorder,
 ) *Handler {
-	h := &Handler{gateway: gateway, roleScoper: roleScoper, mrtr: mrtr, tasks: tasks, subs: subs}
+	return NewHandlerWithApps(gateway, roleScoper, mrtr, tasks, subs, nil, rec...)
+}
+
+// NewHandlerWithApps wires all mediated protocol capabilities.
+func NewHandlerWithApps(
+	gateway *RPCGateway,
+	roleScoper appmcp.RoleScoper,
+	mrtr MRTRSupport,
+	tasks TasksSupport,
+	subs SubscriptionsSupport,
+	apps appmcp.AppsMediator,
+	rec ...ProtocolValidationRecorder,
+) *Handler {
+	h := &Handler{gateway: gateway, roleScoper: roleScoper, mrtr: mrtr, tasks: tasks, subs: subs, apps: apps}
 	if len(rec) > 0 {
 		h.protocol = rec[0]
 	}
@@ -165,6 +179,8 @@ func (h *Handler) Handle(c *fiber.Ctx) error {
 	var req rpcRequest
 	parseErr := json.Unmarshal(body, &req)
 	era := protocolEraLegacy
+	var clientCapabilities map[string]any
+	var appsCapability appmcp.MCPAppsClientCapability
 	if parseErr != nil || invalidTopLevel {
 		if protocolHeader != "" && !isSupportedProtocolVersion(protocolHeader) {
 			h.recordProtocolValidation(c, codeUnsupportedProtocolVersion, protocolEraModern)
@@ -190,6 +206,7 @@ func (h *Handler) Handle(c *fiber.Ctx) error {
 			return writeProtocolError(c, req.ID, protocolErr)
 		}
 		if era == protocolEraModern {
+			clientCapabilities = rawClientCapabilities(req.Params)
 			headers := modernHeaders(c)
 			headers.subscriptionsEnabled = h.subs.Enabled()
 			if protocolErr := validateModernRequest(req, headers); protocolErr != nil {
@@ -211,6 +228,15 @@ func (h *Handler) Handle(c *fiber.Ctx) error {
 				skipMetrics(c)
 				return writeRPCErrorStatus(c, req.ID, fiber.StatusNotFound, codeMethodNotFound, "method not found", nil)
 			}
+			if req.Method == "server/discover" {
+				var err error
+				appsCapability, err = declaredMCPAppsCapability(clientCapabilities)
+				if err != nil {
+					h.recordProtocolValidation(c, codeInvalidParams, era)
+					skipMetrics(c)
+					return writeBoundaryRPCError(c, req.ID, era, codeInvalidParams, "invalid params")
+				}
+			}
 			// A listen is refused on its params before the consumer is resolved,
 			// so a malformed negotiation costs no lookup, rate limit or plugin.
 			if req.Method == appmcp.MethodSubscriptionsListen {
@@ -227,7 +253,7 @@ func (h *Handler) Handle(c *fiber.Ctx) error {
 		if era == protocolEraModern {
 			c.SetUserContext(appmcp.WithClientCapabilities(
 				c.UserContext(),
-				h.mediatableCapabilities(declaredClientCapabilities(req.Params)),
+				h.mediatableCapabilities(appmcp.AllowlistedClientCapabilities(clientCapabilities)),
 			))
 		}
 	}
@@ -273,6 +299,10 @@ func (h *Handler) Handle(c *fiber.Ctx) error {
 			tasksEndToEnd(h.tasks, rc),
 			subscriptionsEndToEnd(h.subs, rc),
 		)
+		if h.apps != nil {
+			addAppsExtension(discovery["capabilities"].(map[string]any),
+				h.apps.Advertise(c.UserContext(), true, rc, appsCapability))
+		}
 		normalized, err := normalizeModernResult(req.Method, discovery, rc, nil)
 		if err != nil {
 			return writeRPCErrorStatus(c, req.ID, fiber.StatusInternalServerError, codeInternalError, "internal error", nil)
@@ -426,9 +456,7 @@ func mrtrRoundFromTrace(ctx context.Context) string {
 	return round
 }
 
-// declaredClientCapabilities keeps only the allowlisted kinds a modern client
-// declared in request metadata.
-func declaredClientCapabilities(params json.RawMessage) map[string]any {
+func rawClientCapabilities(params json.RawMessage) map[string]any {
 	metadata, ok := decodeObject(params)
 	if !ok {
 		return nil
@@ -441,7 +469,19 @@ func declaredClientCapabilities(params json.RawMessage) map[string]any {
 	if err := json.Unmarshal(meta[appmcp.MetaKeyClientCapabilities], &caps); err != nil {
 		return nil
 	}
-	return appmcp.AllowlistedClientCapabilities(caps)
+	return caps
+}
+
+func declaredMCPAppsCapability(capabilities map[string]any) (appmcp.MCPAppsClientCapability, error) {
+	extensions, ok := capabilities[appmcp.CapabilityKindExtensions].(map[string]any)
+	if !ok {
+		return appmcp.MCPAppsClientCapability{}, nil
+	}
+	raw, ok := extensions[appmcp.MCPAppsExtensionIdentifier]
+	if !ok {
+		return appmcp.MCPAppsClientCapability{}, nil
+	}
+	return appmcp.ParseMCPAppsClientCapability(raw)
 }
 
 // mediatableCapabilities is the single fail-closed choke point for the tasks

--- a/pkg/api/handler/http/mcp/mcp_handler_test.go
+++ b/pkg/api/handler/http/mcp/mcp_handler_test.go
@@ -15,12 +15,14 @@
 package mcp_test
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	mcphttp "github.com/NeuralTrust/TrustGate/pkg/api/handler/http/mcp"
@@ -109,7 +111,7 @@ func newAppWithRunnerAndLimiter(t *testing.T, composer appmcp.Composer, plugins 
 	return app
 }
 
-func newAppWithRegistries(t *testing.T, registries ...*registrydomain.Registry) *fiber.App {
+func newAppWithRegistries(t *testing.T, apps appmcp.AppsMediator, registries ...*registrydomain.Registry) *fiber.App {
 	t.Helper()
 	authID := ids.New[ids.AuthKind]()
 	gwID := ids.New[ids.GatewayKind]()
@@ -133,12 +135,23 @@ func newAppWithRegistries(t *testing.T, registries ...*registrydomain.Registry) 
 		c.SetUserContext(ctx)
 		return c.Next()
 	})
-	handler := mcphttp.NewHandler(
+	handler := mcphttp.NewHandlerWithApps(
 		mcphttp.NewRPCGateway(mocks.NewComposer(t), noopRunner(), nil),
 		appmcp.NewRoleScoper(approle.NewOIDCResolver()),
+		mcphttp.MRTRSupport{},
+		mcphttp.TasksSupport{},
+		mcphttp.SubscriptionsSupport{},
+		apps,
 	)
 	app.Post(mcpPath, handler.Handle)
 	return app
+}
+
+type recordingAppsMediator struct{ calls atomic.Int32 }
+
+func (m *recordingAppsMediator) Advertise(_ context.Context, _ bool, _ *appconsumer.RoutableConsumer, client appmcp.MCPAppsClientCapability) bool {
+	m.calls.Add(1)
+	return len(client.MIMETypes) == 1 && client.MIMETypes[0] == appmcp.MCPAppsHTMLMIMEType
 }
 
 func discardLogger() *slog.Logger {
@@ -447,7 +460,7 @@ func TestHandler_Initialize_VersionTracksTheToolSurface(t *testing.T) {
 	notion, linear := reg("notion"), reg("linear")
 
 	versionFor := func(regs ...*registrydomain.Registry) string {
-		app := newAppWithRegistries(t, regs...)
+		app := newAppWithRegistries(t, nil, regs...)
 		_, body := rpcCall(t, app, `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`)
 		info := body["result"].(map[string]any)["serverInfo"].(map[string]any)
 		return info["version"].(string)
@@ -1276,5 +1289,45 @@ func TestHandler_GETIs405(t *testing.T) {
 	}
 	if allow := res.Header.Get(fiber.HeaderAllow); allow != fiber.MethodPost {
 		t.Fatalf("Allow = %q, want POST", allow)
+	}
+}
+
+func TestHandler_ServerDiscover_ParsesMCPApps(t *testing.T) {
+	tests := []struct {
+		name, settings string
+		status         int
+		advertise      bool
+		calls          int32
+	}{
+		{"supported", `{"mimeTypes":["text/html;profile=mcp-app"]}`, fiber.StatusOK, true, 1},
+		{"unsupported", `{"mimeTypes":["text/html"]}`, fiber.StatusOK, false, 1},
+		{"malformed", `{"mimeTypes":[7]}`, fiber.StatusBadRequest, false, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mediator := &recordingAppsMediator{}
+			app := newAppWithRegistries(t, mediator, modernMCPRegistry(t, ids.New[ids.GatewayKind]()))
+			request := `{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{"_meta":{` +
+				`"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":` +
+				`{"extensions":{"io.modelcontextprotocol/ui":` + tt.settings + `}}}}}`
+			status, body := rpcCallWithHeaders(t, app, request, modernHeadersFor("server/discover"))
+			require.Equal(t, tt.status, status)
+			require.Equal(t, tt.calls, mediator.calls.Load())
+			if status == fiber.StatusBadRequest {
+				require.Equal(t, float64(-32602), body["error"].(map[string]any)["code"])
+				return
+			}
+			capabilities := body["result"].(map[string]any)["capabilities"].(map[string]any)
+			for _, kind := range []string{"tools", "prompts", "resources"} {
+				require.Contains(t, capabilities, kind)
+			}
+			if !tt.advertise {
+				require.NotContains(t, capabilities, "extensions")
+				return
+			}
+			require.Equal(t, map[string]any{appmcp.MCPAppsExtensionIdentifier: map[string]any{
+				"mimeTypes": []any{appmcp.MCPAppsHTMLMIMEType},
+			}}, capabilities["extensions"])
+		})
 	}
 }

--- a/pkg/api/handler/http/mcp/server_discover.go
+++ b/pkg/api/handler/http/mcp/server_discover.go
@@ -71,6 +71,20 @@ func addTasksExtension(capabilities map[string]any, tasks bool) {
 	}
 }
 
+func addAppsExtension(capabilities map[string]any, advertise bool) {
+	if !advertise {
+		return
+	}
+	extensions, _ := capabilities[appmcp.CapabilityKindExtensions].(map[string]any)
+	if extensions == nil {
+		extensions = make(map[string]any)
+		capabilities[appmcp.CapabilityKindExtensions] = extensions
+	}
+	extensions[appmcp.MCPAppsExtensionIdentifier] = map[string]any{
+		"mimeTypes": []string{appmcp.MCPAppsHTMLMIMEType},
+	}
+}
+
 func configuredCapabilities(rc *appconsumer.RoutableConsumer, mrtr bool) map[string]any {
 	capabilities := make(map[string]any)
 	if rc == nil || rc.Consumer == nil {

--- a/pkg/api/handler/http/mcp/server_discover_test.go
+++ b/pkg/api/handler/http/mcp/server_discover_test.go
@@ -88,6 +88,7 @@ func TestServerDiscoveryResultAdvertisesListChanged(t *testing.T) {
 		policy      *consumerdomain.MCPPolicy
 		mrtr        bool
 		tasks       bool
+		apps        bool
 		listChanged bool
 		want        map[string]any
 	}{
@@ -121,6 +122,7 @@ func TestServerDiscoveryResultAdvertisesListChanged(t *testing.T) {
 		{
 			name:        "on survives the tasks extension",
 			tasks:       true,
+			apps:        true,
 			listChanged: true,
 			want: map[string]any{
 				"tools":     map[string]any{"listChanged": true},
@@ -128,6 +130,9 @@ func TestServerDiscoveryResultAdvertisesListChanged(t *testing.T) {
 				"resources": map[string]any{"listChanged": true},
 				"extensions": map[string]any{
 					"io.modelcontextprotocol/tasks": map[string]any{},
+					"io.modelcontextprotocol/ui": map[string]any{
+						"mimeTypes": []string{"text/html;profile=mcp-app"},
+					},
 				},
 			},
 		},
@@ -157,6 +162,7 @@ func TestServerDiscoveryResultAdvertisesListChanged(t *testing.T) {
 				Consumer: &consumerdomain.Consumer{MCP: tc.policy},
 			}
 			result := serverDiscoveryResultWith(rc, tc.mrtr, tc.tasks, tc.listChanged)
+			addAppsExtension(result["capabilities"].(map[string]any), tc.apps)
 			require.Equal(t, tc.want, result["capabilities"])
 		})
 	}

--- a/pkg/app/mcp/apps_capability.go
+++ b/pkg/app/mcp/apps_capability.go
@@ -14,36 +14,135 @@
 
 package mcp
 
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"time"
+
+	appconsumer "github.com/NeuralTrust/TrustGate/pkg/app/consumer"
+	registrydomain "github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+	"golang.org/x/sync/errgroup"
+)
+
 // MCPAppsExtensionIdentifier is the SEP-1865 UI extension identifier.
 const MCPAppsExtensionIdentifier = "io.modelcontextprotocol/ui"
 
 // MCPAppsHTMLMIMEType is the SEP-1865 HTML resource MIME type.
 const MCPAppsHTMLMIMEType = "text/html;profile=mcp-app"
 
+const appsAdvertisementProbeBudget = 2 * time.Second
+
 // MCPAppsClientCapability is a normalized client UI declaration.
 type MCPAppsClientCapability struct {
 	MIMETypes []string
 }
 
+var errMalformedMCPAppsCapability = errors.New("malformed MCP Apps capability")
+
 // ParseMCPAppsClientCapability parses a SEP-1865 UI extension settings object.
-func ParseMCPAppsClientCapability(raw any) (MCPAppsClientCapability, bool) {
+func ParseMCPAppsClientCapability(raw any) (MCPAppsClientCapability, error) {
 	settings, ok := raw.(map[string]any)
 	if !ok || len(settings) != 1 {
-		return MCPAppsClientCapability{}, false
+		return MCPAppsClientCapability{}, errMalformedMCPAppsCapability
 	}
 	mimeTypes, ok := settings["mimeTypes"].([]any)
 	if !ok || len(mimeTypes) == 0 {
-		return MCPAppsClientCapability{}, false
+		return MCPAppsClientCapability{}, errMalformedMCPAppsCapability
 	}
 	capability := MCPAppsClientCapability{}
 	for _, value := range mimeTypes {
 		mimeType, ok := value.(string)
 		if !ok {
-			return MCPAppsClientCapability{}, false
+			return MCPAppsClientCapability{}, errMalformedMCPAppsCapability
 		}
 		if mimeType == MCPAppsHTMLMIMEType {
 			capability.MIMETypes = []string{MCPAppsHTMLMIMEType}
 		}
 	}
-	return capability, len(capability.MIMETypes) == 1
+	return capability, nil
+}
+
+// AppCapabilityResolver resolves Apps support for a credentialed upstream target.
+type AppCapabilityResolver interface {
+	Resolve(ctx context.Context, target Target) (MCPAppsClientCapability, error)
+}
+
+// AppsMediator decides whether server discovery may advertise MCP Apps.
+type AppsMediator interface {
+	Advertise(ctx context.Context, modern bool, rc *appconsumer.RoutableConsumer, client MCPAppsClientCapability) bool
+}
+
+type appsMediator struct {
+	enabled  bool
+	ready    bool
+	budget   time.Duration
+	creds    CredentialResolver
+	resolver AppCapabilityResolver
+}
+
+// NewAppsMediator creates the fail-closed MCP Apps policy mediator.
+func NewAppsMediator(enabled, ready bool, creds CredentialResolver, resolver AppCapabilityResolver) AppsMediator {
+	return &appsMediator{enabled: enabled, ready: ready, budget: appsAdvertisementProbeBudget, creds: creds, resolver: resolver}
+}
+
+func (m *appsMediator) Advertise(
+	ctx context.Context,
+	modern bool,
+	rc *appconsumer.RoutableConsumer,
+	client MCPAppsClientCapability,
+) bool {
+	if !m.enabled || !m.ready || !modern || !supportsMCPApps(client) || rc == nil || rc.Consumer == nil ||
+		m.creds == nil || m.resolver == nil {
+		return false
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, m.budget)
+	defer cancel()
+	var group errgroup.Group
+	group.SetLimit(discoveryFanOut)
+	var found atomic.Bool
+	for _, reg := range mcpRegistries(rc) {
+		if probeCtx.Err() != nil {
+			break
+		}
+		if !reg.Enabled || reg.MCPTarget.ProtocolMode == registrydomain.MCPProtocolModeLegacy || !registryPermitsApps(rc, reg) {
+			continue
+		}
+		group.Go(func() error {
+			if probeCtx.Err() != nil {
+				return nil
+			}
+			target := targetFor(probeCtx, rc, reg)
+			if err := m.creds.Apply(probeCtx, rc, reg, &target); err != nil || probeCtx.Err() != nil {
+				return nil
+			}
+			capability, err := m.resolver.Resolve(probeCtx, target)
+			if err == nil && supportsMCPApps(capability) && found.CompareAndSwap(false, true) {
+				cancel()
+			}
+			return nil
+		})
+	}
+	_ = group.Wait()
+	return ctx.Err() == nil && found.Load()
+}
+
+func supportsMCPApps(capability MCPAppsClientCapability) bool {
+	return len(capability.MIMETypes) == 1 && capability.MIMETypes[0] == MCPAppsHTMLMIMEType
+}
+
+func registryPermitsApps(rc *appconsumer.RoutableConsumer, reg *registrydomain.Registry) bool {
+	toolkit := rc.Consumer.Toolkit()
+	if toolkit == nil {
+		return true
+	}
+	var tools, resources bool
+	for _, entry := range toolkit {
+		if entry.RegistryID != reg.ID {
+			continue
+		}
+		tools = tools || entry.Tool != ""
+		resources = resources || entry.Resource != ""
+	}
+	return tools && resources
 }

--- a/pkg/app/mcp/apps_capability_test.go
+++ b/pkg/app/mcp/apps_capability_test.go
@@ -14,24 +14,104 @@
 
 package mcp
 
-import "testing"
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	appconsumer "github.com/NeuralTrust/TrustGate/pkg/app/consumer"
+	consumerdomain "github.com/NeuralTrust/TrustGate/pkg/domain/consumer"
+	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
+	registrydomain "github.com/NeuralTrust/TrustGate/pkg/domain/registry"
+)
+
+type appsCredentialFunc func(context.Context, *appconsumer.RoutableConsumer, *registrydomain.Registry, *Target) error
+
+func (f appsCredentialFunc) Apply(ctx context.Context, rc *appconsumer.RoutableConsumer, reg *registrydomain.Registry, target *Target) error {
+	return f(ctx, rc, reg, target)
+}
+
+type appsResolverFunc func(context.Context, Target) (MCPAppsClientCapability, error)
+
+func (f appsResolverFunc) Resolve(ctx context.Context, target Target) (MCPAppsClientCapability, error) {
+	return f(ctx, target)
+}
 
 func TestParseMCPAppsClientCapability(t *testing.T) {
-	valid, ok := ParseMCPAppsClientCapability(map[string]any{"mimeTypes": []any{MCPAppsHTMLMIMEType, MCPAppsHTMLMIMEType}})
-	if !ok || len(valid.MIMETypes) != 1 || valid.MIMETypes[0] != MCPAppsHTMLMIMEType {
-		t.Fatalf("capability = %+v, %v", valid, ok)
+	valid, err := ParseMCPAppsClientCapability(map[string]any{"mimeTypes": []any{MCPAppsHTMLMIMEType, MCPAppsHTMLMIMEType}})
+	if err != nil || len(valid.MIMETypes) != 1 || valid.MIMETypes[0] != MCPAppsHTMLMIMEType {
+		t.Fatalf("capability = %+v, %v", valid, err)
 	}
 	invalid := map[string]any{
 		"non-object":        "ui",
 		"missing MIME list": map[string]any{},
 		"empty MIME list":   map[string]any{"mimeTypes": []any{}},
 		"malformed MIME":    map[string]any{"mimeTypes": []any{7}},
-		"unsupported MIME":  map[string]any{"mimeTypes": []any{"text/html+skybridge"}},
 		"unknown key":       map[string]any{"mimeTypes": []any{MCPAppsHTMLMIMEType}, "features": []any{"smuggled"}},
 	}
 	for name, declaration := range invalid {
-		if got, ok := ParseMCPAppsClientCapability(declaration); ok {
+		if got, err := ParseMCPAppsClientCapability(declaration); err == nil {
 			t.Errorf("%s: capability = %+v, want rejected", name, got)
 		}
 	}
+}
+
+func TestAppsMediatorCancellationJoinsBoundedWorkers(t *testing.T) {
+	for _, cancelCaller := range []bool{false, true} {
+		rc := appsConsumer(make([]registrydomain.MCPProtocolMode, discoveryFanOut+2))
+		for _, reg := range rc.Registries {
+			reg.MCPTarget.ProtocolMode = registrydomain.MCPProtocolModeModern
+		}
+		rc.Registries[0].Enabled = false
+		var calls, active atomic.Int32
+		started := make(chan struct{}, discoveryFanOut)
+		creds := appsCredentialFunc(func(_ context.Context, _ *appconsumer.RoutableConsumer, _ *registrydomain.Registry, _ *Target) error {
+			calls.Add(1)
+			return nil
+		})
+		resolver := appsResolverFunc(func(ctx context.Context, _ Target) (MCPAppsClientCapability, error) {
+			active.Add(1)
+			started <- struct{}{}
+			<-ctx.Done()
+			active.Add(-1)
+			return MCPAppsClientCapability{}, ctx.Err()
+		})
+		ctx, cancel := context.WithCancel(context.Background())
+		mediator := NewAppsMediator(true, true, creds, resolver).(*appsMediator)
+		mediator.budget = 20 * time.Millisecond
+		if cancelCaller {
+			go func() {
+				for range discoveryFanOut {
+					<-started
+				}
+				cancel()
+			}()
+		}
+		advertised := mediator.Advertise(ctx, true, rc, appsClient())
+		cancel()
+		if advertised || calls.Load() != discoveryFanOut || active.Load() != 0 {
+			t.Fatalf("advertised=%v calls=%d active=%d", advertised, calls.Load(), active.Load())
+		}
+	}
+}
+
+func appsClient() MCPAppsClientCapability {
+	return MCPAppsClientCapability{MIMETypes: []string{MCPAppsHTMLMIMEType}}
+}
+
+func appsConsumer(modes []registrydomain.MCPProtocolMode) *appconsumer.RoutableConsumer {
+	rc := &appconsumer.RoutableConsumer{Consumer: &consumerdomain.Consumer{ID: ids.New[ids.ConsumerKind]()}}
+	rc.Consumer.MCP = &consumerdomain.MCPPolicy{}
+	for _, mode := range modes {
+		reg := &registrydomain.Registry{
+			ID: ids.New[ids.RegistryKind](), Type: registrydomain.TypeMCP, Enabled: true,
+			MCPTarget: &registrydomain.MCPTarget{URL: "https://upstream.example/mcp", ProtocolMode: mode},
+		}
+		rc.Registries = append(rc.Registries, reg)
+		rc.Consumer.MCP.Toolkit = append(rc.Consumer.MCP.Toolkit,
+			consumerdomain.ToolkitEntry{RegistryID: reg.ID, Tool: "*"},
+			consumerdomain.ToolkitEntry{RegistryID: reg.ID, Resource: "*"})
+	}
+	return rc
 }

--- a/pkg/container/modules/mcp.go
+++ b/pkg/container/modules/mcp.go
@@ -40,6 +40,8 @@ import (
 	vaultrepo "github.com/NeuralTrust/TrustGate/pkg/infra/repository/vault"
 )
 
+const mcpAppsPipelineReady = false
+
 func MCP(c *container.Container) error {
 	if err := c.Provide(mcpclient.New); err != nil {
 		return err
@@ -125,6 +127,20 @@ func MCP(c *container.Container) error {
 		logger *slog.Logger,
 	) appmcp.CredentialResolver {
 		return appmcp.NewCredentialResolver(exchanger, vault, connect, provider, logger)
+	}); err != nil {
+		return err
+	}
+	if err := c.Provide(func(manager *cache.TTLMapManager) appmcp.AppCapabilityResolver {
+		return mcpclient.NewAppCapabilityResolver(manager.GetTTLMap(cache.MCPAppsTTLName))
+	}); err != nil {
+		return err
+	}
+	if err := c.Provide(func(
+		cfg *config.Config,
+		creds appmcp.CredentialResolver,
+		resolver appmcp.AppCapabilityResolver,
+	) appmcp.AppsMediator {
+		return appmcp.NewAppsMediator(cfg.Server.MCPApps.Enabled, mcpAppsPipelineReady, creds, resolver)
 	}); err != nil {
 		return err
 	}
@@ -217,9 +233,10 @@ func MCP(c *container.Container) error {
 		policy appmcp.SubscriptionPolicy,
 		targets appmcp.SubscriptionTargetResolver,
 		multiplexer *appmcp.SubscriptionMultiplexer,
+		apps appmcp.AppsMediator,
 		cfg *config.Config,
 	) *mcphttp.Handler {
-		return mcphttp.NewHandlerWithSubscriptions(
+		return mcphttp.NewHandlerWithApps(
 			gw,
 			scoper,
 			mcphttp.MRTRSupport{
@@ -238,6 +255,7 @@ func MCP(c *container.Container) error {
 				multiplexer,
 				mcphttp.NewSubscriptionsRecorder(cfg.Telemetry.OpsMetricsEnabled),
 			),
+			apps,
 			mcphttp.NewProtocolValidationRecorder(cfg.Telemetry.OpsMetricsEnabled),
 		)
 	})

--- a/pkg/container/modules/mcp_subscriptions_test.go
+++ b/pkg/container/modules/mcp_subscriptions_test.go
@@ -27,6 +27,10 @@ import (
 	"go.uber.org/dig"
 )
 
+func TestMCPAppsProductionPipelineIsNotReady(t *testing.T) {
+	require.False(t, mcpAppsPipelineReady)
+}
+
 func subscriptionsConfig(enabled bool) *config.Config {
 	cfg := &config.Config{}
 	cfg.Server.MCPSubscriptions = config.MCPSubscriptionsConfig{

--- a/pkg/infra/mcp/client/probe_test.go
+++ b/pkg/infra/mcp/client/probe_test.go
@@ -29,7 +29,10 @@ import (
 	"testing"
 	"time"
 
+	appconsumer "github.com/NeuralTrust/TrustGate/pkg/app/consumer"
 	appmcp "github.com/NeuralTrust/TrustGate/pkg/app/mcp"
+	consumerdomain "github.com/NeuralTrust/TrustGate/pkg/domain/consumer"
+	"github.com/NeuralTrust/TrustGate/pkg/domain/ids"
 	registrydomain "github.com/NeuralTrust/TrustGate/pkg/domain/registry"
 	"github.com/NeuralTrust/TrustGate/pkg/infra/cache"
 	"github.com/NeuralTrust/TrustGate/pkg/version"
@@ -1222,6 +1225,46 @@ func testAppsResolver(transport http.RoundTripper) *AppCapabilityResolver {
 	resolver.transport = transport
 	return resolver
 }
+
+type appsCredentialPassthrough struct{}
+
+func (appsCredentialPassthrough) Apply(context.Context, *appconsumer.RoutableConsumer, *registrydomain.Registry, *appmcp.Target) error {
+	return nil
+}
+
+func TestAppsMediatorCancelsRealResolverFlights(t *testing.T) {
+	started := make(chan struct{}, 2)
+	var active atomic.Int32
+	resolver := testAppsResolver(roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Host == "positive.example" {
+			<-started
+			<-started
+			return appsResponse(appsPositive), nil
+		}
+		active.Add(1)
+		started <- struct{}{}
+		defer active.Add(-1)
+		<-req.Context().Done()
+		return nil, req.Context().Err()
+	}))
+	rc := &appconsumer.RoutableConsumer{Consumer: &consumerdomain.Consumer{}}
+	for _, host := range []string{"slow-a.example", "slow-b.example", "positive.example"} {
+		rc.Registries = append(rc.Registries, &registrydomain.Registry{
+			ID: ids.New[ids.RegistryKind](), Type: registrydomain.TypeMCP, Enabled: true,
+			MCPTarget: &registrydomain.MCPTarget{URL: "https://" + host + "/mcp", ProtocolMode: registrydomain.MCPProtocolModeModern},
+		})
+	}
+	if !appmcp.NewAppsMediator(true, true, appsCredentialPassthrough{}, resolver).
+		Advertise(context.Background(), true, rc, appmcp.MCPAppsClientCapability{MIMETypes: []string{appmcp.MCPAppsHTMLMIMEType}}) {
+		t.Fatal("positive real resolver did not advertise")
+	}
+	resolver.mu.Lock()
+	defer resolver.mu.Unlock()
+	if active.Load() != 0 || len(resolver.flights) != 0 {
+		t.Fatalf("active=%d flights=%d", active.Load(), len(resolver.flights))
+	}
+}
+
 func TestParseAppsCapability(t *testing.T) {
 	tests := map[string]error{
 		`{}`: ErrAppCapabilityUnsupported,


### PR DESCRIPTION
## Summary
- parse strict northbound `io.modelcontextprotocol/ui` declarations at the JSON-RPC boundary
- advertise the exact Apps MIME only after policy, consumer surface, credentials, and a modern upstream all qualify
- preserve core discovery and existing capabilities when Apps is absent, unsupported, malformed, or unavailable

This is RUN-1107 phase 3. It targets the unifying MCP branch after phase 2 landed through #471. It does not target `develop` or `main`, and draft PR #468 remains unmerged.

## Safety and performance
- keep production pipeline readiness hard-disabled until UI metadata/resource passthrough lands
- skip disabled, legacy, and unauthorized registries before credential resolution
- bound probe fan-out to 8 and total advertisement probing to 2 seconds
- cancel sibling probes on first positive and join all workers before returning
- return `-32602` for malformed known Apps declarations without upstream work

## Test plan
- [x] `make lint`
- [x] `make test`
- [x] `go vet ./...` in both Go modules
- [x] `go build ./...` in both Go modules
- [x] race tests for bounded fan-out, caller cancellation, timeout, and real resolver teardown
- [x] HTTP handler tests for supported, unsupported, and malformed declarations
- [x] reviewer, security, and performance reviews with no remaining blockers

Linear: https://linear.app/neuraltrust/issue/RUN-1107/featmcp-support-secure-mcp-apps-passthrough

Made with [Cursor](https://cursor.com)