### PR TITLE
fix: fail closed on TrustGuard evaluate auth rejections (RUN-1126)

### DIFF
--- a/pkg/infra/plugins/trustguard/client.go
+++ b/pkg/infra/plugins/trustguard/client.go
@@ -62,6 +62,20 @@ func (e *entitlementsUnavailableError) Error() string {
 	return "trustguard: rate limit entitlements unavailable"
 }
 
+// authRejectedError is returned when TrustGuard deliberately refuses the
+// evaluate call (403, or 401 after token refresh). Must not fail-open: the
+// guard is reachable and the plugin is misconfigured or unauthorized.
+type authRejectedError struct {
+	status int
+}
+
+func (e *authRejectedError) Error() string {
+	if e == nil {
+		return "trustguard: unauthorized"
+	}
+	return fmt.Sprintf("trustguard: unauthorized status %d", e.status)
+}
+
 type client struct {
 	http *http.Client
 }
@@ -102,6 +116,9 @@ func (c *client) Guard(ctx context.Context, baseURL, token, traceID string, body
 	}
 	if res.StatusCode == http.StatusUnauthorized {
 		return nil, errUnauthorized
+	}
+	if res.StatusCode == http.StatusForbidden {
+		return nil, &authRejectedError{status: http.StatusForbidden}
 	}
 	if res.StatusCode == http.StatusTooManyRequests {
 		return nil, &rateLimitedError{

--- a/pkg/infra/plugins/trustguard/config.go
+++ b/pkg/infra/plugins/trustguard/config.go
@@ -29,11 +29,18 @@ const (
 	inspectResponse        = "response"
 	inspectRequestResponse = "request_response"
 	defaultInspect         = inspectRequestResponse
+
+	onErrorFailOpen   = "fail_open"
+	onErrorFailClosed = "fail_closed"
+	defaultOnError    = onErrorFailOpen
 )
 
 type Settings struct {
 	Inspect     string `mapstructure:"inspect"`
 	CollectorID string `mapstructure:"collector_id"`
+	// OnError controls transport / 5xx failure behaviour. Auth/config
+	// rejections (401/403) always fail closed regardless of this setting.
+	OnError string `mapstructure:"on_error"`
 }
 
 func parseConfig(settings map[string]any) (Settings, error) {
@@ -62,6 +69,9 @@ func (s *Settings) applyDefaults() {
 	if s.Inspect == "" {
 		s.Inspect = defaultInspect
 	}
+	if s.OnError == "" {
+		s.OnError = defaultOnError
+	}
 }
 
 func (s *Settings) validate() error {
@@ -70,6 +80,11 @@ func (s *Settings) validate() error {
 	default:
 		return fmt.Errorf("trustguard: inspect must be one of request, response, request_response")
 	}
+	switch s.OnError {
+	case onErrorFailOpen, onErrorFailClosed:
+	default:
+		return fmt.Errorf("trustguard: on_error must be one of fail_open, fail_closed")
+	}
 	if strings.TrimSpace(s.CollectorID) == "" {
 		return fmt.Errorf("trustguard: collector_id is required")
 	}
@@ -77,6 +92,10 @@ func (s *Settings) validate() error {
 		return fmt.Errorf("trustguard: collector_id must be a valid UUID")
 	}
 	return nil
+}
+
+func (s Settings) failClosedOnTransport() bool {
+	return s.OnError == onErrorFailClosed
 }
 
 func (s Settings) selectsStage(stage policy.Stage) bool {

--- a/pkg/infra/plugins/trustguard/config_test.go
+++ b/pkg/infra/plugins/trustguard/config_test.go
@@ -33,31 +33,43 @@ func TestParseConfig(t *testing.T) {
 		settings    map[string]any
 		wantErr     bool
 		wantInspect string
+		wantOnError string
 	}{
 		{
 			name:        "valid minimal config defaults inspect",
 			settings:    map[string]any{"collector_id": testCollectorID},
 			wantInspect: inspectRequestResponse,
+			wantOnError: onErrorFailOpen,
 		},
 		{
 			name:        "inspect request accepted",
 			settings:    map[string]any{"inspect": inspectRequest, "collector_id": testCollectorID},
 			wantInspect: inspectRequest,
+			wantOnError: onErrorFailOpen,
 		},
 		{
 			name:        "catalog direction alias maps to inspect",
 			settings:    map[string]any{"direction": inspectRequest, "collector_id": testCollectorID},
 			wantInspect: inspectRequest,
+			wantOnError: onErrorFailOpen,
 		},
 		{
 			name:        "inspect response accepted",
 			settings:    map[string]any{"inspect": inspectResponse, "collector_id": testCollectorID},
 			wantInspect: inspectResponse,
+			wantOnError: onErrorFailOpen,
 		},
 		{
 			name:        "inspect request_response accepted",
 			settings:    map[string]any{"inspect": inspectRequestResponse, "collector_id": testCollectorID},
 			wantInspect: inspectRequestResponse,
+			wantOnError: onErrorFailOpen,
+		},
+		{
+			name:        "on_error fail_closed accepted",
+			settings:    map[string]any{"collector_id": testCollectorID, "on_error": onErrorFailClosed},
+			wantInspect: inspectRequestResponse,
+			wantOnError: onErrorFailClosed,
 		},
 		{
 			name:     "invalid inspect",
@@ -65,9 +77,15 @@ func TestParseConfig(t *testing.T) {
 			wantErr:  true,
 		},
 		{
+			name:     "invalid on_error",
+			settings: map[string]any{"collector_id": testCollectorID, "on_error": "panic"},
+			wantErr:  true,
+		},
+		{
 			name:        "legacy base_url in settings ignored",
 			settings:    map[string]any{"base_url": "http://guard.local", "collector_id": testCollectorID},
 			wantInspect: inspectRequestResponse,
+			wantOnError: onErrorFailOpen,
 		},
 		{
 			name:     "missing collector_id rejected",
@@ -89,6 +107,7 @@ func TestParseConfig(t *testing.T) {
 			}
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantInspect, cfg.Inspect)
+			assert.Equal(t, tt.wantOnError, cfg.OnError)
 		})
 	}
 }

--- a/pkg/infra/plugins/trustguard/data.go
+++ b/pkg/infra/plugins/trustguard/data.go
@@ -101,6 +101,8 @@ type guardData struct {
 	FindingsCount  int            `json:"findings_count,omitempty"`
 	Findings       []GuardFinding `json:"findings,omitempty"`
 	FailedOpen     bool           `json:"failed_open,omitempty"`
+	FailedClosed   bool           `json:"failed_closed,omitempty"`
+	FailureReason  string         `json:"failure_reason,omitempty"`
 	Degraded       bool           `json:"degraded,omitempty"`
 	DegradedReason string         `json:"degraded_reason,omitempty"`
 }

--- a/pkg/infra/plugins/trustguard/metrics.go
+++ b/pkg/infra/plugins/trustguard/metrics.go
@@ -1,0 +1,51 @@
+// Copyright 2026 NeuralTrust
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trustguard
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+const (
+	failureReasonUnauthorized = "unauthorized"
+	failureReasonTransport    = "transport"
+)
+
+var (
+	evaluateFailuresOnce sync.Once
+	evaluateFailures     metric.Int64Counter
+)
+
+func recordEvaluateFailure(ctx context.Context, reason string) {
+	evaluateFailuresOnce.Do(func() {
+		c, err := otel.Meter("trustgate/trustguard").Int64Counter(
+			"trustguard_evaluate_failures_total",
+			metric.WithDescription("TrustGuard /v1/evaluate call failures by reason"),
+		)
+		if err != nil {
+			return
+		}
+		evaluateFailures = c
+	})
+	if evaluateFailures == nil {
+		return
+	}
+	evaluateFailures.Add(ctx, 1, metric.WithAttributes(attribute.String("reason", reason)))
+}

--- a/pkg/infra/plugins/trustguard/plugin.go
+++ b/pkg/infra/plugins/trustguard/plugin.go
@@ -47,14 +47,15 @@ const (
 )
 
 const (
-	decisionBlocked     = "blocked"
-	decisionReported    = "reported"
-	decisionAllowed     = "allowed"
-	decisionFailedOpen  = "failed_open"
-	decisionTransformed = "transformed"
-	statusBlock         = "block"
-	statusReport        = "report"
-	statusTransform     = "transform"
+	decisionBlocked      = "blocked"
+	decisionReported     = "reported"
+	decisionAllowed      = "allowed"
+	decisionFailedOpen   = "failed_open"
+	decisionFailedClosed = "failed_closed"
+	decisionTransformed  = "transformed"
+	statusBlock          = "block"
+	statusReport         = "report"
+	statusTransform      = "transform"
 )
 
 const (
@@ -336,14 +337,14 @@ func (p *Plugin) Execute(ctx context.Context, in appplugins.ExecInput) (*appplug
 			setExtras(in.Event, guardData{Direction: direction, Decision: decisionBlocked})
 			return nil, unavailableError(unavailable)
 		}
-		p.warn(ctx, "trustguard call failed, failing open",
-			slog.String("plugin", PluginName),
-			slog.String("stage", string(in.Stage)),
-			slog.String("direction", direction),
-			slog.Any("error", err),
-		)
-		setExtras(in.Event, guardData{Direction: direction, Decision: decisionFailedOpen, FailedOpen: true})
-		return passThrough(), nil
+		var auth *authRejectedError
+		if errors.As(err, &auth) {
+			return p.failClosedAuth(ctx, in, direction, err)
+		}
+		if errors.Is(err, errUnauthorized) {
+			return p.failClosedAuth(ctx, in, direction, &authRejectedError{status: http.StatusUnauthorized})
+		}
+		return p.handleTransportError(ctx, in, cfg, direction, err)
 	}
 
 	data := guardData{
@@ -456,10 +457,11 @@ func (p *Plugin) config(settings map[string]any) (Settings, error) {
 // be parsed decides which legs both of them inspect.
 func configCacheKey(settings map[string]any) string {
 	return fmt.Sprintf(
-		"%v\x00%v\x00%v",
+		"%v\x00%v\x00%v\x00%v",
 		settings["inspect"],
 		settings["direction"],
 		settings["collector_id"],
+		settings["on_error"],
 	)
 }
 
@@ -510,7 +512,64 @@ func (p *Plugin) guard(ctx context.Context, baseURL, collectorID, traceID string
 	if err != nil {
 		return nil, err
 	}
-	return p.client.Guard(ctx, baseURL, token, traceID, body, playground)
+	resp, err = p.client.Guard(ctx, baseURL, token, traceID, body, playground)
+	if err == nil {
+		return resp, nil
+	}
+	if errors.Is(err, errUnauthorized) {
+		return nil, &authRejectedError{status: http.StatusUnauthorized}
+	}
+	return nil, err
+}
+
+func (p *Plugin) failClosedAuth(ctx context.Context, in appplugins.ExecInput, direction string, err error) (*appplugins.Result, error) {
+	recordEvaluateFailure(ctx, failureReasonUnauthorized)
+	p.error(ctx, "trustguard auth/config rejected, failing closed",
+		slog.String("plugin", PluginName),
+		slog.String("stage", string(in.Stage)),
+		slog.String("direction", direction),
+		slog.Any("error", err),
+	)
+	var auth *authRejectedError
+	if !errors.As(err, &auth) {
+		auth = &authRejectedError{status: http.StatusUnauthorized}
+	}
+	data := guardData{
+		Direction:     direction,
+		Decision:      decisionFailedClosed,
+		FailedClosed:  true,
+		FailureReason: failureReasonUnauthorized,
+	}
+	recordGuardOutcome(in.Event, data)
+	return nil, unauthorizedError(auth)
+}
+
+func (p *Plugin) handleTransportError(ctx context.Context, in appplugins.ExecInput, cfg Settings, direction string, err error) (*appplugins.Result, error) {
+	if cfg.failClosedOnTransport() {
+		recordEvaluateFailure(ctx, failureReasonTransport)
+		p.error(ctx, "trustguard call failed, failing closed",
+			slog.String("plugin", PluginName),
+			slog.String("stage", string(in.Stage)),
+			slog.String("direction", direction),
+			slog.Any("error", err),
+		)
+		data := guardData{
+			Direction:     direction,
+			Decision:      decisionFailedClosed,
+			FailedClosed:  true,
+			FailureReason: failureReasonTransport,
+		}
+		recordGuardOutcome(in.Event, data)
+		return nil, transportFailClosedError()
+	}
+	p.warn(ctx, "trustguard call failed, failing open",
+		slog.String("plugin", PluginName),
+		slog.String("stage", string(in.Stage)),
+		slog.String("direction", direction),
+		slog.Any("error", err),
+	)
+	setExtras(in.Event, guardData{Direction: direction, Decision: decisionFailedOpen, FailedOpen: true})
+	return passThrough(), nil
 }
 
 func (p *Plugin) warn(ctx context.Context, msg string, attrs ...any) {
@@ -518,6 +577,13 @@ func (p *Plugin) warn(ctx context.Context, msg string, attrs ...any) {
 		return
 	}
 	p.logger.WarnContext(ctx, msg, attrs...)
+}
+
+func (p *Plugin) error(ctx context.Context, msg string, attrs ...any) {
+	if p.logger == nil {
+		return
+	}
+	p.logger.ErrorContext(ctx, msg, attrs...)
 }
 
 func protocolFor(consumerType string) string {

--- a/pkg/infra/plugins/trustguard/plugin_test.go
+++ b/pkg/infra/plugins/trustguard/plugin_test.go
@@ -416,6 +416,124 @@ func TestExecuteServerErrorStillFailsOpen(t *testing.T) {
 	}
 }
 
+func TestExecuteForbiddenFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{status: http.StatusForbidden}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	event, span := newEvent()
+	in := execInputWithEvent(policy.StagePreRequest, policy.ModeEnforce, settings(""), requestContext(), nil, event)
+	res, err := p.Execute(context.Background(), in)
+	if res != nil {
+		t.Fatalf("expected nil result on 403, got %+v", res)
+	}
+	pe, ok := appplugins.AsPluginError(err)
+	if !ok {
+		t.Fatalf("expected *PluginError, got %v", err)
+	}
+	if pe.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d", pe.StatusCode, http.StatusBadGateway)
+	}
+	if pe.Type != typeUnauthorized {
+		t.Fatalf("type = %q, want %q", pe.Type, typeUnauthorized)
+	}
+	attrs := span.PluginAttrsCopy()
+	extras, ok := attrs.Extras.(guardData)
+	if !ok {
+		t.Fatalf("extras type = %T, want guardData", attrs.Extras)
+	}
+	if !extras.FailedClosed || extras.Decision != decisionFailedClosed || extras.FailureReason != failureReasonUnauthorized {
+		t.Fatalf("extras = %+v, want failed_closed unauthorized", extras)
+	}
+}
+
+func TestExecuteForbiddenFailsClosedEvenWithFailOpenSetting(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{status: http.StatusForbidden}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	set := settings("")
+	set["on_error"] = onErrorFailOpen
+	in := execInput(policy.StagePreRequest, policy.ModeObserve, set, requestContext(), nil)
+	_, err := p.Execute(context.Background(), in)
+	pe, ok := appplugins.AsPluginError(err)
+	if !ok {
+		t.Fatalf("auth rejection must fail closed even when on_error=fail_open, got %v", err)
+	}
+	if pe.Type != typeUnauthorized {
+		t.Fatalf("type = %q, want %q", pe.Type, typeUnauthorized)
+	}
+}
+
+func TestExecuteTransportErrorFailClosed(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeGuard{status: http.StatusInternalServerError}
+	srv := newServer(t, f)
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+
+	set := settings("")
+	set["on_error"] = onErrorFailClosed
+	event, span := newEvent()
+	in := execInputWithEvent(policy.StagePreRequest, policy.ModeEnforce, set, requestContext(), nil, event)
+	res, err := p.Execute(context.Background(), in)
+	if res != nil {
+		t.Fatalf("expected nil result when on_error=fail_closed, got %+v", res)
+	}
+	pe, ok := appplugins.AsPluginError(err)
+	if !ok {
+		t.Fatalf("expected *PluginError, got %v", err)
+	}
+	if pe.StatusCode != http.StatusBadGateway || pe.Type != typeGuardError {
+		t.Fatalf("plugin error = %+v, want 502 %s", pe, typeGuardError)
+	}
+	attrs := span.PluginAttrsCopy()
+	extras, ok := attrs.Extras.(guardData)
+	if !ok {
+		t.Fatalf("extras type = %T, want guardData", attrs.Extras)
+	}
+	if !extras.FailedClosed || extras.FailureReason != failureReasonTransport {
+		t.Fatalf("extras = %+v, want failed_closed transport", extras)
+	}
+}
+
+func TestExecutePersistent401FailsClosed(t *testing.T) {
+	t.Parallel()
+
+	var guardHits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case tokenPath:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(tokenResponse{AccessToken: "tok", TokenType: "Bearer", ExpiresIn: 3600})
+		case evaluatePath:
+			atomic.AddInt32(&guardHits, 1)
+			w.WriteHeader(http.StatusUnauthorized)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	p := New(adapter.NewRegistry(), srv.URL, testTimeout, "test-client", "test-secret", nil)
+	in := execInput(policy.StagePreRequest, policy.ModeEnforce, settings(""), requestContext(), nil)
+	_, err := p.Execute(context.Background(), in)
+	pe, ok := appplugins.AsPluginError(err)
+	if !ok {
+		t.Fatalf("persistent 401 must fail closed, got %v", err)
+	}
+	if pe.Type != typeUnauthorized {
+		t.Fatalf("type = %q, want %q", pe.Type, typeUnauthorized)
+	}
+	if got := atomic.LoadInt32(&guardHits); got != 2 {
+		t.Fatalf("guard hits = %d, want 2 (original + refresh retry)", got)
+	}
+}
+
 func TestExecutePreResponseBlockReturns403(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/infra/plugins/trustguard/reject.go
+++ b/pkg/infra/plugins/trustguard/reject.go
@@ -26,10 +26,14 @@ import (
 const typeBlocked = "trustguard_blocked"
 const typeRateLimited = "trustguard_rate_limited"
 const typeUnavailable = "trustguard_unavailable"
+const typeUnauthorized = "trustguard_unauthorized"
+const typeGuardError = "trustguard_error"
 
 const blockMessage = "request blocked due to a policy infraction"
 const rateLimitMessage = "rate limit exceeded"
 const unavailableMessage = "rate limit entitlements unavailable"
+const unauthorizedMessage = "trustguard authentication or configuration rejected"
+const guardErrorMessage = "trustguard unavailable"
 
 func blockError(resp *GuardResponse) *appplugins.PluginError {
 	message := clientBlockMessage(resp)
@@ -64,6 +68,37 @@ func unavailableError(err *entitlementsUnavailableError) *appplugins.PluginError
 		StatusCode: http.StatusServiceUnavailable,
 		Type:       typeUnavailable,
 		Message:    unavailableMessage,
+		Body:       body,
+	}
+}
+
+func unauthorizedError(err *authRejectedError) *appplugins.PluginError {
+	upstream := http.StatusUnauthorized
+	if err != nil && err.status != 0 {
+		upstream = err.status
+	}
+	body, _ := json.Marshal(map[string]any{
+		"error":           typeUnauthorized,
+		"message":         unauthorizedMessage,
+		"upstream_status": upstream,
+	})
+	return &appplugins.PluginError{
+		StatusCode: http.StatusBadGateway,
+		Type:       typeUnauthorized,
+		Message:    unauthorizedMessage,
+		Body:       body,
+	}
+}
+
+func transportFailClosedError() *appplugins.PluginError {
+	body, _ := json.Marshal(map[string]any{
+		"error":   typeGuardError,
+		"message": guardErrorMessage,
+	})
+	return &appplugins.PluginError{
+		StatusCode: http.StatusBadGateway,
+		Type:       typeGuardError,
+		Message:    guardErrorMessage,
 		Body:       body,
 	}
 }


### PR DESCRIPTION
## Summary
- Split TrustGuard plugin evaluate failures: 401/403 (auth/config) always fail closed instead of silently serving unguarded 200s.
- Add `on_error: fail_open | fail_closed` (default `fail_open`) for transport/5xx so regulated deployments can block when the guard is unreachable.
- Log auth rejections at ERROR, emit `trustguard_evaluate_failures_total{reason=unauthorized}`, and surface `failed_closed` / `failure_reason` on span extras.

## Linear
Fixes RUN-1126
https://linear.app/neuraltrust/issue/RUN-1126/fixtrustguard-plugin-auth-failures-fail-open-serving-unguarded-traffic

## Test plan
- [x] `go test ./pkg/infra/plugins/trustguard/`
- [x] Unit coverage for 403 fail-closed, persistent 401 fail-closed, 500 fail-open default, `on_error=fail_closed` transport path
- [ ] Confirm a misbound `collector_id` returns 502 `trustguard_unauthorized` instead of 200 in a hybrid env

Replaces #475 (branch renamed to the `fix/` convention).

Made with [Cursor](https://cursor.com)