### PR TITLE
feat: validate MCP Apps metadata and origins (RUN-1107)

### DIFF
--- a/pkg/app/mcp/apps_metadata.go
+++ b/pkg/app/mcp/apps_metadata.go
@@ -1,0 +1,280 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcp
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+
+	"golang.org/x/net/publicsuffix"
+)
+
+const maxAppsURIBytes, maxAppsOriginBytes, maxAppsMetadataFields, maxAppsMetadataKeyBytes, maxAppsPathSegments, maxAppsPolicyEntries = 2048, 512, 64, 128, 32, 64
+
+var (
+	// ErrInvalidAppsMetadata identifies fail-closed MCP Apps metadata rejection.
+	ErrInvalidAppsMetadata = &AppsMetadataError{}
+	knownPermissions       = map[string]bool{"camera": true, "microphone": true, "geolocation": true, "clipboardWrite": true}
+	cspDirectives          = map[string]bool{"connectDomains": true, "resourceDomains": false, "frameDomains": false, "baseUriDomains": false}
+	dnsNamePattern         = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$`)
+	pathSegmentPattern     = regexp.MustCompile(`^[a-z0-9._~-]+$`)
+	ipLikeHostPattern      = regexp.MustCompile(`^(?:0x[0-9a-f]+|[0-9]+)$|(?:^|\.)(?:0x[0-9a-f]+|[0-9]+)(?:\.(?:0x[0-9a-f]+|[0-9]+))+(?:\.|$)`)
+	rebindHostPattern      = regexp.MustCompile(`(?:^|\.)(?:nip\.io|sslip\.io|xip\.io|localtest\.me|lvh\.me)$`)
+)
+
+// AppsMetadataReason is a bounded rejection category for protocol error mapping.
+type AppsMetadataReason uint8
+
+const AppsMetadataPolicyReason, AppsMetadataURIReason, AppsMetadataToolReason, AppsMetadataResourceReason AppsMetadataReason = 0, 1, 2, 3
+
+// AppsMetadataError reports a bounded metadata rejection reason.
+type AppsMetadataError struct{ Reason AppsMetadataReason }
+
+func (e *AppsMetadataError) Error() string                { return "invalid MCP Apps metadata" }
+func (e *AppsMetadataError) Is(target error) bool         { return target == ErrInvalidAppsMetadata }
+func invalidAppsMetadata(reason AppsMetadataReason) error { return &AppsMetadataError{Reason: reason} }
+
+// AppsMetadataPolicy is an immutable MCP Apps origin and permission policy.
+type AppsMetadataPolicy struct {
+	maxPerDirective, maxTotal int
+	origins, permissions      map[string]bool
+}
+
+// NewAppsMetadataPolicy builds an independent, fail-closed metadata policy.
+func NewAppsMetadataPolicy(maxPerDirective, maxTotal int, allowedOrigins, allowedPermissions []string) (AppsMetadataPolicy, error) {
+	if maxPerDirective < 1 || maxTotal < maxPerDirective || maxTotal > maxAppsPolicyEntries ||
+		len(allowedOrigins) > maxTotal || len(allowedPermissions) > len(knownPermissions) {
+		return AppsMetadataPolicy{}, invalidAppsMetadata(AppsMetadataPolicyReason)
+	}
+	policy := AppsMetadataPolicy{maxPerDirective: maxPerDirective, maxTotal: maxTotal, origins: make(map[string]bool, len(allowedOrigins)), permissions: make(map[string]bool, len(allowedPermissions))}
+	for _, origin := range allowedOrigins {
+		if !validAppsOrigin(origin, true) || policy.origins[origin] {
+			return AppsMetadataPolicy{}, invalidAppsMetadata(AppsMetadataPolicyReason)
+		}
+		policy.origins[origin] = true
+	}
+	for _, permission := range allowedPermissions {
+		if policy.permissions[permission] || !knownPermissions[permission] {
+			return AppsMetadataPolicy{}, invalidAppsMetadata(AppsMetadataPolicyReason)
+		}
+		policy.permissions[permission] = true
+	}
+	return policy, nil
+}
+
+// ValidateAppsURI validates a logical, non-network ui:// identifier and preserves it byte-for-byte.
+func ValidateAppsURI(value string) (string, error) {
+	if len(value) > maxAppsURIBytes || !strings.HasPrefix(value, "ui://") {
+		return "", invalidAppsMetadata(AppsMetadataURIReason)
+	}
+	parts := strings.Split(strings.TrimPrefix(value, "ui://"), "/")
+	if len(parts) == 0 || len(parts)-1 > maxAppsPathSegments || !validDNSName(parts[0], true) {
+		return "", invalidAppsMetadata(AppsMetadataURIReason)
+	}
+	for _, segment := range parts[1:] {
+		if strings.Trim(segment, ".") == "" || !pathSegmentPattern.MatchString(segment) {
+			return "", invalidAppsMetadata(AppsMetadataURIReason)
+		}
+	}
+	return value, nil
+}
+
+// ToolAppsMetadata is an immutable parsed tool UI declaration.
+type ToolAppsMetadata struct {
+	ResourceURI                                                         string
+	HasCanonicalURI, HasDeprecatedURI, ModelVisible, ApplicationVisible bool
+}
+
+// ParseToolAppsMetadata validates tool _meta and returns its UI declaration.
+func ParseToolAppsMetadata(meta map[string]any) (ToolAppsMetadata, error) {
+	result := ToolAppsMetadata{ModelVisible: true, ApplicationVisible: true}
+	if !validAppsKeys(meta, maxAppsMetadataFields) {
+		return ToolAppsMetadata{}, invalidAppsMetadata(AppsMetadataToolReason)
+	}
+	if raw, present := meta["ui"]; present {
+		ui, ok := raw.(map[string]any)
+		if !ok || !validAppsKeys(ui, 2) {
+			return ToolAppsMetadata{}, invalidAppsMetadata(AppsMetadataToolReason)
+		}
+		for key := range ui {
+			if key != "resourceUri" && key != "visibility" {
+				return ToolAppsMetadata{}, invalidAppsMetadata(AppsMetadataToolReason)
+			}
+		}
+		if rawURI, ok := ui["resourceUri"]; ok {
+			uri, valid := rawURI.(string)
+			if !valid || len(uri) > maxAppsURIBytes {
+				return ToolAppsMetadata{}, invalidAppsMetadata(AppsMetadataToolReason)
+			}
+			result.ResourceURI, result.HasCanonicalURI = uri, true
+		}
+		if rawVisibility, ok := ui["visibility"]; ok {
+			model, app, err := parseAppsVisibility(rawVisibility)
+			if err != nil {
+				return ToolAppsMetadata{}, err
+			}
+			result.ModelVisible, result.ApplicationVisible = model, app
+		}
+	}
+	for key := range meta {
+		if strings.HasPrefix(key, "ui/") && key != "ui/resourceUri" {
+			return ToolAppsMetadata{}, invalidAppsMetadata(AppsMetadataToolReason)
+		}
+	}
+	if rawURI, ok := meta["ui/resourceUri"]; ok {
+		uri, valid := rawURI.(string)
+		if !valid || len(uri) > maxAppsURIBytes || result.HasCanonicalURI && uri != result.ResourceURI {
+			return ToolAppsMetadata{}, invalidAppsMetadata(AppsMetadataToolReason)
+		}
+		result.ResourceURI, result.HasDeprecatedURI = uri, true
+	}
+	if result.HasCanonicalURI || result.HasDeprecatedURI {
+		if _, err := ValidateAppsURI(result.ResourceURI); err != nil {
+			return ToolAppsMetadata{}, err
+		}
+	}
+	return result, nil
+}
+func parseAppsVisibility(raw any) (bool, bool, error) {
+	values, ok := raw.([]any)
+	if !ok || len(values) == 0 || len(values) > 2 {
+		return false, false, invalidAppsMetadata(AppsMetadataToolReason)
+	}
+	seen := make(map[string]bool, len(values))
+	for _, value := range values {
+		visibility, valid := value.(string)
+		if !valid || visibility != "model" && visibility != "app" || seen[visibility] {
+			return false, false, invalidAppsMetadata(AppsMetadataToolReason)
+		}
+		seen[visibility] = true
+	}
+	return seen["model"], seen["app"], nil
+}
+
+// ValidateResourceAppsMetadata validates a resource _meta.ui value.
+func ValidateResourceAppsMetadata(raw any, policy AppsMetadataPolicy) error {
+	ui, ok := raw.(map[string]any)
+	if !ok || !validAppsKeys(ui, 4) {
+		return invalidAppsMetadata(AppsMetadataResourceReason)
+	}
+	for key, value := range ui {
+		var err error
+		switch key {
+		case "domain":
+			return invalidAppsMetadata(AppsMetadataResourceReason)
+		case "prefersBorder":
+			if _, valid := value.(bool); !valid {
+				return invalidAppsMetadata(AppsMetadataResourceReason)
+			}
+		case "csp":
+			err = validateAppsCSP(value, policy)
+		case "permissions":
+			err = validateAppsPermissions(value, policy)
+		default:
+			return invalidAppsMetadata(AppsMetadataResourceReason)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+func validateAppsCSP(raw any, policy AppsMetadataPolicy) error {
+	csp, ok := raw.(map[string]any)
+	if !ok || !validAppsKeys(csp, 4) {
+		return invalidAppsMetadata(AppsMetadataResourceReason)
+	}
+	total := 0
+	for directive, rawOrigins := range csp {
+		allowWSS, known := cspDirectives[directive]
+		origins, valid := rawOrigins.([]any)
+		if !known || !valid {
+			return invalidAppsMetadata(AppsMetadataResourceReason)
+		}
+		total += len(origins)
+		if len(origins) > policy.maxPerDirective || total > policy.maxTotal {
+			return invalidAppsMetadata(AppsMetadataResourceReason)
+		}
+		seen := make(map[string]bool, len(origins))
+		for _, rawOrigin := range origins {
+			origin, valid := rawOrigin.(string)
+			if !valid || !validAppsOrigin(origin, allowWSS) || !policy.origins[origin] || seen[origin] {
+				return invalidAppsMetadata(AppsMetadataResourceReason)
+			}
+			seen[origin] = true
+		}
+	}
+	return nil
+}
+func validateAppsPermissions(raw any, policy AppsMetadataPolicy) error {
+	permissions, ok := raw.(map[string]any)
+	if !ok || !validAppsKeys(permissions, len(knownPermissions)) {
+		return invalidAppsMetadata(AppsMetadataResourceReason)
+	}
+	for permission, rawValue := range permissions {
+		value, object := rawValue.(map[string]any)
+		if !object || len(value) != 0 || !policy.permissions[permission] {
+			return invalidAppsMetadata(AppsMetadataResourceReason)
+		}
+	}
+	return nil
+}
+
+// SelectResourceAppsMetadata applies content-item-over-listing UI precedence.
+func SelectResourceAppsMetadata(listingMeta, contentMeta map[string]any) (any, bool) {
+	if value, ok := contentMeta["ui"]; ok {
+		return value, true
+	}
+	value, ok := listingMeta["ui"]
+	return value, ok
+}
+func validAppsOrigin(origin string, allowWSS bool) bool {
+	if len(origin) > maxAppsOriginBytes {
+		return false
+	}
+	scheme, authority, ok := strings.Cut(origin, "://")
+	if !ok || scheme != "https" && (!allowWSS || scheme != "wss") || authority == "" ||
+		strings.ContainsAny(authority, "/?#@%\\*[] \t\r\n") {
+		return false
+	}
+	host := authority
+	if strings.Count(authority, ":") > 1 {
+		return false
+	}
+	if before, after, found := strings.Cut(authority, ":"); found {
+		host = before
+		n, err := strconv.Atoi(after)
+		if err != nil || n < 1 || n > 65535 || n == 443 || strconv.Itoa(n) != after {
+			return false
+		}
+	}
+	_, icann := publicsuffix.PublicSuffix(host)
+	return icann && !rebindHostPattern.MatchString(host) && validDNSName(host, false)
+}
+func validDNSName(name string, singleLabel bool) bool {
+	return name != "" && len(name) <= 253 && name != "localhost" && !strings.HasSuffix(name, ".localhost") && !ipLikeHostPattern.MatchString(name) && name == strings.ToLower(name) && (singleLabel || strings.Contains(name, ".")) && dnsNamePattern.MatchString(name)
+}
+func validAppsKeys(values map[string]any, maxFields int) bool {
+	if len(values) > maxFields {
+		return false
+	}
+	for key := range values {
+		if len(key) > maxAppsMetadataKeyBytes {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/app/mcp/apps_metadata_test.go
+++ b/pkg/app/mcp/apps_metadata_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcp
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestAppsMetadataValidation(t *testing.T) {
+	for _, uri := range []string{"ui://widget", "ui://tenant.internal/view", "ui://nip.io/view", "ui://widget.example", "ui://xn--bcher-kva.example/a/b-._~9"} {
+		got, err := ValidateAppsURI(uri)
+		requireApps(t, err == nil && got == uri)
+	}
+	invalid := []string{"UI://widget", "ui://", "ui://LOCALHOST", "ui://localhost", "ui://api.localhost", "ui://127.0.0.1", "ui://2130706433", "ui://017700000001", "ui://0x7f000001", "ui://[::1]", "ui://user@host.example", "ui://host.example:444", "ui://host.example/", "ui://host.example/a//b",
+		"ui://host.example/.", "ui://host.example/..", "ui://host.example/a?b", "ui://host.example/a#b", "ui://host.example/a%20b", "ui://host.example/a\\b", "ui://host.example/a b", "ui://host.example/...", "ui://host.example/A", "ui://host_example", "ui://Host.example", "ui://host.example/é", "ui://host.example/\x01"}
+	invalid = append(invalid, "ui://host.example/"+strings.Repeat("a/", maxAppsPathSegments+1), "ui://host.example/"+strings.Repeat("a", maxAppsURIBytes))
+	for _, uri := range invalid {
+		_, err := ValidateAppsURI(uri)
+		requireApps(t, err != nil)
+	}
+	_, err := ValidateAppsURI("ui://host.example/%secret")
+	requireAppsError(t, err, AppsMetadataURIReason, "ui://host.example/%secret")
+	reject := func(per, total int, origins, permissions []string) {
+		_, err := NewAppsMetadataPolicy(per, total, origins, permissions)
+		requireAppsError(t, err, AppsMetadataPolicyReason, strings.Join(origins, ","))
+	}
+	for _, limits := range [][2]int{{0, 1}, {1, 0}, {2, 1}, {1, 65}} {
+		reject(limits[0], limits[1], nil, nil)
+	}
+	reject(1, 1, []string{"https://a.example.com", "https://b.example.com"}, nil)
+	reject(2, 2, []string{"https://a.example.com", "https://a.example.com"}, nil)
+	reject(1, 1, nil, []string{"camera", "camera"})
+	reject(1, 1, nil, []string{"usb"})
+	reject(1, 1, nil, []string{"camera", "microphone", "geolocation", "clipboardWrite", "usb"})
+	for _, origin := range []string{"https://*.example.com", "https://2130706433", "https://0177.0.0.1", "https://127.0.0.1.nip.io", "https://app.github.io", "https://service.internal", "https://example.com:443", "https://example.com:0443", "https://example.com:0", "https://example.com:65536", "https://user@example.com", "HTTPS://example.com", "https://" + strings.Repeat("a", maxAppsOriginBytes)} {
+		reject(1, 1, []string{origin}, nil)
+	}
+	input := map[string]any{"ui": map[string]any{"resourceUri": "ui://widget/a"}, "ui/resourceUri": "ui://widget/a", "opaque": 7}
+	got, err := ParseToolAppsMetadata(input)
+	requireApps(t, err == nil && got.ResourceURI == "ui://widget/a" && got.HasCanonicalURI && got.HasDeprecatedURI && got.ModelVisible && got.ApplicationVisible && input["opaque"] == 7 && input["ui/resourceUri"] == "ui://widget/a" && input["ui"].(map[string]any)["resourceUri"] == "ui://widget/a")
+	appOnly, err := ParseToolAppsMetadata(map[string]any{"ui": map[string]any{"visibility": []any{"app"}}})
+	requireApps(t, err == nil && appOnly.ResourceURI == "" && !appOnly.ModelVisible && appOnly.ApplicationVisible && !appOnly.HasCanonicalURI && !appOnly.HasDeprecatedURI)
+	canonical, canonicalErr := ParseToolAppsMetadata(map[string]any{"ui": map[string]any{"resourceUri": "ui://widget"}})
+	deprecated, deprecatedErr := ParseToolAppsMetadata(map[string]any{"ui/resourceUri": "ui://widget"})
+	requireApps(t, canonicalErr == nil && deprecatedErr == nil && canonical.HasCanonicalURI && !canonical.HasDeprecatedURI && !deprecated.HasCanonicalURI && deprecated.HasDeprecatedURI)
+	oversized := map[string]any{}
+	for i := 0; i <= maxAppsMetadataFields; i++ {
+		oversized[strings.Repeat("x", i+1)] = nil
+	}
+	for _, meta := range map[string]map[string]any{
+		"conflict": {"ui": map[string]any{"resourceUri": "ui://one"}, "ui/resourceUri": "ui://two"}, "non-string": {"ui/resourceUri": 1}, "unknown UI": {"ui": map[string]any{"resourceUri": "ui://one", "x": true}},
+		"unknown legacy UI": {"ui/resourceUri": "ui://one", "ui/x": true}, "empty visibility": {"ui": map[string]any{"resourceUri": "ui://one", "visibility": []any{}}}, "duplicate visibility": {"ui": map[string]any{"resourceUri": "ui://one", "visibility": []any{"app", "app"}}},
+		"unknown visibility": {"ui": map[string]any{"resourceUri": "ui://one", "visibility": []any{"host"}}}, "too much visibility": {"ui": map[string]any{"visibility": []any{"model", "app", "model"}}}, "oversized URI": {"ui/resourceUri": "ui://" + strings.Repeat("a", maxAppsURIBytes)},
+		"too many UI fields": {"ui": map[string]any{"resourceUri": "ui://one", "visibility": []any{"app"}, "x": nil}}, "too many metadata fields": oversized, "long metadata key": {strings.Repeat("k", maxAppsMetadataKeyBytes+1): nil},
+	} {
+		_, err := ParseToolAppsMetadata(meta)
+		requireAppsError(t, err, AppsMetadataToolReason, "ui://two")
+	}
+	_, err = ParseToolAppsMetadata(map[string]any{"ui/resourceUri": "ui://localhost"})
+	requireAppsError(t, err, AppsMetadataURIReason, "ui://localhost")
+	origins := []string{"https://cdn.example.com", "https://api.example.com:8443", "wss://socket.example.com:8443"}
+	permissions := []string{"camera", "clipboardWrite"}
+	policy, err := NewAppsMetadataPolicy(3, 5, origins, permissions)
+	requireApps(t, err == nil)
+	origins[0], permissions[0] = "https://changed.example.com", "microphone"
+	validResource := map[string]any{"csp": map[string]any{"connectDomains": []any{"https://api.example.com:8443", "wss://socket.example.com:8443"}, "resourceDomains": []any{"https://cdn.example.com"}}, "permissions": map[string]any{"camera": map[string]any{}, "clipboardWrite": map[string]any{}}, "prefersBorder": true}
+	for _, raw := range []any{validResource, map[string]any{}, map[string]any{"csp": map[string]any{}}} {
+		requireApps(t, ValidateResourceAppsMetadata(raw, policy) == nil)
+	}
+	for name, raw := range map[string]any{
+		"non-object": 7, "unknown UI": map[string]any{"x": true}, "host domain intentionally forbidden": map[string]any{"domain": "app.example.com"},
+		"border": map[string]any{"prefersBorder": "yes"}, "unknown CSP": map[string]any{"csp": map[string]any{"scriptDomains": []any{}}}, "wss resource": map[string]any{"csp": map[string]any{"resourceDomains": []any{"wss://socket.example.com:8443"}}},
+		"duplicate": map[string]any{"csp": map[string]any{"resourceDomains": []any{"https://cdn.example.com", "https://cdn.example.com"}}}, "not allowed": map[string]any{"csp": map[string]any{"resourceDomains": []any{"https://other.example.com"}}}, "unknown permission": map[string]any{"permissions": map[string]any{"usb": map[string]any{}}},
+		"denied permission": map[string]any{"permissions": map[string]any{"microphone": map[string]any{}}}, "too many resource fields": map[string]any{"csp": map[string]any{}, "permissions": map[string]any{}, "prefersBorder": true, "domain": nil, "x": nil},
+		"too many CSP fields": map[string]any{"csp": map[string]any{"connectDomains": []any{}, "resourceDomains": []any{}, "frameDomains": []any{}, "baseUriDomains": []any{}, "x": []any{}}}, "too many permissions": map[string]any{"permissions": map[string]any{"camera": map[string]any{}, "microphone": map[string]any{}, "geolocation": map[string]any{}, "clipboardWrite": map[string]any{}, "usb": map[string]any{}}},
+	} {
+		requireAppsError(t, ValidateResourceAppsMetadata(raw, policy), AppsMetadataResourceReason, name)
+	}
+	requireAppsError(t, ValidateResourceAppsMetadata(map[string]any{"permissions": map[string]any{"camera": map[string]any{"secret": "front-camera-secret"}}}, policy), AppsMetadataResourceReason, "front-camera-secret")
+	bounded, _ := NewAppsMetadataPolicy(1, 2, []string{"https://cdn.example.com", "https://api.example.com:8443"}, nil)
+	for _, csp := range []any{map[string]any{"resourceDomains": []any{"https://cdn.example.com", "https://api.example.com:8443"}}, map[string]any{"resourceDomains": []any{"https://cdn.example.com"}, "frameDomains": []any{"https://api.example.com:8443"}, "baseUriDomains": []any{"https://cdn.example.com"}}} {
+		requireAppsError(t, ValidateResourceAppsMetadata(map[string]any{"csp": csp}, bounded), AppsMetadataResourceReason, "")
+	}
+	listing := map[string]any{"ui": map[string]any{"prefersBorder": true}}
+	content := map[string]any{"ui": map[string]any{}}
+	selected, ok := SelectResourceAppsMetadata(listing, content)
+	ui, valid := selected.(map[string]any)
+	requireApps(t, ok && valid && len(ui) == 0)
+	selected, ok = SelectResourceAppsMetadata(listing, nil)
+	ui, valid = selected.(map[string]any)
+	requireApps(t, ok && valid && ui["prefersBorder"] == true)
+	_, ok = SelectResourceAppsMetadata(nil, nil)
+	requireApps(t, !ok)
+	selected, _ = SelectResourceAppsMetadata(nil, map[string]any{"ui": map[string]any{"domain": "app.example.com"}})
+	requireAppsError(t, ValidateResourceAppsMetadata(selected, AppsMetadataPolicy{}), AppsMetadataResourceReason, "app.example.com")
+}
+func requireAppsError(t *testing.T, err error, reason AppsMetadataReason, secret string) {
+	var typed *AppsMetadataError
+	requireApps(t, errors.Is(err, ErrInvalidAppsMetadata) && errors.As(err, &typed) && typed.Reason == reason && (secret == "" || !strings.Contains(err.Error(), secret)))
+}
+func requireApps(t *testing.T, valid bool) {
+	if !valid {
+		t.FailNow()
+	}
+}


### PR DESCRIPTION
## Summary
- add fail-closed validation for logical `ui://` identifiers and tool UI metadata
- validate CSP origins, permissions, bounds, and listing/content metadata precedence
- preserve canonical and deprecated resource URI forms without rewriting valid identifiers

This is RUN-1107 phase 4. It targets the unifying MCP branch after phase 3 landed through #472. It does not target `develop` or `main`, and draft PR #468 remains unmerged.

## Security contract
- treat `ui://` as an opaque logical namespace, never a network origin
- reject direct IP/numeric/localhost authorities, malformed paths, controls, Unicode, and normalization ambiguities
- require exact operator-allowlisted CSP origins; block wildcards, internal/rebinding hosts, duplicates, and unsafe ports
- reject unknown/denied permissions and host-defined `domain` metadata
- bound all metadata maps, keys, URI segments, origins, policy counts, and error categories

## Test plan
- [x] `make lint`
- [x] `make test`
- [x] `go vet ./...` in both Go modules
- [x] `go build ./...` in both Go modules
- [x] race tests for URI, tool metadata, CSP, permissions, precedence, and immutability
- [x] reviewer, security, and performance reviews with no remaining blockers
- [x] confirm validators are not wired into runtime content paths yet

Linear: https://linear.app/neuraltrust/issue/RUN-1107/featmcp-support-secure-mcp-apps-passthrough

Made with [Cursor](https://cursor.com)