### PR TITLE
feat: decode bounded MCP Apps documents (RUN-1107)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,6 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
-	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/cobra v1.10.2 // indirect
@@ -131,6 +130,7 @@ require (
 	github.com/NeuralTrust/TrustGate/pkg/metrics v0.0.0
 	github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.6.36
 	github.com/redis/go-redis/v9 v9.22.0
+	github.com/segmentio/encoding v0.5.4
 	go.opentelemetry.io/otel/metric v1.45.0
 	go.opentelemetry.io/otel/sdk/metric v1.45.0
 	go.opentelemetry.io/otel/trace v1.45.0

--- a/pkg/app/mcp/apps_document.go
+++ b/pkg/app/mcp/apps_document.go
@@ -1,0 +1,304 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcp
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"unicode/utf8"
+
+	segmentjson "github.com/segmentio/encoding/json"
+)
+
+const (
+	appsDocumentMIME                                         = "text/html;profile=mcp-app"
+	minAppsDocumentBytes, maxAppsDocumentBytes               = 64 * 1024, 2 * 1024 * 1024
+	maxAppsJSONDepth, maxAppsJSONFields, maxAppsJSONKeyBytes = 64, 64, 128
+	maxAppsJSONTokens                                        = 1024
+)
+
+var (
+	// ErrInvalidAppsDocument identifies fail-closed MCP Apps document rejection.
+	ErrInvalidAppsDocument = &AppsDocumentError{}
+	errAppsDocument        = errors.New("invalid document")
+)
+
+// AppsDocumentReason is a bounded rejection category for protocol error mapping.
+type AppsDocumentReason uint8
+
+const (
+	AppsDocumentPolicyReason AppsDocumentReason = iota
+	AppsDocumentEnvelopeReason
+	AppsDocumentSizeReason
+	AppsDocumentEncodingReason
+)
+
+// AppsDocumentError reports a bounded document rejection reason.
+type AppsDocumentError struct{ Reason AppsDocumentReason }
+
+func (e *AppsDocumentError) Error() string                { return "invalid MCP Apps document" }
+func (e *AppsDocumentError) Is(target error) bool         { return target == ErrInvalidAppsDocument }
+func invalidAppsDocument(reason AppsDocumentReason) error { return &AppsDocumentError{Reason: reason} }
+
+// AppsDocumentEncoding identifies the decoded resource representation.
+type AppsDocumentEncoding uint8
+
+const (
+	AppsDocumentTextEncoding AppsDocumentEncoding = iota
+	AppsDocumentBlobEncoding
+)
+
+// AppsDocumentMetadata contains only bounded decoding metadata.
+type AppsDocumentMetadata struct {
+	Encoding    AppsDocumentEncoding
+	DecodedSize int
+}
+
+type appsDecodedDocument struct {
+	body     []byte
+	metadata AppsDocumentMetadata
+}
+
+type appsDocumentWire struct {
+	Contents []appsDocumentContent `json:"contents"`
+	Meta     json.RawMessage       `json:"_meta"`
+}
+
+type appsDocumentContent struct {
+	URI  json.RawMessage `json:"uri"`
+	MIME json.RawMessage `json:"mimeType"`
+	Text json.RawMessage `json:"text"`
+	Blob json.RawMessage `json:"blob"`
+	Meta json.RawMessage `json:"_meta"`
+}
+
+func decodeAppsDocument(expectedURI string, maxBytes int, raw json.RawMessage) (appsDecodedDocument, error) {
+	if maxBytes < minAppsDocumentBytes || maxBytes > maxAppsDocumentBytes {
+		return appsDecodedDocument{}, invalidAppsDocument(AppsDocumentPolicyReason)
+	}
+	if _, err := ValidateAppsURI(expectedURI); err != nil {
+		return appsDecodedDocument{}, invalidAppsDocument(AppsDocumentPolicyReason)
+	}
+	if len(raw) > maxBytes*6+1024 || !utf8.Valid(raw) || validateAppsJSON(raw) != nil {
+		return appsDecodedDocument{}, invalidAppsDocument(AppsDocumentEnvelopeReason)
+	}
+	var envelope appsDocumentWire
+	flags := segmentjson.DisallowUnknownFields | segmentjson.DontCopyRawMessage | segmentjson.DontMatchCaseInsensitiveStructFields
+	remaining, parseErr := segmentjson.Parse(raw, &envelope, flags)
+	if parseErr != nil || len(remaining) != 0 || len(envelope.Contents) != 1 || !validAppsMeta(envelope.Meta) {
+		return appsDecodedDocument{}, invalidAppsDocument(AppsDocumentEnvelopeReason)
+	}
+	content := envelope.Contents[0]
+	uri, _, uriErr := decodeAppsJSONString(content.URI, maxAppsURIBytes)
+	mime, _, mimeErr := decodeAppsJSONString(content.MIME, len(appsDocumentMIME))
+	_, returnedURIErr := ValidateAppsURI(string(uri))
+	if uriErr != nil || returnedURIErr != nil || string(uri) != expectedURI ||
+		mimeErr != nil || string(mime) != appsDocumentMIME || !validAppsMeta(content.Meta) {
+		return appsDecodedDocument{}, invalidAppsDocument(AppsDocumentEnvelopeReason)
+	}
+	hasText, hasBlob := content.Text != nil, content.Blob != nil
+	if hasText == hasBlob {
+		return appsDecodedDocument{}, invalidAppsDocument(AppsDocumentEnvelopeReason)
+	}
+	if hasText {
+		return decodeAppsText(content.Text, maxBytes)
+	}
+	return decodeAppsBlob(content.Blob, maxBytes)
+}
+
+func validateAppsJSON(raw []byte) error {
+	stack := make([]map[string]bool, 0, maxAppsJSONDepth)
+	tokenizer := segmentjson.NewTokenizer(raw)
+	tokens := 0
+	for tokenizer.Next() {
+		tokens++
+		if tokens > maxAppsJSONTokens {
+			return errAppsDocument
+		}
+		switch tokenizer.Delim {
+		case '{':
+			if len(stack) >= maxAppsJSONDepth {
+				return errAppsDocument
+			}
+			stack = append(stack, map[string]bool{})
+		case '[':
+			if len(stack) >= maxAppsJSONDepth {
+				return errAppsDocument
+			}
+			stack = append(stack, nil)
+		case '}', ']':
+			if len(stack) == 0 || tokenizer.Delim == '}' && stack[len(stack)-1] == nil ||
+				tokenizer.Delim == ']' && stack[len(stack)-1] != nil {
+				return errAppsDocument
+			}
+			stack = stack[:len(stack)-1]
+		default:
+			if tokenizer.IsKey {
+				if len(stack) == 0 || stack[len(stack)-1] == nil ||
+					len(tokenizer.Value) > maxAppsJSONKeyBytes*6+2 {
+					return errAppsDocument
+				}
+				key := string(tokenizer.String())
+				fields := stack[len(stack)-1]
+				if len(key) > maxAppsJSONKeyBytes || fields[key] || len(fields) >= maxAppsJSONFields {
+					return errAppsDocument
+				}
+				fields[key] = true
+			}
+		}
+	}
+	if tokenizer.Err != nil || len(stack) != 0 {
+		return errAppsDocument
+	}
+	return nil
+}
+
+func validAppsMeta(raw []byte) bool {
+	raw = bytes.TrimSpace(raw)
+	return len(raw) == 0 || len(raw) > 1 && raw[0] == '{' && raw[len(raw)-1] == '}'
+}
+
+func decodeAppsJSONString(raw []byte, max int) ([]byte, bool, error) {
+	if len(raw) < 2 || raw[0] != '"' || raw[len(raw)-1] != '"' || !utf8.Valid(raw) {
+		return nil, false, errAppsDocument
+	}
+	size, valid := appsJSONStringSize(raw, max)
+	if !valid || size < 0 {
+		return nil, false, errAppsDocument
+	}
+	if size > max {
+		return nil, true, errAppsDocument
+	}
+	value := segmentjson.RawValue(raw).AppendUnquote(make([]byte, 0, size))
+	if len(value) != size {
+		return nil, false, errAppsDocument
+	}
+	return value, false, nil
+}
+
+func appsJSONStringSize(raw []byte, max int) (int, bool) {
+	size := 0
+	for i := 1; i < len(raw)-1; {
+		if raw[i] != '\\' {
+			_, width := utf8.DecodeRune(raw[i:])
+			size, i = size+width, i+width
+		} else if raw[i+1] != 'u' {
+			size, i = size+1, i+2
+		} else {
+			if i+6 > len(raw)-1 {
+				return 0, false
+			}
+			r, valid := appsHexRune(raw[i+2 : i+6])
+			if !valid {
+				return 0, false
+			}
+			i += 6
+			if r >= 0xD800 && r <= 0xDBFF {
+				if i+6 > len(raw)-1 || raw[i] != '\\' || raw[i+1] != 'u' {
+					return 0, false
+				}
+				low, lowValid := appsHexRune(raw[i+2 : i+6])
+				if !lowValid || low < 0xDC00 || low > 0xDFFF {
+					return 0, false
+				}
+				size, i = size+4, i+6
+				continue
+			}
+			width := utf8.RuneLen(r)
+			if r >= 0xDC00 && r <= 0xDFFF || width < 0 {
+				return 0, false
+			}
+			size += width
+		}
+		if size > max {
+			return size, true
+		}
+	}
+	return size, true
+}
+
+func appsHexRune(raw []byte) (rune, bool) {
+	var value rune
+	for _, current := range raw {
+		var digit rune
+		switch {
+		case current >= '0' && current <= '9':
+			digit = rune(current - '0')
+		case current >= 'a' && current <= 'f':
+			digit = rune(current-'a') + 10
+		case current >= 'A' && current <= 'F':
+			digit = rune(current-'A') + 10
+		default:
+			return 0, false
+		}
+		value = value*16 + digit
+	}
+	return value, true
+}
+
+func decodeAppsText(raw []byte, max int) (appsDecodedDocument, error) {
+	body, oversized, err := decodeAppsJSONString(raw, max)
+	if oversized {
+		return appsDecodedDocument{}, invalidAppsDocument(AppsDocumentSizeReason)
+	}
+	if err != nil {
+		return appsDecodedDocument{}, invalidAppsDocument(AppsDocumentEncodingReason)
+	}
+	return appsDecodedDocument{
+		body: body,
+		metadata: AppsDocumentMetadata{
+			Encoding:    AppsDocumentTextEncoding,
+			DecodedSize: len(body),
+		},
+	}, nil
+}
+
+func decodeAppsBlob(raw []byte, max int) (appsDecodedDocument, error) {
+	value, oversized, err := decodeAppsJSONString(raw, base64.StdEncoding.EncodedLen(max))
+	if oversized {
+		return appsDecodedDocument{}, invalidAppsDocument(AppsDocumentSizeReason)
+	}
+	if err != nil || len(value)%4 != 0 || bytes.ContainsAny(value, " \t\r\n-_") {
+		return appsDecodedDocument{}, invalidAppsDocument(AppsDocumentEncodingReason)
+	}
+	projected := base64.StdEncoding.DecodedLen(len(value))
+	if bytes.HasSuffix(value, []byte("==")) {
+		projected -= 2
+	} else if bytes.HasSuffix(value, []byte("=")) {
+		projected--
+	}
+	if projected > max {
+		return appsDecodedDocument{}, invalidAppsDocument(AppsDocumentSizeReason)
+	}
+	var body bytes.Buffer
+	decoder := base64.NewDecoder(base64.StdEncoding.Strict(), bytes.NewReader(value))
+	n, decodeErr := io.Copy(&body, io.LimitReader(decoder, int64(max)+1))
+	if n > int64(max) {
+		return appsDecodedDocument{}, invalidAppsDocument(AppsDocumentSizeReason)
+	}
+	if decodeErr != nil || n != int64(projected) {
+		return appsDecodedDocument{}, invalidAppsDocument(AppsDocumentEncodingReason)
+	}
+	return appsDecodedDocument{
+		body: body.Bytes(),
+		metadata: AppsDocumentMetadata{
+			Encoding:    AppsDocumentBlobEncoding,
+			DecodedSize: int(n),
+		},
+	}, nil
+}

--- a/pkg/app/mcp/apps_metadata_test.go
+++ b/pkg/app/mcp/apps_metadata_test.go
@@ -15,6 +15,9 @@
 package mcp
 
 import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -116,4 +119,77 @@ func requireApps(t *testing.T, valid bool) {
 	if !valid {
 		t.FailNow()
 	}
+}
+
+func TestAppsDocumentValidation(t *testing.T) {
+	textBody := "<escaped>\tcontent"
+	for _, tc := range []struct {
+		field, wire string
+		body        []byte
+		encoding    AppsDocumentEncoding
+	}{
+		{"text", textBody, []byte(textBody), AppsDocumentTextEncoding},
+		{"blob", "aaaa", []byte{105, 166, 154}, AppsDocumentBlobEncoding},
+		{"blob", "YQ==", []byte("a"), AppsDocumentBlobEncoding},
+	} {
+		raw := appsDocumentRaw(tc.field, tc.wire, `,"_meta":{"ui":{}}`)
+		original := append(json.RawMessage(nil), raw...)
+		got, err := decodeAppsDocument("ui://widget", minAppsDocumentBytes, raw)
+		requireApps(t, err == nil && got.metadata.Encoding == tc.encoding && got.metadata.DecodedSize == len(tc.body) && bytes.Equal(got.body, tc.body) && bytes.Equal(raw, original))
+		for i := range raw {
+			raw[i] = 0
+		}
+		requireApps(t, bytes.Equal(got.body, tc.body))
+	}
+	for _, malformed := range []string{`"\u000g"`, `"\ud800"`, `"\ud800\u0041"`, `"\udc00"`} {
+		_, _, err := decodeAppsJSONString([]byte(malformed), minAppsDocumentBytes)
+		requireApps(t, err != nil)
+	}
+	boundary := strings.Repeat("<", minAppsDocumentBytes)
+	for _, max := range []int{minAppsDocumentBytes, maxAppsDocumentBytes} {
+		got, err := decodeAppsDocument("ui://widget", max, appsDocumentRaw("text", boundary, ""))
+		requireApps(t, err == nil && len(got.body) == len(boundary))
+	}
+	deepMeta := strings.Repeat(`{"x":`, maxAppsJSONDepth+1) + "0" + strings.Repeat("}", maxAppsJSONDepth+1)
+	invalidTopUTF8 := json.RawMessage(bytes.Replace([]byte(`{"_meta":{"x":"bad"},"contents":[]}`), []byte("bad"), []byte{0xff}, 1))
+	invalidContentUTF8 := json.RawMessage(bytes.Replace([]byte(`{"contents":[{"uri":"ui://widget","mimeType":"text/html;profile=mcp-app","text":"x","_meta":{"x":"bad"}}]}`), []byte("bad"), []byte{0xff}, 1))
+	tooManyTokens := json.RawMessage(`{"contents":[` + strings.Repeat("0,", maxAppsJSONTokens) + `0]}`)
+	requireApps(t, validateAppsJSON(tooManyTokens) != nil)
+	cases := []struct {
+		raw    json.RawMessage
+		max    int
+		reason AppsDocumentReason
+		secret string
+	}{
+		{json.RawMessage(`null`), minAppsDocumentBytes, AppsDocumentEnvelopeReason, ""}, {json.RawMessage(`{"contents":[]}`), minAppsDocumentBytes, AppsDocumentEnvelopeReason, ""}, {json.RawMessage(`{"contents":[{},{}]}`), minAppsDocumentBytes, AppsDocumentEnvelopeReason, ""},
+		{json.RawMessage(`{"contents":[],"contents":[]}`), minAppsDocumentBytes, AppsDocumentEnvelopeReason, ""}, {json.RawMessage(`{"_meta":{"x":1,"x":2},"contents":[]}`), minAppsDocumentBytes, AppsDocumentEnvelopeReason, ""},
+		{json.RawMessage(`{"contents":[{"uri":"ui://widget","\u0075ri":"ui://widget","mimeType":"text/html;profile=mcp-app","text":"x"}]}`), minAppsDocumentBytes, AppsDocumentEnvelopeReason, ""},
+		{json.RawMessage(`{"_meta":null,"contents":[{"uri":"ui://widget","mimeType":"text/html;profile=mcp-app","text":"x"}]}`), minAppsDocumentBytes, AppsDocumentEnvelopeReason, ""},
+		{json.RawMessage(`{"contents":[{"uri":"ui://widget","mimeType":"text/html;profile=mcp-app","_meta":[],"text":"x"}]}`), minAppsDocumentBytes, AppsDocumentEnvelopeReason, ""},
+		{json.RawMessage(`{"unknown":1,"contents":[]}`), minAppsDocumentBytes, AppsDocumentEnvelopeReason, ""}, {json.RawMessage(`{"contents":[{"uri":"ui://widget","mimeType":"text/html;profile=mcp-app","name":"link","text":"x"}]}`), minAppsDocumentBytes, AppsDocumentEnvelopeReason, ""},
+		{json.RawMessage(`{"contents":[{"uri":"ui://other","mimeType":"text/html;profile=mcp-app","text":"x"}]}`), minAppsDocumentBytes, AppsDocumentEnvelopeReason, ""}, {json.RawMessage(`{"contents":[{"uri":"ui://widget","mimeType":"text/html","text":"x"}]}`), minAppsDocumentBytes, AppsDocumentEnvelopeReason, ""},
+		{json.RawMessage(`{"contents":[{"uri":"ui://widget","mimeType":"text/html;profile=mcp-app"}]}`), minAppsDocumentBytes, AppsDocumentEnvelopeReason, ""},
+		{json.RawMessage(`{"contents":[}`), minAppsDocumentBytes, AppsDocumentEnvelopeReason, ""}, {json.RawMessage(`{"_meta":` + deepMeta + `,"contents":[]}`), minAppsDocumentBytes, AppsDocumentEnvelopeReason, ""},
+		{json.RawMessage(`{"_meta":{"` + strings.Repeat("k", maxAppsJSONKeyBytes+1) + `":1},"contents":[]}`), minAppsDocumentBytes, AppsDocumentEnvelopeReason, ""},
+		{invalidTopUTF8, minAppsDocumentBytes, AppsDocumentEnvelopeReason, ""}, {invalidContentUTF8, minAppsDocumentBytes, AppsDocumentEnvelopeReason, ""}, {tooManyTokens, minAppsDocumentBytes, AppsDocumentEnvelopeReason, ""},
+		{appsDocumentRaw("text", textBody, ""), minAppsDocumentBytes - 1, AppsDocumentPolicyReason, ""}, {appsDocumentRaw("text", textBody, ""), maxAppsDocumentBytes + 1, AppsDocumentPolicyReason, ""},
+		{appsDocumentRaw("text", boundary+"x", ""), minAppsDocumentBytes, AppsDocumentSizeReason, ""}, {appsDocumentRaw("blob", base64.StdEncoding.EncodeToString([]byte(boundary+"x")), ""), minAppsDocumentBytes, AppsDocumentSizeReason, ""},
+		{appsDocumentRaw("blob", "%%%=", ""), minAppsDocumentBytes, AppsDocumentEncodingReason, "%%%="}, {appsDocumentRaw("blob", "AB==", ""), minAppsDocumentBytes, AppsDocumentEncodingReason, "AB=="}, {appsDocumentRaw("blob", "____", ""), minAppsDocumentBytes, AppsDocumentEncodingReason, "____"},
+		{appsDocumentRaw("blob", "YQ", ""), minAppsDocumentBytes, AppsDocumentEncodingReason, "YQ"}, {appsDocumentRaw("blob", "YQ==\n", ""), minAppsDocumentBytes, AppsDocumentEncodingReason, "YQ=="},
+		{appsDocumentRaw("blob", "YQ==AAAA", ""), minAppsDocumentBytes, AppsDocumentEncodingReason, "YQ=="}, {appsDocumentRaw("text", textBody, `,"blob":"YQ=="`), minAppsDocumentBytes, AppsDocumentEnvelopeReason, ""},
+		{json.RawMessage(`{"contents":[{"uri":"ui://secret.example","mimeType":"text/html;profile=mcp-app","text":"x"}]}`), minAppsDocumentBytes, AppsDocumentEnvelopeReason, "ui://secret.example"},
+	}
+	for _, tc := range cases {
+		_, err := decodeAppsDocument("ui://widget", tc.max, tc.raw)
+		var typed *AppsDocumentError
+		requireApps(t, errors.Is(err, ErrInvalidAppsDocument) && errors.As(err, &typed) && typed.Reason == tc.reason && (tc.secret == "" || !strings.Contains(err.Error(), tc.secret)))
+	}
+}
+
+func appsDocumentRaw(field, body, extra string) json.RawMessage {
+	value, err := json.Marshal(body)
+	if err != nil {
+		return nil
+	}
+	return json.RawMessage(`{"_meta":{"trace":{"ok":true}},"contents":[{"uri":"ui://widget","mimeType":"text/html;profile=mcp-app","` + field + `":` + string(value) + extra + `}]}`)
 }


### PR DESCRIPTION
## Summary
- validate the MCP Apps `resources/read` envelope with duplicate-key, nesting, cardinality, and UTF-8 bounds
- decode text and strict padded RFC 4648 blob bodies under the configured caller limit
- keep the decoder runtime-unwired until Phase 5B adds strict HTML validation

## Linear
RUN-1107 — https://linear.app/neuraltrust/issue/RUN-1107/featmcp-support-secure-mcp-apps-passthrough

## Test plan
- [x] `make lint`
- [x] `make test-race`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] pre-commit security, license, formatting, and test hooks

## Stack note
This Phase 5A PR targets the RUN-1103 unifying branch. Phase 5B will add bounded structural HTML validation before any production wiring.

Made with [Cursor](https://cursor.com)